### PR TITLE
Intégration : ajout d'un paramètre `id` à l'index des rdvs

### DIFF
--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -7,6 +7,10 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
 
     rdvs = rdvs.includes(:organisation, :motif, :lieu, :agents, :users, participations: [:user], motif: [:motif_category])
 
+    if params[:id].present?
+      rdvs = rdvs.where(id: params[:id])
+    end
+
     if params[:user_id].present?
       rdvs = rdvs.where(participations: { user_id: params[:user_id] })
     end

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -31,5 +31,17 @@ RSpec.describe "RDV API" do
       expect(parsed_response_body["rdvs"].count).to eq 1
       expect(parsed_response_body["rdvs"].first["id"]).to eq rdv_with_user_and_agent.id
     end
+
+    it "filters by id" do
+      get "/api/v1/rdvs", headers: headers, params: { ids: [rdv_with_user_and_other_agent, rdv_with_other_user_and_agent] }, as: :json
+      expect(parsed_response_body["rdvs"].count).to eq 2
+
+      response_ids = [
+        parsed_response_body["rdvs"].first["id"],
+        parsed_response_body["rdvs"].second["id"],
+      ]
+
+      expect(response_ids).to contain_exactly(rdv_with_user_and_other_agent.id, rdv_with_other_user_and_agent.id)
+    end
   end
 end

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe "RDV API" do
       expect(parsed_response_body["rdvs"].first["id"]).to eq rdv_with_user_and_agent.id
     end
 
-    it "filters by id" do
-      get "/api/v1/rdvs", headers: headers, params: { ids: [rdv_with_user_and_other_agent, rdv_with_other_user_and_agent] }, as: :json
+    it "filters by id when passing an array" do
+      get "/api/v1/rdvs", headers: headers, params: { id: [rdv_with_user_and_other_agent.id, rdv_with_other_user_and_agent.id] }, as: :json
       expect(parsed_response_body["rdvs"].count).to eq 2
 
       response_ids = [
@@ -42,6 +42,12 @@ RSpec.describe "RDV API" do
       ]
 
       expect(response_ids).to contain_exactly(rdv_with_user_and_other_agent.id, rdv_with_other_user_and_agent.id)
+    end
+
+    it "filters by id with only one value" do
+      get "/api/v1/rdvs", headers: headers, params: { id: rdv_with_user_and_agent.id }, as: :json
+      expect(parsed_response_body["rdvs"].count).to eq 1
+      expect(parsed_response_body["rdvs"].first["id"]).to eq rdv_with_user_and_agent.id
     end
   end
 end

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
       tags "RDV"
       produces "application/json"
       operationId "getRdvs"
-      description "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres optionels passés en paramètre"
+      description "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres facultatifs passés en paramètre"
 
       parameter name: :organisation_id, in: :query, type: :string, description: "Identifiant de l'organisation", example: "20", required: false
 

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/v1/rdvs" do
-    get "Lister les rendez-vous d'une organisation" do
+    get "Lister les rendez-vous" do
       with_authentication
 
       tags "RDV"
@@ -19,6 +19,9 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
                 example: 123, required: false
       parameter name: :agent_id, in: :query, type: :integer,
                 description: "Filtre pour obtenir uniquement les rendez-vous de l'agent qui a cet id",
+                example: 456, required: false
+      parameter name: :id, in: :query,
+                description: "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste. Vous pouvez passer soit un tableau d'entier, soit un seul entier pour obtenir un seul rdv",
                 example: 456, required: false
 
       parameter name: :starts_after, in: :query, type: :string,

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -21,8 +21,12 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
                 description: "Filtre pour obtenir uniquement les rendez-vous de l'agent qui a cet id",
                 example: 456, required: false
       parameter name: :id, in: :query,
-                description: "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste. Vous pouvez passer soit un tableau d'entier, soit un seul entier pour obtenir un seul rdv",
-                example: 456, required: false
+                description: <<~DOC,
+                  Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.
+                  Vous pouvez passer soit un tableau d'entier pour obtenir plusieurs rdvs, soit un seul entier pour obtenir un seul rdv.
+                  Si vous passez un tableau d'entier, le format attendu est id[]=1234&id[]=5678
+                DOC
+                example: "789 ou id[]=1234&id[]=5678", required: false
 
       parameter name: :starts_after, in: :query, type: :string,
                 description: "Filtre les rendez-vous avec un starts_at aprés cette date. Accepte des formats date ou time (iso8601).",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -2758,7 +2758,7 @@
     },
     "/api/v1/rdvs": {
       "get": {
-        "summary": "Lister les rendez-vous d'une organisation",
+        "summary": "Lister les rendez-vous",
         "security": [
           {
             "access_token": [],
@@ -2825,6 +2825,13 @@
             }
           },
           {
+            "name": "id",
+            "in": "query",
+            "description": "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste. Vous pouvez passer soit un tableau d'entier, soit un seul entier pour obtenir un seul rdv",
+            "example": 456,
+            "required": false
+          },
+          {
             "name": "starts_after",
             "in": "query",
             "description": "Filtre les rendez-vous avec un starts_at aprés cette date. Accepte des formats date ou time (iso8601).",
@@ -2849,7 +2856,7 @@
           "RDV"
         ],
         "operationId": "getRdvs",
-        "description": "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres optionels passés en paramètre",
+        "description": "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres facultatifs passés en paramètre",
         "responses": {
           "200": {
             "description": "Appel API réussi",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -2827,8 +2827,8 @@
           {
             "name": "id",
             "in": "query",
-            "description": "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste. Vous pouvez passer soit un tableau d'entier, soit un seul entier pour obtenir un seul rdv",
-            "example": 456,
+            "description": "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.\nVous pouvez passer soit un tableau d'entier pour obtenir plusieurs rdvs, soit un seul entier pour obtenir un seul rdv.\nSi vous passez un tableau d'entier, le format attendu est id[]=1234&id[]=5678\n",
+            "example": "789 ou id[]=1234&id[]=5678",
             "required": false
           },
           {


### PR DESCRIPTION
# Contexte

Dans le contexte de l'intégration avec Démarches Simplifiées, ils vont enregistrer la liste des ids des rendez-vous liés à une démarche.
Il leur faut ensuite un endpoint pour récupérer la liste des rendez-vous liés à cette démarche au moment où ils chargent la page de détails de la démarche.

En venant chercher les infos de manière synchrone, ça évite les problèmes de synchronisation (les nerds qui aiment le cap theorem diraient qu'on échange de l'availability contre de la consistency), et ça leur permet d'afficher les infos à jour de tous les rendez-vous.

Il leur faut donc pouvoir récupérer une liste de rendez-vous.

# Solution

Petit choix discutable : je fais déborder la permissivité d'activerecord en acceptant soit un entier soit un tableau d'entier pour ce nouveau paramètre. C'est un peu excentrique, mais tellement pratique.

