### PR TITLE
Rétablir la possibilité d'activer certains champs usager

### DIFF
--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -94,6 +94,11 @@ class Territory < ApplicationRecord
     enable_birth_date_field: :birth_date,
   }.merge(SOCIAL_FIELD_TOGGLES).freeze
 
+  # Nous voulons permettre à tous les espaces d'activer ou non ces champs, qualifiés de "légitimes"
+  # En revanche, les autres champs listés ci-dessus sont considérés comme "legacy" et seulement
+  # affichés aux espaces qui les avaient déjà activés.
+  LEGITIMATE_TOGGLES = %i[enable_birth_date_field enable_address_details enable_case_number].freeze
+
   def mairies?
     name == MAIRIES_NAME
   end
@@ -116,10 +121,6 @@ class Territory < ApplicationRecord
 
   def any_social_field_enabled?
     attributes.symbolize_keys.slice(*SOCIAL_FIELD_TOGGLES.keys).values.any?
-  end
-
-  def any_optional_user_field_enabled?
-    attributes.symbolize_keys.slice(*OPTIONAL_FIELD_TOGGLES.keys).values.any?
   end
 
   def to_s

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -97,7 +97,9 @@ class Territory < ApplicationRecord
   # Nous voulons permettre à tous les espaces d'activer ou non ces champs, qualifiés de "légitimes"
   # En revanche, les autres champs listés ci-dessus sont considérés comme "legacy" et seulement
   # affichés aux espaces qui les avaient déjà activés.
-  LEGITIMATE_TOGGLES = %i[enable_birth_date_field enable_address_details enable_case_number].freeze
+  legitimate_toggle_keys = %i[enable_birth_date_field enable_address_details enable_case_number]
+  LEGITIMATE_TOGGLES = OPTIONAL_FIELD_TOGGLES.slice(*legitimate_toggle_keys)
+  LEGACY_TOGGLES = OPTIONAL_FIELD_TOGGLES.except(*legitimate_toggle_keys)
 
   def mairies?
     name == MAIRIES_NAME
@@ -121,6 +123,10 @@ class Territory < ApplicationRecord
 
   def any_social_field_enabled?
     attributes.symbolize_keys.slice(*SOCIAL_FIELD_TOGGLES.keys).values.any?
+  end
+
+  def any_legacy_fields_enabled?
+    attributes.symbolize_keys.slice(*LEGACY_TOGGLES.keys).values.any?
   end
 
   def to_s

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -98,8 +98,8 @@ class Territory < ApplicationRecord
   # En revanche, les autres champs listés ci-dessus sont considérés comme "legacy" et seulement
   # affichés aux espaces qui les avaient déjà activés.
   legitimate_toggle_keys = %i[enable_birth_date_field enable_address_details enable_case_number]
-  LEGITIMATE_TOGGLES = OPTIONAL_FIELD_TOGGLES.slice(*legitimate_toggle_keys)
-  LEGACY_TOGGLES = OPTIONAL_FIELD_TOGGLES.except(*legitimate_toggle_keys)
+  LEGITIMATE_TOGGLES = OPTIONAL_FIELD_TOGGLES.slice(*legitimate_toggle_keys).freeze
+  LEGACY_TOGGLES = OPTIONAL_FIELD_TOGGLES.except(*legitimate_toggle_keys).freeze
 
   def mairies?
     name == MAIRIES_NAME

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -46,7 +46,7 @@ h1.m-2.rdv-text-align-center.border-bottom.pb-2 = t("admin.territories.show.titl
           | Sectorisation
         p Créer, importer, affecter vos secteurs géographiques.
 
-  - if Agent::TerritoryPolicy.new(current_agent, current_territory).edit? && current_territory.any_optional_user_field_enabled?
+  - if Agent::TerritoryPolicy.new(current_agent, current_territory).edit?
     .col.col-md-4.p-2.rounded.settings-box
       = link_to edit_admin_territory_user_fields_path(current_territory) do
         h2.fw-bold.mb-0

--- a/app/views/admin/territories/user_fields/edit.html.slim
+++ b/app/views/admin/territories/user_fields/edit.html.slim
@@ -11,8 +11,6 @@
 
           p.text-muted.font-14= t(".hint_1")
           p.text-muted.font-14= t(".hint_2")
-          - legitimate_toggles, legacy_toggles = Territory::OPTIONAL_FIELD_TOGGLES.partition { |toggle, _| toggle.in?(Territory::LEGITIMATE_TOGGLES) }.map(&:to_h)
-
           - Territory::LEGITIMATE_TOGGLES.each do |toggle, field_name|
             = f.input toggle, label: User.human_attribute_name(field_name)
 

--- a/app/views/admin/territories/user_fields/edit.html.slim
+++ b/app/views/admin/territories/user_fields/edit.html.slim
@@ -11,8 +11,15 @@
 
           p.text-muted.font-14= t(".hint_1")
           p.text-muted.font-14= t(".hint_2")
-          - Territory::OPTIONAL_FIELD_TOGGLES.each do |toggle, field_name|
+          - legitimate_toggles, legacy_toggles = Territory::OPTIONAL_FIELD_TOGGLES.partition { |toggle, _| toggle.in?(Territory::LEGITIMATE_TOGGLES) }.map(&:to_h)
+
+          - legitimate_toggles.each do |toggle, field_name|
             = f.input toggle, label: User.human_attribute_name(field_name)
+
+          p.text-muted.font-14= t(".legacy_toggles_explanations")
+          - legacy_toggles.each do |toggle, field_name|
+            - if current_territory.send(toggle)
+              = f.input toggle, label: User.human_attribute_name(field_name)
 
           .text-right
             = f.button :submit

--- a/app/views/admin/territories/user_fields/edit.html.slim
+++ b/app/views/admin/territories/user_fields/edit.html.slim
@@ -13,13 +13,14 @@
           p.text-muted.font-14= t(".hint_2")
           - legitimate_toggles, legacy_toggles = Territory::OPTIONAL_FIELD_TOGGLES.partition { |toggle, _| toggle.in?(Territory::LEGITIMATE_TOGGLES) }.map(&:to_h)
 
-          - legitimate_toggles.each do |toggle, field_name|
+          - Territory::LEGITIMATE_TOGGLES.each do |toggle, field_name|
             = f.input toggle, label: User.human_attribute_name(field_name)
 
-          p.text-muted.font-14= t(".legacy_toggles_explanations")
-          - legacy_toggles.each do |toggle, field_name|
-            - if current_territory.send(toggle)
-              = f.input toggle, label: User.human_attribute_name(field_name)
+          - if current_territory.any_legacy_fields_enabled?
+            p.text-muted.font-14= t(".legacy_toggles_explanations")
+            - Territory::LEGACY_TOGGLES.each do |toggle, field_name|
+              - if current_territory.send(toggle)
+                = f.input toggle, label: User.human_attribute_name(field_name)
 
           .text-right
             = f.button :submit

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -132,4 +132,5 @@ fr:
           title: Champs de la fiche usager
           card_title: Champs optionnels pour les fiches usagers
           hint_1: Vous pouvez activer ou désactiver les champs suivants sur les fiches usagers.
-          hint_2: "Les champs seront simplement masqués dans l’interface : les données préexistantes ne seront pas supprimées."
+          hint_2: "Lorsque vous dé-cochez un champ ici, il sera simplement masqué dans l’interface : les données préexistantes ne seront pas supprimées."
+          legacy_toggles_explanations: "Les champs ci-dessous sont dépréciés : si vous en décochez un, il ne sera pas possible de le re-cocher."

--- a/spec/features/territory_admins/territory_admin_can_manage_user_fields_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_user_fields_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe "territory admin can manage user fields", type: :feature do
+  describe "affichage des champs légitimes ou déjà cochés" do
+    context "quand tous les toggles sont désactivés (espace tout juste créé)" do
+      let!(:territory) { create(:territory) }
+      let!(:agent) { create(:agent, role_in_territories: [territory]) }
+
+      it "affiche uniquement les champs légitimes" do
+        login_as(agent, scope: :agent)
+        visit edit_admin_territory_user_fields_path(territory)
+        expect(page).to have_content("Date de naissance")
+        expect(page).to have_content("Complément d'adresse")
+        expect(page).to have_content("Numéro de dossier")
+
+        expect(page).not_to have_content("Logement")
+        expect(page).not_to have_content("Remarques")
+        expect(page).not_to have_content("Caisse d'affiliation")
+        expect(page).not_to have_content("Numéro d'allocataire")
+        expect(page).not_to have_content("Situation familiale")
+        expect(page).not_to have_content("Nombre d'enfants")
+      end
+    end
+
+    context "quand certains toggles sont activés sur le territoire" do
+      let!(:territory) { create(:territory, enable_logement_field: true, enable_number_of_children_field: true) }
+      let!(:agent) { create(:agent, role_in_territories: [territory]) }
+
+      it "affiche les champs légitimes et les champs activés" do
+        login_as(agent, scope: :agent)
+        visit edit_admin_territory_user_fields_path(territory)
+
+        # Les champs légitimes sont affichés.
+        expect(page).to have_content("Date de naissance")
+        expect(page).to have_content("Complément d'adresse")
+        expect(page).to have_content("Numéro de dossier")
+
+        # Ces champs legacy sont affichés car actuellement enabled
+        expect(page).to have_content("Nombre d'enfants")
+        expect(page).to have_content("Logement")
+
+        # Les autres champs legacy ne sont pas affichés
+        expect(page).not_to have_content("Remarques")
+        expect(page).not_to have_content("Caisse d'affiliation")
+        expect(page).not_to have_content("Numéro d'allocataire")
+        expect(page).not_to have_content("Situation familiale")
+      end
+    end
+  end
+end

--- a/spec/features/territory_admins/territory_admin_can_manage_user_fields_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_user_fields_spec.rb
@@ -45,10 +45,16 @@ RSpec.describe "admin d'espace peut gérer les champs de fiche usager", type: :f
       it "affiche uniquement les champs légitimes" do
         login_as(agent, scope: :agent)
         visit edit_admin_territory_user_fields_path(territory)
+
+        # Les champs légitimes sont affichés
         expect(page).to have_content("Date de naissance")
         expect(page).to have_content("Complément d'adresse")
         expect(page).to have_content("Numéro de dossier")
 
+        # pas la peine d'afficher les infos sur les champs legacy
+        expect(page).not_to have_content("Les champs ci-dessous sont dépréciés")
+
+        # Aucun champ legacy n'est affiché
         expect(page).not_to have_content("Logement")
         expect(page).not_to have_content("Remarques")
         expect(page).not_to have_content("Caisse d'affiliation")
@@ -83,6 +89,9 @@ RSpec.describe "admin d'espace peut gérer les champs de fiche usager", type: :f
         expect(page).to have_content("Date de naissance")
         expect(page).to have_content("Complément d'adresse")
         expect(page).to have_content("Numéro de dossier")
+
+        # On affiche une explication sur le fonctionnement des champs legacy
+        expect(page).to have_content("Les champs ci-dessous sont dépréciés")
 
         # Ces champs legacy sont affichés car actuellement enabled
         expect(page).to have_content("Nombre d'enfants")

--- a/spec/features/territory_admins/territory_admin_can_manage_user_fields_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_user_fields_spec.rb
@@ -1,7 +1,45 @@
-RSpec.describe "territory admin can manage user fields", type: :feature do
+RSpec.describe "admin d'espace peut gérer les champs de fiche usager", type: :feature do
+  let!(:territory) { create(:territory) }
+  let!(:agent) { create(:agent, role_in_territories: [territory]) }
+
+  it "works (cas général)" do
+    login_as(agent, scope: :agent)
+    visit edit_admin_territory_user_fields_path(territory)
+
+    check "Date de naissance"
+    expect { click_on "Enregistrer" }.to change { territory.reload.enable_birth_date_field }.from(false).to(true)
+
+    uncheck "Date de naissance"
+    expect { click_on "Enregistrer" }.to change { territory.reload.enable_birth_date_field }.from(true).to(false)
+  end
+
+  it "permet de décocher les champs legcay précédemment activés" do
+    territory.update!(enable_logement_field: true)
+    login_as(agent, scope: :agent)
+    visit edit_admin_territory_user_fields_path(territory)
+
+    uncheck "Logement"
+    expect { click_on "Enregistrer" }.to change { territory.reload.enable_logement_field }.from(true).to(false)
+    # Le champ n'est plus proposé une fois décoché
+    expect(page).not_to have_content("Logement")
+  end
+
   describe "affichage des champs légitimes ou déjà cochés" do
     context "quand tous les toggles sont désactivés (espace tout juste créé)" do
-      let!(:territory) { create(:territory) }
+      let!(:territory) do
+        create(
+          :territory,
+          enable_notes_field: false,
+          enable_caisse_affiliation_field: false,
+          enable_affiliation_number_field: false,
+          enable_family_situation_field: false,
+          enable_number_of_children_field: false,
+          enable_logement_field: false,
+          enable_case_number: false,
+          enable_birth_date_field: false,
+          enable_address_details: false
+        )
+      end
       let!(:agent) { create(:agent, role_in_territories: [territory]) }
 
       it "affiche uniquement les champs légitimes" do
@@ -21,7 +59,20 @@ RSpec.describe "territory admin can manage user fields", type: :feature do
     end
 
     context "quand certains toggles sont activés sur le territoire" do
-      let!(:territory) { create(:territory, enable_logement_field: true, enable_number_of_children_field: true) }
+      let!(:territory) do
+        create(
+          :territory,
+          enable_notes_field: false,
+          enable_caisse_affiliation_field: false,
+          enable_affiliation_number_field: false,
+          enable_family_situation_field: false,
+          enable_number_of_children_field: true,
+          enable_logement_field: true,
+          enable_case_number: false,
+          enable_birth_date_field: false,
+          enable_address_details: false
+        )
+      end
       let!(:agent) { create(:agent, role_in_territories: [territory]) }
 
       it "affiche les champs légitimes et les champs activés" do

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -98,5 +98,15 @@ RSpec.describe Territory, type: :model do
       expect(described_class.new(enable_number_of_children_field: true).any_social_field_enabled?).to be_truthy
     end
   end
+
+  describe "#any_legacy_fields_enabled?" do
+    it "returns true if any legacy field is enabled" do
+      expect(described_class.new.any_legacy_fields_enabled?).to be_falsey
+      expect(described_class.new(enable_address_details: true).any_legacy_fields_enabled?).to be_falsey
+
+      expect(described_class.new(enable_number_of_children_field: true).any_legacy_fields_enabled?).to be_truthy
+      expect(described_class.new(enable_notes_field: true).any_legacy_fields_enabled?).to be_truthy
+    end
+  end
   # rubocop:enable RSpec/PredicateMatcher
 end

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -98,13 +98,5 @@ RSpec.describe Territory, type: :model do
       expect(described_class.new(enable_number_of_children_field: true).any_social_field_enabled?).to be_truthy
     end
   end
-
-  describe "#any_optional_user_field_enabled?" do
-    it "returns true if any optional field is enabled" do
-      expect(described_class.new.any_optional_user_field_enabled?).to be_falsey
-      expect(described_class.new(enable_number_of_children_field: true).any_optional_user_field_enabled?).to be_truthy
-      expect(described_class.new(enable_notes_field: true).any_optional_user_field_enabled?).to be_truthy
-    end
-  end
   # rubocop:enable RSpec/PredicateMatcher
 end


### PR DESCRIPTION
Closes #5353

# Contexte

L'issue décrit très bien le contexte (merci @mekaidmekaid :heart_eyes: ), je pense qu'il n'y a rien à ajouter.

# Solution

Dans le code j'ai qualifié les champs de soit "legacy" soit "légitime", avec les 3 champs légitimes listés dans l'issue, et le reste considéré comme "legacy".

Nous n'avions pas de spec pour les user fields donc c'était l'occasion d'en créer une !

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/11f00566-9e58-400e-965a-695e9970fdc4) | ![image](https://github.com/user-attachments/assets/d233b2d9-e7a5-40c4-a3fb-d63b954a9299)
![image](https://github.com/user-attachments/assets/f753e62c-f0cd-47d0-af54-74eb7f0d4cce) | ![image](https://github.com/user-attachments/assets/23cc0d39-29b4-4280-98c6-d37a91765ee6)
![image](https://github.com/user-attachments/assets/04cd3faf-9e61-43cf-883e-7255fb0316e4) | ![image](https://github.com/user-attachments/assets/2ec5f8c4-900f-4db8-b7fb-64b9c4273122)
