### PR TITLE
Refactors RDV Updatable concern et RdvEditForm

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -161,19 +161,14 @@ class Admin::RdvsController < AgentAuthController
   def rdv_update_params
     allowed_params = params.require(:rdv).permit(:status, :lieu_id, :duration_in_min, :starts_at, :context, :ignore_benign_errors, :max_participants_count, :name,
                                                  participations_attributes: %i[user_id send_lifecycle_notifications send_reminder_notification id _destroy],
-                                                 lieu_attributes: %i[name address latitude longitude id])
+                                                 lieu_attributes: %i[name address latitude longitude id],
+                                                 agent_ids: [])
 
     # Quand un lieu ponctuel est saisi, il faut faire en sorte qu'il soit créé dans l'organisation courante.
     # Nous le faisons ici, côté serveur pour empêcher de spécifier une valeur arbitraire.
     if allowed_params[:lieu_attributes].present?
       allowed_params[:lieu_attributes][:organisation] = current_organisation
       allowed_params[:lieu_attributes][:availability] = :single_use
-    end
-
-    if params[:rdv][:agent_ids].present?
-      # La méthode Motif#authorized_agents est aussi utilisée pour lister les agents du select
-      # de l'edit, c'est donc cohérent de l'utiliser ici pour sanitizer les IDs d'agent.
-      allowed_params[:agent_ids] = @rdv.motif.authorized_agents.where(id: params[:rdv][:agent_ids]).pluck(:id).uniq
     end
 
     allowed_params

--- a/app/form_models/admin/edit_rdv_form.rb
+++ b/app/form_models/admin/edit_rdv_form.rb
@@ -14,7 +14,7 @@ class Admin::EditRdvForm
     @rdv.update_and_notify(agent_context.agent, rdv_attributes) do |rdv_before_save|
       authorize(rdv_before_save, :update?, policy_class: Agent::RdvPolicy)
       @rdv = rdv_before_save
-      validate!
+      valid?
     end
   end
 

--- a/app/form_models/admin/edit_rdv_form.rb
+++ b/app/form_models/admin/edit_rdv_form.rb
@@ -11,25 +11,12 @@ class Admin::EditRdvForm
   end
 
   def submit(rdv_attributes)
-    raise ArgumentError, "agent_ids est accepté mais pas agents" if rdv_attributes.key?(:agents)
-
-    previous_agent_ids = @rdv.agent_ids
-
-    @rdv.assign_attributes(rdv_attributes)
-
-    @selected_agent_ids = @rdv.agent_ids
-
-    authorize(@rdv, :update?, policy_class: Agent::RdvPolicy)
-
-    if valid?
-      @rdv.save_and_notify(agent_context.agent)
-    else
-      @rdv.agent_ids = previous_agent_ids
-      false
+    @rdv.update_and_notify(agent_context.agent, rdv_attributes) do |rdv_before_save|
+      authorize(rdv_before_save, :update?, policy_class: Agent::RdvPolicy)
+      @rdv = rdv_before_save
+      validate!
     end
   end
-
-  attr_reader :selected_agent_ids
 
   private
 

--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -1,12 +1,38 @@
 module Rdv::Updatable
   extend ActiveSupport::Concern
 
+  # rubocop:disable Metrics/PerceivedComplexity
   def update_and_notify(author, attributes, &block)
-    raise ArgumentError, "agent_ids est accepté mais pas agents" if attributes.key?(:agents)
+    Rdv.transaction do
+      @old_agent_ids = agent_ids.to_a
+      assign_attributes(attributes) # this can assign agent_ids and thus persist
+      self.updated_at = Time.zone.now
 
-    res = Rdv.transaction { do_update_and_notify(author, attributes, &block) }
-    res.to_boolean # Rdv.transaction returns nil when rollbacked
+      previous_participations = participations.select(&:persisted?)
+      remove_duplicate_participations
+      set_created_by_for_new_participations(author)
+
+      if status_changed? && valid?
+        self.cancelled_at = status.in?(%w[excused revoked noshow]) ? Time.zone.now : nil
+        change_participation_statuses
+        participations.reload # reload is needed after .persisted? method call
+      end
+
+      if block_given?
+        unless block.call(self) # yield RDV before saving, can be used to run policy check
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      if save
+        notify!(author, previous_participations)
+        true
+      else
+        raise ActiveRecord::Rollback
+      end
+    end
   end
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def participation_token(user_id)
     # For user invited with tokens, nil default for not invited users
@@ -40,35 +66,15 @@ module Rdv::Updatable
     previous_changes["starts_at"].present?
   end
 
-  def agents_changed?
-    # we cannot use ActiveModel::Dirty methods here for this has_many association
-    @old_agent_ids.to_set != agent_ids.to_set
-  end
-
   def rdv_updated?
     starts_at_changed? || lieu_changed? || agents_changed?
   end
 
   private
 
-  def do_update_and_notify(author, attributes)
-    @old_agent_ids = agent_ids.to_a
-    assign_attributes(attributes) # this can assign agent_ids and thus persist
-    self.updated_at = Time.zone.now
-    previous_participations = participations.select(&:persisted?)
-    remove_duplicate_participations
-    set_created_by_for_new_participations(author)
-    if status_changed? && valid?
-      self.cancelled_at = status.in?(%w[excused revoked noshow]) ? Time.zone.now : nil
-      change_participation_statuses
-      participations.reload # reload is needed after .persisted? method call
-    end
-    yield(self) if block_given? # yield RDV before saving, can be used to run policy check
-    save!
-    notify!(author, previous_participations)
-    true
-  rescue ActiveRecord::RecordInvalid, ActiveModel::ValidationError
-    raise ActiveRecord::Rollback
+  def agents_changed?
+    # we cannot use ActiveModel::Dirty methods here for this has_many association
+    @old_agent_ids.to_set != agent_ids.to_set
   end
 
   def remove_duplicate_participations

--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -2,35 +2,10 @@ module Rdv::Updatable
   extend ActiveSupport::Concern
 
   def update_and_notify(author, attributes, &block)
-    @old_agent_ids = agent_ids.to_a
-    assign_attributes(attributes)
-    save_and_notify(author, &block)
-  end
+    raise ArgumentError, "agent_ids est accepté mais pas agents" if attributes.key?(:agents)
 
-  def save_and_notify(author)
-    Rdv.transaction do
-      self.updated_at = Time.zone.now
-      previous_participations = participations.select(&:persisted?)
-      remove_duplicate_participations
-
-      set_created_by_for_new_participations(author)
-
-      if status_changed? && valid?
-        self.cancelled_at = status.in?(%w[excused revoked noshow]) ? Time.zone.now : nil
-        change_participation_statuses
-        # Reload is needed after .persisted? method call.
-        participations.reload
-      end
-
-      yield self if block_given? # yield RDV before saving, can be used to run policy check
-
-      if save
-        notify!(author, previous_participations)
-        true
-      else
-        false
-      end
-    end
+    res = Rdv.transaction { do_update_and_notify(author, attributes, &block) }
+    res.to_boolean # Rdv.transaction returns nil when rollbacked
   end
 
   def participation_token(user_id)
@@ -65,13 +40,36 @@ module Rdv::Updatable
     previous_changes["starts_at"].present?
   end
 
+  def agents_changed?
+    # we cannot use ActiveModel::Dirty methods here for this has_many association
+    @old_agent_ids.to_set != agent_ids.to_set
+  end
+
   def rdv_updated?
-    # TODO : How to pass the list of old agents from Admin::EditRdvForm to Updatable ?
-    # TODO : add agents_changed?
-    starts_at_changed? || lieu_changed?
+    starts_at_changed? || lieu_changed? || agents_changed?
   end
 
   private
+
+  def do_update_and_notify(author, attributes)
+    @old_agent_ids = agent_ids.to_a
+    assign_attributes(attributes) # this can assign agent_ids and thus persist
+    self.updated_at = Time.zone.now
+    previous_participations = participations.select(&:persisted?)
+    remove_duplicate_participations
+    set_created_by_for_new_participations(author)
+    if status_changed? && valid?
+      self.cancelled_at = status.in?(%w[excused revoked noshow]) ? Time.zone.now : nil
+      change_participation_statuses
+      participations.reload # reload is needed after .persisted? method call
+    end
+    yield(self) if block_given? # yield RDV before saving, can be used to run policy check
+    save!
+    notify!(author, previous_participations)
+    true
+  rescue ActiveRecord::RecordInvalid, ActiveModel::ValidationError
+    raise ActiveRecord::Rollback
+  end
 
   def remove_duplicate_participations
     existing_participations = Participation.where(rdv_id: id).to_a # pour éviter une requête N+1

--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -67,7 +67,8 @@ module Rdv::Updatable
   end
 
   def rdv_updated?
-    starts_at_changed? || lieu_changed? || agents_changed?
+    starts_at_changed? || lieu_changed?
+    # || agents_changed? désactivé pour l’instant cf https://github.com/betagouv/rdv-service-public/pull/5399
   end
 
   private

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -7,7 +7,7 @@ class Agent::RdvPolicy < ApplicationPolicy
   alias new? create?
 
   def update?
-    same_agent_or_has_access? && users_authorized?
+    same_agent_or_has_access? && users_and_agents_authorized?
   end
   alias status? update?
 

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -57,7 +57,7 @@
               = f.input :address, label: "Lieu (RDV à domicile)", disabled: true, input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }
             = f.association :agents,
               collection: @rdv_form.motif.authorized_agents,
-              selected: @rdv_form.selected_agent_ids || @rdv.agent_ids,
+              selected: @rdv.agent_ids,
               label_method: :full_name_and_service,
               input_html: { multiple: true, class: "select2-input", data: { "auto-select-sole-option": true } }
 

--- a/spec/features/agents/agent_can_update_rdv_spec.rb
+++ b/spec/features/agents/agent_can_update_rdv_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Agent can update a RDV", js: true do
   context "ajout d’un agent au RDV" do
     let!(:agent_jungyoon) { create(:agent, first_name: "Jung Yoon", last_name: "Han", email: "jungyoon@angouleme.fr", service:, basic_role_in_organisations: [organisation]) }
 
-    it "envoie un email à l’agent ajouté" do
+    it "envoie un email à l’agent ajouté", skip: "cf PR #5399" do # rubocop:disable RSpec/Pending
       visit edit_admin_organisation_rdv_path(organisation, rdv)
       select("Jung Yoon HAN (Urbanisme)", from: "rdv_agent_ids")
       click_button "Enregistrer"

--- a/spec/features/agents/agent_can_update_rdv_spec.rb
+++ b/spec/features/agents/agent_can_update_rdv_spec.rb
@@ -78,6 +78,22 @@ RSpec.describe "Agent can update a RDV", js: true do
   context "ajout d’un agent au RDV" do
     let!(:agent_jungyoon) { create(:agent, first_name: "Jung Yoon", last_name: "Han", email: "jungyoon@angouleme.fr", service:, basic_role_in_organisations: [organisation]) }
 
+    it "envoie un email à l’agent ajouté" do
+      visit edit_admin_organisation_rdv_path(organisation, rdv)
+      select("Jung Yoon HAN (Urbanisme)", from: "rdv_agent_ids")
+      click_button "Enregistrer"
+
+      expect(page).to have_content("Jung Yoon HAN (Urbanisme)")
+      expect(page).to have_content("Shiraz NADIR (Urbanisme)")
+      perform_enqueued_jobs
+      mail_shiraz = ActionMailer::Base.deliveries.find { _1.to.first == "shiraz@angouleme.fr" }
+      expect(mail_shiraz).not_to be_nil
+      expect(mail_shiraz.subject).to match(/RDV .* modifié/)
+      mail_jungyoon = ActionMailer::Base.deliveries.find { _1.to.first == "jungyoon@angouleme.fr" }
+      expect(mail_jungyoon).not_to be_nil
+      expect(mail_jungyoon.subject).to match(/Nouveau RDV/)
+    end
+
     context "un RDV existe à la même heure pour l’agent ajouté" do
       before { create(:rdv, agents: [agent_jungyoon], starts_at: rdv.starts_at) }
 

--- a/spec/features/agents/agent_can_update_rdv_spec.rb
+++ b/spec/features/agents/agent_can_update_rdv_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe "Agent can update a RDV", js: true do
     expect(page).to have_content("Café de la gare")
     expect(page).to have_content("3 Place de la Gare, Strasbourg, 67000")
     expect(page).to have_selector(".badge-info", text: /Ponctuel/)
+    perform_enqueued_jobs
+    mail = ActionMailer::Base.deliveries.find { _1.to.first == "shiraz@angouleme.fr" }
+    expect(mail).not_to be_nil
+    expect(mail.subject).to match(/RDV .* modifié/)
   end
 
   it "update existing RDV with existing lieu" do

--- a/spec/features/agents/agent_can_update_rdv_spec.rb
+++ b/spec/features/agents/agent_can_update_rdv_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe "Agent can update a RDV", js: true do
     expect(page).to have_content("3 Place de la Gare, Strasbourg, 67000")
     expect(page).to have_selector(".badge-info", text: /Ponctuel/)
     perform_enqueued_jobs
-    mail = ActionMailer::Base.deliveries.find { _1.to.first == "shiraz@angouleme.fr" }
-    expect(mail).not_to be_nil
-    expect(mail.subject).to match(/RDV .* modifié/)
+    open_email "shiraz@angouleme.fr"
+    expect(current_email).not_to be_nil
+    expect(current_email.subject).to match(/RDV .* modifié/)
   end
 
   it "update existing RDV with existing lieu" do
@@ -86,12 +86,12 @@ RSpec.describe "Agent can update a RDV", js: true do
       expect(page).to have_content("Jung Yoon HAN (Urbanisme)")
       expect(page).to have_content("Shiraz NADIR (Urbanisme)")
       perform_enqueued_jobs
-      mail_shiraz = ActionMailer::Base.deliveries.find { _1.to.first == "shiraz@angouleme.fr" }
-      expect(mail_shiraz).not_to be_nil
-      expect(mail_shiraz.subject).to match(/RDV .* modifié/)
-      mail_jungyoon = ActionMailer::Base.deliveries.find { _1.to.first == "jungyoon@angouleme.fr" }
-      expect(mail_jungyoon).not_to be_nil
-      expect(mail_jungyoon.subject).to match(/Nouveau RDV/)
+      open_email "shiraz@angouleme.fr"
+      expect(current_email).not_to be_nil
+      expect(current_email.subject).to match(/RDV .* modifié/)
+      open_email "jungyoon@angouleme.fr"
+      expect(current_email).not_to be_nil
+      expect(current_email.subject).to match(/Nouveau RDV/)
     end
 
     context "un RDV existe à la même heure pour l’agent ajouté" do

--- a/spec/features/agents/agent_can_update_rdv_spec.rb
+++ b/spec/features/agents/agent_can_update_rdv_spec.rb
@@ -1,17 +1,16 @@
 RSpec.describe "Agent can update a RDV", js: true do
   let!(:organisation) { create(:organisation) }
   let(:rdv) do
-    create(:rdv, organisation: organisation, motif: motif, agents: [agent], lieu: lieu)
+    create(:rdv, organisation: organisation, motif: motif, agents: [agent_shiraz], lieu: lieu)
   end
-  let!(:service) { create(:service) }
-  let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", service: service, basic_role_in_organisations: [organisation]) }
-
+  let!(:service) { create(:service, name: "Urbanisme") }
+  let!(:agent_shiraz) { create(:agent, first_name: "Shiraz", last_name: "NADIR", email: "shiraz@angouleme.fr", service:, basic_role_in_organisations: [organisation]) }
   let!(:motif) { create(:motif, service: service, organisation: organisation) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
 
   before do
     stub_netsize_ok
-    login_as(agent, scope: :agent)
+    login_as(agent_shiraz, scope: :agent)
   end
 
   it "update existing RDV with single_use lieu" do
@@ -30,7 +29,7 @@ RSpec.describe "Agent can update a RDV", js: true do
 
   it "update existing RDV with existing lieu" do
     lieu_ponctuel = create(:lieu, organisation: organisation, availability: :single_use)
-    rdv = create(:rdv, organisation: organisation, motif: motif, agents: [agent], lieu: lieu_ponctuel)
+    rdv = create(:rdv, organisation: organisation, motif: motif, agents: [agent_shiraz], lieu: lieu_ponctuel)
 
     visit edit_admin_organisation_rdv_path(organisation, rdv)
 
@@ -72,23 +71,21 @@ RSpec.describe "Agent can update a RDV", js: true do
     end
   end
 
-  context "adding agents" do
-    let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation], services: agent.services) }
-    let!(:other_rdv) { create(:rdv, agents: [other_agent], starts_at: rdv.starts_at) }
+  context "ajout d’un agent au RDV" do
+    let!(:agent_jungyoon) { create(:agent, first_name: "Jung Yoon", last_name: "Han", email: "jungyoon@angouleme.fr", service:, basic_role_in_organisations: [organisation]) }
 
-    context "when there is a warning" do
-      it "works" do
+    context "un RDV existe à la même heure pour l’agent ajouté" do
+      before { create(:rdv, agents: [agent_jungyoon], starts_at: rdv.starts_at) }
+
+      it "affiche un avertissement, une fois contourné l’agent est bien ajouté" do
         visit edit_admin_organisation_rdv_path(organisation, rdv)
-
-        select(other_agent.full_name, from: "rdv_agent_ids")
+        select("Jung Yoon HAN (Urbanisme)", from: "rdv_agent_ids")
         click_button "Enregistrer"
         expect(page).to have_content "Ce rendez-vous en chevauche un autre"
-        expect(rdv.reload.agents).to eq [agent]
-
+        expect(rdv.reload.agents).to contain_exactly(agent_shiraz)
         click_button "Confirmer en ignorant les avertissements"
-
         expect(page).to have_content "Le rendez-vous a été modifié."
-        expect(rdv.reload.agents).to eq [agent, other_agent]
+        expect(rdv.reload.agents).to contain_exactly(agent_shiraz, agent_jungyoon)
       end
     end
   end

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Admin::EditRdvForm, type: :form do
             agent_ids: [agent_mayra.id, agent_stefan.id]
           )
           expect(form.rdv.starts_at).to eq Time.zone.parse("2025-04-28 10:30")
-          expect(Agent.where(id: form.selected_agent_ids)).to contain_exactly(agent_mayra, agent_stefan)
+          expect(form.rdv.agents).to contain_exactly(agent_mayra, agent_stefan)
           rdv2.reload
           expect(rdv2.starts_at).to eq Time.zone.parse("2025-04-29 18:00")
           expect(rdv2.agents).to contain_exactly(agent_mayra)
@@ -107,7 +107,7 @@ RSpec.describe Admin::EditRdvForm, type: :form do
           ignore_benign_errors: "1"
         )
         expect(form.rdv.starts_at).to eq Time.zone.parse("2025-04-28 10:30")
-        expect(Agent.where(id: form.selected_agent_ids)).to contain_exactly(agent_mayra)
+        expect(form.rdv.agents).to contain_exactly(agent_mayra)
         rdv2.reload
         expect(rdv2.starts_at).to eq Time.zone.parse("2025-04-28 10:30")
         expect(rdv2.agents).to contain_exactly(agent_mayra)
@@ -123,7 +123,7 @@ RSpec.describe Admin::EditRdvForm, type: :form do
           agent_ids: [agent_mayra.id]
         )
         expect(form.rdv.starts_at).to eq Time.zone.parse("2025-04-28 10:30")
-        expect(Agent.where(id: form.selected_agent_ids)).to contain_exactly(agent_mayra)
+        expect(form.rdv.agents).to contain_exactly(agent_mayra)
         rdv2.reload
         expect(rdv2.starts_at).to eq Time.zone.parse("2025-04-29 18:00")
         expect(rdv2.agents).to contain_exactly(agent_mayra, agent_stefan)

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Admin::EditRdvForm, type: :form do
   let(:organisation) { create(:organisation) }
-  let(:agent) { create(:agent) }
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent, organisation: organisation) }
 
   before { stub_netsize_ok }
@@ -47,36 +47,86 @@ RSpec.describe Admin::EditRdvForm, type: :form do
     end
 
     context "ajout d’un agent à un RDV avec une erreur contournable" do
-      subject do
-        described_class.new(rdv2, agent_context).submit(attributes)
-        rdv2.reload.agents.map(&:full_name).sort.to_sentence
-      end
-
       let!(:organisation) { create(:organisation) }
-      let!(:agent_mayra) { create(:agent, first_name: "Mayra", last_name: "Castello", basic_role_in_organisations: [organisation]) }
-      let!(:agent_stefan) { create(:agent, first_name: "Stefan", last_name: "Hoyt", basic_role_in_organisations: [organisation]) }
+      let!(:agent_mayra) { create(:agent, first_name: "Mayra", basic_role_in_organisations: [organisation]) }
+      let!(:agent_stefan) { create(:agent, first_name: "Stefan", basic_role_in_organisations: [organisation]) }
       let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent_mayra, organisation:) }
       let!(:rdv1) { create(:rdv, agents: [agent_mayra], organisation:, starts_at: Time.zone.parse("2025-04-28 10:30")) }
-      let!(:rdv2) { create(:rdv, agents: [agent_mayra], organisation:, starts_at: Time.zone.parse("2025-04-29 18:00")) }
-      let(:base_attributes) do
-        {
-          starts_at: Time.zone.parse("2025-04-28 10:30"), # le même horaire que rdv1, déclenche une erreur contournable
-          agent_ids: [agent_mayra.id, agent_stefan.id],
-        }
-      end
 
       before { travel_to Time.zone.parse("2025-04-24 10:00") }
 
       context "l’avertissement est contourné" do
-        let(:attributes) { base_attributes.merge(ignore_benign_errors: "1") }
-
-        it { is_expected.to eq("Mayra CASTELLO et Stefan HOYT") }
+        it "met à jour les agents et le rendez-vous" do
+          rdv2 = create(:rdv, agents: [agent_mayra], organisation:, starts_at: Time.zone.parse("2025-04-29 18:00"))
+          form = described_class.new(rdv2, agent_context)
+          form.submit(
+            starts_at: Time.zone.parse("2025-04-28 10:30"), # le même horaire que rdv1, déclenche une erreur contournable
+            agent_ids: [agent_mayra.id, agent_stefan.id],
+            ignore_benign_errors: "1"
+          )
+          expect(form.rdv.starts_at).to eq Time.zone.parse("2025-04-28 10:30")
+          rdv2.reload
+          expect(rdv2.agents).to contain_exactly(agent_mayra, agent_stefan)
+        end
       end
 
       context "l’avertissement n’est pas contourné" do
-        let(:attributes) { base_attributes }
+        it "met à jour les agents et le rendez-vous en mémoire pour réafficher le formulaire, mais pas en base" do
+          rdv2 = create(:rdv, agents: [agent_mayra], organisation:, starts_at: Time.zone.parse("2025-04-29 18:00"))
+          form = described_class.new(rdv2, agent_context)
+          form.submit(
+            starts_at: Time.zone.parse("2025-04-28 10:30"), # le même horaire que rdv1, déclenche une erreur contournable
+            agent_ids: [agent_mayra.id, agent_stefan.id]
+          )
+          expect(form.rdv.starts_at).to eq Time.zone.parse("2025-04-28 10:30")
+          expect(Agent.where(id: form.selected_agent_ids)).to contain_exactly(agent_mayra, agent_stefan)
+          rdv2.reload
+          expect(rdv2.starts_at).to eq Time.zone.parse("2025-04-29 18:00")
+          expect(rdv2.agents).to contain_exactly(agent_mayra)
+        end
+      end
+    end
+  end
 
-        it { is_expected.to eq("Mayra CASTELLO") }
+  context "suppression d’un agent d’un RDV avec une erreur contournable" do
+    let!(:organisation) { create(:organisation) }
+    let!(:agent_mayra) { create(:agent, first_name: "Mayra", basic_role_in_organisations: [organisation]) }
+    let!(:agent_stefan) { create(:agent, first_name: "Stefan", basic_role_in_organisations: [organisation]) }
+    let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent_mayra, organisation:) }
+    let!(:rdv1) { create(:rdv, agents: [agent_mayra], organisation:, starts_at: Time.zone.parse("2025-04-28 10:30")) }
+
+    before { travel_to Time.zone.parse("2025-04-24 10:00") }
+
+    context "l’avertissement est contourné" do
+      it "l’agent est bien supprimé" do
+        rdv2 = create(:rdv, agents: [agent_mayra, agent_stefan], organisation:, starts_at: Time.zone.parse("2025-04-29 18:00"))
+        form = described_class.new(rdv2, agent_context)
+        form.submit(
+          starts_at: Time.zone.parse("2025-04-28 10:30"), # le même horaire que rdv1, déclenche une erreur contournable
+          agent_ids: [agent_mayra.id],
+          ignore_benign_errors: "1"
+        )
+        expect(form.rdv.starts_at).to eq Time.zone.parse("2025-04-28 10:30")
+        expect(Agent.where(id: form.selected_agent_ids)).to contain_exactly(agent_mayra)
+        rdv2.reload
+        expect(rdv2.starts_at).to eq Time.zone.parse("2025-04-28 10:30")
+        expect(rdv2.agents).to contain_exactly(agent_mayra)
+      end
+    end
+
+    context "l’avertissement n’est pas contourné" do
+      it "met à jour les agents et le rendez-vous en mémoire pour réafficher le formulaire, mais pas en base" do
+        rdv2 = create(:rdv, agents: [agent_mayra, agent_stefan], organisation:, starts_at: Time.zone.parse("2025-04-29 18:00"))
+        form = described_class.new(rdv2, agent_context)
+        form.submit(
+          starts_at: Time.zone.parse("2025-04-28 10:30"), # le même horaire que rdv1, déclenche une erreur contournable
+          agent_ids: [agent_mayra.id]
+        )
+        expect(form.rdv.starts_at).to eq Time.zone.parse("2025-04-28 10:30")
+        expect(Agent.where(id: form.selected_agent_ids)).to contain_exactly(agent_mayra)
+        rdv2.reload
+        expect(rdv2.starts_at).to eq Time.zone.parse("2025-04-29 18:00")
+        expect(rdv2.agents).to contain_exactly(agent_mayra, agent_stefan)
       end
     end
   end

--- a/spec/models/concerns/rdv/updatable_spec.rb
+++ b/spec/models/concerns/rdv/updatable_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Rdv::Updatable, type: :concern do
     end
 
     it "returns a success" do
-      expect(rdv.update_and_notify(agent, status: "noshow")).to be(true)
+      expect(rdv.update_and_notify(agent, status: "noshow")).to be_truthy
     end
 
     %w[excused revoked noshow].each do |status|
@@ -45,7 +45,7 @@ RSpec.describe Rdv::Updatable, type: :concern do
     end
 
     it "returns a failure when the Rdv can't be updated" do
-      expect(rdv.update_and_notify(agent, ends_at: nil)).to be(false)
+      expect(rdv.update_and_notify(agent, ends_at: nil)).to be_falsey
     end
 
     describe "clear the file_attentes" do

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -103,6 +103,31 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     end
   end
 
+  context "RDV existant pour l’agent courant et un autre agent auquel iel a accès" do
+    let(:organisation) { create(:organisation) }
+    let(:service) { create(:service) }
+    let(:agent1) { create(:agent, basic_role_in_organisations: [organisation], service:) }
+    let(:agent2) { create(:agent, basic_role_in_organisations: [organisation], service:) }
+    let(:motif) { create(:motif, organisation:, service: service) }
+    let!(:rdv) { create(:rdv, agents: [agent1, agent2], motif:, organisation:) }
+    let(:pundit_context) { AgentOrganisationContext.new(agent1, organisation) }
+
+    it_behaves_like "permit actions", :rdv, :update?, :status?
+  end
+
+  context "RDV existant pour l’agent courant et un autre agent auquel iel n’a pas accès (autre organisation)" do
+    # NOTE: ce cas de deux agents partageant un RDV mais n’ayant pas d’accès l’un à l’autre est peu probable
+    let(:organisation) { create(:organisation) }
+    let(:service) { create(:service) }
+    let(:agent1) { create(:agent, basic_role_in_organisations: [organisation], service:) }
+    let(:agent2) { create(:agent, basic_role_in_organisations: [create(:organisation)], service:) }
+    let(:motif) { create(:motif, organisation:, service: service) }
+    let!(:rdv) { create(:rdv, agents: [agent1, agent2], motif:, organisation:) }
+    let(:pundit_context) { AgentOrganisationContext.new(agent1, organisation) }
+
+    it_behaves_like "not permit actions", :rdv, :update?, :status?
+  end
+
   # Certains controllers ajoutent des usagers à un RDV à travers
   # `@rdv.participations.build(...)`, puis appellent cette policy.
   # Cette section teste ce cas de figure.
@@ -163,6 +188,4 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     it_behaves_like "not permit actions", :rdv
     it_behaves_like "included in scope"
   end
-
-  # TODO: write cases for :new? and create? which
 end


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5399.osc-secnum-fr1.scalingo.io/) 

> [!NOTE]
> Cette PR est une version alternative de #5277 où on utilise des transactions plutôt que la gem activerecord_defer_persist

# Contexte 

Cette PR prépare la correction du bug #5170 : les agents ajoutés à un RDV ne sont actuellement pas notifiés de ce RDV. Cette PR est une PR de pur refacto qui ne devrait pas changer le comportement.

On « nettoie » une partie de solutions un peu bancales installées pour d’autres sujets connexes sur la MàJ des agents sur un RDV (permissions, avertissement contournable…) 

Les bugs identifiés si on activait dès maintenant l’envoi de notifs aux agents sont : 
- Lorsqu’on retire un agent d’un RDV existant, le mail envoyé à cet agent indique des infos fausses « Le RDV a été annulé sur demande de l’usager »
- Lorsqu’on ajoute un agent à un RDV existant le mail envoyé à cet agent indique à tort qu’un RDV a été créé
- Lorsqu’on modifie uniquement les agents sur un RDV un mail est envoyé à l’usager mais la diff n’est pas affichée, c’est inutile

# Solution

> [!NOTE]
> Cette PR est à lire commit par commit ! j’ai mis des messages descriptifs dans les commit messages

Grace à @francois-ferrandis cette version utilise les transactions ✨ ça me paraît nettement moins dangereux et exotique que la gem que je m’apprêtais à introduire.

## Retenir les agent_ids avant la MàJ

Le problème principal corrigé ici est que les agents ajoutés à un RDV ne sont actuellement pas notifiés de ce RDV. Au niveau du concern `Rdv::Updatable`, il est actuellement compliqué de comparer les agent_ids avant la mise à jour et après.

Cette solution permet de toujours passer par la méthode `Rdv::Updatable.update_and_notify` qui fait elle-même le `agent.assign_attributes` et retient les `agent_ids` avant cet assign.

## Application des permissions

Actuellement on applique une partie des autorisations hors de la policy, au moment du parsing des params dans le controller. On filtre les `agent_ids` passés en params pour ne garder que ceux auxquels l’agent a effectivement accès.

La solution proposée permet de s’appuyer sur la policy existante en appelant `authorize` après avoir assigné les nouveaux `agent_ids`. 

## Persistence des agents sélectionnés lors d’un avertissement

Lorsqu’il y a un avertissement contournable, par exemple un autre RDV commençant à la même heure, on veut réafficher les agents sélectionnés même s’ils n’ont pas été persistés en base. 

Il y a actuellement une solution temporaire qui rollbacke manuellement le changement dans ce cas cf https://github.com/betagouv/rdv-service-public/commit/dc5f0855c83ad896a8975fb79b1c0d643d4b679a . 

La nouvelle solution permet d’éviter ce rollback et de revenir à un comportement plus naturel où l’objet est « dirty » au sens AR : son attribut `agents` est différent de ce qu’il y a en base. On n’a donc plus besoin de l’attribut supplémentaire `selected_agent_ids` sur le form.

En effet j’apprends avec cette PR que les transactions rollbacked laissent les objets AR dans des états « sales » qui sont super pratiques pour ce cas : 

```rb
rdv = Rdv.last
puts rdv.agents.map(&:email).to_sentence
# => martine@demo.rdv-solidarites.fr

Rdv.transaction do 
  rdv.agent_ids = [
    Agent.find_by(email: "martine@demo.rdv-solidarites.fr").id,
    Agent.find_by(email:"polo@demo.rdv-solidarites.fr").id
  ]
  raise ActiveRecord::Rollback
end

puts rdv.agents.map(&:email).to_sentence
# => martine@demo.rdv-solidarites.fr et polo@demo.rdv-solidarites.fr

puts rdv.agents_rdvs.map(&:agent).map(&:email).to_sentence
# => martine@demo.rdv-solidarites.fr et polo@demo.rdv-solidarites.fr

rdv.reload

puts rdv.agents.map(&:email).to_sentence
# => martine@demo.rdv-solidarites.fr

puts rdv.agents_rdvs.map(&:agent).map(&:email).to_sentence
# => martine@demo.rdv-solidarites.fr
```

# TODO

- [x] vérifier qu’il n’y a pas de changement de comportement dans le cas : une secretaire cree un rdv pour 2 agents de services differents. un de ces deux agents tente de modifier lheure du RDV.
