### PR TITLE
Ajout d’un job qui vérifie l’état de l’API IGN

### DIFF
--- a/app/jobs/cron_job/ign_health_check_job.rb
+++ b/app/jobs/cron_job/ign_health_check_job.rb
@@ -1,0 +1,12 @@
+class CronJob::IGNHealthCheckJob < CronJob
+  # Ce job vérifie que l’API adresse de l’IGN est accessible.
+  # Cette API étant utilisée uniquement en front pour l’auto-complétion des adresses, nous n’avions pas de remontée d’erreur
+  # lorsqu’elle était en panne.
+  def perform
+    response = Faraday.get("https://data.geopf.fr/geocodage/search?q=1+place+de+la+republique+75011+paris&limit=1")
+
+    if response.status != 200
+      Sentry.capture_message("L'API adresse de l'IGN est inaccessible (HTTP status: #{response.status}). Vérifier l’état du service ici : https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9/7ec26cae-995d-4974-926a-9130b14f77be?SelectedPeriod=Last30Days")
+    end
+  end
+end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -76,5 +76,9 @@ Rails.application.configure do
       cron: "every day at 08:00 Europe/Paris",
       class: "CronJob::SynchronizeCrm",
     },
+    ign_health_check: {
+      cron: "every minute",
+      class: "CronJob::IGNHealthCheckJob",
+    },
   }
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,6 +14,7 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.irregular "lieu", "lieux"
   inflect.uncountable "created_by"
   inflect.irregular "demande_support", "demandes_support"
+  inflect.acronym "IGN"
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/spec/jobs/cron_job/ign_health_check_job_spec.rb
+++ b/spec/jobs/cron_job/ign_health_check_job_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe CronJob::IGNHealthCheckJob, type: :job do
+  subject(:perform_now) { described_class.perform_now }
+
+  before do
+    stub_request(:get, "https://data.geopf.fr/geocodage/search?q=1+place+de+la+republique+75011+paris&limit=1")
+      .to_return(status: 200, body: "", headers: {})
+  end
+
+  it "ne déclenche pas de Sentry" do
+    expect(Faraday).to receive(:get).with("https://data.geopf.fr/geocodage/search?q=1+place+de+la+republique+75011+paris&limit=1")
+    expect(Sentry).not_to receive(:capture_message)
+    perform_now
+  end
+
+  context "quand l’API de l’IGN renvoie une erreur" do
+    before do
+      stub_request(:get, "https://data.geopf.fr/geocodage/search?q=1+place+de+la+republique+75011+paris&limit=1")
+        .to_return(status: 500, body: "", headers: {})
+    end
+
+    it "déclenche un message Sentry" do
+      expect(Sentry).to receive(:capture_message).with(
+        "L'API adresse de l'IGN est inaccessible (HTTP status: 500). Vérifier l’état du service ici : https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9/7ec26cae-995d-4974-926a-9130b14f77be?SelectedPeriod=Last30Days"
+      )
+      perform_now
+    end
+  end
+end


### PR DESCRIPTION
# Contexte

Je me suis rendu compte ce matin par hasard que l’API adresse IGN que nous utilisons pour autocompléter nos champs d’adresse était hors service.
Nous avons donc pu mettre en place les mesures de communication nécessaire pour avertir nos usagers et agents. Néanmoins, si je n’étais pas en train de travailler sur l’autocomplétion d’adresse à ce moment-là, nous ne nous serions peut-être pas rendu compte de la panne. Nous n’aurions pas pu avertir nos utilisateurs et nous aurions certainement reçu des demandes au support.
Il semble donc nécessaire que nous ayons un système d’alerte automatique.

# Solution

La solution proposée est assez simple. Une fois par minute, nous envoyons une requête à l’API IGN et nous vérifions que l’API nous renvoie une 200.
Nous aurions pu mettre en place un système pour éviter de répéter la Sentry toutes les minutes tant que le système est en panne, mais cela me semble complexifier le job. Si nous voulons mettre en pause l’alerte il nous suffit d’appuyer sur ⏸️ dans Goodjob.
