### PR TITLE
Ajout du lien vers le dossier sur les applis partenaires

### DIFF
--- a/app/controllers/api/v1/rdv_plans_controller.rb
+++ b/app/controllers/api/v1/rdv_plans_controller.rb
@@ -10,7 +10,8 @@ class Api::V1::RdvPlansController < Api::V1::AgentAuthBaseController
         planning_agent: current_agent,
         user: user,
         oauth_application: doorkeeper_token&.application,
-        return_url: params[:return_url]
+        return_url: params[:return_url],
+        dossier_url: params[:dossier_url]
       )
     end
     render json: RdvPlanBlueprint.render(rdv_plan, root: "rdv_plan"), status: :created

--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -111,6 +111,17 @@ a[disabled] {
   flex-direction: column;
 }
 
+.justify-content-space-between {
+  justify-content: space-between;
+}
+
+.align-items-start-or-stretch {
+  align-items: stretch;
+  @include media-breakpoint-up(md) {
+    align-items: flex-start;
+  }
+}
+
 .rdv-flex-direction-row-md {
   @include media-breakpoint-up(md) {
     flex-direction: row;

--- a/app/models/concerns/ics_payloads/rdv.rb
+++ b/app/models/concerns/ics_payloads/rdv.rb
@@ -1,6 +1,6 @@
 module IcsPayloads
   module Rdv
-    def payload(action = nil, recipient = users.first) # rubocop:disable Metrics/CyclomaticComplexity
+    def payload(action = nil, recipient = users.first)
       payload = {
         name: "rdv-#{uuid}-#{starts_at.to_s.parameterize}.ics",
         starts_at: starts_at,
@@ -11,15 +11,7 @@ module IcsPayloads
         domain: domain,
       }
 
-      description = ""
-      description += "RDV Téléphonique " if motif.phone?
-      description += case recipient
-                     when User
-                       "Infos et annulation: #{Rails.application.routes.url_helpers.rdvs_short_url(host: domain.host_name)}"
-                     when Agent
-                       "Voir sur #{domain.name}: #{Rails.application.routes.url_helpers.admin_organisation_rdv_url(organisation_id, self, host: domain.host_name)}"
-                     end
-      payload[:description] = description
+      payload[:description] = ics_description(recipient)
 
       # NOTE: for agents, we include all agents as the attendees. This also changes the method from PUBLISH to REQUEST.
       if recipient.is_a? Agent
@@ -30,6 +22,25 @@ module IcsPayloads
       payload[:action] = action if action.present?
 
       payload
+    end
+
+    private
+
+    def ics_description(recipient)
+      description = ""
+      description += "RDV Téléphonique " if motif.phone?
+      description += case recipient
+                     when User
+                       "Infos et annulation: #{Rails.application.routes.url_helpers.rdvs_short_url(host: domain.host_name)}"
+                     when Agent
+                       "Voir sur #{domain.name}: #{Rails.application.routes.url_helpers.admin_organisation_rdv_url(organisation_id, self, host: domain.host_name)}"
+                     end
+
+      if recipient.is_a?(Agent) && rdv_plan&.dossier_url
+        description += "\nVoir sur #{rdv_plan.oauth_application&.name}: #{rdv_plan.dossier_url}"
+      end
+
+      description
     end
   end
 end

--- a/app/models/concerns/outlook/event_serializer_and_listener.rb
+++ b/app/models/concerns/outlook/event_serializer_and_listener.rb
@@ -105,10 +105,15 @@ module Outlook
       show_link = url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: agent.domain.host_name)
       edit_link = url_helpers.edit_admin_organisation_rdv_url(rdv.organisation, rdv.id, host: agent.domain.host_name)
 
+      dossier_link = ""
+      if rdv.rdv_plan&.dossier_url
+        dossier_link = "<a href=\"#{rdv.rdv_plan&.dossier_url}\">Voir sur #{rdv.rdv_plan.oauth_application&.name}</a><br />"
+      end
+
       <<~HTML
         Plus d'infos sur <a href="#{show_link}">#{agent.domain_name}</a>:
         <br />
-
+        #{dossier_link}
         Attention: ne modifiez pas cet évènement directement dans Outlook, car il ne sera pas mis à jour sur #{agent.domain_name}.
         Pour modifier ce rendez-vous, allez sur <a href="#{edit_link}">#{agent.domain_name}</a>
       HTML

--- a/app/views/admin/participations/_user_card.html.slim
+++ b/app/views/admin/participations/_user_card.html.slim
@@ -1,19 +1,18 @@
-.col-12
-  .card.light-gray-card
-    .card-body.p-2
-      .mb-1
-        = render "admin/users/identity", user: participation.user
-      - annotation = participation.user.annotation_for(current_territory)
-      - if current_territory.enable_notes_field? && annotation.present?
-        .participation_notes
-          i.fa.fa-info-circle.text-primary-blue.mr-2
-          = simple_format(annotation, {}, wrapper_tag: :span)
+.card.light-gray-card
+  .card-body.p-2
+    .mb-1
+      = render "admin/users/identity", user: participation.user
+    - annotation = participation.user.annotation_for(current_territory)
+    - if current_territory.enable_notes_field? && annotation.present?
+      .participation_notes
+        i.fa.fa-info-circle.text-primary-blue.mr-2
+        = simple_format(annotation, {}, wrapper_tag: :span)
+    div
+      = render "admin/participations/notifications_email", participation: participation
+    div
+      = render "admin/participations/notifications_sms", participation: participation
+    div
+    = render "admin/participations/notifications_lifecycle", participation: participation
+    - if participation.rdv.collectif?
       div
-        = render "admin/participations/notifications_email", participation: participation
-      div
-        = render "admin/participations/notifications_sms", participation: participation
-      div
-      = render "admin/participations/notifications_lifecycle", participation: participation
-      - if participation.rdv.collectif?
-        div
-        = render "admin/participations/participation_status_dropdown", participation: participation, agent: agent
+      = render "admin/participations/participation_status_dropdown", participation: participation, agent: agent

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -17,7 +17,7 @@
         = render "admin/rdvs/individual_rdv_status_dropdown", rdv: rdv
   hr.fr-my-0.fr-pb-0.fr-mx-3
   .card-body.fr-grid-row.fr-pb-0
-    .fr-col-12.d-flex.flex-direction-column.rdv-flex-direction-row-md.justify-content-space-between.align-items-start-or-stretch
+    .fr-col-12.d-flex.flex-direction-column.rdv-flex-direction-row-md.rdv-justify-content-space-between.align-items-start-or-stretch
       div.fr-pb-2w
         - if rdv.rdv_plan&.dossier_url
           .fr-btns-group.fr-btns-group--inline-md

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -15,25 +15,28 @@
         = render "admin/rdvs/collective_rdv_status_dropdown", rdv: rdv
       - else
         = render "admin/rdvs/individual_rdv_status_dropdown", rdv: rdv
-  hr.my-0.mx-3
-  .card-body.py-3.row
-    .col-md-8.col-sm-12
-      .d-flex.justify-content-between.flex-wrap.mb-1
-        p.card-text
-          i.fa.fa-fw.fa-calendar.mr-1.text-primary-blue
-          = rdv_starts_at_and_duration(rdv, :time_only)
-          - if rdv.agents.first
-            |&nbsp;
-            = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
-      = render "admin/rdvs/rdv_details", rdv: rdv
+  hr.fr-my-0.fr-pb-0.fr-mx-3
+  .card-body.fr-grid-row.fr-pb-0
+    .fr-col-12.d-flex.flex-direction-column.rdv-flex-direction-row-md.justify-content-space-between.align-items-start-or-stretch
+      div.fr-pb-2w
+        - if rdv.rdv_plan&.dossier_url
+          .fr-btns-group.fr-btns-group--inline-md
+            = link_to("Voir sur #{rdv.rdv_plan.oauth_application&.name}", rdv.rdv_plan&.dossier_url, target: :_blank, class: "fr-btn fr-btn--tertiary fr-mb-2w")
+        .d-flex.justify-content-between.flex-wrap.mb-1
+          p.card-text
+            i.fa.fa-fw.fa-calendar.mr-1.text-primary-blue
+            = rdv_starts_at_and_duration(rdv, :time_only)
+            - if rdv.agents.first
+              |&nbsp;
+              = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
+        = render "admin/rdvs/rdv_details", rdv: rdv
 
-    .col-md-4.col-sm-12
-      div.d-flex.justify-content-end.mt-1
-        = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "btn btn-outline-primary btn-sm mr-2"
+      ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--right.fr-mb-0
+        = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "fr-btn fr-btn--secondary fr-btn--sm "
         - if rdv.individuel?
-          = link_to t("admin.rdvs.show.duplicate"), admin_organisation_creneaux_search_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "btn btn-outline-primary btn-sm"
+          = link_to t("admin.rdvs.show.duplicate"), admin_organisation_creneaux_search_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "fr-btn fr-btn--secondary fr-btn--sm"
         - else
-          = link_to t("admin.rdvs.show.duplicate"), new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: rdv.motif_id, duplicated_rdv_id: rdv.id), class: "btn btn-outline-primary btn-sm"
+          = link_to t("admin.rdvs.show.duplicate"), new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: rdv.motif_id, duplicated_rdv_id: rdv.id), class: "fr-btn fr-btn--secondary fr-btn--sm fr-mb-0"
 
   .mx-3
   - if rdv.users.any?

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -58,18 +58,18 @@
         input.custom-control-input[type="checkbox" id="show-users-details-switch" data-toggle="collapse" data-target=".users-details"]
         label.custom-control-label for="show-users-details-switch" Afficher plus de détails usagers
 
-    .row.justify-content-center.pb-3
-      .col-md-12.col-lg-8
+    .fr-grid-row.fr-pb-3w
+      .fr-col-12
         .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
         = render(partial: "rdv", collection: @rdvs_in_page, locals: { agent: nil })
         .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
   - else
-    .row.justify-content-center.pb-3
-      .col-md-12.col-lg-8
+    .fr-grid-row.fr-py-3w
+      .fr-col-12
         .card
           .card-body
-            .row.justify-content-md-center
-              .col-md-6.rdv-text-align-center.my-5
+            .fr-grid-row.justify-content-center
+              .fr-col-6.rdv-text-align-center.fr-mt-2w.fr-mb-5w
                 p.mb-2.lead
                   | Aucun RDV
                 span.fa-stack.fa-4x

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -15,15 +15,15 @@
 - content_for :title do
   = "RDV #{rdv_title_for_agent(@rdv)}"
 
-.row.justify-content-md-center
-  .col-md-11
+.row
+  .col-12
     / @agent is only used for links in breadcrumb and redirecting if update
     = render partial: "rdv", collection: [@rdv], locals: { agent: @agent }
 
-.row.justify-content-center
-  .col-md-11
+.row
+  .col-12
     = render "admin/receipts/receipts", rdv: @rdv
 
-.row.justify-content-center
-  .col-md-11
+.row
+  .col-md-12
     = render "admin/versions/resource_versions_row", resource_policy: policy(@rdv, policy_class: Agent::RdvPolicy), resource: @rdv

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -15,15 +15,15 @@
 - content_for :title do
   = "RDV #{rdv_title_for_agent(@rdv)}"
 
-.row
-  .col-12
+.fr-grid-row
+  .fr-col-12
     / @agent is only used for links in breadcrumb and redirecting if update
     = render partial: "rdv", collection: [@rdv], locals: { agent: @agent }
 
-.row
-  .col-12
+.fr-grid-row
+  .fr-col-12
     = render "admin/receipts/receipts", rdv: @rdv
 
-.row
-  .col-md-12
+.fr-grid-row
+  .fr-col-12
     = render "admin/versions/resource_versions_row", resource_policy: policy(@rdv, policy_class: Agent::RdvPolicy), resource: @rdv

--- a/db/migrate/20250530124357_add_rdv_plan_dossier_url.rb
+++ b/db/migrate/20250530124357_add_rdv_plan_dossier_url.rb
@@ -1,0 +1,5 @@
+class AddRdvPlanDossierUrl < ActiveRecord::Migration[7.1]
+  def change
+    add_column :rdv_plans, :dossier_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_02_123003) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_30_124357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -605,6 +605,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_02_123003) do
     t.datetime "updated_at", null: false
     t.enum "location_type", enum_type: "location_type"
     t.bigint "oauth_application_id"
+    t.text "dossier_url"
     t.index ["lieu_id"], name: "index_rdv_plans_on_lieu_id"
     t.index ["motif_id"], name: "index_rdv_plans_on_motif_id"
     t.index ["oauth_application_id"], name: "index_rdv_plans_on_oauth_application_id"

--- a/docs/guide_integration.md
+++ b/docs/guide_integration.md
@@ -62,7 +62,7 @@ POST /api/v1/rdv_plans
         "birth_date": "1990-12-31"
     },
     "return_url": "https://monsuivisocial.incubateur.anct.gouv.fr/callback/123", // l'agent sera redirigé vers cette url après la page de confirmation du rdv.
-    "dossier_url": "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123" // sera affiché à l'agent (mais pas à l'usager) sur la page de détail du rdv et la pièce jointe ICS de l'email de confirmation. Pas encore implémenté
+    "dossier_url": "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123" // sera affiché à l'agent (mais pas à l'usager) sur la page de détail du rdv et la pièce jointe ICS de l'email de confirmation.
 }
 ```
 

--- a/scripts/mon_suivi_social_local.rb
+++ b/scripts/mon_suivi_social_local.rb
@@ -45,6 +45,11 @@ class MonSuiviSocial < Sinatra::Base
     end
   end
 
+  get "/francis_factice" do
+    status 200
+    "Francis Factice est un usager"
+  end
+
   get "/auth/rdvservicepublic/callback" do
     session[:email] = request.env["omniauth.auth"]["info"]["agent"]["email"]
     session[:access_token] = request.env["omniauth.auth"]["credentials"]["token"]
@@ -68,6 +73,7 @@ class MonSuiviSocial < Sinatra::Base
           first_name: "Francis",
           last_name: "Factice",
         },
+        dossier_url: "http://localhost:3010/francis_factice",
       }.to_json,
       {
         "Content-Type": "application/json",

--- a/spec/models/concerns/ics_payloads/rdv_spec.rb
+++ b/spec/models/concerns/ics_payloads/rdv_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
           description = "Voir sur RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{rdv.organisation_id}/rdvs/#{rdv.id}"
           expect(rdv.payload(nil, agent)[:description]).to eq(description)
         end
+
+        context "when there is a link to a dossier in an external app" do
+          before do
+            create(:rdv_plan, rdv: rdv, dossier_url: "http://demarches-simplifies.test/exemple", oauth_application:)
+          end
+
+          let(:oauth_application) { create(:oauth_application, name: "Démarches Simplifiées") }
+
+          it "provides the link in the description" do
+            expect(rdv.payload(nil, agent)[:description]).to include("Voir sur Démarches Simplifiées: http://demarches-simplifies.test/exemple")
+          end
+        end
       end
     end
 

--- a/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
+++ b/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
@@ -259,4 +259,20 @@ RSpec.describe Outlook::EventSerializerAndListener do
       end
     end
   end
+
+  context "when the rdv has a link in a partner application" do
+    let(:rdv_plan) do
+      create(:rdv_plan, dossier_url: "http://demarches-simplifies.test/exemple", oauth_application: oauth_application)
+    end
+    let(:oauth_application) do
+      create(:oauth_application, name: "Démarches Simplifiées")
+    end
+
+    it "adds a link to the dossier_url" do
+      rdv = create(:rdv, rdv_plan: rdv_plan)
+
+      # On triche en testant directement la méthode qui donne la description pour éviter de passer par des stubs trop compliqués
+      expect(rdv.agents_rdvs.first.send(:event_description)).to include("<a href=\"http://demarches-simplifies.test/exemple\">Voir sur Démarches Simplifiées</a><br />")
+    end
+  end
 end

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe "RDV Plan API" do
             birth_date: "1990-12-31",
           },
           return_url: "https://demo.demarches-simplifiees.fr/callback/123",
+          dossier_url: "https://demo.demarches-simplifiees.fr/dossier/456",
         }
       end
 
@@ -158,6 +159,7 @@ RSpec.describe "RDV Plan API" do
         expect(rdv_plan).to have_attributes(
           planning_agent: agent,
           return_url: "https://demo.demarches-simplifiees.fr/callback/123",
+          dossier_url: "https://demo.demarches-simplifiees.fr/dossier/456",
           oauth_application_id: application.id
         )
 


### PR DESCRIPTION
# Contexte

Dans le cadre des intégrations, on veut permettre aux agents de retrouver facilement le dossier lié à un rendez-vous, que ça soit sur Mon Suivi Social, Démarches Simplifiées, ou la coop de la médiation numérique, ou un autre service.

Quand un rdv est créé via une intégration, l'application partenaire nous envoie une url liée au rendez-vous. L'objectif est donc d'afficher cette url aux différents endroits où elle peut être utile :

sur la page de détails du rendez-vous
dans la pièce jointe ics ou le calendrier outlook : on a déjà un lien "Plus d'infos sur RDV Service Public", et on ajoute en dessous un lien "Voir sur Mon Suivi Social"

# Solution

On a validé les différents affichages avec Téo, et on en a profité pour passer l'affichage des rendez-vous en 12 colonnes sur le show et l'index. Vu toutes les infos qu'il y a, c'est pas du luxe d'avoir plus de largeur.

J'ai découpé tout ça en commits cohérents pour faciliter la relecture

## Captures d'écran

Avant | Après
:- | -:
<img width="1420" alt="Screenshot 2025-06-05 at 15 31 01" src="https://github.com/user-attachments/assets/c89d7cf8-2019-4587-a677-5e914c315d3c" />|<img width="1424" alt="Screenshot 2025-06-05 at 15 30 46" src="https://github.com/user-attachments/assets/060ce759-55a8-4fa7-9860-e09ac87d6d2d" />
![www rdv-mairie localhost_3000_admin_organisations_4_rdvs_8047_agent_id=2(iPhone 12 Pro) (1)](https://github.com/user-attachments/assets/2fd89b2e-9541-4d41-94c5-78a6ec94e527)|![www rdv-mairie localhost_3000_admin_organisations_4_rdvs_8047_agent_id=2(iPhone 12 Pro) (2)](https://github.com/user-attachments/assets/11fa9ee7-e9d5-4934-9685-863f1efc1a04)
![www rdv-mairie localhost_3000_admin_organisations_4_rdvs_agent_id= user_id=10014 lieu_ids%5B%5D= motif_ids%5B%5D= status= start=__%2F__%2F____ end=__%2F__%2F____ (2)](https://github.com/user-attachments/assets/921e8a05-071a-4759-9796-2953ab5a29e1)|![www rdv-mairie localhost_3000_admin_organisations_4_rdvs_agent_id= user_id=10014 lieu_ids%5B%5D= motif_ids%5B%5D= status= start=__%2F__%2F____ end=__%2F__%2F____ (2)](https://github.com/user-attachments/assets/a595e958-d7c5-480e-8fd6-6dfdb5eebca7)
