### PR TITLE
Amélioration de l’IGN Health Check pour éviter les Sentry intempestifs

### DIFF
--- a/app/jobs/cron_job/ign_health_check_job.rb
+++ b/app/jobs/cron_job/ign_health_check_job.rb
@@ -2,11 +2,19 @@ class CronJob::IGNHealthCheckJob < CronJob
   # Ce job vérifie que l’API adresse de l’IGN est accessible.
   # Cette API étant utilisée uniquement en front pour l’auto-complétion des adresses, nous n’avions pas de remontée d’erreur
   # lorsqu’elle était en panne.
+  # Si l’API est inaccessible, nous incrémentons un compteur dans Redis. Si ce compteur atteint 3, nous envoyons une alerte Sentry.
+  # Le job étant exécuté toutes les minutes, la détection de l’indisponibilité se fera 3 minutes après la première erreur.
   def perform
     response = Faraday.get("https://data.geopf.fr/geocodage/search?q=1+place+de+la+republique+75011+paris&limit=1")
 
     if response.status != 200
-      Sentry.capture_message("L'API adresse de l'IGN est inaccessible (HTTP status: #{response.status}). Vérifier l’état du service ici : https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9/7ec26cae-995d-4974-926a-9130b14f77be?SelectedPeriod=Last30Days")
+      Redis.with_connection do |redis|
+        if redis.incr("ign_api_health_check_failures") > 2
+          Sentry.capture_message("L'API adresse de l'IGN est inaccessible (HTTP status: #{response.status}). Vérifier l’état du service ici : https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9/7ec26cae-995d-4974-926a-9130b14f77be?SelectedPeriod=Last30Days")
+        end
+
+        redis.expire("ign_api_health_check_failures", 120) # expire après 2 minutes
+      end
     end
   end
 end

--- a/spec/jobs/cron_job/ign_health_check_job_spec.rb
+++ b/spec/jobs/cron_job/ign_health_check_job_spec.rb
@@ -18,11 +18,32 @@ RSpec.describe CronJob::IGNHealthCheckJob, type: :job do
         .to_return(status: 500, body: "", headers: {})
     end
 
-    it "déclenche un message Sentry" do
-      expect(Sentry).to receive(:capture_message).with(
-        "L'API adresse de l'IGN est inaccessible (HTTP status: 500). Vérifier l’état du service ici : https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9/7ec26cae-995d-4974-926a-9130b14f77be?SelectedPeriod=Last30Days"
-      )
+    it "incrémente le compteur Redis" do
       perform_now
+      expect(Redis.with_connection { |redis| redis.get("ign_api_health_check_failures").to_i }).to eq(1)
+    end
+
+    it "fais expirer le compteur Redis après 2 minutes" do
+      perform_now
+      expect(Redis.with_connection { |redis| redis.ttl("ign_api_health_check_failures") }).to eq(120)
+    end
+
+    it "ne déclenche pas de message Sentry" do
+      expect(Sentry).not_to receive(:capture_message)
+      perform_now
+    end
+  end
+
+  context "quand l’API de l’IGN renvoie une erreur 3 fois" do
+    before do
+      stub_request(:get, "https://data.geopf.fr/geocodage/search?q=1+place+de+la+republique+75011+paris&limit=1")
+        .to_return(status: 500, body: "", headers: {})
+    end
+
+    it "déclenche un message Sentry après 3 échecs consécutifs" do
+      expect(Sentry).to receive(:capture_message).with("L'API adresse de l'IGN est inaccessible (HTTP status: 500). Vérifier l’état du service ici : https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9/7ec26cae-995d-4974-926a-9130b14f77be?SelectedPeriod=Last30Days")
+      3.times { described_class.perform_now }
+      expect(Redis.with_connection { |redis| redis.get("ign_api_health_check_failures").to_i }).to eq(3)
     end
   end
 end


### PR DESCRIPTION
# Contexte

Suite à la mise en place de #5401
Nous nous sommes rendu compte que l’API avait parfois des petites latences très temporaires qui génère des Sentry.

# Solution

Afin d’éviter d’avoir des Sentry intempestifs, on attend 3 minutes avant de déclencher l’alerte.


