### PR TITLE
Garder les refresh tokens qui n'ont pas besoin d'être expirés

### DIFF
--- a/app/jobs/cron_job/destroy_old_oauth_objects.rb
+++ b/app/jobs/cron_job/destroy_old_oauth_objects.rb
@@ -1,6 +1,19 @@
 class CronJob::DestroyOldOauthObjects < CronJob
   def perform
     Doorkeeper::AccessGrant.where("created_at < ?", 24.hours.ago).delete_all
-    Doorkeeper::AccessToken.where("created_at < ?", 30.days.ago).delete_all
+    old_access_tokens_with_a_more_recent_duplicate.delete_all
+  end
+
+  private
+
+  def old_access_tokens_with_a_more_recent_duplicate
+    Doorkeeper::AccessToken.where("oauth_access_tokens.created_at < ?", 30.days.ago)
+      .joins(<<~SQL.squish
+        INNER JOIN oauth_access_tokens as recent_tokens ON
+          oauth_access_tokens.resource_owner_id = recent_tokens.resource_owner_id AND
+          oauth_access_tokens.application_id = recent_tokens.application_id AND
+          oauth_access_tokens.created_at < recent_tokens.created_at
+      SQL
+            )
   end
 end

--- a/spec/factories/oauth_application.rb
+++ b/spec/factories/oauth_application.rb
@@ -1,7 +1,9 @@
 FactoryBot.define do
+  sequence(:client_id) { |n| "fake_app_id_#{n}" }
+
   factory :oauth_application, class: OauthApplication do
     name { "Démarches Simplifiées" }
-    uid { "fake_app_id" }
+    uid { generate(:client_id) }
     logo_base64 { "" }
     redirect_uri { "http://localhost:4567/omniauth/rdvservicepublic/callback\nhttps://demo.demarches-simplifiees.fr/omniauth/rdvservicepublic/callback" }
   end

--- a/spec/features/agents/oauth_provider_spec.rb
+++ b/spec/features/agents/oauth_provider_spec.rb
@@ -89,25 +89,5 @@ RSpec.describe "OAuth provider", js: true do
     click_on "Se connecter"
 
     expect(page).to have_content("Votre email est francis@factice.org")
-
-    visit "http://localhost:4567/logout"
-
-    # Un mois plus tard, si on ne s'est pas reconnecté, il faut à nouveau donner la permission à l'application
-    travel_to(31.days.from_now)
-    CronJob::DestroyOldOauthObjects.perform_now
-
-    visit "http://localhost:4567/"
-    click_button "Se connecter avec RDV Service Public"
-
-    fill_in "Adresse email", with: agent.email
-    fill_in "Mot de passe", with: agent.password
-    click_on "Se connecter"
-
-    expect(page).to have_content("Connexion réussie")
-    expect(page).to have_content("En continuant, vous allez permettre à Démarches Simplifiées d'accéder à votre compte RDV Solidarités")
-    expect(page).to have_content(agent.email) # On indique à l'agent le compte utilisé pour la connexion
-    click_on "Continuer"
-
-    expect(page).to have_content("Votre email est francis@factice.org")
   end
 end

--- a/spec/jobs/cron_job/destroy_old_oauth_objects_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_oauth_objects_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe CronJob::DestroyOldOauthObjects do
+  let(:oauth_application) { create(:oauth_application) }
+  let(:agent) { create(:agent) }
+
+  context "when there is only one access token for this user and this application" do
+    let!(:token) do
+      Doorkeeper::AccessToken.create!(
+        resource_owner_id: agent.id,
+        application_id: oauth_application.id,
+        created_at: 1.year.ago
+      )
+    end
+
+    it "keeps it indefinitely, so that the client can keep on using the refresh token" do
+      described_class.new.perform
+      expect(Doorkeeper::AccessToken.first).to eq token
+    end
+  end
+end

--- a/spec/jobs/cron_job/destroy_old_oauth_objects_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_oauth_objects_spec.rb
@@ -16,4 +16,27 @@ RSpec.describe CronJob::DestroyOldOauthObjects do
       expect(Doorkeeper::AccessToken.first).to eq token
     end
   end
+
+  context "when there is an old access token, and a more recent one for the same app and agent" do
+    let!(:old_token) do
+      Doorkeeper::AccessToken.create!(
+        resource_owner_id: agent.id,
+        application_id: oauth_application.id,
+        created_at: 1.year.ago
+      )
+    end
+
+    let!(:recent_token) do
+      Doorkeeper::AccessToken.create!(
+        resource_owner_id: agent.id,
+        application_id: oauth_application.id,
+        created_at: 1.week.ago
+      )
+    end
+
+    it "deletes the old one and keeps the recent one" do
+      described_class.new.perform
+      expect(Doorkeeper::AccessToken.all).to eq [recent_token]
+    end
+  end
 end

--- a/spec/jobs/cron_job/destroy_old_oauth_objects_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_oauth_objects_spec.rb
@@ -39,4 +39,36 @@ RSpec.describe CronJob::DestroyOldOauthObjects do
       expect(Doorkeeper::AccessToken.all).to eq [recent_token]
     end
   end
+
+  context "when there are other tokens, but we still want to keep the old one" do
+    let!(:token) do
+      Doorkeeper::AccessToken.create!(
+        resource_owner_id: agent.id,
+        application_id: oauth_application.id,
+        created_at: 1.year.ago
+      )
+    end
+
+    # Ces autres tokens permettent de vérifier que le JOIN est correct
+    let!(:token_for_other_agent) do
+      Doorkeeper::AccessToken.create!(
+        resource_owner_id: create(:agent).id,
+        application: oauth_application,
+        created_at: 1.week.ago
+      )
+    end
+
+    let!(:token_for_other_application) do
+      Doorkeeper::AccessToken.create!(
+        resource_owner_id: agent.id,
+        application: create(:oauth_application),
+        created_at: 1.week.ago
+      )
+    end
+
+    it "keeps it indefinitely, so that the client can keep on using the refresh token" do
+      described_class.new.perform
+      expect(Doorkeeper::AccessToken.all).to contain_exactly(token, token_for_other_agent, token_for_other_application)
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

Au moment où on avait introduit l'oauth, le premier cas d'usager était pour RDV Insertion, qui se sert de nous comme provider d'identité (https://github.com/betagouv/rdv-service-public/pull/4749).
Dans ce cas d'usage, les agents passent par le parcours d'oauth tous les jours, et ajoutent une entrée à la table `oauth_access_tokens` à chaque fois. On voit sur l'instance RDV Solidarités que ça nous crée environ 300 tokens par jour ouvré.

On avait donc ajouté un job pour supprimer régulièrement les vieux tokens, pour éviter d'avoir une table pleine de données mortes.

# Le problème

Dans le cadre des intégrations avec d'autres services, si les tokens expirent au bout d'un mois, ça veut dire qu'on ne peut pas utiliser les refresh tokens, puisqu'ils sont sur la table `oauth_access_tokens`.
Ça oblige donc l'agent à refaire le parcours d'oauth tous les mois, plutôt que d'avoir une connexion durable.

# Solution

On fait donc évoluer le job de suppression des vieux tokens pour ne supprimer un token que s'il a été remplacé par un autre token plus récent.
