### PR TITLE
Ne pas limiter le select d'agent à 20 résultats

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -10,7 +10,7 @@ class Admin::AgentsController < AgentAuthController
     @invited_agents_count = @agents.invitation_not_accepted.where.not(invitation_sent_at: nil).created_by_invite.count
 
     @agents = index_params[:term].present? ? @agents.search_by_text(index_params[:term]) : @agents.ordered_by_last_name
-    @agents = @agents.page(page_number)
+    @agents = @agents.page(page_number) unless request.format.json?
   end
 
   def new

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -2,15 +2,16 @@ class Admin::AgentsController < AgentAuthController
   respond_to :html, :json
 
   def index
-    @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
-      .includes(:services, :roles, :organisations)
-      .active
+    @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).active
 
     @agents = @agents.joins(:organisations).where(organisations: { id: current_organisation.id }) if current_organisation
-    @invited_agents_count = @agents.invitation_not_accepted.where.not(invitation_sent_at: nil).created_by_invite.count
-
     @agents = index_params[:term].present? ? @agents.search_by_text(index_params[:term]) : @agents.ordered_by_last_name
-    @agents = @agents.page(page_number) unless request.format.json?
+
+    if request.format.html?
+      @invited_agents_count = @agents.invitation_not_accepted.where.not(invitation_sent_at: nil).created_by_invite.count
+      @agents = @agents.includes(:services, :roles, :organisations)
+      @agents = @agents.page(page_number)
+    end
   end
 
   def new


### PR DESCRIPTION
Note : Je règle ce problème en amont de la grosse PR sur le rework du planning (#5396), qui utilisera toujours le même appel Ajax pour sélectionner des agents.

# Contexte

Nous avons depuis plusieurs années (!) des remontées d'agent qui nous signalent qu'il ne trouvent pas le nom de leur collègue dans le select d'agent situé dans le menu de gauche. **En effet, la liste d'agents affichée est actuellement limitée à 20, que ce soit l'affichage initial ou les résultats d'une recherche.** Et donc lorsqu'un agent n'utilise pas la recherche textuelle mais scrolle simplement, il ne voit que les 20 premiers agents, et se demande donc pourquoi il ne trouve pas celui qu'il cherche.

# Solution

Ne plus paginer cette liste quand on est dans un appel Ajax, ça me paraît raisonnable, il faut voir si ça crée une montée en charge trop importante (car on charge plus de données), ou si ça pose des problèmes de perf pour les agents (la liste met plus de temps à apparaître). Je veux bien votre avis sur ces aspects perf et charge.

Pour ce qui est du code, j'ai eu la grande joie de mettre dans un `if` tout qui était propre à la page HTML : 
- la pagination (le changement essentiel de cette PR)
- le `includes`, car la réponse Ajax n'a pas besoin d'accéder à des associations, tout est dispo sur les `Agent` (on pourrait limite sélectionner uniquement les champs, nécessaire, avec `select(:id, :email, :last_name, :birth_name, :first_name)`)
- la variable de `@invited_agents_count` qui est uniquement utilisé sur le template HTML `app/views/admin/agents/index.html.slim`
