### PR TITLE
Introduction d’un premier Cron Monitor Sentry sur le job des files d’attente

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -1,8 +1,32 @@
 class CronJob < ApplicationJob
   queue_as :latency_whenever
 
+  module MonitorConcern
+    extend ActiveSupport::Concern
+
+    included do
+      crontab = Rails.configuration.good_job.cron.values.find { _1[:class] == name }&.fetch(:cron)
+      if crontab
+        # cf https://docs.sentry.io/platforms/ruby/crons/#job-monitoring
+        # this will send check in events to Sentry on job start and job end
+        # this will also upsert the Cron Monitor config in Sentry
+        # this upsert runs together with the check in events in the job runtime
+        # NOTE: if you delete a CRON job, you have to manually delete it from Sentry
+        include Sentry::Cron::MonitorCheckIns # does nothing until sentry_monitor_check_ins is called
+        sentry_monitor_check_ins(
+          monitor_config: Sentry::Cron::MonitorConfig.from_crontab(
+            Fugit.parse(crontab).to_cron_s.sub(" Europe/Paris", ""),
+            timezone: "Europe/Paris"
+          )
+        )
+      end
+    end
+  end
+
   class FileAttenteJob < CronJob
     queue_as :latency_30s
+
+    include MonitorConcern
 
     def perform
       FileAttente.send_notifications

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -12,7 +12,7 @@ Sentry.init do |config|
   config.excluded_exceptions -= ["ActiveRecord::RecordNotFound"]
 
   config.before_send = lambda do |event, _hint|
-    return event unless event.exception
+    return event if !event.respond_to?(:exception) || !event.exception
 
     referer = event.request&.headers&.fetch("Referer", "")
     internal_referer = Domain::ALL.map(&:host_name).any? { referer&.include?(_1) }


### PR DESCRIPTION
# Contexte

J’ai découvert que Sentry propose maintenant une fonctionnalité pour surveiller l’exécution des cron jobs. 

Ça fonctionne en configurant des règles à checker : tel job doit s’éxecuter à tel moment.
Puis chaque job cron executé envoie des `CheckIn` events au début et à la fin.

L’API Ruby est très légère à mettre en place avec ActiveJob : il suffit d’appeler une méthode au niveau de la classe du job. Ce job enverra alors des check in events et fera l’upsert de la règle automatiquement.

# Solution

Je propose ici de mettre en place cette règle pour un seul Cron Job : celui des files d’attente.

Ça permettra de voir comment ça se comporte en production.

Vous pouvez voir à quoi ça ressemble un lancement en dev https://sentry.incubateur.net/organizations/betagouv/alerts/rules/crons/lapins/cronjob-fileattentejob/details/?environment=development&statsPeriod=1h

![image](https://github.com/user-attachments/assets/ad10abb9-b436-405b-8367-cf860612ac4b)
