### PR TITLE
Utilisation de Mariane pour les h1 côté agent

### DIFF
--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -96,12 +96,6 @@
 @import "./components/rdv_solidarites_instance_name";
 @import "./components/alert";
 
-.page-title-box {
-  h1.page-title {
-    line-height: 1.5;
-  }
-}
-
 @import "./structure/bootstrap_overrides";
 
 a[href]:not(.rdv-fc-event-waiting):not(.fr-link):not(.fr-breadcrumb__link) {

--- a/app/javascript/stylesheets/structure/_page-head.scss
+++ b/app/javascript/stylesheets/structure/_page-head.scss
@@ -3,10 +3,6 @@
   justify-content: space-between;
   padding-top: 12px;
 
-  .page-title {
-    margin: 0;
-    line-height: 85px;
-  }
   .page-title-right {
     margin-bottom: 12px;
   }

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -20,7 +20,7 @@ html lang="fr"
           .container-fluid
             - if content_for :title
               .page-title-box
-                h1.page-title.pb-2= yield :title
+                h1.fr-h2= yield :title
                 // TODO: Nous sommes en train de migrer les breadcrumbs vers des fils d'ariane au DSFR qui sont au dessus du titre.
                 // Voir plus haut
                 // Une fois cette transition terminée il faudra renommer ce bloc qui continuera à être utilisé pour les boutons en haut de page (ou refacto).

--- a/spec/support/page_spec_helper.rb
+++ b/spec/support/page_spec_helper.rb
@@ -1,6 +1,6 @@
 module PageSpecHelper
   def expect_page_title(title)
-    expect(page).to have_selector("h1.page-title", text: title)
+    expect(page).to have_selector("h1.fr-h2", text: title)
   end
 
   def expect_page_with_no_record_text(text)


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5410.osc-secnum-fr1.scalingo.io/) 

# Contexte

Suite à discussion avec @Teodora-Stanki et @NesserineZarouri on s’est dit que cela serait pas mal de passer les titres de niveau 1 au DSFR côté agent.
Voici donc une PR avec sa review app pour tester ce changement.

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/a361506b-40af-4744-9e87-27ecdb4031ed) | ![image](https://github.com/user-attachments/assets/88cf7925-1c33-4b2c-8525-75d287ef89ae)
