### PR TITLE
Rails 7.1 - `commit_transaction_on_non_local_return = true`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -218,7 +218,7 @@ Rails.application.config.active_record.before_committed_on_all_records = true
 ###
 # Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.
 #++
-# Rails.application.config.active_record.commit_transaction_on_non_local_return = true
+Rails.application.config.active_record.commit_transaction_on_non_local_return = true
 
 ###
 # Controls when to generate a value for <tt>has_secure_token</tt> declarations.


### PR DESCRIPTION
Antoine et moi avons parcouru nos usages de `transaction do` et n'avons pas trouvé de trace d'usage de `return`, `break` ou `throw` au sein des blocks passés à la méthode `transaction`.

De manière plus générale, il nous semble qu'il est clair dans la tête des devs de cette équipe que la mécanique permettant de déclencher un rollback est bien le `raise`.