### PR TITLE
Rails 7 - `run_after_transaction_callbacks_in_order_defined = true`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -213,7 +213,7 @@ Rails.application.config.active_record.before_committed_on_all_records = true
 # This matches the behaviour of all other callbacks.
 # In previous versions of Rails, they ran in the inverse order.
 #++
-# Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
 
 ###
 # Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.


### PR DESCRIPTION
Nous utilisons les `after_commit` pour lancer des jobs de webhooks et assimilés (webhook, ANTS, Outlook). En lisant le code, nous n'avons pas l'impression qu'il peut y avoir des interférences entre chacun de ces 3 callbacks, et donc nous sommes assez confiants que l'ordre d'exécution n'a pas d'importance.