### PR TITLE
Rails 7 - `hash_digest_class = OpenSSL::Digest::SHA256`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -50,7 +50,7 @@ Rails.application.config.action_controller.allow_deprecated_parameters_hash_equa
 # 2. If you have +config.active_support.key_generator_hash_digest_class+ configured as SHA256 (the new default
 # in 7.0), then you need to configure SHA-256 for Active Record Encryption:
 #++
-# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
 #
 # 3. If you don't currently have data encrypted with Active Record encryption, you can disable this setting to
 # configure the default behavior starting 7.1+:


### PR DESCRIPTION
On peut voir que `SHA256` est déjà actuellement la valeur par défaut en Rails 7.0 : 
https://github.com/rails/rails/blob/14c115b120ed089331ff3dc13f36bd9129ced33d/railties/lib/rails/application/configuration.rb#L240

Ça continue à être le défaut en 7.1 : 
https://github.com/rails/rails/blob/14c115b120ed089331ff3dc13f36bd9129ced33d/railties/lib/rails/application/configuration.rb#L290

Et on confirme en console que c'est bien la méthode utilisée actuellement : 

```ruby
Rails.application.config.active_record.encryption.hash_digest_class
# => OpenSSL::Digest::SHA256
```

Nous avons commencé à utiliser le chiffrement ActiveRecord quand nous étions déjà en Rails 7.0, et donc le digest par défaut était déjà `SHA256`. Nous avons donc toujours utilisé `SHA256` pour le chiffrement ActiveRecord.

Le dé-commentage de ce switch ne devrait avoir absolument aucun effet. Je crée cette PR pour confirmer que les tests passent, et pour suive un peu bêtement la procédure où l'on dé-comment les valeurs de `new_framework_defaults_7_1.rb` une à une pour être sûrs de ne rien oublier.