### PR TITLE
Rails 7 - `marshalling_format_version = 7.1`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -206,7 +206,7 @@ Rails.application.config.active_record.before_committed_on_all_records = true
 # leave this optimization off on the first deploy, then enable it on a
 # subsequent deploy.
 #++
-# Rails.application.config.active_record.marshalling_format_version = 7.1
+Rails.application.config.active_record.marshalling_format_version = 7.1
 
 ###
 # Run `after_commit` and `after_*_commit` callbacks in the order they are defined in a model.


### PR DESCRIPTION
Le commentaire de cette config, indique que le nouveau format n’est pas lisible par les anciennes versions de Rails (< 7.1). À ce jour, nous tournons 100% en 7.1, donc nous pouvons activer sereinement cette config.

