### PR TITLE
Rails 7 - `cache_format_version = 7.1`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,7 +41,7 @@ module Lapin
 
     config.x.redis_url = ENV.fetch("REDIS_URL") { "redis://localhost:6379" }
 
-    config.active_support.cache_format_version = 7.0
+    config.active_support.cache_format_version = 7.1
 
     redis_settings = {
       connect_timeout: 30, # Defaults to 20 seconds


### PR DESCRIPTION
Le commentaire de cette config, indique que le nouveau format n’est pas lisible par les anciennes versions de Rails (< 7.1). À ce jour, nous tournons 100% en 7.1, donc nous pouvons activer sereinement cette config.