### PR TITLE
Rails 7.1 - `default_column_serializer = nil`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -195,7 +195,7 @@ Rails.application.config.active_record.before_committed_on_all_records = true
 # recommended to explicitly define the serialization method for each column
 # rather than to rely on a global default.
 #++
-# Rails.application.config.active_record.default_column_serializer = nil
+Rails.application.config.active_record.default_column_serializer = nil
 
 ###
 # Enable a performance optimization that serializes Active Record models


### PR DESCRIPTION
Notre seul usage de `serialize` est dans `app/models/concerns/recurrence_concern.rb:5` :

```ruby
serialize :recurrence, coder: Montrose::Recurrence
```

On y mentionne explicitement la classe à utiliser pour sérialiser.

Nous n'avons trouvé aucun usage de `serialize`, et à notre connaissance, aucune colonne de la base n'est sérialisée en YAML, donc nous sommes assez sûrs que nous ne nous reposons pas sur la valeur par défaut (`YAML`).