### PR TITLE
Restriction et documentation des Content Security Policies (CSP)

### DIFF
--- a/app/views/admin/territories/sectors/index_map.html.slim
+++ b/app/views/admin/territories/sectors/index_map.html.slim
@@ -1,8 +1,8 @@
 -content_for :html_head_prepend do
   / mapbox is hard to use with webpack because of
   / https://github.com/mapbox/mapbox-gl-js/issues/1649
-  <script src="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.js"></script>
-  <link href="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.css" rel="stylesheet" />
+  script src="https://unpkg.com/mapbox-gl@1.11.1/dist/mapbox-gl.js" crossorigin='anonymous' integrity="sha384-0Zom4D5ryhUWYPBjopSgMAhn3l450eTuFZQypqbSBUPQuS2m2bdUsqi0IYDVgyi6"
+  link href="https://unpkg.com/mapbox-gl@1.11.1/dist/mapbox-gl.css" rel="stylesheet"
 
 = territory_navigation(t(".title"), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory)), link_to("Secteurs", admin_territory_sectors_path(current_territory))])
 

--- a/app/views/admin/territories/sectors/show.html.slim
+++ b/app/views/admin/territories/sectors/show.html.slim
@@ -1,8 +1,8 @@
 -content_for :html_head_prepend do
   / mapbox is hard to use with webpack because of
   / https://github.com/mapbox/mapbox-gl-js/issues/1649
-  <script src="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.js"></script>
-  <link href="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.css" rel="stylesheet" />
+  script src="https://unpkg.com/mapbox-gl@1.11.1/dist/mapbox-gl.js" crossorigin='anonymous' integrity="sha384-0Zom4D5ryhUWYPBjopSgMAhn3l450eTuFZQypqbSBUPQuS2m2bdUsqi0IYDVgyi6"
+  link href="https://unpkg.com/mapbox-gl@1.11.1/dist/mapbox-gl.css" rel="stylesheet"
 
 = territory_navigation(t(".title", name: @sector.name), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory)), link_to("Secteurs", admin_territory_sectors_path(current_territory))])
 

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -9,7 +9,8 @@
   link href="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.css" rel="stylesheet"
 
 - content_for :additional_scripts do
-  script src="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.js"
+  script src="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.js" crossorigin='anonymous' integrity="sha384-bLkmUMwRt9nFp2+XvlPOzIkNUx/mnjvxxE7kI6bJWKMz/sfwiK5nra6w+60B9zyF"
+
   = javascript_include_tag "lieux_map"
 
 p

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -52,9 +52,8 @@ Rails.application.config.content_security_policy do |policy|
   # Il semble aussi que dans les tests capybara en js: true, un petit script est injecté pour lequel il faut aussi ajouter une directive de type sha256.
   #
   # Les directives de type sha permettent de s'assurer que seul le script correspondant exactement au sha peut-être chargé.
-  # Ça nous protège si jamais un attaquant prenait le contrôle d'un domaine utilisé par un partenaire et essayait de charger un script malveillant via une des urls qu'on utilise.
-  unpkg_maplibre_sha = "'sha384-bLkmUMwRt9nFp2+XvlPOzIkNUx/mnjvxxE7kI6bJWKMz/sfwiK5nra6w+60B9zyF'"
-  policy.script_src :self, :unsafe_inline, api_mapbox, headway_cnd, unpkg_maplibre_sha
+  # Cependant, elles ne sont pas prises en compte si la directive 'unsafe_inline' est présente
+  policy.script_src :self, :unsafe_inline, api_mapbox, headway_cnd
 
   if ENV["CI"].present?
     # Autorise à télécharger le binaire chromedriver pour l'exécution de la CI

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -27,6 +27,12 @@ headway_widget = "headway-widget.net"
 # Metabase permet d’embedder des rapports dans l’application
 metabase = "rdv-service-public-metabase.osc-secnum-fr1.scalingo.io"
 
+# Tant qu'on utilise les Turbolinks, c'est très difficile d'avoir des CSP différentes pour chaque pages,
+# puisque les CSP sont uniquement chargées lors de la première requête qui charle le premier document,
+# et pas lors des appels XHR fait par les turbolinks.
+#
+# Si on voulait par exemple avoir une CSP uniquement pour les pages de la sectorisation qui affichent des cartes
+# en JS, il faudrait donc s'assurer que tous les liens vers ces pages ont un attribut "data-turbolinks: false".
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
   policy.font_src :self, :data # :data est nécessaire pour charger les icônes fullcalendar
@@ -36,6 +42,17 @@ Rails.application.config.content_security_policy do |policy|
   policy.frame_src :self, in_status, headway_widget, metabase
   policy.media_src :self, s3_de_rdv_insertion
   policy.img_src :self, :data, :blob, voxusagers, tiles_osm, unpkg_cdn, tiles_data_gouv
+
+  # La directive `unsafe_inline` autorise l'utilisation de js dans un tag `script` dans la page.
+  # Idéalement, on voudrait donc la supprimer, puisque ça ajouterait une couche de protection contre les injections de JS.
+  # On s'en sert pour deux choses:
+  # - un script de customisation de headway qui est inliné : on pourrait ajouter une directive de type sha256 pour éviter ça
+  # - les mises à jour de statuts de rdvs qui utilisent des forms `js: true` et une view en `js.erb`. Si on pouvait éviter ce fonctionnement
+  # (peut-être en utilisant des turbo-frames), on pourrait s'éviter l'usage de cette directive ici.
+  #
+  # Il semble aussi que dans les tests capybara en js: true, un petit script est injecté pour lequel il faut aussi ajouter une directive de type sha256.
+  #
+  # Pour ajouter un directive de type sha256, le plus simple est de récupérer la valeur depuis l'erreur dans la console.
   policy.style_src :self, :unsafe_inline, bootstrap_cdn, api_mapbox, headway_cnd, unpkg_cdn
   policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
   policy.script_src :self, :unsafe_inline, api_mapbox, headway_cnd, unpkg_cdn

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -8,8 +8,7 @@
 in_status = "*.instatus.com"
 # Nous faisons des appels vers cette API dans notre recherche par adresse
 api_adresse_ign = "data.geopf.fr"
-# Nous utilisons mapbox et les tiles etalab pour les interfaces de config de sectorisation
-api_mapbox = "api.mapbox.com"
+# Nous utilisons mapbox via unpkg et les tiles etalab pour les interfaces de config de sectorisation
 tiles_etalab = "etalab-tiles.fr"
 # Nous utilisons unpkg, les tiles OSM et etalab pour afficher une carte des lieux dans les stats avec maplibre
 unpkg_cdn = "unpkg.com"
@@ -39,7 +38,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.child_src :blob, :self
   policy.frame_src :self, in_status, headway_widget, metabase
   policy.img_src :self, :data, :blob, voxusagers, tiles_osm, unpkg_cdn, tiles_data_gouv
-  policy.style_src :self, :unsafe_inline, bootstrap_cdn, api_mapbox, headway_cnd, unpkg_cdn
+  policy.style_src :self, :unsafe_inline, bootstrap_cdn, headway_cnd, unpkg_cdn
   policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
 
   # La source `unsafe_inline` autorise l'utilisation de js dans un tag `script` dans la page.
@@ -55,7 +54,7 @@ Rails.application.config.content_security_policy do |policy|
   # Cependant, elles ne sont pas prises en compte si la source 'unsafe_inline' est présente
   #
   # L'usage de la directive script-src-elem plutôt que script-src permet de ne pas autoriser les event handlers inline dans le html, comme "onclick"
-  policy.script_src_elem :self, :unsafe_inline, api_mapbox, headway_cnd, unpkg_cdn
+  policy.script_src_elem :self, :unsafe_inline, headway_cnd, unpkg_cdn
 
   if ENV["CI"].present?
     # Autorise à télécharger le binaire chromedriver pour l'exécution de la CI

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,8 +6,6 @@
 
 # InStatus est le service dont on se sert pour communiquer les incidents
 in_status = "*.instatus.com"
-# Nous hébergeons la vidéo de la page d'accueil de RDV_MAIRIE sur le s3 de RDV-Insertion
-s3_de_rdv_insertion = "rdv-insertion-medias-production.s3.fr-par.scw.cloud"
 # Nous faisons des appels vers cette API dans notre recherche par adresse
 api_adresse_ign = "data.geopf.fr"
 # Nous utilisons mapbox et les tiles etalab pour les interfaces de config de sectorisation
@@ -40,7 +38,6 @@ Rails.application.config.content_security_policy do |policy|
   policy.worker_src :blob
   policy.child_src :blob, :self
   policy.frame_src :self, in_status, headway_widget, metabase
-  policy.media_src :self, s3_de_rdv_insertion
   policy.img_src :self, :data, :blob, voxusagers, tiles_osm, unpkg_cdn, tiles_data_gouv
 
   # La directive `unsafe_inline` autorise l'utilisation de js dans un tag `script` dans la page.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -42,18 +42,20 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src :self, :unsafe_inline, bootstrap_cdn, api_mapbox, headway_cnd, unpkg_cdn
   policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
 
-  # La directive `unsafe_inline` autorise l'utilisation de js dans un tag `script` dans la page.
+  # La source `unsafe_inline` autorise l'utilisation de js dans un tag `script` dans la page.
   # Idéalement, on voudrait donc la supprimer, puisque ça ajouterait une couche de protection contre les injections de JS.
   # On s'en sert pour deux choses:
-  # - un script de customisation de headway qui est inliné : on pourrait ajouter une directive de type sha pour éviter ça
+  # - un script de customisation de headway qui est inliné : on pourrait ajouter une source de type sha pour éviter ça
   # - les mises à jour de statuts de rdvs qui utilisent des forms `js: true` et une view en `js.erb`. Si on pouvait éviter ce fonctionnement
-  # (peut-être en utilisant des turbo-frames), on pourrait s'éviter l'usage de cette directive ici.
+  # (peut-être en utilisant des turbo-frames), on pourrait s'éviter l'usage de cette source ici.
   #
-  # Il semble aussi que dans les tests capybara en js: true, un petit script est injecté pour lequel il faut aussi ajouter une directive de type sha256.
+  # Il semble aussi que dans les tests capybara en js: true, un petit script est injecté pour lequel il faut aussi ajouter une source de type sha.
   #
-  # Les directives de type sha permettent de s'assurer que seul le script correspondant exactement au sha peut-être chargé.
-  # Cependant, elles ne sont pas prises en compte si la directive 'unsafe_inline' est présente
-  policy.script_src :self, :unsafe_inline, api_mapbox, headway_cnd, unpkg_cdn
+  # Les sources de type sha permettent de s'assurer que seul le script correspondant exactement au sha peut-être chargé.
+  # Cependant, elles ne sont pas prises en compte si la source 'unsafe_inline' est présente
+  #
+  # L'usage de la directive script-src-elem plutôt que script-src permet de ne pas autoriser les event handlers inline dans le html, comme "onclick"
+  policy.script_src_elem :self, :unsafe_inline, api_mapbox, headway_cnd, unpkg_cdn
 
   if ENV["CI"].present?
     # Autorise à télécharger le binaire chromedriver pour l'exécution de la CI

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -57,6 +57,10 @@ Rails.application.config.content_security_policy do |policy|
   policy.script_src_elem :self, headway_cnd, unpkg_cdn
 
   policy.script_src_attr :self, :unsafe_inline
+
+  if Rails.env.test?
+    policy.script_src_elem += ["'sha256-QHkRHtatX/LwAW/EeytFmJTi1biAwojXF23HeTF90PA='"]
+  end
 end
 
 # If you are using UJS then enable automatic nonce generation

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -53,7 +53,7 @@ Rails.application.config.content_security_policy do |policy|
   #
   # Les directives de type sha permettent de s'assurer que seul le script correspondant exactement au sha peut-être chargé.
   # Cependant, elles ne sont pas prises en compte si la directive 'unsafe_inline' est présente
-  policy.script_src :self, :unsafe_inline, api_mapbox, headway_cnd
+  policy.script_src :self, :unsafe_inline, api_mapbox, headway_cnd, unpkg_cdn
 
   if ENV["CI"].present?
     # Autorise à télécharger le binaire chromedriver pour l'exécution de la CI

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -55,11 +55,6 @@ Rails.application.config.content_security_policy do |policy|
   #
   # L'usage de la directive script-src-elem plutôt que script-src permet de ne pas autoriser les event handlers inline dans le html, comme "onclick"
   policy.script_src_elem :self, :unsafe_inline, headway_cnd, unpkg_cdn
-
-  if ENV["CI"].present?
-    # Autorise à télécharger le binaire chromedriver pour l'exécution de la CI
-    policy.script_src(*(policy.script_src + ["ajax.googleapis.com"]))
-  end
 end
 
 # If you are using UJS then enable automatic nonce generation

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -39,6 +39,8 @@ Rails.application.config.content_security_policy do |policy|
   policy.child_src :blob, :self
   policy.frame_src :self, in_status, headway_widget, metabase
   policy.img_src :self, :data, :blob, voxusagers, tiles_osm, unpkg_cdn, tiles_data_gouv
+  policy.style_src :self, :unsafe_inline, bootstrap_cdn, api_mapbox, headway_cnd, unpkg_cdn
+  policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
 
   # La directive `unsafe_inline` autorise l'utilisation de js dans un tag `script` dans la page.
   # Idéalement, on voudrait donc la supprimer, puisque ça ajouterait une couche de protection contre les injections de JS.
@@ -50,8 +52,6 @@ Rails.application.config.content_security_policy do |policy|
   # Il semble aussi que dans les tests capybara en js: true, un petit script est injecté pour lequel il faut aussi ajouter une directive de type sha256.
   #
   # Pour ajouter un directive de type sha256, le plus simple est de récupérer la valeur depuis l'erreur dans la console.
-  policy.style_src :self, :unsafe_inline, bootstrap_cdn, api_mapbox, headway_cnd, unpkg_cdn
-  policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
   policy.script_src :self, :unsafe_inline, api_mapbox, headway_cnd, unpkg_cdn
 
   if ENV["CI"].present?

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -52,15 +52,7 @@ Rails.application.config.content_security_policy do |policy|
   #
   # Les sources de type sha permettent de s'assurer que seul le script correspondant exactement au sha peut-être chargé.
   # Cependant, elles ne sont pas prises en compte si la source 'unsafe_inline' est présente
-  #
-  # L'usage de la directive script-src-elem plutôt que script-src permet de ne pas autoriser les event handlers inline dans le html, comme "onclick"
-  policy.script_src_elem :self, headway_cnd, unpkg_cdn
-
-  policy.script_src_attr :self, :unsafe_inline
-
-  if Rails.env.test?
-    policy.script_src_elem += ["'sha256-QHkRHtatX/LwAW/EeytFmJTi1biAwojXF23HeTF90PA='"]
-  end
+  policy.script_src :self, :unsafe_inline, headway_cnd, unpkg_cdn
 end
 
 # If you are using UJS then enable automatic nonce generation

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -45,14 +45,16 @@ Rails.application.config.content_security_policy do |policy|
   # La directive `unsafe_inline` autorise l'utilisation de js dans un tag `script` dans la page.
   # Idéalement, on voudrait donc la supprimer, puisque ça ajouterait une couche de protection contre les injections de JS.
   # On s'en sert pour deux choses:
-  # - un script de customisation de headway qui est inliné : on pourrait ajouter une directive de type sha256 pour éviter ça
+  # - un script de customisation de headway qui est inliné : on pourrait ajouter une directive de type sha pour éviter ça
   # - les mises à jour de statuts de rdvs qui utilisent des forms `js: true` et une view en `js.erb`. Si on pouvait éviter ce fonctionnement
   # (peut-être en utilisant des turbo-frames), on pourrait s'éviter l'usage de cette directive ici.
   #
   # Il semble aussi que dans les tests capybara en js: true, un petit script est injecté pour lequel il faut aussi ajouter une directive de type sha256.
   #
-  # Pour ajouter un directive de type sha256, le plus simple est de récupérer la valeur depuis l'erreur dans la console.
-  policy.script_src :self, :unsafe_inline, api_mapbox, headway_cnd, unpkg_cdn
+  # Les directives de type sha permettent de s'assurer que seul le script correspondant exactement au sha peut-être chargé.
+  # Ça nous protège si jamais un attaquant prenait le contrôle d'un domaine utilisé par un partenaire et essayait de charger un script malveillant via une des urls qu'on utilise.
+  unpkg_maplibre_sha = "'sha384-bLkmUMwRt9nFp2+XvlPOzIkNUx/mnjvxxE7kI6bJWKMz/sfwiK5nra6w+60B9zyF'"
+  policy.script_src :self, :unsafe_inline, api_mapbox, headway_cnd, unpkg_maplibre_sha
 
   if ENV["CI"].present?
     # Autorise à télécharger le binaire chromedriver pour l'exécution de la CI

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -54,7 +54,9 @@ Rails.application.config.content_security_policy do |policy|
   # Cependant, elles ne sont pas prises en compte si la source 'unsafe_inline' est présente
   #
   # L'usage de la directive script-src-elem plutôt que script-src permet de ne pas autoriser les event handlers inline dans le html, comme "onclick"
-  policy.script_src_elem :self, :unsafe_inline, headway_cnd, unpkg_cdn
+  policy.script_src_elem :self, headway_cnd, unpkg_cdn
+
+  policy.script_src_attr :self, :unsafe_inline
 end
 
 # If you are using UJS then enable automatic nonce generation


### PR DESCRIPTION
# Contexte

Dans le cadre de la préparation au bug bounty, on refait une passe sur nos CSP pour voir comment on peut les améliorer.

# Solution

Les deux principaux blocages que j'ai trouvé sont nos usages des turbolinks et de vues `js.erb`. J'ai mis en commentaire les explications pour qu'on puisse les retrouver plus facilement.

J'ai quand même pu faire certaines améliorations :
- supprimer une csp obsolète liée au s3 de rdv insertion
- ajouter des attributs `integrity` aux scripts qu'on charge depuis d'autres domaines pour s'assurer qu'ils ne puissent pas changer
- réutiliser unpkg plutôt que mapbox pour diminuer notre surface d'attaque.
- pour le moment je me suis surtour concentré sur le JS, et j'ai pas trop attaqué le css
