### PR TITLE
Rails 7.1 : run_commit_callbacks_on_first_saved_instances_in_transaction = false

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -64,7 +64,7 @@ Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::D
 # state which matches what was committed to the database, typically the last
 # instance to save.
 #++
-# Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
+Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
 
 ###
 # Configures SQLite with a strict strings mode, which disables double-quoted string literals.


### PR DESCRIPTION
(voir le commentaire qui décrit ce toggle pour comprendre son effet, ça me semble assez clair)

Nous utilisons les `after_commit` dans 3 contextes (toujours pour créer des jobs qui synchronisent l'état d'un objet vers un système externe) : Webhooks, ANTS et Outlook.

# 1. `WebhookDeliverable`

Ici on sérialise les modèles en JSON pour les envoyer en webhook. On peut voir dans `app/models/concerns/webhook_deliverable.rb:11` qu'on recharge le modèle depuis la base de données dans un object `record` tout neuf :

```ruby
record = self.class.unscoped.find(id)
```

donc ce callback ne dépend pas de l'état de `self`, ce qui signifie que sa seule dépendance est l'ID, et donc qu'il peut être appelé sur n'importe quelle instance indifféremment. 

# 2. `Ants::AppointmentSerializerAndListener`

Ici, je suis beaucoup moins serein, car nous avons défini des callbacks à la fois sur `Rdv` et `Participation`. Or, nous faisons toutes sortes d'incantations vaudou sur les participations dans `app/models/concerns/rdv/updatable.rb`.

**Mais**, ce qui est assez rassurant, c'est que nous centralisons sur l'instance de `Rdv` (unique instance en mémoire :crossed_fingers:) le marquage de `needs_sync_to_ants`. Donc nous pouvons manipuler tout un tas d'instances de `Participations`, tant qu'au moins l'une déclenche un `rdv.needs_sync_to_ants = true`, alors le `after_commit` de l'unique objet `Rdv`  appellera `enqueue_sync_for_marked_record` qui fera son boulot correctement. 

# 3. `Outlook::EventSerializerAndListener`

Similaire au système ci-dessus pour l'ANTS, en plus simple.

# Conclusion

À mes yeux, il est très difficile de déterminer si le changement va causer de nouveaux bugs, ou même résoudre des bugs que nous avons sans le savoir. Nous avons donc plusieurs options : 
1. ajouter des specs pour des cas tordus (si on est capables d'en inventer / trouver) :brain: 
2. passer le toggle à  `false` et croiser les doigts :crossed_fingers: 
3. garder ce toggle à `true` dans `application.rb` et garder le comportement actuel :shrug: 