### PR TITLE
Ne plus utiliser `support@rdv-aide-numerique.fr` en expéditeur des e-mails

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -55,7 +55,7 @@ class Domain
       online_reservation_with_public_link: true,
       sms_sender_name: "RdvAideNum",
       france_connect_enabled: false,
-      support_email: "support@rdv-aide-numerique.fr",
+      support_email: "support@rdv-service-public.fr",
       verticale: :rdv_aide_numerique,
       allow_self_onboarding: false,
       secretariat_email: "secretariat-auto@rdv-solidarites.fr"

--- a/spec/features/users/account/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/account/user_can_reset_his_password_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "User resets his password spec" do
         fill_in "user_email", with: user.email
         click_on "Envoyer"
         open_email(user.email)
-        expect(current_email.base.email[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-aide-numerique.fr>))
+        expect(current_email.base.email[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-service-public.fr>))
         expect(current_email.html_part.body.to_s).to include('<a href="http://www.rdv-aide-numerique-test.localhost/users/password/edit?reset_password_token=')
       end
     end

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe AddConseillerNumerique do
 
       expect(invitation_email).to have_attributes(
         to: ["exemple@tierslieuxettransitions.fr"],
-        from: ["support@rdv-aide-numerique.fr"]
+        from: ["support@rdv-service-public.fr"]
       )
 
       # And when trying a second time, it doesn't re-create the agent or the organisation


### PR DESCRIPTION
# Contexte

Nous souhaitons faire disparaître la marque et le nom de domaine https://www.rdv-aide-numerique.fr/

Nous payons une boite mail Gandi (60 € / an) pour l'adresse support@rdv-aide-numerique.fr alors que cette boite reçoit 20 mails par mois, 95 % de spam. Je viens donc de supprimer cette boite sur Gandi au profit d'une redirection vers support@rdv-service-public.fr

Je propose ici de ne plus mentionner cette adresse dans notre appli, c'est à dire de ne plus l'utiliser dans le champ FROM des mails qu'on envoie. Nous allons donc envoyer des mails depuis support@rdv-service-public.fr avec des liens dedans qui pointent vers des pages de `www.rdv-aide-numerique.fr`, ce qui d'après mes recherches ne devrait pas avoir d'impact sur notre score de spam.

Une question que je me pose : à long terme, les agents qui sont sur RDV Aide Numérique vont soit migrer vers la nouvelle instance, soit finir par utiliser le domaine `www.rdv-solidarites.fr`. Est-ce qu'il serait judicieux d'utiliser ici `"support@rdv-solidarites.fr"`  plutôt que `"support@rdv-service-public.fr"` ?

# Note sur la config Gandi + Zammad

Afin que Zammad accepte de récupérer sur la boite `support@rdv-service-public.fr` des mails qui ont pour champ TO `support@rdv-aide-numerique.fr`, il est nécessaire que l'entrée de config de `support@rdv-service-public.fr` existe, même en erreur et désactivée. Si on supprime cette entrée, les mails redirigés ne seront plus transformés en ticket Zammad (bien qu'ils soient présents dans la boite `support@rdv-service-public.fr`).

![image](https://github.com/user-attachments/assets/5f73b008-37b7-448f-a195-553f1fe3a195)
