### PR TITLE
Ajout d'un lien vers le rdv d'accompagnement dans l'email d'ouverture d'espace

### DIFF
--- a/app/views/mailers/agents/territory_creation_request_mailer/accepted.html.slim
+++ b/app/views/mailers/agents/territory_creation_request_mailer/accepted.html.slim
@@ -18,4 +18,6 @@ p Pour bien démarrer, #{link_to("consultez notre tutoriel", tutoriel_url)} pour
 .btn-wrapper
   = link_to "Consulter le tutoriel", tutoriel_url,  class: "btn btn-secondary"
 
+p Besoin d’aide ? Notre équipe est là pour vous accompagner, #{ link_to("planifiez un temps d'échange", "https://cal.com/team/rdv-service-public/accompagnement")}.
+
 = t("mailers.common.farewell_html", domain_name: domain.name)


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="668" alt="Screenshot 2025-06-12 at 15 38 14" src="https://github.com/user-attachments/assets/cbbdcd88-8d92-4ef0-a72f-c8cd9d2e468c" />|<img width="617" alt="Screenshot 2025-06-12 at 15 38 00" src="https://github.com/user-attachments/assets/72d0cdc0-5292-4e5c-be2d-f2fc51a03eb4" />

# Contexte

Aucun des agents pour lesquels on ouvre de compte ne nous contacte pour qu'on l'aide, donc on essaye de les encourager un peu plus.

# Solution

On ajoute le lien pour nous contacter dans le mail
