### PR TITLE
Encourager les agents à nous contacter suite à une ouverture de compte

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -1,5 +1,7 @@
 module AgentsHelper
   def may_need_onboarding_help?
+    return false if current_agent.territory_creation_request.blank?
+
     # Pour éviter d'avoir des problèmes de perfs en faisant un COUNT(*) sur tous les rdvs de l'organisation,
     # on limite à 5 puisque c'est le nombre qu'on considère comme un bon indicateur que l'organisation a réussi à configurer son compte
     current_organisation.rdvs.limit(5).count < 5

--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -8,12 +8,6 @@
   | Configuration
 
 .fr-container-fluid
-  - if may_need_onboarding_help?
-    .fr-callout.fr-p-2w
-      p.fr-callout__text
-        = icon("fr-icon-lightbulb-line", class: "fr-mr-3v")
-        | Besoin d'aide pour configurer votre organisation ? Nous pouvons vous aider
-        = external_link_to("Contacter l'équipe", "https://cal.com/team/rdv-service-public/accompagnement", class: "fr-btn fr-btn--secondary fr-ml-1w")
   .fr-grid-row.fr-grid-row--gutters.fr-mt-4w
 
     .fr-col-12.fr-col-md-4.fr-mb-2w

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -30,3 +30,4 @@ header.header.bg-white
               | Se déconnecter
 
   = render "layouts/super_admin_sign_in_as_warning"
+  = render "layouts/meet_the_team_banner"

--- a/app/views/layouts/_meet_the_team_banner.html.slim
+++ b/app/views/layouts/_meet_the_team_banner.html.slim
@@ -1,0 +1,8 @@
+- if may_need_onboarding_help?
+  .fr-notice.fr-notice--info
+    .fr-notice__body
+      p.fr-mb-0.fr-ml-6w
+        span.fr-notice__desc
+          | Besoin d'aide pour bien démarrer ? Nous pouvons vous aider
+          = " "
+          = external_link_to("Rencontrer l'équipe", "https://cal.com/team/rdv-service-public/accompagnement", class: "fr-btn fr-btn--tertiary fr-ml-1w")


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1423" alt="Screenshot 2025-06-12 at 18 03 12" src="https://github.com/user-attachments/assets/ad5de3a0-d78a-4fa4-a54f-5b41b196c8a2" />|<img width="1424" alt="Screenshot 2025-06-12 at 18 03 03" src="https://github.com/user-attachments/assets/51b0748a-d17a-4d6e-961d-10cbf6554ec3" />
<img width="1423" alt="Screenshot 2025-06-12 at 18 03 20" src="https://github.com/user-attachments/assets/679e3df1-7fe7-4ef2-8750-c55e9415f840" />|<img width="1426" alt="Screenshot 2025-06-12 at 18 02 56" src="https://github.com/user-attachments/assets/70589988-9d53-4fb9-aeb5-3b0d113a7bc0" />


# Contexte

On a beaucoup d'agents qui demandent des ouvertures de compte, mais aucun qui ne prend de rdv en visio avec nous par la suite.


# Solution

On les encourage à nous contacter en mettant une bannière omniprésente qui insiste beaucoup plus que celle qu'on affichait sur la page de configuration.

Texte co-écrit et validé avec Léa et Matis.


