### PR TITLE
Faciliter les rendez-vous avec les professionnels

### DIFF
--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -3,11 +3,33 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
 
   def show
     authorize(@organisation, policy_class: Agent::OrganisationPolicy)
+    set_motifs
+  end
 
+  def update
+    authorize(@organisation, policy_class: Agent::OrganisationPolicy)
+
+    if @organisation.update(permitted_params)
+      flash[:success] = "Configuration mise à jour"
+      redirect_to admin_organisation_online_booking_path(@organisation)
+    else
+      flash[:error] = @organisation.errors.full_messages.to_sentence
+      set_motifs
+      render :show
+    end
+  end
+
+  private
+
+  def set_motifs
     @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif)
       .available_motifs_for_organisation_and_agent(current_organisation, current_agent)
       .active
       .includes(:organisation)
       .includes(:service)
+  end
+
+  def permitted_params
+    params.require(:organisation).permit(:online_booking_for_particuliers, :online_booking_for_professionnels)
   end
 end

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -10,11 +10,14 @@ class AgentConnectController < ApplicationController
     )
     session[:agent_connect_state] = auth_client.state
     session[:nonce] = auth_client.nonce
+    if params[:for_user]
+      session[:proconnect_for_user] = true
+    end
 
     redirect_to auth_client.redirect_url(agent_connect_callback_url), allow_other_host: true
   end
 
-  def callback # rubocop:disable Metrics/PerceivedComplexity
+  def callback
     callback_client = AgentConnectOpenIdClient::Callback.new(
       session_state: session.delete(:agent_connect_state),
       params_state: params[:state],
@@ -24,11 +27,45 @@ class AgentConnectController < ApplicationController
       client_secret: current_domain.agent_connect_client_secret
     )
 
-    unless callback_client.fetch_user_info_from_code!(params[:code])
-      flash[:error] = generic_error_message
-      redirect_to(new_agent_session_path) and return
-    end
+    if callback_client.fetch_user_info_from_code!(params[:code])
 
+      if session.delete(:proconnect_for_user)
+        connect_user(callback_client)
+      else
+        connect_agent(callback_client)
+      end
+    else
+      flash[:error] = generic_error_message
+      redirect_to(new_agent_session_path)
+    end
+  end
+
+  private
+
+  # Devise fournit un mécanisme `store_location_for` qui permet de revenir
+  # vers le path demandé après le process de login.
+  # Ce controller gère l'authentification, nous ne souhaitons donc
+  # jamais revenir vers ses paths après un login.
+  def storable_location?
+    false
+  end
+
+  def connect_user(callback_client)
+    user = User.find_or_initialize_by(pro_connect_openid_sub: callback_client.openid_sub)
+
+    user.confirmed_at ||= Time.zone.now # Nécessaire pour que Devise autorise la connexion
+    user.update!(
+      first_name: callback_client.user_first_name,
+      last_name: callback_client.user_last_name,
+      notification_email: callback_client.user_email
+    )
+
+    bypass_sign_in(user, scope: :user)
+    session[:agent_connect_id_token] = callback_client.id_token_for_logout
+    redirect_to after_sign_in_path_for(user)
+  end
+
+  def connect_agent(callback_client)
     # Agent Connect recommande de faire la réconciliation sur l'email et non pas sur le sub
     # voir https://github.com/numerique-gouv/agentconnect-documentation/blob/main/doc_fs/donnees_fournies.md#le-champ-sub
     agent = Agent.active.find_by(email: callback_client.user_email)
@@ -60,8 +97,6 @@ class AgentConnectController < ApplicationController
       redirect_to new_agent_session_path
     end
   end
-
-  private
 
   def generic_error_message
     support_email = current_domain.support_email

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -42,7 +42,7 @@ class Users::RdvWizardStepsController < UserAuthController
         name: "step1",
         number: 1,
         title: "Vos informations",
-        next_step: current_user.signed_in_with_invitation_token? ? :step3 : :step2,
+        next_step: UserRdvWizard::Base.skip_proches_step?(current_user) ? :step3 : :step2,
         stepper_index: 1,
       },
       step2: {
@@ -56,12 +56,11 @@ class Users::RdvWizardStepsController < UserAuthController
         name: "step3",
         number: 3,
         title: "Confirmation",
-        stepper_index: current_user.signed_in_with_invitation_token? ? 2 : 3,
+        stepper_index: UserRdvWizard::Base.skip_proches_step?(current_user) ? 2 : 3,
       },
     }
 
-    # Dans le cas d'une invitation, on passe l’étape 2
-    steps.delete(:step2) if current_user.signed_in_with_invitation_token?
+    steps.delete(:step2) if UserRdvWizard::Base.skip_proches_step?(current_user)
 
     steps
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -35,7 +35,18 @@ class Users::SessionsController < Devise::SessionsController
   def destroy
     @connected_with_franceconnect = user_signed_in? && session[:connected_with_franceconnect]
     # so it's accessible in after_sign_out_path_for
-    super
+
+    agent_connect_id_token = session.delete(:agent_connect_id_token)
+
+    sign_out(:user)
+
+    if agent_connect_id_token
+      agent_connect_client = AgentConnectOpenIdClient::Logout.new(agent_connect_id_token)
+
+      redirect_to agent_connect_client.agent_connect_logout_url(root_url), allow_other_host: true
+    else
+      redirect_to after_sign_out_path_for(:user)
+    end
   end
 
   private

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -80,6 +80,27 @@ module UserRdvWizard
       end
     end
 
+    def display_france_connect?
+      motif.organisation.online_booking_for_particuliers
+    end
+
+    def display_pro_connect?
+      motif.organisation.online_booking_for_professionnels
+    end
+
+    # On a parfois besoin de cette méthode avant d'avoir une instance de RdvWizard, donc on factorise l'implémentation
+    # avec cette méthode de classe
+    def self.skip_proches_step?(user)
+      # L'étape 2 propose de prendre rendez-vous pour un proche
+      # Dans le cas d'une invitation, c'est l'usager qui est invité, donc on saute cette étape
+      # Si l'usager est un professionnel connecté via ProConnect, on ne lui propose pas non plus de prendre rendez-vous pour un proche
+      user.signed_in_with_invitation_token? || user.pro_connect_openid_sub
+    end
+
+    def skip_proches_step?
+      self.class.skip_proches_step?(user)
+    end
+
     private
 
     def lieu

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -42,6 +42,7 @@ class Organisation < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :territory }
   validates :external_id, uniqueness: { scope: :territory, allow_nil: true }
   validate :validate_organisation_phone_number
+  validate :validate_at_least_one_user_type
 
   # Scopes
   scope :attributed_to_sectors, lambda { |sectors:, most_relevant: false|
@@ -104,5 +105,13 @@ class Organisation < ApplicationRecord
 
   def sectorized?
     sector_attributions.any? && motifs.active.sectorized.any?
+  end
+
+  private
+
+  def validate_at_least_one_user_type
+    return if online_booking_for_particuliers || online_booking_for_professionnels
+
+    errors.add(:base, "Vous devez choisir au moins un type d'usager entre particulier et professionnels.")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -279,6 +279,10 @@ class User < ApplicationRecord
     Annotation.upsert!(content, user: self, territory:)
   end
 
+  def connected_with_sso?
+    (franceconnect_openid_sub || pro_connect_openid_sub).present?
+  end
+
   protected
 
   def generate_rdv_invitation_token

--- a/app/services/agent_connect_open_id_client/callback.rb
+++ b/app/services/agent_connect_open_id_client/callback.rb
@@ -43,6 +43,10 @@ module AgentConnectOpenIdClient
       @user_info["siret"]
     end
 
+    def openid_sub
+      @user_info["sub"]
+    end
+
     private
 
     def validate_state!

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -44,6 +44,10 @@ class MergeUsersService < BaseService
       @user_target.logged_once_with_franceconnect = true
       @user_target.franceconnect_openid_sub = @user_to_merge.franceconnect_openid_sub
     end
+
+    if @user_to_merge.pro_connect_openid_sub?
+      @user_target.pro_connect_openid_sub = @user_to_merge.pro_connect_openid_sub
+    end
     @user_target.save!
   end
 

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -18,6 +18,14 @@
       - org_booking_link = public_link_to_org_url(organisation_id: current_organisation.id, org_slug: current_organisation.slug)
       = render partial: "admin/organisations/online_bookings/booking_link", locals: { booking_link: org_booking_link }
 
+.card
+  .card-body
+    p Qui participe aux rendez-vous avec les agents de votre organisation ?
+    = simple_form_for @organisation, url: admin_organisation_online_booking_path(@organisation)  do |f|
+      = f.input :online_booking_for_particuliers, label: "des particuliers", hint: sanitize("On leur proposera la connexion avec #{dsfr_link_to('FranceConnect', 'https://franceconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
+      = f.input :online_booking_for_professionnels, label: "des professionnels", hint: sanitize("On leur proposera la connexion avec #{dsfr_link_to('ProConnect', 'https://www.proconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
+      = f.submit "Enregistrer", class: "fr-btn"
+
 ul.list-group.my-1
   - @motifs.each do |motif|
     li.card

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -6,8 +6,7 @@
       - if display_agent_connect_button?
         h2 Se créer un compte avec ProConnect
         .rdv-text-align-center
-          - if display_agent_connect_button?
-            = render "common/proconnect_button_dsfr", login_hint: resource.email
+          = render "common/proconnect_button_dsfr", login_hint: resource.email
 
         p.fr-mt-3w.fr-hr-or = "ou"
 

--- a/app/views/common/_proconnect_button.html.slim
+++ b/app/views/common/_proconnect_button.html.slim
@@ -2,5 +2,5 @@ div.text-center
   form[action="/agent_connect/auth" method="get"]
     button.proconnect-button[aria-label="S'identifier avec ProConnect"]
   p
-    a[href="https://proconnect.gouv.fr/" target="_blank" rel="noopener noreferrer" title="Qu’est-ce que ProConnect ? - nouvelle fenêtre"]
+    a[href="https://www.proconnect.gouv.fr/" target="_blank" rel="noopener noreferrer" title="Qu’est-ce que ProConnect ? - nouvelle fenêtre"]
       |  Qu’est-ce que ProConnect ?

--- a/app/views/common/_proconnect_button_dsfr.html.slim
+++ b/app/views/common/_proconnect_button_dsfr.html.slim
@@ -1,13 +1,15 @@
-/# locals: (login_hint: nil)
+/# locals: (login_hint: nil, for_user: false)
 form.fr-connect-group[action="#{agent_connect_auth_path}" method="get"]
 
   - if login_hint
     input[type="hidden" value="#{login_hint}" name="login_hint"]
+  - if for_user
+    input[type="hidden" value="1" name="for_user"]
   button.fr-connect.fr-proconnect
     span.fr-connect__login
       | S’identifier avec
     span.fr-connect__brand
       | ProConnect
   p
-    a[href="https://proconnect.gouv.fr/" target="_blank" rel="noopener noreferrer" title="Qu’est-ce que ProConnect ? - nouvelle fenêtre"]
+    a[href="https://www.proconnect.gouv.fr/" target="_blank" rel="noopener noreferrer" title="Qu’est-ce que ProConnect ? - nouvelle fenêtre"]
       |  Qu’est-ce que ProConnect ?

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -57,7 +57,7 @@ ul.list-group.list-group-flush.fr-mt-0
           | Usager :&nbsp;
           = users_to_sentence(rdv_wizard.users)
         .col-auto
-          - step = current_user&.signed_in_with_invitation_token? ? 1 : 2 # Les usagers connectés par invitation ont une étape de moins
+          - step = @rdv_wizard.skip_proches_step? ? 1 : 2
           = link_to "modifier", new_users_rdv_wizard_step_path(step: , **@rdv_wizard.to_query), title: "Modifier les usagers"
     li.list-group-item
       .row

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -5,6 +5,9 @@
     - if resource.logged_once_with_franceconnect?
       .fr-alert.fr-alert--info.fr-mb-3w
         | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de FranceConnect
+    - if resource.pro_connect_openid_sub
+      .fr-alert.fr-alert--info.fr-mb-3w
+        | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de ProConnect
     = form_for resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put }, builder: Dsfr::FormBuilder do |f|
       = f.dsfr_email_field :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), autocomplete: "email"
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -4,7 +4,7 @@
   = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard if @rdv_wizard.present?
 
   .card-body
-    - if current_domain.france_connect_enabled || params[:force_franceconnect].present?
+    - if params[:force_franceconnect].present? || (current_domain.france_connect_enabled && (@rdv_wizard.blank? || @rdv_wizard.display_france_connect?))
       h2 Se connecter avec FranceConnect
       = render "common/franceconnect_button"
 

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -10,6 +10,14 @@
 
       p.fr-hr-or ou
 
+    / Contrairement à FranceConnect, on n'affiche pas le bouton ProConnect en dehors de la prise de rendez-vous
+    - if display_agent_connect_button? && @rdv_wizard&.display_pro_connect?
+      h2 Se connecter avec ProConnect
+
+      .rdv-text-align-center
+        = render "common/proconnect_button_dsfr", login_hint: resource.email, for_user: true
+
+      p.fr-hr-or ou
     h2 Se connecter avec son compte
 
     = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -7,11 +7,11 @@ ruby:
 = form_for user, url: form_url, method: form_method, builder: Dsfr::FormBuilder do |f|
   = render "model_errors", model: user, f: f
   .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
-    .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, disabled: user.logged_once_with_franceconnect?, autocomplete: "given-name"
-    .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, autocomplete: "family-name"
+    .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, disabled: user.connected_with_sso?, autocomplete: "given-name"
+    .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, disabled: user.pro_connect_openid_sub, autocomplete: "family-name"
   .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
-    - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
-      .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
+    - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE || user.pro_connect_openid_sub
+      .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_name, placeholder: "Nom de naissance", disabled: user.connected_with_sso?
     - if !current_user.signed_in_with_invitation_token? && rdv_wizard&.rdv&.territory&.enable_birth_date_field?
       .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_date, type: "date", disabled: user.logged_once_with_franceconnect?, autocomplete: "bday"
   - if rdv_wizard&.rdv&.requires_ants_predemande_number?

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -41,6 +41,7 @@ tables:
       - logement
       - ants_pre_demande_number
       - franceconnect_openid_sub
+      - pro_connect_openid_sub
       - encrypted_password
       - confirmation_token
       - reset_password_token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -246,7 +246,7 @@ Rails.application.routes.draw do
           end
         end
         scope module: "organisations" do
-          resource :online_booking, only: [:show]
+          resource :online_booking, only: %i[show update]
           resource :configuration, only: [:show]
           resources :stats, only: :index do
             collection do

--- a/db/migrate/20250530083924_add_users_types_to_organisations.rb
+++ b/db/migrate/20250530083924_add_users_types_to_organisations.rb
@@ -1,0 +1,14 @@
+class AddUsersTypesToOrganisations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :organisations, :online_booking_for_particuliers, :boolean, null: false, default: true
+    add_column :organisations, :online_booking_for_professionnels, :boolean, null: false, default: false
+
+    change_column_comment :organisations, :online_booking_for_particuliers, from: nil, to: <<~COMMENT
+      Indique que l'organisation gère des rendez-vous avec des particuliers, et donc qu'on propose le bouton FranceConnect lors de la prise de rendez-vous en ligne.
+    COMMENT
+
+    change_column_comment :organisations, :online_booking_for_professionnels, from: nil, to: <<~COMMENT
+      Indique que l'organisation gère des rendez-vous avec des professionnels, et donc qu'on propose le bouton ProConnect lors de la prise de rendez-vous en ligne.
+    COMMENT
+  end
+end

--- a/db/migrate/20250617121151_add_users_connected_with_proconnect.rb
+++ b/db/migrate/20250617121151_add_users_connected_with_proconnect.rb
@@ -1,0 +1,5 @@
+class AddUsersConnectedWithProconnect < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :pro_connect_openid_sub, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_30_124357) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_17_121151) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -522,6 +522,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_30_124357) do
     t.string "external_id", comment: "The organisation's unique and immutable id in the system managing them and adding them to our application"
     t.enum "verticale", default: "rdv_solidarites", null: false, enum_type: "verticale"
     t.boolean "ants_connectable", default: false, null: false, comment: "Autorise l'organisation à être branchée sur le moteur de recherche de l'ANTS sur https://rendezvouspasseport.ants.gouv.fr/. Pour éviter de brancher n'importe qui sur ce moteur de recherche, cette option n'est pas activable par les agents.\n"
+    t.boolean "online_booking_for_particuliers", default: true, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des particuliers, et donc qu'on propose le bouton FranceConnect lors de la prise de rendez-vous en ligne.\n"
+    t.boolean "online_booking_for_professionnels", default: false, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des professionnels, et donc qu'on propose le bouton ProConnect lors de la prise de rendez-vous en ligne.\n"
     t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["name", "territory_id"], name: "index_organisations_on_name_and_territory_id", unique: true
     t.index ["territory_id"], name: "index_organisations_on_territory_id"
@@ -827,6 +829,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_30_124357) do
     t.datetime "rdv_invitation_token_updated_at"
     t.string "notification_email", comment: "Used for notifications only, multiple users can share the same email notification address"
     t.virtual "text_search_terms_with_notification_email", type: :tsvector, as: "((((((setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(last_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(first_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(birth_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'C'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(notification_email, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(email, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(phone_number_formatted, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text)), 'D'::\"char\"))", stored: true
+    t.string "pro_connect_openid_sub"
     t.index ["birth_date"], name: "index_users_on_birth_date"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_through"], name: "index_users_on_created_through"

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -24,6 +24,29 @@ RSpec.describe AgentConnectController do
         nonce: be_a(String)
       )
     end
+
+    describe "with the for_user param" do
+      it "saves the information that we want to log in a user rather than an agent in the session" do
+        get :auth, params: { login_hint: "francis.factice@exemple.gouv.fr", for_user: true }
+
+        expect(response).to redirect_to(start_with("https://fca.integ01.dev-agentconnect.fr/api/v2/authorize?"))
+
+        redirect_url = response.headers["Location"]
+        redirect_url_query_params = Rack::Utils.parse_query(URI.parse(redirect_url).query)
+
+        expect(redirect_url_query_params.symbolize_keys).to match(
+          login_hint: "francis.factice@exemple.gouv.fr",
+          acr_values: "eidas1",
+          client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
+          redirect_uri: "http://test.host/agent_connect/callback",
+          response_type: "code",
+          scope: "openid email given_name usual_name siret",
+          state: be_a(String),
+          nonce: be_a(String)
+        )
+        expect(session["proconnect_for_user"]).to be_present
+      end
+    end
   end
 
   describe "#callback" do
@@ -67,6 +90,45 @@ RSpec.describe AgentConnectController do
       expect(session["agent_connect_id_token"]).to be_present
 
       expect(response).to redirect_to("/agents/edit")
+    end
+
+    context "when logging in a user" do
+      before do
+        session["proconnect_for_user"] = true
+        session[:user_return_to] = "/users/informations" # Pour simuler le retour vers la page demandée avant la connexion
+      end
+
+      it "creates the user" do
+        expect do
+          get :callback, params: { state: state, code: code }
+        end.to change(User, :count).by(1)
+
+        expect(User.last).to have_attributes(
+          pro_connect_openid_sub: "ab70770d-1285-46e6-b4d0-3601b49698d4",
+          first_name: "Francis",
+          last_name: "Factice",
+          confirmed_at: be_within(10.seconds).of(Time.zone.now)
+        )
+        expect(session["agent_connect_id_token"]).to be_present
+
+        expect(response).to redirect_to("/users/informations")
+      end
+
+      context "when the user already exists" do
+        let!(:user) { create(:user, pro_connect_openid_sub: "ab70770d-1285-46e6-b4d0-3601b49698d4") }
+
+        it "updates and logs in the user" do
+          get :callback, params: { state: state, code: code }
+
+          expect(user.reload).to have_attributes(
+            first_name: "Francis",
+            last_name: "Factice"
+          )
+          expect(session["agent_connect_id_token"]).to be_present
+
+          expect(response).to redirect_to("/users/informations")
+        end
+      end
     end
 
     context "when the agent has a name with two words" do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -1,9 +1,9 @@
-RSpec.describe Agents::SessionsController do
-  let(:agent) { create(:agent) }
+RSpec.describe Users::SessionsController do
+  let(:user) { create(:user) }
 
   before do
-    request.env["devise.mapping"] = Devise.mappings[:agent] # d'après la doc de Devise
-    sign_in agent
+    request.env["devise.mapping"] = Devise.mappings[:user] # d'après la doc de Devise
+    sign_in user
   end
 
   describe "#destroy" do

--- a/spec/features/agents/agent_can_configure_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_configure_online_booking_spec.rb
@@ -97,4 +97,37 @@ RSpec.describe "Agents can configure online booking" do
       end
     end
   end
+
+  describe "choix du type d'usager qui participer au rendez-vous" do
+    before do
+      login_as(agent, scope: :agent)
+      visit admin_organisation_online_booking_path(organisation)
+    end
+
+    it "permet de passer de particulier à professionnel" do
+      find("label", text:  "des particuliers").click
+      find("label", text:  "des professionnels").click
+      click_on "Enregistrer"
+
+      expect(page).to have_content "Configuration mise à jour"
+
+      expect(organisation.reload).to have_attributes(
+        online_booking_for_particuliers: false,
+        online_booking_for_professionnels: true
+      )
+    end
+
+    context "si on ne remplit aucune des options" do
+      it "affiche un message d'erreur" do
+        find("label", text:  "des particuliers").click
+        click_on "Enregistrer"
+        expect(page).to have_content "Vous devez choisir au moins un type d'usager entre particulier et professionnels."
+
+        expect(organisation.reload).to have_attributes(
+          online_booking_for_particuliers: true,
+          online_booking_for_professionnels: false
+        )
+      end
+    end
+  end
 end

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -309,6 +309,24 @@ RSpec.describe MergeUsersService, type: :service do
     end
   end
 
+  context "when one user is connected by ProConnect" do
+    it "keep ProConnect attributes when merged user uses ProConnect" do
+      user_to_merge = create(:user, pro_connect_openid_sub: "unechainedecharacteres", organisations: [organisation])
+      user_target = create(:user, organisations: [organisation])
+      described_class.perform_with(user_target, user_to_merge, attributes_to_merge, organisation)
+      user_target.reload
+      expect(user_target.pro_connect_openid_sub).to eq("unechainedecharacteres")
+    end
+
+    it "keep ProConnect attributes when user uses ProConnect" do
+      user_to_merge = create(:user, organisations: [organisation])
+      user_target = create(:user, pro_connect_openid_sub: "unechainedecharacteres", organisations: [organisation])
+      described_class.perform_with(user_target, user_to_merge, attributes_to_merge, organisation)
+      user_target.reload
+      expect(user_target.pro_connect_openid_sub).to eq("unechainedecharacteres")
+    end
+  end
+
   context "when the participation was created by a prescripteur" do
     let(:user_target) { create(:user, organisations: [organisation]) }
     let(:user_to_merge) { create(:user, organisations: [organisation], created_through: :prescripteur) }


### PR DESCRIPTION
voir https://www.notion.so/rdvs/Permettre-les-rendez-vous-avec-des-professionnels-2062b05ced41803f97bcf697700aad62

Cette PR permet de proposer la connexion ProConnect lors de la prise de rendez-vous en ligne pour un professionnels. Ça permet à des administrations de proposer la prise de rendez-vous pour des agents ("agents" au sens de l'administration, pas au sens de l'application).

On introduit donc la possibilité que des usagers (au sens "les personnes qui participent au rendez-vous") soient des professionnels, et non pas des particuliers comme c'était historiquement le cas.

Là où c'est possible, on rend les champs introduits par ProConnect read-only, mais il faudra peut-être améliorer cette logique dans les formulaires d'usagers côté agent, et sur le formulaire de fusion d'usager. Ce sont des cas très exceptionnels pour le moment, donc c'est un compromis acceptable.

On ne fait pas de réconciliation entre les comptes usagers existants et les comptes usagers qui utilisent ProConnect. Dans le cas d'un usager qui utiliserait la même adresse email pour des rendez-vous pros et particulier, c'est pratique de ne pas mélanger les deux comptes.


On pourra suivre l'usage de cette fonctionnalité via les nouvelles colonnes ajoutées en base.

# Captures d'écran

## Côté agent

<img width="1418" alt="Screenshot 2025-06-18 at 10 52 27" src="https://github.com/user-attachments/assets/808b25b3-da41-44e0-8951-77208f9aff42" />

## Côté usager

<img width="1423" alt="Screenshot 2025-06-18 at 10 53 10" src="https://github.com/user-attachments/assets/c416f181-5a59-41e5-9c2d-f90a3cf1fafb" />

![www rdv-solidarites localhost_3000_users_rdv_wizard_step_new_departement=75 motif_id=14 motif_name_with_location_type=etre_rappele_par_la_mds-phone public_link_organisation_id=4 service_id=3 starts_at=2025-06-24+14%3A30%3A00+%2B0200 (1)](https://github.com/user-attachments/assets/bc7388bb-476a-4b4c-a10f-992a53835c18)



<img width="1218" alt="Screenshot 2025-06-18 at 10 55 12" src="https://github.com/user-attachments/assets/2fa05c71-8e40-4fe5-8e32-3537cfc62b14" />


Comme pour les rendez-vous par invitation, on saute l'étape de choix de proche pour les professionnels.