### PR TITLE
[Bugfix] ANTS non prévenue lorsque l'on retire plusieurs usagers d'un RDV

### DIFF
--- a/app/models/concerns/ants/appointment_serializer_and_listener.rb
+++ b/app/models/concerns/ants/appointment_serializer_and_listener.rb
@@ -59,8 +59,11 @@ module Ants
       rdvs.each do |rdv|
         next unless rdv.requires_ants_predemande_number?
 
-        rdv.assign_attributes(needs_sync_to_ants: true)
-        rdv.assign_attributes(obsolete_ants_data:) if obsolete_ants_data.present?
+        rdv.needs_sync_to_ants = true
+        if obsolete_ants_data.present?
+          rdv.obsolete_ants_data ||= Set.new
+          rdv.obsolete_ants_data.add(obsolete_ants_data)
+        end
       end
     end
 
@@ -70,10 +73,12 @@ module Ants
           Ants::SyncAppointmentJob.perform_later(ants_pre_demande_number:)
         end
         if rdv.obsolete_ants_data.present?
-          Ants::SyncAppointmentJob.perform_later(
-            ants_pre_demande_number: rdv.obsolete_ants_data[:pre_demande_number],
-            obsolete_meeting_point_id: rdv.obsolete_ants_data[:meeting_point_id]
-          )
+          rdv.obsolete_ants_data.each do |obsolete_ants_data|
+            Ants::SyncAppointmentJob.perform_later(
+              ants_pre_demande_number: obsolete_ants_data[:pre_demande_number],
+              obsolete_meeting_point_id: obsolete_ants_data[:meeting_point_id]
+            )
+          end
         end
         rdv.assign_attributes(needs_sync_to_ants: false)
       end

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -464,10 +464,57 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         ],
       }
 
+      expect(rdv.users.count).to eq(3)
       expect { rdv.update_and_notify(rdv.agents.first, params_to_destroy_participations_1_and_3) }.to have_enqueued_job(Ants::SyncAppointmentJob).at_least(2).times
+      expect(rdv.users.count).to eq(1)
+
       # On vérifie qu'on a bien enqueue au moins un job pour chacun des participations qu'on vient de supprimer.
       # Le job a pour seule référence le numéro de dossier et synchronise de manière intelligente l'état de l'appointment ANTS.
       expect(enqueued_jobs.pluck("arguments").map(&:first).pluck("ants_pre_demande_number").uniq).to include("1111111111", "3333333333")
+    end
+  end
+
+  describe "plusieurs usagers sont ajoutés à un RDV" do
+    let!(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let!(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
+    let!(:motif) { create(:motif, motif_category: create(:motif_category, :passeport), organisation:) }
+    let!(:user1) { create(:user, ants_pre_demande_number: "1111111111", organisations: [organisation]) }
+    let!(:user2) { create(:user, ants_pre_demande_number: "2222222222", organisations: [organisation]) }
+    let!(:user3) { create(:user, ants_pre_demande_number: "3333333333", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user1], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+
+    before do
+      # on nettoie les jobs déclenchés lors de la création du RDV
+      rdv.reload
+      clear_enqueued_jobs
+    end
+
+    it "informe l'ANTS que les RDVs avec ces usagers n'existent plus" do
+      # C'est bien via ce mécanisme (fourni par `accepts_nested_attributes_for`)
+      # que nous utilisons dans notre formulaire d'édition de RDV.
+      params_to_add_user_2_and_3 = {
+        participations_attributes: [
+          {
+            user_id: user2.id,
+            send_lifecycle_notifications: "0",
+            send_reminder_notification: "0",
+            _destroy: "false",
+          },
+          {
+            user_id: user3.id,
+            send_lifecycle_notifications: "1",
+            send_reminder_notification: "1",
+            _destroy: "false",
+          },
+        ],
+      }
+
+      expect(rdv.users.count).to eq(1)
+      expect { rdv.update_and_notify(rdv.agents.first, params_to_add_user_2_and_3) }.to have_enqueued_job(Ants::SyncAppointmentJob).at_least(2).times
+      expect(rdv.users.count).to eq(3)
+
+      # On vérifie qu'on a bien enqueue au moins un job pour chacun des participations qu'on vient d'ajouter.
+      expect(enqueued_jobs.pluck("arguments").map(&:first).pluck("ants_pre_demande_number").uniq).to include("2222222222", "3333333333")
     end
   end
 

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -433,6 +433,44 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     end
   end
 
+  describe "plusieurs usagers sont retirés d'un RDV" do
+    let!(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let!(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
+    let!(:motif) { create(:motif, motif_category: create(:motif_category, :passeport), organisation:) }
+    let!(:user1) { create(:user, ants_pre_demande_number: "1111111111", organisations: [organisation]) }
+    let!(:user2) { create(:user, ants_pre_demande_number: "2222222222", organisations: [organisation]) }
+    let!(:user3) { create(:user, ants_pre_demande_number: "3333333333", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user1, user2, user3], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+
+    before do
+      # on nettoie les jobs déclenchés lors de la création du RDV
+      rdv.reload
+      clear_enqueued_jobs
+    end
+
+    it "informe l'ANTS que les RDVs avec ces usagers n'existent plus" do
+      # C'est bien via ce mécanisme (fourni par `accepts_nested_attributes_for`)
+      # que nous utilisons dans notre formulaire d'édition de RDV.
+      params_to_destroy_participations_1_and_3 = {
+        participations_attributes: [
+          {
+            id: rdv.participations.where(user: user1).sole.id,
+            _destroy: true,
+          },
+          {
+            id: rdv.participations.where(user: user3).sole.id,
+            _destroy: true,
+          },
+        ],
+      }
+
+      expect { rdv.update_and_notify(rdv.agents.first, params_to_destroy_participations_1_and_3) }.to have_enqueued_job(Ants::SyncAppointmentJob).at_least(2).times
+      # On vérifie qu'on a bien enqueue au moins un job pour chacun des participations qu'on vient de supprimer.
+      # Le job a pour seule référence le numéro de dossier et synchronise de manière intelligente l'état de l'appointment ANTS.
+      expect(enqueued_jobs.pluck("arguments").map(&:first).pluck("ants_pre_demande_number").uniq).to include("1111111111", "3333333333")
+    end
+  end
+
   describe "un usager est retiré du RDV mais l’ANTS ne renvoie aucun appointment" do
     let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
     let(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }


### PR DESCRIPTION
En travaillant sur #5418, j'ai constaté le bug suivant : 

Dans `appointment_serializer_and_listener.rb:16`, dans le cas où nous ajoutons, modifions ou supprimons plusieurs participations à la fois (ça se fait très bien depuis l'interface web), alors le callback est appelé sur chaque participation, et vient écraser la valeur de `rdv.obsolete_ants_data` définie par le callback précédent ! :grimacing: 

Cela a pour conséquence de ne pas enqueue de job pour les numéros de dossiers qui se sont faits écraser. Ce n'est grave que dans le cas d'une suppression, car dans le cas d'une création / modification, des jobs sont enqueue pour tous les participants du RDV **après ma mise à jour faite** via cette ligne : https://github.com/betagouv/rdv-service-public/blob/a3152b1d3e7b54755cea8ec18053f5c2f22c81a0/app/models/concerns/ants/appointment_serializer_and_listener.rb#L69

C'est pourquoi c'est seulement dans le cas où des usagers sont retirés du RDV qu'il vient à manquer un job pour eux : ces usagers ne sont plus retournés par `rdv.users` dans la ligne de code pointée ci-dessus.