### PR TITLE
Spec to doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,10 @@ jobs:
           POSTGRES_USER: lapin_test
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
+          SURGE_LOGIN: victor@ahaoho.io
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+          UPLOAD_TO_SURGE: true
+          SPEC_TO_DOC: true
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,9 @@ jobs:
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
           UPLOAD_TO_SURGE: true
           SPEC_TO_DOC: true
+      - name: SpecToDoc upload to Surge
+        run: "ruby -e \"require_relative 'spec/support/spec_to_doc'; SpecToDoc.upload_to_surge\""
+        continue-on-error: true # On ne veut pas faire échouer le build si l'upload à surge échoue
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,12 +319,15 @@ jobs:
           POSTGRES_USER: lapin_test
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
-          SURGE_LOGIN: victor@ahaoho.io
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
           UPLOAD_TO_SURGE: true
       - name: SpecToDoc upload to Surge
         run: "ruby -e \"require_relative 'spec/support/spec_to_doc'; SpecToDoc.upload_to_surge\""
         continue-on-error: true # On ne veut pas faire échouer le build si l'upload à surge échoue
+        # if: ${{ github.ref == 'refs/heads/production' }}
+        env:
+          SURGE_LOGIN: victor@ahaoho.io
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+          UPLOAD_TO_SURGE: true
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
       - name: SpecToDoc upload to Surge
         run: "ruby -e \"require_relative 'spec/support/spec_to_doc'; SpecToDoc.upload_to_surge\""
         continue-on-error: true # On ne veut pas faire échouer le build si l'upload à surge échoue
-        # if: ${{ github.ref == 'refs/heads/production' }}
+        if: ${{ github.ref == 'refs/heads/production' }}
         env:
           SURGE_LOGIN: victor@ahaoho.io
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,10 @@ jobs:
         include:
           - dirname: agents
             command: "parallel:spec[spec/features/agents]"
+            name: agents
           - dirname: "*"
             command: "parallel:spec['spec/features/(?!agents)']"
+            name: other
     services:
       postgres:
         image: postgres
@@ -257,7 +259,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-capybara-${{ matrix.dirname }}
+          name: artifacts-capybara-${{ matrix.name }}
           path: tmp/capybara
           if-no-files-found: ignore
   test_boot_without_db:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,73 @@ jobs:
           POSTGRES_USER: lapin_test
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: artifacts-capybara-${{ matrix.name }}
+          path: tmp/capybara
+          if-no-files-found: ignore
+  test_features_spec_to_doc:
+    name: Feature Tests using spec to doc
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: lapin_test
+          POSTGRES_PASSWORD: lapin_test
+          POSTGRES_DB: lapin_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports: ["5432:5432"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: WitherZuo/set-timezone@v1.0.0
+        with:
+          timezoneLinux: "Europe/Paris"
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+      # TODO: Remove this workaround that specify the Chrome version used by the CI
+      # inspired by https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2731100953
+      # once the linked issue on selenium would have been fixed
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
+      - name: Setup stable Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 128
+          install-chromedriver: true
+          install-dependencies: true
+      - name: Set up Redis
+        uses: zhulik/redis-action@1.1.0
+      - name: Cache js dependencies
+        uses: actions/cache@v4
+        with:
+          key: node_modules-${{ hashFiles('yarn.lock') }}
+          path: node_modules
+      - name: Install JS dependencies
+        run: yarn install
+      - name: Precompile assets
+        run: yarn run build
+      - name: Setup parallel tests and run feature specs
+        run: RAILS_ENV=test bundle exec rake db:drop db:create db:load_schema; bundle exec rspec spec/features/spec_to_doc
+        env:
+          HOST: http://example.com
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: lapin_test
+          POSTGRES_PASSWORD: lapin_test
+          POSTGRES_DB: lapin_test
           SURGE_LOGIN: victor@ahaoho.io
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
           UPLOAD_TO_SURGE: true
@@ -261,9 +328,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-capybara-${{ matrix.name }}
+          name: artifacts-capybara-spec-to-doc
           path: tmp/capybara
-          if-no-files-found: ignore
   test_boot_without_db:
     name: Boot web server without database
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-capybara
+          name: artifacts-capybara-${{ matrix.dirname }}
           path: tmp/capybara
           if-no-files-found: ignore
   test_boot_without_db:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
       - name: Precompile assets
         run: yarn run build
       - name: Setup parallel tests and run feature specs
-        run: RAILS_ENV=test bundle exec rake db:drop db:create db:load_schema; bundle exec rspec spec/features/spec_to_doc
+        run: RAILS_ENV=test bundle exec rake db:drop db:create db:schema:load; bundle exec rspec spec/features/spec_to_doc
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
             command: "parallel:spec[spec/features/agents]"
             name: agents
           - dirname: "*"
-            command: "parallel:spec['spec/features/(?!agents)']"
+            command: "parallel:spec['spec/features/(?!(agents|spec_to_doc))']"
             name: other
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,6 @@ jobs:
           SURGE_LOGIN: victor@ahaoho.io
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
           UPLOAD_TO_SURGE: true
-          SPEC_TO_DOC: true
       - name: SpecToDoc upload to Surge
         run: "ruby -e \"require_relative 'spec/support/spec_to_doc'; SpecToDoc.upload_to_surge\""
         continue-on-error: true # On ne veut pas faire échouer le build si l'upload à surge échoue

--- a/app/views/super_admins/application/_navigation.html.erb
+++ b/app/views/super_admins/application/_navigation.html.erb
@@ -22,5 +22,9 @@ as defined by the routes in the `admin/` namespace
   <%= link_to "Ouverture de compte", new_super_admins_compte_path, class: "navigation__link"%>
   <%= link_to "Demandes d'ouverture d'espace", super_admins_territory_creation_requests_path, class: "navigation__link"%>
 
+  <hr />
   <%= link_to "Good Job", super_admins_good_job_path, class: "navigation__link" if current_super_admin.legacy_admin_member?%>
+
+  <hr />
+  <%= link_to "Documentation interne", "https://rdv-service-public-production.surge.sh/", class: "navigation__link" %>
 </nav>

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prettier": "3.3.2",
     "sass": "^1.51.0",
     "sass-loader": "^12.6.0",
+    "surge": "^0.24.6",
     "webpack": "^5.94.0",
     "webpack-cli": "^4.9.2"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prettier": "3.3.2",
     "sass": "^1.51.0",
     "sass-loader": "^12.6.0",
-    "surge": "^0.24.6",
+    "surge": "victormours/surge",
     "webpack": "^5.94.0",
     "webpack-cli": "^4.9.2"
   },

--- a/spec/features/spec_to_doc/creation_espace_spec.rb
+++ b/spec/features/spec_to_doc/creation_espace_spec.rb
@@ -1,10 +1,13 @@
 # Ce fichier reprend l'idée d'une doc swagger, mais pour communiquer à l'équipe non tech
-RSpec.describe "Ouverture d'un espace", js: true do
+RSpec.describe "Ouverture d'un espace", js: true, spec_to_doc: true do
   let!(:agent) { create(:agent, :no_services, first_name: "Francis", last_name: "Factice", password: "c0rrecThorse!") }
+
+  around { |example| perform_enqueued_jobs { example.run } }
 
   specify do
     doc = SpecToDoc.start_scenario("Ouverture d'un espace", self)
 
+    doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")
 
     visit "http://www.rdv-mairie-test.localhost/"
@@ -42,5 +45,50 @@ RSpec.describe "Ouverture d'un espace", js: true do
     doc.add_screenshot(page,
                        text: "L'équipe déploiement a ensuite reçu la demande de création de compte dans le super admin",
                        wait_for: "Votre demande a bien été enregistrée.")
+
+    doc.start_section("Côté super admin")
+
+    super_admin = create :super_admin
+
+    create(:service, name: "Service social")
+
+    login_as(super_admin, scope: :super_admin)
+
+    visit super_admins_territory_creation_requests_url(host: "http://www.rdv-mairie-test.localhost")
+
+    doc.add_screenshot(page,
+                       text: "Je consulte la liste des demandes d'ouverture d'espace",
+                       wait_for: "Commune de Montreuil")
+
+    click_on "Commune de Montreuil"
+
+    doc.add_screenshot(page,
+                       text: "J'examine la demande. C'est à cette étape que je peux avoir des informations sur des doublons potentiels",
+                       wait_for: "Accepter")
+
+    click_on "Accepter"
+
+    select "Commune", from: "Catégorie de l'espace"
+
+    select "Service social", from: "Service"
+    doc.add_screenshot(page,
+                       text: "Je remplis le formulaire puis je valide")
+
+    click_on "Enregistrer"
+
+    doc.add_screenshot(page,
+                       text: "J'ai un message de confirmation",
+                       wait_for: "Le nouvel espace a été créé")
+
+    doc.start_section("Côté agent")
+    open_email(agent.email)
+    expect(current_email.subject).to eq "Votre espace RDV Service Public est ouvert 🚀"
+
+    doc.add_screenshot(current_email, text: "J'ai un message de confirmation. Je clique sur le cta principal")
+
+    current_email.click_on "Accéder à mon espace"
+
+    doc.add_screenshot(page,
+                       text: "J'arrive dans mon espace")
   end
 end

--- a/spec/features/spec_to_doc/creation_espace_spec.rb
+++ b/spec/features/spec_to_doc/creation_espace_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     doc = SpecToDoc.start_scenario("Ouverture d'un espace", self)
 
     doc.start_section("Côté agent")
-    doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public.")
+    doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")
 
     visit "http://www.rdv-mairie-test.localhost/"
     doc.add_screenshot(page,

--- a/spec/features/spec_to_doc/creation_espace_spec.rb
+++ b/spec/features/spec_to_doc/creation_espace_spec.rb
@@ -7,29 +7,24 @@ RSpec.describe "Ouverture d'un espace", js: true do
 
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")
 
-    doc.add_text("Je me rends sur la page d'accueil")
     visit "http://www.rdv-mairie-test.localhost/"
-    doc.add_screenshot(page, wait_for: "Créer un espace")
+    doc.add_screenshot(page,
+                       text: "Je clique sur 'Créer un espace'",
+                       wait_for: "Créer un espace")
 
-    doc.add_text("Je clique sur 'Créer un espace'")
     click_on "Créer un espace"
-
-    doc.add_spacing
-
-    doc.add_screenshot(page, wait_for: "Connexion agent à")
-
-    doc.add_text("Je me ProConnecte.")
-    doc.add_spacing
+    doc.add_screenshot(page,
+                       text: "Je me ProConnecte.",
+                       wait_for: "Connexion agent à")
 
     # ProConnect ne marche pas en tests, donc on utilise l'email et le mot de passe
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"
 
-    doc.add_screenshot(page, wait_for: "Pour commencer, aidez-nous à en savoir plus")
-
-    doc.add_text("Je clique sur Demander à ouvrir un espace")
-    doc.add_spacing
+    doc.add_screenshot(page,
+                       text: "Je clique sur Demander à ouvrir un espace",
+                       wait_for: "Pour commencer, aidez-nous à en savoir plus")
 
     click_on "Demander à ouvrir un espace"
 
@@ -39,17 +34,13 @@ RSpec.describe "Ouverture d'un espace", js: true do
     fill_in("Nom de votre première organisation", with: "CCAS de Montreuil")
     fill_in("Pour quel service souhaitez-vous gérer des rendez-vous ?", with: "Action Sociale")
 
-    doc.add_text("Je remplis le formulaire puis je valide")
-    doc.add_spacing
-
-    doc.add_screenshot(page)
-
-    doc.add_spacing
+    doc.add_screenshot(page,
+                       text: "Je remplis le formulaire puis je valide")
 
     click_on "Envoyer la demande"
 
-    doc.add_screenshot(page, wait_for: "Votre demande a bien été enregistrée.")
-
-    doc.add_text("L'équipe déploiement a ensuite reçu la demande de création de compte dans le super admin")
+    doc.add_screenshot(page,
+                       text: "L'équipe déploiement a ensuite reçu la demande de création de compte dans le super admin",
+                       wait_for: "Votre demande a bien été enregistrée.")
   end
 end

--- a/spec/features/spec_to_doc/creation_espace_spec.rb
+++ b/spec/features/spec_to_doc/creation_espace_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     doc = SpecToDoc.start_scenario("Ouverture d'un espace", self)
 
     doc.start_section("Côté agent")
-    doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")
+    doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public.")
 
     visit "http://www.rdv-mairie-test.localhost/"
     doc.add_screenshot(page,

--- a/spec/features/spec_to_doc/creation_espace_spec.rb
+++ b/spec/features/spec_to_doc/creation_espace_spec.rb
@@ -1,21 +1,55 @@
 # Ce fichier reprend l'idée d'une doc swagger, mais pour communiquer à l'équipe non tech
-RSpec.describe "Ouverture d'un espace" do
+RSpec.describe "Ouverture d'un espace", js: true do
+  let!(:agent) { create(:agent, :no_services, first_name: "Francis", last_name: "Factice", password: "c0rrecThorse!") }
+
   specify do
-    Capybara.current_driver = :desktop
+    doc = SpecToDoc.start_scenario("Ouverture d'un espace", self)
 
-    scenar = SpecToDoc.build_scenario(self.class.top_level_description)
-    scenar.add_text("Pour un agent qui se crée un compte")
+    doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")
 
+    doc.add_text("Je me rends sur la page d'accueil")
     visit "http://www.rdv-mairie-test.localhost/"
-    scenar.add_screenshot(page)
+    doc.add_screenshot(page, wait_for: "Créer un espace")
 
-    scenar.add_text("Cliquer sur 'Créer un espace'")
+    doc.add_text("Je clique sur 'Créer un espace'")
     click_on "Créer un espace"
-    expect(page).to have_content("Connexion agent à")
-    scenar.add_screenshot(page)
 
-    scenar.add_text("Se connecter via ProConnect")
+    doc.add_spacing
 
-    SpecToDoc.render
+    doc.add_screenshot(page, wait_for: "Connexion agent à")
+
+    doc.add_text("Je me ProConnecte.")
+    doc.add_spacing
+
+    # ProConnect ne marche pas en tests, donc on utilise l'email et le mot de passe
+    fill_in "Adresse email", with: agent.email
+    fill_in "Mot de passe", with: agent.password
+    click_on "Se connecter"
+
+    doc.add_screenshot(page, wait_for: "Pour commencer, aidez-nous à en savoir plus")
+
+    doc.add_text("Je clique sur Demander à ouvrir un espace")
+    doc.add_spacing
+
+    click_on "Demander à ouvrir un espace"
+
+    doc.add_screenshot(page, wait_for: "Nom de")
+
+    fill_in("Nom de l’espace", with: "Commune de Montreuil")
+    fill_in("Nom de votre première organisation", with: "CCAS de Montreuil")
+    fill_in("Pour quel service souhaitez-vous gérer des rendez-vous ?", with: "Action Sociale")
+
+    doc.add_text("Je remplis le formulaire puis je valide")
+    doc.add_spacing
+
+    doc.add_screenshot(page)
+
+    doc.add_spacing
+
+    click_on "Envoyer la demande"
+
+    doc.add_screenshot(page, wait_for: "Votre demande a bien été enregistrée.")
+
+    doc.add_text("L'équipe déploiement a ensuite reçu la demande de création de compte dans le super admin")
   end
 end

--- a/spec/features/spec_to_doc/creation_espace_spec.rb
+++ b/spec/features/spec_to_doc/creation_espace_spec.rb
@@ -1,0 +1,17 @@
+# Ce fichier reprend l'idée d'une doc swagger, mais pour communiquer à l'équiep non tech
+RSpec.describe "Ouverture d'un espace" do
+  specify do
+    scenar = SpecToDoc::Scenario.new(self.class.top_level_description)
+    scenar.add_step("Pour un agent qui se crée un compte")
+
+    visit "/"
+    scenar.add_screenshot
+
+    scenar.add_step("Cliquer sur 'Créer un espace'")
+    click_on "Créer un espace"
+    sleep 0.2
+    scenar.add_screenshot
+
+    scenar.add_step("Se connecter via ProConnect")
+  end
+end

--- a/spec/features/spec_to_doc/creation_espace_spec.rb
+++ b/spec/features/spec_to_doc/creation_espace_spec.rb
@@ -1,5 +1,6 @@
-# Ce fichier reprend l'idée d'une doc swagger, mais pour communiquer à l'équipe non tech
-RSpec.describe "Ouverture d'un espace", js: true, spec_to_doc: true do
+# Les captures d'écran des emails dans spec_to_doc causent des erreurs JS à cause d'images qui ne chargent pas correctement
+# donc on désactive cette vérification pour ces specs
+RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
   let!(:agent) { create(:agent, :no_services, first_name: "Francis", last_name: "Factice", password: "c0rrecThorse!") }
 
   around { |example| perform_enqueued_jobs { example.run } }

--- a/spec/features/spec_to_doc/creation_espace_spec.rb
+++ b/spec/features/spec_to_doc/creation_espace_spec.rb
@@ -1,17 +1,21 @@
-# Ce fichier reprend l'idée d'une doc swagger, mais pour communiquer à l'équiep non tech
+# Ce fichier reprend l'idée d'une doc swagger, mais pour communiquer à l'équipe non tech
 RSpec.describe "Ouverture d'un espace" do
   specify do
-    scenar = SpecToDoc::Scenario.new(self.class.top_level_description)
-    scenar.add_step("Pour un agent qui se crée un compte")
+    Capybara.current_driver = :desktop
 
-    visit "/"
-    scenar.add_screenshot
+    scenar = SpecToDoc.build_scenario(self.class.top_level_description)
+    scenar.add_text("Pour un agent qui se crée un compte")
 
-    scenar.add_step("Cliquer sur 'Créer un espace'")
+    visit "http://www.rdv-mairie-test.localhost/"
+    scenar.add_screenshot(page)
+
+    scenar.add_text("Cliquer sur 'Créer un espace'")
     click_on "Créer un espace"
-    sleep 0.2
-    scenar.add_screenshot
+    expect(page).to have_content("Connexion agent à")
+    scenar.add_screenshot(page)
 
-    scenar.add_step("Se connecter via ProConnect")
+    scenar.add_text("Se connecter via ProConnect")
+
+    SpecToDoc.render
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -105,6 +105,12 @@ RSpec.configure do |config|
     end
   end
 
+  config.after(:suite) do
+    if ENV["SPEC_TO_DOC"]
+      SpecToDoc.render
+    end
+  end
+
   config.before do
     setup_sentry_test
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -105,11 +105,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.after(:suite) do
-    if ENV["SPEC_TO_DOC"]
-      SpecToDoc.render
-    end
-  end
+  config.after(:suite) { SpecToDoc.render }
 
   config.before do
     setup_sentry_test

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -40,6 +40,8 @@ if ENV["HEADLESS"] == "false"
 end
 
 RSpec.configure do |config|
+  # Les captures d'écran des emails dans spec_to_doc causent des erreurs JS à cause d'images qui ne chargent pas correctement
+  # donc on désactive cette vérification pour ces specs
   config.after(:each, js: true, spec_to_doc: nil) do
     logs = page.driver.browser.logs.get(:browser)
     aggregate_failures "javascript errors" do

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -40,9 +40,7 @@ if ENV["HEADLESS"] == "false"
 end
 
 RSpec.configure do |config|
-  # Les captures d'écran des emails dans spec_to_doc causent des erreurs JS à cause d'images qui ne chargent pas correctement
-  # donc on désactive cette vérification pour ces specs
-  config.after(:each, js: true, spec_to_doc: nil) do
+  config.after(:each, ignore_js_errors: nil, js: true) do
     logs = page.driver.browser.logs.get(:browser)
     aggregate_failures "javascript errors" do
       logs.each do |log|

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -40,7 +40,7 @@ if ENV["HEADLESS"] == "false"
 end
 
 RSpec.configure do |config|
-  config.after(:each, js: true) do
+  config.after(:each, js: true, spec_to_doc: nil) do
     logs = page.driver.browser.logs.get(:browser)
     aggregate_failures "javascript errors" do
       logs.each do |log|

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -25,6 +25,15 @@ class SpecToDoc
       ]
       ).join("<br />")
     )
+
+    if ENV["UPLOAD_TO_SURGE"]
+      branch_name = `git rev-parse --abbrev-ref HEAD`.strip
+      domain_name = "rdv-service-public-#{branch_name}.surge.sh"
+      puts "running yarn run surge tmp/capybara/spec_to_doc #{domain_name}"
+      `yarn run surge tmp/capybara/spec_to_doc #{domain_name}`
+
+      puts "La documentation est disponible sur https://#{domain_name}"
+    end
   end
 
   class Scenario
@@ -49,7 +58,8 @@ class SpecToDoc
       path = Rails.root.join("tmp/capybara/spec_to_doc/#{filename}")
       page.driver.browser.save_screenshot(path)
 
-      @steps << "<img src=#{path} width=800 style='border: solid 2px grey'/>"
+      img_src = ENV["UPLOAD_TO_SURGE"] ? "/#{filename}" : path
+      @steps << "<img src='#{img_src}' width=800 style='border: solid 2px grey'/>"
     end
 
     def add_spacing

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -2,7 +2,7 @@ class SpecToDoc
   @scenarios = []
 
   def self.start_scenario(title, example)
-    scenario = Scenario.new(title, @scenarios.length, example)
+    scenario = Scenario.new(title, example)
     @scenarios << scenario
     scenario
   end
@@ -10,8 +10,8 @@ class SpecToDoc
   def self.render
     `mkdir -p tmp/capybara/spec_to_doc`
 
-    @scenarios.each.with_index do |scenario, i|
-      Rails.root.join("tmp/capybara/spec_to_doc/scenario_#{i}.html").write(
+    @scenarios.each do |scenario|
+      Rails.root.join("tmp/capybara/spec_to_doc/scenario_#{scenario.index}.html").write(
         Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/layout.html.slim")).render(scenario) do
           Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/scenario.html.slim")).render(scenario).html_safe # rubocop:disable Rails/OutputSafety
         end
@@ -38,15 +38,15 @@ class SpecToDoc
   end
 
   class Scenario
-    def initialize(title, index, example)
+    def initialize(title, example)
       @title = title
-      @index = index
+      @index = Digest::SHA1.hexdigest(title)[0..8]
       @example = example
       @sections = []
       @current_section = nil
     end
 
-    attr_reader :title
+    attr_reader :title, :index
 
     def start_section(title)
       @current_section = Section.new(title)

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -9,7 +9,11 @@ class SpecToDoc
     `mkdir -p tmp/capybara/spec_to_doc`
 
     @scenarios.values.each.with_index do |scenario, i|
-      Rails.root.join("tmp/capybara/spec_to_doc/scenario_#{i}.html").write(scenario.render)
+      Rails.root.join("tmp/capybara/spec_to_doc/scenario_#{i}.html").write(
+        Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/layout.html.slim")).render(scenario) do
+          Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/scenario.html.slim")).render(scenario).html_safe # rubocop:disable Rails/OutputSafety
+        end
+      )
     end
 
     Rails.root.join("tmp/capybara/spec_to_doc/index.html").write(
@@ -33,36 +37,56 @@ class SpecToDoc
       @title = title
       @index = index
       @example = example
-      @steps = []
+      @sections = []
+      @current_section = nil
+    end
+
+    def start_section(title)
+      @current_section = Section.new(title)
+      @sections << @current_section
     end
 
     def add_text(description)
-      @steps << {
+      @current_section.steps << {
         text: description,
       }
     end
 
-    def add_screenshot(page, text: nil, wait_for: nil)
+    def add_screenshot(page_or_email, text: nil, wait_for: nil)
       if wait_for
-        @example.expect(page).to(@example.have_content(wait_for))
+        @example.expect(page_or_email).to(@example.have_content(wait_for))
       end
 
-      filename = "scenario_#{@index}_step_#{@steps.count}.png"
+      filename = "scenario_#{@index}_section_#{@sections.count}_step_#{@current_section.steps.count}.png"
       `mkdir -p tmp/capybara/spec_to_doc`
 
       path = Rails.root.join("tmp/capybara/spec_to_doc/#{filename}")
 
-      page.driver.browser.save_screenshot(path)
+      if page_or_email.is_a?(Capybara::Node::Email)
+        Capybara.current_session.driver.visit "file://#{page_or_email.save_page}"
+        Capybara.current_session.driver.browser.save_screenshot(path)
+      else
+        page_or_email.driver.browser.save_screenshot(path)
+      end
 
       img_src = ENV["UPLOAD_TO_SURGE"] ? "/#{filename}" : path
 
-      @steps << { text: text, img_src: img_src }
+      @current_section.steps << { text: text, img_src: img_src }
     end
 
-    def render
-      Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/layout.html.slim")).render(self) do
-        Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/scenario.html.slim")).render(self).html_safe # rubocop:disable Rails/OutputSafety
-      end
+    def add_email(email, text: nil)
+      File.read(email.save_page)
+      visit "data:text/html,#{email.body}"
+      @current_section.steps << { text: text, email_html: email.body }
     end
+  end
+
+  class Section
+    def initialize(title)
+      @title = title
+      @steps = []
+    end
+
+    attr_accessor :title, :steps
   end
 end

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -6,24 +6,16 @@ class SpecToDoc
   end
 
   def self.render
-    rendered_scenarios = @scenarios.values.map(&:render)
-
     `mkdir -p tmp/capybara/spec_to_doc`
-    rendered_scenarios.each.with_index do |scenario_content, i|
-      Rails.root.join("tmp/capybara/spec_to_doc/scenario_#{i}.html").write(scenario_content)
+
+    @scenarios.values.each.with_index do |scenario, i|
+      Rails.root.join("tmp/capybara/spec_to_doc/scenario_#{i}.html").write(scenario.render)
     end
 
     Rails.root.join("tmp/capybara/spec_to_doc/index.html").write(
-      (
-        [
-          "Cette page documente différentes fonctionnalités de RDV Service Public",
-        ] +
-      @scenarios.keys.map.with_index.map do |title, i|
-        "<a href='scenario_#{i}.html'>#{title}</a>"
-      end + [
-        "Dernière mise à jour le #{I18n.l(Time.zone.now)}",
-      ]
-      ).join("<br />")
+      Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/layout.html.slim")).render(self) do
+        Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/index.html.slim")).render(self).html_safe # rubocop:disable Rails/OutputSafety
+      end
     )
 
     if ENV["UPLOAD_TO_SURGE"]
@@ -45,29 +37,32 @@ class SpecToDoc
     end
 
     def add_text(description)
-      @steps << "<p>#{description}</p>"
+      @steps << {
+        text: description,
+      }
     end
 
-    def add_screenshot(page, wait_for: nil)
+    def add_screenshot(page, text: nil, wait_for: nil)
       if wait_for
         @example.expect(page).to(@example.have_content(wait_for))
       end
 
       filename = "scenario_#{@index}_step_#{@steps.count}.png"
       `mkdir -p tmp/capybara/spec_to_doc`
+
       path = Rails.root.join("tmp/capybara/spec_to_doc/#{filename}")
+
       page.driver.browser.save_screenshot(path)
 
       img_src = ENV["UPLOAD_TO_SURGE"] ? "/#{filename}" : path
-      @steps << "<img src='#{img_src}' width=800 style='border: solid 2px grey'/>"
-    end
 
-    def add_spacing
-      @steps << "<div style='margin-top: 64px'></div>"
+      @steps << { text: text, img_src: img_src }
     end
 
     def render
-      @steps.join("\n")
+      Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/layout.html.slim")).render(self) do
+        Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/scenario.html.slim")).render(self).html_safe # rubocop:disable Rails/OutputSafety
+      end
     end
   end
 end

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -1,16 +1,8 @@
-Capybara.register_driver :desktop do |capybara_app|
-  Capybara::Selenium::Driver.new(
-    capybara_app,
-    browser: :firefox,
-    options: Selenium::WebDriver::Firefox::Options.new(args: %w[--headless --width=1280 --height=1024])
-  )
-end
-
 class SpecToDoc
   @scenarios = {}
 
-  def self.build_scenario(title)
-    @scenarios[title] = Scenario.new(title, @scenarios.length)
+  def self.start_scenario(title, example)
+    @scenarios[title] = Scenario.new(title, @scenarios.length, example)
   end
 
   def self.render
@@ -22,39 +14,50 @@ class SpecToDoc
     end
 
     Rails.root.join("tmp/capybara/spec_to_doc/index.html").write(
+      (
+        [
+          "Cette page documente différentes fonctionnalités de RDV Service Public",
+        ] +
       @scenarios.keys.map.with_index.map do |title, i|
         "<a href='scenario_#{i}.html'>#{title}</a>"
-      end.join("<br />")
+      end + [
+        "Dernière mise à jour le #{I18n.l(Time.zone.now)}",
+      ]
+      ).join("<br />")
     )
   end
 
   class Scenario
-    def initialize(title, index)
+    def initialize(title, index, example)
       @title = title
       @index = index
+      @example = example
       @steps = []
     end
 
     def add_text(description)
-      @steps << description
+      @steps << "<p>#{description}</p>"
     end
 
-    def add_screenshot(page)
+    def add_screenshot(page, wait_for: nil)
+      if wait_for
+        @example.expect(page).to(@example.have_content(wait_for))
+      end
+
       filename = "scenario_#{@index}_step_#{@steps.count}.png"
       `mkdir -p tmp/capybara/spec_to_doc`
       path = Rails.root.join("tmp/capybara/spec_to_doc/#{filename}")
-      @steps << { screenshot_path: path }
       page.driver.browser.save_screenshot(path)
+
+      @steps << "<img src=#{path} width=800 style='border: solid 2px grey'/>"
+    end
+
+    def add_spacing
+      @steps << "<div style='margin-top: 64px'></div>"
     end
 
     def render
-      @steps.map do |step|
-        if step.is_a?(String)
-          "<p>#{step}</p>"
-        else
-          "<img src=#{step[:screenshot_path]} width=800 style='border: solid 2px grey'/>"
-        end
-      end.join("\n")
+      @steps.join("\n")
     end
   end
 end

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -26,6 +26,9 @@ class SpecToDoc
   end
 
   def self.upload_to_surge
+    files_to_upload = `ls tmp/capybara/spec_to_doc`
+    return unless files_to_upload["index.html"]
+
     branch_name = `git rev-parse --abbrev-ref HEAD`.strip
     domain_name = "rdv-service-public-#{branch_name}.surge.sh"
     puts "running yarn run surge tmp/capybara/spec_to_doc #{domain_name}"

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -1,0 +1,60 @@
+Capybara.register_driver :desktop do |capybara_app|
+  Capybara::Selenium::Driver.new(
+    capybara_app,
+    browser: :firefox,
+    options: Selenium::WebDriver::Firefox::Options.new(args: %w[--headless --width=1280 --height=1024])
+  )
+end
+
+class SpecToDoc
+  @scenarios = {}
+
+  def self.build_scenario(title)
+    @scenarios[title] = Scenario.new(title, @scenarios.length)
+  end
+
+  def self.render
+    rendered_scenarios = @scenarios.values.map(&:render)
+
+    `mkdir -p tmp/capybara/spec_to_doc`
+    rendered_scenarios.each.with_index do |scenario_content, i|
+      Rails.root.join("tmp/capybara/spec_to_doc/scenario_#{i}.html").write(scenario_content)
+    end
+
+    Rails.root.join("tmp/capybara/spec_to_doc/index.html").write(
+      @scenarios.keys.map.with_index.map do |title, i|
+        "<a href='scenario_#{i}.html'>#{title}</a>"
+      end.join("<br />")
+    )
+  end
+
+  class Scenario
+    def initialize(title, index)
+      @title = title
+      @index = index
+      @steps = []
+    end
+
+    def add_text(description)
+      @steps << description
+    end
+
+    def add_screenshot(page)
+      filename = "scenario_#{@index}_step_#{@steps.count}.png"
+      `mkdir -p tmp/capybara/spec_to_doc`
+      path = Rails.root.join("tmp/capybara/spec_to_doc/#{filename}")
+      @steps << { screenshot_path: path }
+      page.driver.browser.save_screenshot(path)
+    end
+
+    def render
+      @steps.map do |step|
+        if step.is_a?(String)
+          "<p>#{step}</p>"
+        else
+          "<img src=#{step[:screenshot_path]} width=800 style='border: solid 2px grey'/>"
+        end
+      end.join("\n")
+    end
+  end
+end

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -22,7 +22,7 @@ class SpecToDoc
       end
     )
 
-    if ENV["UPLOAD_TO_SURGE"]
+    if ENV["UPLOAD_TO_SURGE"] && @scenarios.any?
       branch_name = `git rev-parse --abbrev-ref HEAD`.strip
       domain_name = "rdv-service-public-#{branch_name}.surge.sh"
       puts "running yarn run surge tmp/capybara/spec_to_doc #{domain_name}"

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -1,14 +1,16 @@
 class SpecToDoc
-  @scenarios = {}
+  @scenarios = []
 
   def self.start_scenario(title, example)
-    @scenarios[title] = Scenario.new(title, @scenarios.length, example)
+    scenario = Scenario.new(title, @scenarios.length, example)
+    @scenarios << scenario
+    scenario
   end
 
   def self.render
     `mkdir -p tmp/capybara/spec_to_doc`
 
-    @scenarios.values.each.with_index do |scenario, i|
+    @scenarios.each.with_index do |scenario, i|
       Rails.root.join("tmp/capybara/spec_to_doc/scenario_#{i}.html").write(
         Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/layout.html.slim")).render(scenario) do
           Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/scenario.html.slim")).render(scenario).html_safe # rubocop:disable Rails/OutputSafety
@@ -41,6 +43,8 @@ class SpecToDoc
       @current_section = nil
     end
 
+    attr_reader :title
+
     def start_section(title)
       @current_section = Section.new(title)
       @sections << @current_section
@@ -72,12 +76,6 @@ class SpecToDoc
       img_src = ENV["UPLOAD_TO_SURGE"] ? "/#{filename}" : path
 
       @current_section.steps << { text: text, img_src: img_src }
-    end
-
-    def add_email(email, text: nil)
-      File.read(email.save_page)
-      visit "data:text/html,#{email.body}"
-      @current_section.steps << { text: text, email_html: email.body }
     end
   end
 

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -23,15 +23,15 @@ class SpecToDoc
         Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/index.html.slim")).render(self).html_safe # rubocop:disable Rails/OutputSafety
       end
     )
+  end
 
-    if ENV["UPLOAD_TO_SURGE"] && @scenarios.any?
-      branch_name = `git rev-parse --abbrev-ref HEAD`.strip
-      domain_name = "rdv-service-public-#{branch_name}.surge.sh"
-      puts "running yarn run surge tmp/capybara/spec_to_doc #{domain_name}"
-      `yarn run surge tmp/capybara/spec_to_doc #{domain_name}`
+  def self.upload_to_surge
+    branch_name = `git rev-parse --abbrev-ref HEAD`.strip
+    domain_name = "rdv-service-public-#{branch_name}.surge.sh"
+    puts "running yarn run surge tmp/capybara/spec_to_doc #{domain_name}"
+    `yarn run surge tmp/capybara/spec_to_doc #{domain_name}`
 
-      puts "La documentation est disponible sur https://#{domain_name}"
-    end
+    puts "La documentation est disponible sur https://#{domain_name}"
   end
 
   class Scenario
@@ -51,9 +51,7 @@ class SpecToDoc
     end
 
     def add_text(description)
-      @current_section.steps << {
-        text: description,
-      }
+      @current_section.steps << { text: description }
     end
 
     def add_screenshot(page_or_email, text: nil, wait_for: nil)

--- a/spec/support/spec_to_doc/index.html.slim
+++ b/spec/support/spec_to_doc/index.html.slim
@@ -1,0 +1,8 @@
+h1 Documentation
+
+p Cette page documente différentes fonctionnalités de RDV Service Public
+
+- @scenarios.keys.each.with_index do |title, i|
+  a[href='scenario_#{i}.html'] #{title}
+
+p Dernière mise à jour le #{I18n.l(Time.zone.now)}

--- a/spec/support/spec_to_doc/index.html.slim
+++ b/spec/support/spec_to_doc/index.html.slim
@@ -2,7 +2,7 @@ h1 Documentation
 
 p Cette page documente différentes fonctionnalités de RDV Service Public
 
-- @scenarios.each.with_index do |scenario, i|
-  a[href='scenario_#{i}.html'] #{scenario.title}
+- @scenarios.each do |scenario|
+  a[href='scenario_#{scenario.index}.html'] #{scenario.title}
 
 p Dernière mise à jour le #{I18n.l(Time.zone.now)}

--- a/spec/support/spec_to_doc/index.html.slim
+++ b/spec/support/spec_to_doc/index.html.slim
@@ -2,7 +2,7 @@ h1 Documentation
 
 p Cette page documente différentes fonctionnalités de RDV Service Public
 
-- @scenarios.keys.each.with_index do |title, i|
-  a[href='scenario_#{i}.html'] #{title}
+- @scenarios.each.with_index do |scenario, i|
+  a[href='scenario_#{i}.html'] #{scenario.title}
 
 p Dernière mise à jour le #{I18n.l(Time.zone.now)}

--- a/spec/support/spec_to_doc/index.html.slim
+++ b/spec/support/spec_to_doc/index.html.slim
@@ -2,7 +2,9 @@ h1 Documentation
 
 p Cette page documente différentes fonctionnalités de RDV Service Public
 
+ul
 - @scenarios.each do |scenario|
-  a[href='scenario_#{scenario.index}.html'] #{scenario.title}
+  li
+    a[href='scenario_#{scenario.index}.html'] #{scenario.title}
 
 p Dernière mise à jour le #{I18n.l(Time.zone.now)}

--- a/spec/support/spec_to_doc/layout.html.slim
+++ b/spec/support/spec_to_doc/layout.html.slim
@@ -1,0 +1,4 @@
+head
+  link href="https://unpkg.com/@gouvfr/dsfr@1.13.2/dist/dsfr.min.css" rel="stylesheet"
+body
+  = yield

--- a/spec/support/spec_to_doc/scenario.html.slim
+++ b/spec/support/spec_to_doc/scenario.html.slim
@@ -2,9 +2,7 @@
   a[href="index.html"] retour
   h1 = @title
   - @sections.each.with_index do |section, index|
-    h2
-      = "#{index +1}) "
-      = section.title
+    h2 = "#{index +1}) #{section.title}"
     div[style="display: flex"]
       - section.steps.each do |step|
         div[style="padding: 8px; display: flex; flex-direction: column; align-items: center"]

--- a/spec/support/spec_to_doc/scenario.html.slim
+++ b/spec/support/spec_to_doc/scenario.html.slim
@@ -1,10 +1,19 @@
-h1 = @title
-div[style="display: flex"]
-  - @steps.each do |step|
-    div[style="padding: 8px; display: flex; flex-direction: column; align-items: center"]
-      - if step[:img_src]
-        img[src='#{step[:img_src]}' width=800 style='border: solid 2px grey']
-        - if step[:text]
-          p = step[:text]
-      - else
-        p[style="min-width: 300px"] = step[:text]
+.fr-m-2w
+  a[href="index.html"] retour
+  h1 = @title
+  - @sections.each.with_index do |section, index|
+    h2
+      = "#{index +1}) "
+      = section.title
+    div[style="display: flex"]
+      - section.steps.each do |step|
+        div[style="padding: 8px; display: flex; flex-direction: column; align-items: center"]
+          - if step[:email_html]
+            div = "This step has an email content"
+          /  div = step[:email_html].html_safe # rubocop:disable Rails/OutputSafety
+          - if step[:img_src]
+            img[src='#{step[:img_src]}' width=800 style='border: solid 2px grey']
+            - if step[:text]
+              p.fr-mt-2w = step[:text]
+          - else
+            p[style="min-width: 300px"] = step[:text]

--- a/spec/support/spec_to_doc/scenario.html.slim
+++ b/spec/support/spec_to_doc/scenario.html.slim
@@ -1,0 +1,10 @@
+h1 = @title
+div[style="display: flex"]
+  - @steps.each do |step|
+    div[style="padding: 8px; display: flex; flex-direction: column; align-items: center"]
+      - if step[:img_src]
+        img[src='#{step[:img_src]}' width=800 style='border: solid 2px grey']
+        - if step[:text]
+          p = step[:text]
+      - else
+        p[style="min-width: 300px"] = step[:text]

--- a/spec/support/spec_to_doc/scenario.html.slim
+++ b/spec/support/spec_to_doc/scenario.html.slim
@@ -8,9 +8,6 @@
     div[style="display: flex"]
       - section.steps.each do |step|
         div[style="padding: 8px; display: flex; flex-direction: column; align-items: center"]
-          - if step[:email_html]
-            div = "This step has an email content"
-          /  div = step[:email_html].html_safe # rubocop:disable Rails/OutputSafety
           - if step[:img_src]
             img[src='#{step[:img_src]}' width=800 style='border: solid 2px grey']
             - if step[:text]

--- a/yarn.lock
+++ b/yarn.lock
@@ -341,7 +341,7 @@ ajv-keywords@^5.0.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.12.5:
+ajv@^6.12.3, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -361,6 +361,11 @@ ajv@^8.0.0, ajv@^8.8.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
@@ -369,6 +374,23 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+asn1@~0.2.3:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
+  dependencies:
+    safer-buffer "~2.1.0"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 autocomplete.js@^0.37.1:
   version "0.37.1"
   resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.37.1.tgz#a29a048d827e7d2bf8f7df8b831766e5cc97df01"
@@ -376,15 +398,55 @@ autocomplete.js@^0.37.1:
   dependencies:
     immediate "^3.2.3"
 
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
+
+aws4@^1.8.0:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
+  integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
+
+axios@1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.3.tgz#a1125f2faf702bc8e8f2104ec3a76fab40257d85"
+  integrity sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
+babar@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/babar/-/babar-0.2.3.tgz#25690d918deea4a4b6ea7909df9e76eb80f558c8"
+  integrity sha512-1hmYKLj+7m5qHsJ3hosOlO7Z5BYe3E8u9u/W2BEqB4kytysuHYuGe5OIrEr7q4Zyg3y3EytFb4YrPZokYSix8g==
+  dependencies:
+    colors "~1.4.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
+  dependencies:
+    tweetnacl "^0.14.3"
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+block-stream@*:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  integrity sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==
+  dependencies:
+    inherits "~2.0.0"
 
 bootstrap@^4.3.1:
   version "4.6.1"
@@ -403,6 +465,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
+  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@~3.0.2:
   version "3.0.3"
@@ -426,10 +495,23 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
 caniuse-lite@^1.0.30001646:
   version "1.0.30001690"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz"
   integrity sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
 chart.js@4, chart.js@^4.2.1:
   version "4.2.1"
@@ -472,6 +554,15 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
+cli-table3@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.1.tgz#36ce9b7af4847f288d3cdd081fbd09bf7bd237b8"
+  integrity sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    colors "1.4.0"
+
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
@@ -485,6 +576,18 @@ colorette@^2.0.14:
   version "2.0.16"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
+
+colors@1.4.0, colors@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 commander@^2.20.0:
   version "2.20.3"
@@ -500,6 +603,11 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+core-util-is@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
 
 cross-spawn@^7.0.3:
   version "7.0.6"
@@ -534,15 +642,49 @@ custom-event-polyfill@^1.0.7:
   resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz#9bc993ddda937c1a30ccd335614c6c58c4f87aee"
   integrity sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==
 
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
+  dependencies:
+    assert-plus "^1.0.0"
+
 date-fns@>=2:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
+ecc-jsbn@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  integrity sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==
+  dependencies:
+    jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
+
 electron-to-chromium@^1.5.4:
   version "1.5.13"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz#1abf0410c5344b2b829b7247e031f02810d442e6"
   integrity sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 enhanced-resolve@^5.17.1:
   version "5.17.1"
@@ -557,10 +699,37 @@ envinfo@^7.7.3:
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
   integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==
 
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
 es-module-lexer@^1.2.1:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.4.tgz#a8efec3a3da991e60efa6b633a7cad6ab8d26b78"
   integrity sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 escalade@^3.1.2:
   version "3.1.2"
@@ -612,6 +781,21 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
+
+extsprintf@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -642,6 +826,36 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
+
+form-data@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.3.tgz#608b1b3f3e28be0fccf5901fc85fb3641e5cf0ae"
+  integrity sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -652,7 +866,7 @@ fsevents@~2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
-fstream@^1.0.12:
+fstream@1.0.12, fstream@>=1.0.12, fstream@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
   integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
@@ -667,10 +881,46 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+get-intrinsic@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
+
 get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
+  dependencies:
+    assert-plus "^1.0.0"
 
 glob-parent@~5.1.2:
   version "5.1.2"
@@ -696,15 +946,45 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 graceful-fs@^4.1.2, graceful-fs@^4.2.11, graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
+
+har-validator@~5.1.3:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
+  dependencies:
+    ajv "^6.12.3"
+    har-schema "^2.0.0"
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-symbols@^1.0.3, has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
 
 has@^1.0.3:
   version "1.0.3"
@@ -712,6 +992,27 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hasown@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
+human-readable-numbers@^0.9.5:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/human-readable-numbers/-/human-readable-numbers-0.9.5.tgz#bbbd61e06ed0bafbba79b28734e512fec4dd3407"
+  integrity sha512-VC1uYLm7FR+4UkLaQdXPLodz7xTVLBte3X6iMCYK/uPJywoHyEZfR40+kCN4YqYd+FNCPJAJNYv2CSMvAprgsQ==
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -749,7 +1050,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.0:
+inherits@2, inherits@2.0.4, inherits@~2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -773,10 +1074,20 @@ is-core-module@^2.8.0:
   dependencies:
     has "^1.0.3"
 
+is-domain@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/is-domain/-/is-domain-0.0.1.tgz#7ffb288d5cced6b07c4f2df91c9be9153511348e"
+  integrity sha512-hLm9uZUDm/sk0+xZgxyJluSf4B37sg3ivzv4ndTxNCAMnWFUUsHh1u4eh2maEcEvQl3mc65a9pJ/KURGItbLIg==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.3"
@@ -802,6 +1113,11 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -811,6 +1127,11 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
 jest-worker@^27.4.5:
   version "27.5.1"
@@ -840,6 +1161,11 @@ jquery-datetimepicker@^2.5.21:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
+
 json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
@@ -855,10 +1181,35 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
+json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
+json-stringify-safe@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
+
+jsprim@^1.2.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
+  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.4.0"
+    verror "1.10.0"
+
 kind-of@>=6.0.3, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+kleur@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
 klona@^2.0.4:
   version "2.0.5"
@@ -884,6 +1235,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -894,7 +1250,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -913,6 +1269,13 @@ mini-css-extract-plugin@^2.6.0:
   dependencies:
     schema-utils "^4.0.0"
 
+minimatch@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.6.tgz#845d6f254d8f4a5e4fd6baf44d5f10c8448365fb"
+  integrity sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -920,7 +1283,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.5, minimist@^1.2.6:
+minimist@1.2.6, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -932,6 +1295,16 @@ minimist@^1.2.5, minimist@^1.2.6:
   dependencies:
     minimist "^1.2.5"
 
+moniker@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/moniker/-/moniker-0.1.2.tgz#872dfba575dcea8fa04a5135b13d5f24beccc97e"
+  integrity sha512-Uj9iV0QYr6281G+o0TvqhKwHHWB2Q/qUTT4LPQ3qDGc0r8cbMuqQjRXPZuVZ+gcL7APx+iQgE8lcfWPrj1LsLA==
+
+mute-stream@~0.0.4:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 nanoid@^3.3.6:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
@@ -941,6 +1314,11 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+netrc@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
+  integrity sha512-ye8AIYWQcP9MvoM1i0Z2jV0qed31Z8EWXYnyGNkiUAd+Fo8J+7uy90xTV8g/oAbhtjkY7iZbNTizQaXdKUuwpQ==
 
 node-releases@^2.0.18:
   version "2.0.18"
@@ -958,6 +1336,11 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 once@^1.3.0:
   version "1.4.0"
@@ -1011,6 +1394,11 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
 php-date-formatter@^1.3.4:
   version "1.3.6"
@@ -1104,10 +1492,45 @@ prettier@3.3.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.2.tgz#03ff86dc7c835f2d2559ee76876a3914cec4a90a"
   integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==
 
+progress@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+prompts@*:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
+  integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
+  dependencies:
+    kleur "^3.0.3"
+    sisteransi "^1.0.5"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+psl@^1.1.28:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+punycode@^2.1.1, punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+qs@~6.5.2:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -1115,6 +1538,13 @@ randombytes@^2.1.0:
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
+
+read@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.5.tgz#007a3d169478aa710a491727e453effb92e76203"
+  integrity sha512-hDLATrzYLoMu23c/69pMC6u3fO3Y0qLTIygJkEZHLOn+AO2gSapu6QgrgwX9ehyVtaRoZVZbF4IuiZPPRdGgdg==
+  dependencies:
+    mute-stream "~0.0.4"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -1129,6 +1559,32 @@ rechoir@^0.7.0:
   integrity sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==
   dependencies:
     resolve "^1.9.0"
+
+request@^2.88.0:
+  version "2.88.2"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.5.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 require-from-string@^2.0.2:
   version "2.0.2"
@@ -1163,10 +1619,15 @@ rimraf@2:
   dependencies:
     glob "^7.1.3"
 
-safe-buffer@^5.1.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sass-loader@^12.6.0:
   version "12.6.0"
@@ -1252,6 +1713,11 @@ signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+sisteransi@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
@@ -1270,6 +1736,44 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+split@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
+  dependencies:
+    through "2"
+
+sshpk@^1.7.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
+  integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
+
+string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
@@ -1287,10 +1791,80 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+surge-fstream-ignore@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/surge-fstream-ignore/-/surge-fstream-ignore-1.1.0.tgz#631d37b4db5a4f7c6c8362210e2b43866c83cbc9"
+  integrity sha512-A3PZYu/d1/gCQtfI0k8uWQN5/WTKKsIAC1wGtCREbctXjE9cxgORZxJm6TCq/Wy6L1jl6PFQIpf4NidcWSkKMQ==
+  dependencies:
+    fstream "1.0.12"
+    inherits "2.0.4"
+    minimatch "7.4.6"
+
+surge-ignore@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/surge-ignore/-/surge-ignore-0.2.0.tgz#5a7f8a20a71188cf9e75a2cfe8eb182de90daf3b"
+  integrity sha512-ay4MPFjfiQzDsyTidljJLXQi22l2AwjcuamYnJWj/LdhaHdKmDJxRox52WXimdcLpMuLDtkQvv4+jEu+wu9eSw==
+
+surge-ignore@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/surge-ignore/-/surge-ignore-0.3.0.tgz#3044e6ca2330f358401e285f900c6d28cf5edc2e"
+  integrity sha512-tFq03FSTC2w6iVyJkzgFzwa2+lW4DZheIvStTO4Vn82Mk1x9aJyt/WUz5sKZE9woCn5dPB7nLARVFqJXDv5trA==
+
+surge-sdk@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/surge-sdk/-/surge-sdk-0.6.4.tgz#76865abd0157a4df66abdc2e7eed7c17f1119b28"
+  integrity sha512-v22+Kz8oyO/SL9EULWj2d+WuZFEL07UWfOaCBMDrcwSi1gf1GNmadhlJRSlvZ/IVUW1/PoyVlckKNkYXqiuxTw==
+  dependencies:
+    axios "1.7.3"
+
+surge-stream@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/surge-stream/-/surge-stream-0.6.4.tgz#c57576dab4484c320009b4a21916c595c06a6724"
+  integrity sha512-wf2Pl/R5vPMFNQkEajzNggRWhWHeeeW7XtTbfUWhjndId651yk3eLbns5B3t56L2Z5SzWEec7SIeKgoTph2A6g==
+  dependencies:
+    axios "1.7.3"
+    request "^2.88.0"
+    split "^1.0.1"
+    surge-fstream-ignore "^1.1.0"
+    surge-ignore "^0.3.0"
+    tarr "^1.1.0"
+
+surge@^0.24.6:
+  version "0.24.6"
+  resolved "https://registry.yarnpkg.com/surge/-/surge-0.24.6.tgz#6698013e1e5f974788829f2407300e7ec4ffff23"
+  integrity sha512-tfJpTBlTyrAgmEVp21cyagcszFXNBZA6Ba9SkngRHHtKtfbJdJXQ7G1udW6HTLaUkzWDB7aheiyG+NSkZy/0PQ==
+  dependencies:
+    babar "^0.2.0"
+    cli-table3 "0.6.1"
+    colors "1.4.0"
+    human-readable-numbers "^0.9.5"
+    is-domain "0.0.1"
+    minimist "1.2.6"
+    moniker "0.1.2"
+    netrc "0.1.4"
+    progress "2.0.3"
+    prompts "*"
+    read "1.0.5"
+    request "^2.88.0"
+    surge-ignore "0.2.0"
+    surge-sdk "0.6.4"
+    surge-stream "0.6.4"
+    url-parse-as-address "1.0.0"
+    xbytes "^1.7.0"
+
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
+
+tarr@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tarr/-/tarr-1.1.0.tgz#d7a9532ce97f08f5200b78ae0a82a6883173c8c8"
+  integrity sha512-tENbQ43IQckay71stp1p1lljRhoEZpZk10FzEZKW2tJcMcnLwV3CfZdxBAERlH6nwnFvnHMS9eJOJl6IzSsG0g==
+  dependencies:
+    block-stream "*"
+    fstream ">=1.0.12"
+    inherits "2"
 
 terser-webpack-plugin@^5.3.10:
   version "5.3.10"
@@ -1313,6 +1887,11 @@ terser@^5.26.0:
     commander "^2.20.0"
     source-map-support "~0.5.20"
 
+through@2:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -1320,15 +1899,35 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
 tslib@^2.1.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 turbolinks@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
   integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
 
 update-browserslist-db@^1.1.0:
   version "1.1.0"
@@ -1345,10 +1944,29 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+url-parse-as-address@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-as-address/-/url-parse-as-address-1.0.0.tgz#fb80901883f338b3cbed3538f5faa26adaf7f2e7"
+  integrity sha512-1WJ8YX1Kcec9wgxy8d/ATzGP1ayO6BRnd3iB6NlM+7cOnn6U8p5PKppRTCPLobh3CSdJ4d0TdPjopzyU2KcVFw==
+
 util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+uuid@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
 
 watchpack@^2.4.1:
   version "2.4.2"
@@ -1439,6 +2057,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+xbytes@^1.7.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/xbytes/-/xbytes-1.9.1.tgz#0a6a883205257a3fb747ef7cf45f52f8fc770523"
+  integrity sha512-29E0ygMFWrM5JW2W1ypmezjyR2FOS5aCszdLe620ymSJBoZzL0/RCLJKCoUFu3DfQGhZ/FWykEBp5dfEy6+hjA==
 
 yallist@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,30 @@
 # yarn lockfile v1
 
 
+"@cypress/request@^3.0.0":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.8.tgz#992f1f42ba03ebb14fa5d97290abe9d015ed0815"
+  integrity sha512-h0NFgh1mJmm1nr4jCwkGHwKneVYKghUyWe6TMNrk0B9zsjAJxpg8C4/+BAcmLgCPa1vj1V8rNUaILl+zYRUWBQ==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~4.0.0"
+    http-signature "~1.4.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    performance-now "^2.1.0"
+    qs "6.14.0"
+    safe-buffer "^5.1.2"
+    tough-cookie "^5.0.0"
+    tunnel-agent "^0.6.0"
+    uuid "^8.3.2"
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
@@ -341,7 +365,7 @@ ajv-keywords@^5.0.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.12.3, ajv@^6.12.5:
+ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -408,10 +432,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
-axios@1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.3.tgz#a1125f2faf702bc8e8f2104ec3a76fab40257d85"
-  integrity sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==
+axios@^1.8.3:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.10.0.tgz#af320aee8632eaf2a400b6a1979fa75856f38d54"
+  integrity sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -503,6 +527,14 @@ call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
+call-bound@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
+
 caniuse-lite@^1.0.30001646:
   version "1.0.30001690"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz"
@@ -582,7 +614,7 @@ colors@1.4.0, colors@~1.4.0:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -836,7 +868,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
-form-data@^4.0.0:
+form-data@^4.0.0, form-data@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.3.tgz#608b1b3f3e28be0fccf5901fc85fb3641e5cf0ae"
   integrity sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==
@@ -845,15 +877,6 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.2"
-    mime-types "^2.1.12"
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
@@ -886,7 +909,7 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-intrinsic@^1.2.6:
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -956,19 +979,6 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.11, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-  integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
-
-har-validator@~5.1.3:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
-  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
-  dependencies:
-    ajv "^6.12.3"
-    har-schema "^2.0.0"
-
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
@@ -1000,14 +1010,14 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
+http-signature@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.4.0.tgz#dee5a9ba2bf49416abc544abd6d967f6a94c8c3f"
+  integrity sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==
   dependencies:
     assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
+    jsprim "^2.0.2"
+    sshpk "^1.18.0"
 
 human-readable-numbers@^0.9.5:
   version "0.9.5"
@@ -1191,10 +1201,10 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-jsprim@^1.2.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
-  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
+jsprim@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-2.0.2.tgz#77ca23dbcd4135cd364800d22ff82c2185803d4d"
+  integrity sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==
   dependencies:
     assert-plus "1.0.0"
     extsprintf "1.3.0"
@@ -1337,10 +1347,10 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-oauth-sign@~0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
-  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+object-inspect@^1.13.3:
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
+  integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
 
 once@^1.3.0:
   version "1.4.0"
@@ -1510,27 +1520,17 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
-psl@^1.1.28:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
-  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
-  dependencies:
-    punycode "^2.3.1"
-
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-punycode@^2.1.1, punycode@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
-  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
-qs@~6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
-  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
+qs@6.14.0:
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
+  integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
+  dependencies:
+    side-channel "^1.1.0"
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -1559,32 +1559,6 @@ rechoir@^0.7.0:
   integrity sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==
   dependencies:
     resolve "^1.9.0"
-
-request@^2.88.0:
-  version "2.88.2"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
-  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
 
 require-from-string@^2.0.2:
   version "2.0.2"
@@ -1708,6 +1682,46 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+side-channel-list@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.0.tgz#10cb5984263115d3b7a0e336591e290a830af8ad"
+  integrity sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+
+side-channel-map@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
+  integrity sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+
+side-channel-weakmap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz#11dda19d5368e40ce9ec2bdc1fb0ecbc0790ecea"
+  integrity sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+    side-channel-map "^1.0.1"
+
+side-channel@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
+  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+    side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
+
 signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -1743,7 +1757,7 @@ split@^1.0.1:
   dependencies:
     through "2"
 
-sshpk@^1.7.0:
+sshpk@^1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
   integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
@@ -1800,40 +1814,17 @@ surge-fstream-ignore@^1.1.0:
     inherits "2.0.4"
     minimatch "7.4.6"
 
-surge-ignore@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/surge-ignore/-/surge-ignore-0.2.0.tgz#5a7f8a20a71188cf9e75a2cfe8eb182de90daf3b"
-  integrity sha512-ay4MPFjfiQzDsyTidljJLXQi22l2AwjcuamYnJWj/LdhaHdKmDJxRox52WXimdcLpMuLDtkQvv4+jEu+wu9eSw==
-
 surge-ignore@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/surge-ignore/-/surge-ignore-0.3.0.tgz#3044e6ca2330f358401e285f900c6d28cf5edc2e"
   integrity sha512-tFq03FSTC2w6iVyJkzgFzwa2+lW4DZheIvStTO4Vn82Mk1x9aJyt/WUz5sKZE9woCn5dPB7nLARVFqJXDv5trA==
 
-surge-sdk@0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/surge-sdk/-/surge-sdk-0.6.4.tgz#76865abd0157a4df66abdc2e7eed7c17f1119b28"
-  integrity sha512-v22+Kz8oyO/SL9EULWj2d+WuZFEL07UWfOaCBMDrcwSi1gf1GNmadhlJRSlvZ/IVUW1/PoyVlckKNkYXqiuxTw==
-  dependencies:
-    axios "1.7.3"
-
-surge-stream@0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/surge-stream/-/surge-stream-0.6.4.tgz#c57576dab4484c320009b4a21916c595c06a6724"
-  integrity sha512-wf2Pl/R5vPMFNQkEajzNggRWhWHeeeW7XtTbfUWhjndId651yk3eLbns5B3t56L2Z5SzWEec7SIeKgoTph2A6g==
-  dependencies:
-    axios "1.7.3"
-    request "^2.88.0"
-    split "^1.0.1"
-    surge-fstream-ignore "^1.1.0"
-    surge-ignore "^0.3.0"
-    tarr "^1.1.0"
-
-surge@^0.24.6:
+surge@victormours/surge:
   version "0.24.6"
-  resolved "https://registry.yarnpkg.com/surge/-/surge-0.24.6.tgz#6698013e1e5f974788829f2407300e7ec4ffff23"
-  integrity sha512-tfJpTBlTyrAgmEVp21cyagcszFXNBZA6Ba9SkngRHHtKtfbJdJXQ7G1udW6HTLaUkzWDB7aheiyG+NSkZy/0PQ==
+  resolved "https://codeload.github.com/victormours/surge/tar.gz/0500c45b5bcd8856d7e0528ce8db41e155ce0ba2"
   dependencies:
+    "@cypress/request" "^3.0.0"
+    axios "^1.8.3"
     babar "^0.2.0"
     cli-table3 "0.6.1"
     colors "1.4.0"
@@ -1845,10 +1836,10 @@ surge@^0.24.6:
     progress "2.0.3"
     prompts "*"
     read "1.0.5"
-    request "^2.88.0"
-    surge-ignore "0.2.0"
-    surge-sdk "0.6.4"
-    surge-stream "0.6.4"
+    split "^1.0.1"
+    surge-fstream-ignore "^1.1.0"
+    surge-ignore "^0.3.0"
+    tarr "^1.1.0"
     url-parse-as-address "1.0.0"
     xbytes "^1.7.0"
 
@@ -1892,6 +1883,18 @@ through@2:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
+tldts-core@^6.1.86:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.86.tgz#a93e6ed9d505cb54c542ce43feb14c73913265d8"
+  integrity sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==
+
+tldts@^6.1.32:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.86.tgz#087e0555b31b9725ee48ca7e77edc56115cd82f7"
+  integrity sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==
+  dependencies:
+    tldts-core "^6.1.86"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -1899,13 +1902,12 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+tough-cookie@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.2.tgz#66d774b4a1d9e12dc75089725af3ac75ec31bed7"
+  integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
   dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
+    tldts "^6.1.32"
 
 tslib@^2.1.0:
   version "2.8.1"
@@ -1954,10 +1956,10 @@ util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
voir https://rdv-service-public-spike-spec-to-doc.surge.sh/

# Contexte

Pour mieux comprendre comment fonctionne le produit, nos collègues non-tech ont principalement comme outil le serveur de démo et la documentation qui existe parfois. Mais ça ne suffit pas toujours : certains scénarios sont difficile à tester en démo (par exemple des créations de compte), et les documentations ne sont pas toujours maintenue, et pas toujours indexées.

# Solution

Cette PR propose d'ajouter au menu du Super Admin un lien vers une page de documentation, basée sur des captures d'écrans maintenues via des specs.
C'est inspiré par le travail fait par Adrien lors du début du passage au DSFR.

Quelque part, c'est un prolongement de l'idée de RSpec : les specs sont une documentation vivante, et pas juste des tests.

# Fonctionnement

Le coeur de l'idée est dans le fichier `spec/support/spec_to_doc.rb`, et le nouveau fichier de test illustre comment s'en servir.

Ça se passe en plusieurs étapes :
- la feature spec tourne, fait des captures d'écran via capybara, et enregistre en mémoire la suite des étapes du scénario
- le `SpecToDoc.render` dans le `after(:suite)` écrit les fichiers html des différents scénarios enregistrés, ainsi qu'un index
- l'appel à `SpecToDoc.upload_to_surge` uploade le site statique sur surge.sh, avec un subdomain qui prend en compte le nom de la branche.


# Limitations et prochaines étapes

Vu qu'on stocke toutes les infos des scénarios en mémoire, on ne peut pas avoir des scénarios différents avec parallel spec. Il faudra les écrire sur les fichiers.

Le client surge est un peu laissé à l'abandon, et il a plein de dépendances qui ont des failles de sécurité. J'en ai fait un fork sur lequel j'ai mis à jour les packages en question pour ne pas avoir d'erreur.
