### PR TITLE
Bugfix: Crash sur la page de stats de notifs pour un espace donné

### DIFF
--- a/app/views/stats/territory.html.slim
+++ b/app/views/stats/territory.html.slim
@@ -12,7 +12,7 @@
 
 h2= @territory
 
-- if Organisation.joins(:territory).where(territory: [@territory]).empty?
+- if @territory.organisations.none?
   h3 Cette structure n'utilise pas #{current_domain.name}.
 
 - cache([@territory, Time.zone.today], expires_in: 24.hours) do

--- a/app/views/stats/territory_notifications.html.slim
+++ b/app/views/stats/territory_notifications.html.slim
@@ -13,7 +13,7 @@ h2= @territory
 h3 Statistiques de notifications
 
 - cache([@territory, Time.zone.today], expires_in: 24.hours) do
-  - if @territory.present? && Organisation.joins(:territory).where(territories: [@territory]).empty?
+  - if @territory.present? && @territory.organisations.none?
     h3 Cette structure n'utilise pas #{current_domain.name}.
   - else
     .card.mb-5

--- a/spec/features/anybody/anybody_can_see_stats_spec.rb
+++ b/spec/features/anybody/anybody_can_see_stats_spec.rb
@@ -21,4 +21,12 @@ RSpec.describe "Anybody can see stats" do
     visit stats_territory_path(territory: organisation.territory)
     expect(page).to have_content("2 ont des créneaux ouverts au public")
   end
+
+  it "displays the receipts stats on the Notifications page" do
+    rdv = create(:rdv, motif:, organisation:)
+    create(:receipt, rdv:, organisation:, user: rdv.users.first)
+
+    visit stats_territory_notifications_path(territory: organisation.territory)
+    expect(page).to have_content("Notifications envoyées (1)")
+  end
 end


### PR DESCRIPTION
Issue Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/179263/

---

L'expression suivant s'est mise à péter suite à #5383 :

```ruby
Organisation.joins(:territory).where(territories: [@territory]).empty?
```

Je pense que cette l'intention initiale de l'auteur de ce code était d'écrire `where(territories: { id: [@territory] })`, et que par inadvertance la valeur `territories` était interprétée par ActiveRecord < 7.1 comme le nom pluriel d'une association au singulier, alors que l'intention de l'auteur était que `territories` soit interprété comme le nom de la table jointe.

Outre cela, je n'ai pas compris pourquoi on n'utilisait pas simplement `@territory.organisations`. :thinking: 