### PR TITLE
Bugfix : suppression agent bloquée si il a des `api_calls`

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -66,6 +66,7 @@ class Agent < ApplicationRecord
   # Relations
   has_many :agent_services, dependent: :destroy
   has_many :agent_territorial_access_rights, dependent: :destroy
+  has_many :api_calls, dependent: :delete_all
   has_many :plage_ouvertures, dependent: :destroy
   has_many :absences, dependent: :destroy
   has_many :agents_rdvs, dependent: :restrict_with_error


### PR DESCRIPTION
Ce job `DestroyInactiveAgents` en démo était bloqué car un agent avait des `api_calls`. La solution semble être de supprimer les `api_calls` en cascade dans ce cas.

>  ActiveRecord::InvalidForeignKey: PG::ForeignKeyViolation: ERROR: update or delete on table "agents" violates foreign key constraint "fk_rails_9b819b9ee2" on table "api_calls" DETAIL: Key (id)=(284) is still referenced from table "api_calls". 

https://demo.rdv-solidarites.fr/super_admins/good_job/jobs/c2af7d54-34a9-420b-914a-1aa13d78e669?locale=en