### PR TITLE
a11y: retrait des p dans les blockquote

### DIFF
--- a/app/views/dsfr/rdv_mairie/homepage.html.slim
+++ b/app/views/dsfr/rdv_mairie/homepage.html.slim
@@ -328,8 +328,7 @@ hr[aria-hidden="true"]
     .fr-col-12.fr-col-md-8
       figure.fr-quote.fr-quote--column
         blockquote
-          p
-            | « RDV Service Public est très simple à utiliser. Le rappel de SMS est un plus qui est apprécié par les usagers. De manière générale, on est très satisfaites du logiciel. »
+          | « RDV Service Public est très simple à utiliser. Le rappel de SMS est un plus qui est apprécié par les usagers. De manière générale, on est très satisfaites du logiciel. »
         figcaption
           p.fr-quote__author
             | Mairie de Chomérac (07)

--- a/app/views/static_pages/presentation_for_cnfs.html.slim
+++ b/app/views/static_pages/presentation_for_cnfs.html.slim
@@ -124,23 +124,20 @@ section.rdv-background-color-alt-green-menthe.py-5
     .fr-grid-row.mt-3
       .fr-col-md-9.mx-auto
         figure.fr-quote
-          blockquote
-            p « J'ai réduit de 30% mes lapins grâce à l'outil RDV.S c'est un outil vraiment top ! »
+          blockquote « J'ai réduit de 30% mes lapins grâce à l'outil RDV.S c'est un outil vraiment top ! »
           figcaption
             p.fr-quote__author Une conseillère numérique France service de la Nièvre
         figure.fr-quote
           blockquote
-            p
-              |> « J'ai cherché pendant longtemps un outil qui permettait de prendre des rendez-vous selon
-              |> des plages horaires définies avec un temps donné. RDV Solidarités, une solution qui m'a
-              | permis une meilleure gestion des rendez-vous et de travailler en équipe. »
+            |> « J'ai cherché pendant longtemps un outil qui permettait de prendre des rendez-vous selon
+            |> des plages horaires définies avec un temps donné. RDV Solidarités, une solution qui m'a
+            | permis une meilleure gestion des rendez-vous et de travailler en équipe. »
           figcaption
             p.fr-quote__author Un conseiller numérique, Ville du Mans
         figure.fr-quote
           blockquote
-            p
-              |> « Les médiateur⋅rices numériques que je connais qui utilisent RDV Aide
-              | Numérique et moi-même sommes ravis de cette plateforme. »
+            |> « Les médiateur⋅rices numériques que je connais qui utilisent RDV Aide
+            | Numérique et moi-même sommes ravis de cette plateforme. »
           figcaption
             p.fr-quote__author Témoignage recueilli via sondage
       .fr-col-3.rdv-text-align-center.d-none.d-lg-flex


### PR DESCRIPTION
# Contexte

Suite à l’audit d’accessibilité : 

<img width="828" alt="image" src="https://github.com/user-attachments/assets/1a3cc2b3-3c82-426b-9d0c-85db40c6144b" />

