### PR TITLE
a11y: utilisation du alt plutôt que title dans le header

### DIFF
--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -21,7 +21,7 @@ html lang="fr"
 
     = dsfr_header logo_text: "République<br>Française".html_safe, html_attributes: {id: "header"} do |header|
       ruby:
-        header.with_operator_image title: "Accueil - #{current_domain.name}", src: asset_path(current_domain.dark_logo_path), alt: ""
+        header.with_operator_image title: "", src: asset_path(current_domain.dark_logo_path), alt: "Accueil - #{current_domain.name}"
         if current_user.present? && !current_user.signed_in_with_invitation_token?
           header.with_tool_link title: "Vos rendez-vous", path: users_rdvs_path, html_attributes: { class: "fr-icon-calendar-fill" }
           header.with_tool_link title: "Vos informations", path: users_informations_path


### PR DESCRIPTION
# Contexte

Suite à l’audit d’accessibilité : 

> Tu as laissé le `title` dans le lien du logo de l'entête et supprimé l'alternative textuelle de l'image. J'aurais fait l'inverse. Je mettrais une alternative textuelle à l'image, et dans le `title` du lien je reprendrais l'intégralité de mon alternative textuelle avec l'info que ce lien renvoie à la page d'accueil.  

