### PR TITLE
Suppression de reinvite.js.erb obsolète

### DIFF
--- a/app/views/admin/agents/reinvite.js.erb
+++ b/app/views/admin/agents/reinvite.js.erb
@@ -1,2 +1,0 @@
-$('#agent_<%= @agent.id %> .invitation-text').text('Invitation envoyée à l\'instant');
-$('#agent_<%= @agent.id %> .btn').prop("disabled",true);


### PR DESCRIPTION
# Contexte

Nous souhaitons nous séparer des morceaux de JS qui sont inlinés. En regardant les JS concernés, je m’aperçois que le système de ré-invitation n’utilise plus `reinvite.js.erb`

# Solution

On supprime donc ce JS.