### PR TITLE
Correctif pour les changements d'emails lors de la prise de rdv par intégration

### DIFF
--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -59,7 +59,7 @@ class Agents::RdvPlansController < AgentAuthController
   def create_rdv
     rdv_plan_params = params.require(:rdv_plan)
 
-    user_attributes = rdv_plan_params.require(:user).permit(:email, :phone_number)
+    user_attributes = rdv_plan_params.require(:user).permit(:notification_email, :phone_number)
 
     # TODO: possible à mettre en commun ?
     participation_attributes = if @rdv_plan.motif.visible_and_notified?

--- a/app/controllers/api/v1/rdv_plans_controller.rb
+++ b/app/controllers/api/v1/rdv_plans_controller.rb
@@ -35,7 +35,11 @@ class Api::V1::RdvPlansController < Api::V1::AgentAuthBaseController
 
   def build_user(user_params)
     user = User.new(user_params.permit(:first_name, :last_name, :address, :phone_number, :birth_date))
-    # TODO: mettre un commentaire pour expliquer pourquoi cette ligne nous rend triste
+
+    # Il y a un décalage entre les champs utilisé dans l'api de création de rdv plans, et nos colonnes en base :
+    # on demande au client d'envoyer un `email`, mais on l'enregistre dans `notification_email`.
+    # C'est à la fois pour garder une api rétrocompatible, et aussi parce qu'on aurait préféré que la colonne notification_email
+    # reste juste "email", et que la colonne utilisée pour l'email devise ai un autre nom (peut-être `login_email`, `account_email` ou `devise_email`).
     user.notification_email = user_params[:email]
     user.skip_confirmation_notification!
     user

--- a/app/controllers/api/v1/rdv_plans_controller.rb
+++ b/app/controllers/api/v1/rdv_plans_controller.rb
@@ -34,8 +34,10 @@ class Api::V1::RdvPlansController < Api::V1::AgentAuthBaseController
   end
 
   def build_user(user_params)
-    User.new(user_params.permit(:first_name, :last_name, :email, :address, :phone_number, :birth_date))
-      .tap(&:skip_confirmation_notification!)
+    user = User.new(user_params.permit(:first_name, :last_name, :address, :phone_number, :birth_date))
+    user.notification_email = user_params[:email]
+    user.skip_confirmation_notification!
+    user
   end
 
   def find_user(user_params)

--- a/app/controllers/api/v1/rdv_plans_controller.rb
+++ b/app/controllers/api/v1/rdv_plans_controller.rb
@@ -35,6 +35,7 @@ class Api::V1::RdvPlansController < Api::V1::AgentAuthBaseController
 
   def build_user(user_params)
     user = User.new(user_params.permit(:first_name, :last_name, :address, :phone_number, :birth_date))
+    # TODO: mettre un commentaire pour expliquer pourquoi cette ligne nous rend triste
     user.notification_email = user_params[:email]
     user.skip_confirmation_notification!
     user

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -58,7 +58,6 @@ class RdvPlan < ApplicationRecord
     if user.email
       if user_attributes[:notification_email]&.downcase == user.email || user_attributes[:notification_email].blank?
         # L'email est le même, mais on veut quand même changer le numéro de téléphone
-        # TODO: ajouter une spec pour ce cas
         user.update!(user_attributes)
       elsif user.encrypted_password.present? # On essaye de changer l'email de l'usager
         # Dans ce cas l'usager a un compte Devise qui lui sert à se connecter

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -31,6 +31,30 @@ class RdvPlan < ApplicationRecord
   end
 
   def create_rdv(user_attributes:, participation_attributes:)
+    update_user_before_creating_rdv(user_attributes:)
+
+    rdv = Rdv.create(
+      agents: [rdv_agent],
+      participations: [Participation.new(participation_attributes.merge(user_id: user.id))],
+      motif: motif,
+      organisation: organisation,
+      lieu: lieu,
+      starts_at: starts_at,
+      created_by: planning_agent,
+      ends_at: starts_at + (duration_in_minutes || motif.default_duration_in_min).minutes
+    )
+
+    if rdv.persisted?
+      update(rdv: rdv)
+      Notifiers::RdvCreated.perform_with(rdv, planning_agent)
+    end
+
+    rdv
+  end
+
+  private
+
+  def update_user_before_creating_rdv(user_attributes:)
     if user.email
       if user_attributes[:notification_email]&.downcase == user.email || user_attributes[:notification_email].blank?
         # L'email est le même, mais on veut quand même changer le numéro de téléphone
@@ -53,27 +77,7 @@ class RdvPlan < ApplicationRecord
     else
       user.update!(user_attributes)
     end
-
-    rdv = Rdv.create(
-      agents: [rdv_agent],
-      participations: [Participation.new(participation_attributes.merge(user_id: user.id))],
-      motif: motif,
-      organisation: organisation,
-      lieu: lieu,
-      starts_at: starts_at,
-      created_by: planning_agent,
-      ends_at: starts_at + (duration_in_minutes || motif.default_duration_in_min).minutes
-    )
-
-    if rdv.persisted?
-      update(rdv: rdv)
-      Notifiers::RdvCreated.perform_with(rdv, planning_agent)
-    end
-
-    rdv
   end
-
-  private
 
   def return_url_is_authorized
     return if return_url.blank?

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -32,7 +32,7 @@ class RdvPlan < ApplicationRecord
 
   def create_rdv(user_attributes:, participation_attributes:)
     if user.email
-      if user_attributes[:notification_email] == user.email
+      if user_attributes[:notification_email]&.downcase == user.email || user_attributes[:notification_email].blank?
         # L'email est le même, mais on veut quand même changer le numéro de téléphone
         # TODO: ajouter une spec pour ce cas
         user.update!(user_attributes)

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -31,11 +31,26 @@ class RdvPlan < ApplicationRecord
   end
 
   def create_rdv(user_attributes:, participation_attributes:)
-    if user.encrypted_password.blank? # Pour mettre à jour l'email sans renvoyer de mail de confirmation
-      user.skip_confirmation_notification!
-      user.skip_reconfirmation!
+    if user.email
+      if user_attributes[:notification_email] != user.email # On essaye de changer l'email de l'usager
+        if user.encrypted_password.present?
+          # Dans ce cas l'usager a un compte Devise qui lui sert à se connecter
+          # A terme, on voudrait ne pas avoir à faire cette vérification, et que la présence d'une valeur dans la colonne email
+          # suffise à déterminer que l'usager a un compte Devise
+          raise "L'email de cet usager ne peut pas être modifié"
+        else
+          # Pour mettre à jour l'email sans renvoyer de mail de confirmation
+          user.skip_confirmation_notification!
+          user.skip_reconfirmation!
+
+          # Le notification_email peut remplacer l'email sans risque, puisque l'usager n'a pas de compte Devise
+          user.assign_attributes(email: nil)
+          user.update!(user_attributes)
+        end
+      end
+    else
+      user.update!(user_attributes)
     end
-    user.update!(user_attributes)
 
     rdv = Rdv.create(
       agents: [rdv_agent],

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -32,21 +32,23 @@ class RdvPlan < ApplicationRecord
 
   def create_rdv(user_attributes:, participation_attributes:)
     if user.email
-      if user_attributes[:notification_email] != user.email # On essaye de changer l'email de l'usager
-        if user.encrypted_password.present?
-          # Dans ce cas l'usager a un compte Devise qui lui sert à se connecter
-          # A terme, on voudrait ne pas avoir à faire cette vérification, et que la présence d'une valeur dans la colonne email
-          # suffise à déterminer que l'usager a un compte Devise
-          raise "L'email de cet usager ne peut pas être modifié"
-        else
-          # Pour mettre à jour l'email sans renvoyer de mail de confirmation
-          user.skip_confirmation_notification!
-          user.skip_reconfirmation!
+      if user_attributes[:notification_email] == user.email
+        # L'email est le même, mais on veut quand même changer le numéro de téléphone
+        # TODO: ajouter une spec pour ce cas
+        user.update!(user_attributes)
+      elsif user.encrypted_password.present? # On essaye de changer l'email de l'usager
+        # Dans ce cas l'usager a un compte Devise qui lui sert à se connecter
+        # A terme, on voudrait ne pas avoir à faire cette vérification, et que la présence d'une valeur dans la colonne email
+        # suffise à déterminer que l'usager a un compte Devise
+        raise "L'email de cet usager ne peut pas être modifié"
+      else
+        # Pour mettre à jour l'email sans renvoyer de mail de confirmation
+        user.skip_confirmation_notification!
+        user.skip_reconfirmation!
 
-          # Le notification_email peut remplacer l'email sans risque, puisque l'usager n'a pas de compte Devise
-          user.assign_attributes(email: nil)
-          user.update!(user_attributes)
-        end
+        # Le notification_email peut remplacer l'email sans risque, puisque l'usager n'a pas de compte Devise
+        user.assign_attributes(email: nil)
+        user.update!(user_attributes)
       end
     else
       user.update!(user_attributes)

--- a/app/views/agents/rdv_plans/edit_user.html.slim
+++ b/app/views/agents/rdv_plans/edit_user.html.slim
@@ -20,8 +20,7 @@
         = f.fields_for :user, @rdv_plan.user do |ff|
           .row
             .col-6
-              / TODO: gérer le cas des users confirmed (et gérer ce cas dans l'interface principale aussi) : leur nouvelle adresse mail ne sera pas prise en compte tant qu'ils ne la confirment pas
-              = ff.input :email
+              = ff.input :notification_email
             .col-6
               = ff.input :phone_number
         - if @rdv_plan.motif.visible_and_notified?

--- a/app/views/agents/rdv_plans/edit_user.html.slim
+++ b/app/views/agents/rdv_plans/edit_user.html.slim
@@ -20,7 +20,7 @@
         = f.fields_for :user, @rdv_plan.user do |ff|
           .row
             .col-6
-              = ff.input :notification_email
+              = ff.input :notification_email, input_html: { value: @rdv_plan.user.email.presence || @rdv_plan.user.notification_email}, disabled: @rdv_plan.user.encrypted_password.present?
             .col-6
               = ff.input :phone_number
         - if @rdv_plan.motif.visible_and_notified?

--- a/app/views/agents/rdv_plans/edit_user.html.slim
+++ b/app/views/agents/rdv_plans/edit_user.html.slim
@@ -20,8 +20,7 @@
         = f.fields_for :user, @rdv_plan.user do |ff|
           .row
             .col-6
-              / TODO: expliquer dans un hint pourquoi le champs est disabled
-              = ff.input :notification_email, input_html: { value: @rdv_plan.user.email.presence || @rdv_plan.user.notification_email}, disabled: @rdv_plan.user.encrypted_password.present?
+              = ff.input :notification_email, input_html: { value: @rdv_plan.user.email.presence || @rdv_plan.user.notification_email}, disabled: @rdv_plan.user.encrypted_password.present?, hint: "Cet usager utilise cette adresse email pour ce connecter. Elle n'est donc pas modifiable."
             .col-6
               = ff.input :phone_number
         - if @rdv_plan.motif.visible_and_notified?

--- a/app/views/agents/rdv_plans/edit_user.html.slim
+++ b/app/views/agents/rdv_plans/edit_user.html.slim
@@ -20,6 +20,7 @@
         = f.fields_for :user, @rdv_plan.user do |ff|
           .row
             .col-6
+              / TODO: expliquer dans un hint pourquoi le champs est disabled
               = ff.input :notification_email, input_html: { value: @rdv_plan.user.email.presence || @rdv_plan.user.notification_email}, disabled: @rdv_plan.user.encrypted_password.present?
             .col-6
               = ff.input :phone_number

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -67,9 +67,8 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     expect(page).to have_content("Retour sur Démarches Simplifiées")
   end
 
-  context "quand un autre usager utilise déjà cette adresse email" do
-    let(:user) { create(:user, :unregistered, organisations: [organisation]) }
-    let!(:user_with_same_email) { create(:user, organisations: [organisation], email: "francis@exemple.fr") }
+  context "quand l'usager avait déjà une adresse email dans la colonne email et pas notification_email" do
+    let(:user) { create(:user, :unregistered, organisations: [organisation], email: "old_email@exemple.fr") }
     let(:rdv_plan) do
       create(:rdv_plan, user: user, motif: motif, location_type: :public_office, duration_in_minutes: 30,
                         rdv_agent: agent,

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
       lieu: lieu,
       organisation: organisation
     )
-    expect(user.reload.email).to eq "newaddress@exemple.com"
+    expect(user.reload.notification_email).to eq "newaddress@exemple.com"
 
     perform_enqueued_jobs
     emails = ActionMailer::Base.deliveries

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -104,11 +104,21 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     end
 
     context "et l'usager a un compte devise" do
-      let(:user) { create(:user, organisations: [organisation], email: "old_email@exemple.fr") }
+      let(:user) { create(:user, organisations: [organisation], email: "old_email@exemple.fr", phone_number: "0611223344") }
 
       it "ne permet pas la modification de l'email, puisque cela changerait la manière de se connecter pour l'usager" do
         visit edit_user_agents_rdv_plan_path(rdv_plan.id)
         expect(page).to have_field("Email", with: user.email, disabled: true)
+
+        fill_in("Téléphone", with: "0612345678")
+
+        click_on "Confirmer le rendez-vous"
+        expect(page).to have_content "Rendez-vous confirmé"
+
+        expect(user.reload).to have_attributes(
+          email: "old_email@exemple.fr",
+          phone_number: "0612345678"
+        )
       end
     end
   end

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -67,6 +67,38 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     expect(page).to have_content("Retour sur Démarches Simplifiées")
   end
 
+  context "quand un autre usager utilise déjà cette adresse email" do
+    let(:user) { create(:user, :unregistered, organisations: [organisation]) }
+    let!(:user_with_same_email) { create(:user, organisations: [organisation], email: "francis@exemple.fr") }
+    let(:rdv_plan) do
+      create(:rdv_plan, user: user, motif: motif, location_type: :public_office, duration_in_minutes: 30,
+                        rdv_agent: agent,
+                        lieu: lieu,
+                        starts_at: 2.days.from_now,
+                        planning_agent: agent,
+                        oauth_application: application)
+    end
+
+    it "permet quand même de prendre le rendez-vous" do
+      visit edit_user_agents_rdv_plan_path(rdv_plan.id)
+      fill_in("Email", with: "francis@exemple.fr")
+
+      expect(page).to have_content "Envoyer une notification de confirmation"
+      click_on "Confirmer le rendez-vous"
+
+      expect(page).to have_content "Rendez-vous confirmé"
+      rdv = Rdv.last
+      expect(rdv).to have_attributes(
+        users: [user],
+        agents: [agent],
+        motif: motif,
+        lieu: lieu,
+        organisation: organisation
+      )
+      expect(user.reload.notification_email).to eq "francis@exemple.fr"
+    end
+  end
+
   context "quand l'agent n'appartient à aucune organisation" do
     # Ça arrive s'il n'a pas encore fait d'ouverture de compte avec notre équipe déploiement, ou qu'il n'a pas été invité à rejoindre son organisation par ses collègues
     let!(:agent) do

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -99,6 +99,38 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     end
   end
 
+  context "quand un autre usager utilise déjà ce notification_email, et qu'on change l'email" do
+    let(:user) { create(:user, :unregistered, organisations: [organisation], email: nil, notification_email: "francis@precedent.fr") }
+    let!(:user_with_same_email) { create(:user, organisations: [organisation], email: nil, notification_email: "francis@exemple.fr") }
+    let(:rdv_plan) do
+      create(:rdv_plan, user: user, motif: motif, location_type: :public_office, duration_in_minutes: 30,
+                        rdv_agent: agent,
+                        lieu: lieu,
+                        starts_at: 2.days.from_now,
+                        planning_agent: agent,
+                        oauth_application: application)
+    end
+
+    it "permet quand même de prendre le rendez-vous" do
+      visit edit_user_agents_rdv_plan_path(rdv_plan.id)
+      fill_in("Email", with: "francis@exemple.fr")
+
+      expect(page).to have_content "Envoyer une notification de confirmation"
+      click_on "Confirmer le rendez-vous"
+
+      expect(page).to have_content "Rendez-vous confirmé"
+      rdv = Rdv.last
+      expect(rdv).to have_attributes(
+        users: [user],
+        agents: [agent],
+        motif: motif,
+        lieu: lieu,
+        organisation: organisation
+      )
+      expect(user.reload.notification_email).to eq "francis@exemple.fr"
+    end
+  end
+
   context "quand l'agent n'appartient à aucune organisation" do
     # Ça arrive s'il n'a pas encore fait d'ouverture de compte avec notre équipe déploiement, ou qu'il n'a pas été invité à rejoindre son organisation par ses collègues
     let!(:agent) do

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -142,6 +142,9 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
         organisation: organisation
       )
       expect(user.reload.notification_email).to eq "francis@exemple.fr"
+
+      # On a deux usagers avec le même e-mail de notif dans notre base, et c'est pas grave.
+      expect(User.where(notification_email: "francis@exemple.fr").count).to eq(2)
     end
   end
 

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
   end
 
   context "quand l'usager avait déjà une adresse email dans la colonne email et pas notification_email" do
-    let(:user) { create(:user, :unregistered, organisations: [organisation], email: "old_email@exemple.fr") }
     let(:rdv_plan) do
       create(:rdv_plan, user: user, motif: motif, location_type: :public_office, duration_in_minutes: 30,
                         rdv_agent: agent,
@@ -78,23 +77,45 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
                         oauth_application: application)
     end
 
-    it "permet quand même de prendre le rendez-vous" do
-      visit edit_user_agents_rdv_plan_path(rdv_plan.id)
-      fill_in("Email", with: "francis@exemple.fr")
+    context "et l'usager n'a pas de compte devise" do
+      let(:user) { create(:user, :unregistered, organisations: [organisation], email: "old_email@exemple.fr") }
 
-      expect(page).to have_content "Envoyer une notification de confirmation"
-      click_on "Confirmer le rendez-vous"
+      it "remplace l'email par un notification_email" do
+        visit edit_user_agents_rdv_plan_path(rdv_plan.id)
+        fill_in("Email", with: "francis@exemple.fr")
 
-      expect(page).to have_content "Rendez-vous confirmé"
-      rdv = Rdv.last
-      expect(rdv).to have_attributes(
-        users: [user],
-        agents: [agent],
-        motif: motif,
-        lieu: lieu,
-        organisation: organisation
-      )
-      expect(user.reload.notification_email).to eq "francis@exemple.fr"
+        expect(page).to have_content "Envoyer une notification de confirmation"
+        click_on "Confirmer le rendez-vous"
+
+        expect(page).to have_content "Rendez-vous confirmé"
+        rdv = Rdv.last
+        expect(rdv).to have_attributes(
+          users: [user],
+          agents: [agent],
+          motif: motif,
+          lieu: lieu,
+          organisation: organisation
+        )
+        expect(user.reload).to have_attributes(
+          email: nil,
+          notification_email: "francis@exemple.fr"
+        )
+      end
+    end
+
+    context "et l'usager a un compte devise" do
+      let(:user) { create(:user, organisations: [organisation], email: "old_email@exemple.fr") }
+
+      it "lève une erreur" do
+        visit edit_user_agents_rdv_plan_path(rdv_plan.id)
+        fill_in("Email", with: "francis@exemple.fr")
+
+        expect(page).to have_content "Envoyer une notification de confirmation"
+        click_on "Confirmer le rendez-vous"
+
+        expect(page).to have_content("asdf")
+        expect(sentry_events.last.message).to eq("Prescripteur sans infos de creneau. Voir https://github.com/betagouv/rdv-solidarites.fr/issues/3420")
+      end
     end
   end
 

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -106,9 +106,11 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     context "et l'usager a un compte devise" do
       let(:user) { create(:user, organisations: [organisation], email: "old_email@exemple.fr", phone_number: "0611223344") }
 
-      it "ne permet pas la modification de l'email, puisque cela changerait la manière de se connecter pour l'usager" do
+      it "ne permet pas la modification de l'email, puisque cela changerait la manière de se connecter pour l'usager", js: true do
         visit edit_user_agents_rdv_plan_path(rdv_plan.id)
         expect(page).to have_field("Email", with: user.email, disabled: true)
+
+        expect(page).to have_content("Cet usager utilise cette adresse email pour ce connecter. Elle n'est donc pas modifiable.")
 
         fill_in("Téléphone", with: "0612345678")
 

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -106,15 +106,9 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     context "et l'usager a un compte devise" do
       let(:user) { create(:user, organisations: [organisation], email: "old_email@exemple.fr") }
 
-      it "lève une erreur" do
+      it "ne permet pas la modification de l'email, puisque cela changerait la manière de se connecter pour l'usager" do
         visit edit_user_agents_rdv_plan_path(rdv_plan.id)
-        fill_in("Email", with: "francis@exemple.fr")
-
-        expect(page).to have_content "Envoyer une notification de confirmation"
-        click_on "Confirmer le rendez-vous"
-
-        expect(page).to have_content("asdf")
-        expect(sentry_events.last.message).to eq("Prescripteur sans infos de creneau. Voir https://github.com/betagouv/rdv-solidarites.fr/issues/3420")
+        expect(page).to have_field("Email", with: user.email, disabled: true)
       end
     end
   end

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "RDV Plan API" do
         expect(rdv_plan.user).to have_attributes(
           first_name: "Francis",
           last_name: "Factice",
-          email: "francis@factice.org",
+          notification_email: "francis@factice.org",
           phone_number: "0611223344",
           address: "21 rue des Ardennes, 75019 Paris",
           birth_date: Date.parse("1990-12-31")

--- a/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
           expect(rdv_plan.user).to have_attributes(
             first_name: "Francis",
             last_name: "Factice",
-            email: "francis.factice@gmail.com",
+            notification_email: "francis.factice@gmail.com",
             phone_number: "0611223344",
             address: "21 rue des Ardennes, 75019 Paris"
           )


### PR DESCRIPTION
Correctif pour https://sentry.incubateur.net/organizations/betagouv/issues/176055/

# Reproduction du bug

- faire un premier rendez-vous par intégration avec un usager, et lui mettre l'email "francis@factice.fr"
- faire un deuxième rendez-vous par intégration avec un autre usager, et à la fin du parcours lui mettre le même email
- l'erreur a lieu au moment de la confirmation du rendez-vous

# Solution

C'est la contrainte d'unicité sur les emails qui nous cause cette erreur. On corrige ça en basculant sur le `notification_email`, qui permet de mettre le même email de contact pour plusieurs usagers.

On a encore un cas compliqué quand l'usager utilise son adresse email pour se connecter avec Devise. dans ce cas là, on met le champs en read-only (mais il faudra peut-être ajouter à terme une explication). C'est finalement le même comportement qu'on a déjà pour les usagers qui utilisent FranceConnect.

