### PR TITLE
Usager : utilisation des radios boutons DSFR pour changement participant

### DIFF
--- a/app/views/users/participations/index.html.slim
+++ b/app/views/users/participations/index.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "Changer de participants"
+- content_for :title, "Changer de participant"
 
 ul.list-group.fr-mb-3w
   li.list-group-item
@@ -40,15 +40,11 @@ ul.list-group.fr-mb-3w
     span.fr-icon-team-fill.fr-mr-1w[aria-hidden="true"]
     | Participant
 
-    = form_tag users_rdv_participations_path(@rdv) do
-      .form-group
-      - current_user.available_users_for_rdv.each do |possible_participant|
-        label
-          = radio_button_tag :user_id, possible_participant.id, @rdv.users.include?(possible_participant)
-          span>
-          = possible_participant.full_name
-        br
-      .form-group
-        = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv.lieu_id), data: { modal: true }
-      .form-group
-        = submit_tag "Enregistrer", class: "fr-btn"
+    = form_with url: users_rdv_participations_path(@rdv), builder: Dsfr::FormBuilder do |f|
+      - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, hint: birth_date_and_age(user), value: user.id, checked: user.id.in?(@rdv.user_ids) } }
+      = f.dsfr_radio_buttons :users, users, legend: "", required: true, rich: true, name: "user_id"
+      ul.fr-btns-group.fr-btns-group--inline-md.fr-btns-group--right
+        li
+          = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv.lieu_id),  class: "fr-btn fr-btn--tertiary", data: { modal: true }
+        li
+          = submit_tag "Enregistrer", class: "fr-btn"

--- a/app/views/users/participations/index.html.slim
+++ b/app/views/users/participations/index.html.slim
@@ -41,8 +41,8 @@ ul.list-group.fr-mb-3w
     | Participant
 
     = form_with url: users_rdv_participations_path(@rdv), builder: Dsfr::FormBuilder do |f|
-      - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, hint: birth_date_and_age(user), value: user.id, checked: user.id.in?(@rdv.user_ids) } }
-      = f.dsfr_radio_buttons :users, users, legend: "", required: true, rich: true, name: "user_id"
+      - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, value: user.id, checked: user.id.in?(@rdv.user_ids) } }
+      = f.dsfr_radio_buttons :users, users, legend: "", required: true, name: "user_id"
       ul.fr-btns-group.fr-btns-group--inline-md.fr-btns-group--right
         li
           = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv.lieu_id),  class: "fr-btn fr-btn--tertiary", data: { modal: true }

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -17,10 +17,10 @@
           - if current_domain == Domain::RDV_MAIRIE
             .fr-mt-2w
               - current_user.available_users_for_rdv.each do |user|
-                = f.dsfr_check_box "user_ids_#{user.id}", { label: user.full_name, hint: birth_date_and_age(user), checked: (user.id.in?(@rdv.user_ids)), name: "rdv[user_ids][]" }, user.id, nil
+                = f.dsfr_check_box "user_ids_#{user.id}", { label: user.full_name, checked: (user.id.in?(@rdv.user_ids)), name: "rdv[user_ids][]" }, user.id, nil
           - else
-            - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, hint: birth_date_and_age(user), value: user.id, checked: (user.id.in?(@rdv.user_ids) || current_user.id == user.id)} }
-            = f.dsfr_radio_buttons :users, users, legend: "", required: true, rich: true, name: "rdv[user_ids][]"
+            - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, value: user.id, checked: (user.id.in?(@rdv.user_ids) || current_user.id == user.id)} }
+            = f.dsfr_radio_buttons :users, users, legend: "", required: true, name: "rdv[user_ids][]"
 
           .form-group
             = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv_wizard.lieu_id), data: { modal: true }


### PR DESCRIPTION
# Contexte

En travaillant sur #5273 je me suis aperçu que nous avions laissé des anciens radios boutons dans le formulaire de changement de participant côté usager.

# Solution

- Utilisation du DSFR Form Builder
- Utilisation d’un groupement de bouton pour le lien d’ajout de participant et la validation du formulaire.

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/82012ef0-a657-484e-a77e-c33e04ae72ae) | ![image](https://github.com/user-attachments/assets/76bc59cb-0da3-46e0-8d28-48cf65644456)
![image](https://github.com/user-attachments/assets/700dff89-a2c5-47c7-8dc6-5abf10a23470) | ![image](https://github.com/user-attachments/assets/ad4ef10d-1986-4e55-ab12-3b8280b6745b)

