### PR TITLE
a11y: ajout des attributs autocomplete sur les champs email

### DIFF
--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -31,8 +31,8 @@
         .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
           .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, required: true, label: "Votre prénom"
           .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, required: true, label: "Votre nom"
-          .fr-col-12= f.dsfr_email_field :email, required: true, label: "Votre email professionnel", hint: "Format attendu : prenom.prescripteur@domaine.fr"
-          .fr-col-12= f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone professionnel", hint: "Format attendu : 0122334455"
+          .fr-col-12= f.dsfr_email_field :email, required: true, label: "Votre email professionnel", hint: "Format attendu : prenom.prescripteur@domaine.fr", autocomplete: "email"
+          .fr-col-12= f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone professionnel", hint: "Format attendu : 0122334455", autocomplete: "tel"
 
         .rdv-text-align-right
           = f.submit "Continuer", class: "fr-btn"

--- a/app/views/users/invitations/edit.html.slim
+++ b/app/views/users/invitations/edit.html.slim
@@ -14,7 +14,7 @@
         - if resource.email.present?
           .fr-col-md-12= f.dsfr_email_field :email, value: resource.email, disabled: true
         - else
-          .fr-col-md-12= f.dsfr_email_field :email, required: true
+          .fr-col-md-12= f.dsfr_email_field :email, required: true, autocomplete: "email"
         .fr-col-md-12= f.dsfr_phone_field :phone_number, hint: "Saisissez un numéro à 10 chiffres de France métropole ou d’outre-mer, ou bien un numéro international avec le préfixe du pays."
         .fr-col-md-12 = render "common/form/new_password_input", f: f
       .rdv-text-align-center= f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -8,7 +8,7 @@
         = f.label :email, "Adresse e-mail", class: "fr-label" do
           = "Adresse email"
           span.fr-hint-text Format attendu : nom@domaine.fr
-        = f.email_field :email, autofocus: true, required: true, class: "fr-input"
+        = f.email_field :email, autofocus: true, required: true, class: "fr-input", autocomplete: "email"
 
       .rdv-text-align-center
         = f.submit "Envoyer", class: "fr-mb-4v fr-btn"


### PR DESCRIPTION
# Contexte

Lors de l’audit d’accessibilité, il a été remonté le point suivant : 

<img width="827" alt="image" src="https://github.com/user-attachments/assets/37bdca7d-2aa9-48e8-af29-d4a863988fc8" />


# Solution

J’ai ajouté l’autocomplete sur la page en question, et j’en ai profité pour refaire une passe sur tous les `dsfr_email_field`


