### PR TITLE
Rendre unique l'index sur `users.franceconnect_openid_sub`

### DIFF
--- a/db/migrate/20250620085224_add_unique_index_on_users_franceconnect_openid_sub.rb
+++ b/db/migrate/20250620085224_add_unique_index_on_users_franceconnect_openid_sub.rb
@@ -1,0 +1,13 @@
+class AddUniqueIndexOnUsersFranceconnectOpenidSub < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :users, :franceconnect_openid_sub
+    add_index :users, :franceconnect_openid_sub, where: "franceconnect_openid_sub IS NOT NULL", unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :users, :franceconnect_openid_sub
+    add_index :users, :franceconnect_openid_sub, where: "franceconnect_openid_sub IS NOT NULL", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_30_124357) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_20_085224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -832,7 +832,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_30_124357) do
     t.index ["created_through"], name: "index_users_on_created_through"
     t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
     t.index ["first_name"], name: "index_users_on_first_name"
-    t.index ["franceconnect_openid_sub"], name: "index_users_on_franceconnect_openid_sub", where: "(franceconnect_openid_sub IS NOT NULL)"
+    t.index ["franceconnect_openid_sub"], name: "index_users_on_franceconnect_openid_sub", unique: true, where: "(franceconnect_openid_sub IS NOT NULL)"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"


### PR DESCRIPTION
Préalable à #5434,même si c'est pas bloquant.

Nous utilisons le `sub` FranceConnect comme moyen d'identifier de façon unique un `User` lors de sa connexion. Il est donc nécessaire que la colonne `users.franceconnect_openid_sub` soit unique.

On peut lancer le code suivant pour trouver les subs qui sont présents sur plus d'un seul `User` :

```ruby
sql = <<~SQL
  SELECT franceconnect_openid_sub
  FROM users
  WHERE franceconnect_openid_sub IS NOT NULL
  GROUP BY franceconnect_openid_sub
  HAVING COUNT(*) > 1
SQL
duplicate_subs = ActiveRecord::Base.connection.select_values(sql)
```

On trouve 5 cas de doublon sur RDV Solidarités (aucun sur RDV SP). Certains de ces doublons ressemblent bien à des réconciliations erronées (du genre où les deux membres d'un couple partagent le même e-mail) :grimacing: 

## Reste à faire

- régler les 5 doublons présents en base
- adapter la fusion usager pour qu'elle gère les 3 cas (FC chez l'usager source, FC chez l'usager cible, FC chez les deux)