### PR TITLE
Restriction des permissions du github token dans les actions github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
-# On commence par ne donner aucune permission par défaut
+# Cette ligne permet de ne donner aucune permission au GITHUB_TOKEN associé au job qui tourne.
+# On n'utilise pas du tout l'api github dans notre CI (aucun job n'a du code qui va créer des issues ou éditer le wiki du repo), donc on n'en a pas besoin.
 permissions: {}
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+# On commence par ne donner aucune permission par défaut
+permissions: {}
 on:
   push:
     paths-ignore:
@@ -169,7 +171,7 @@ jobs:
       matrix:
         # cette strategy permet de lancer deux jobs de feature specs en parallèle pour accélérer l’exécution
         dirname: [agents, "*"]
-        include: 
+        include:
           - dirname: agents
             command: "parallel:spec[spec/features/agents]"
           - dirname: "*"


### PR DESCRIPTION
Cette PR devrait résoudre les alertes de sécurité liées aux jobs github (risque très faible, mais ça coûte pas cher de patcher ça).

voir https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication