### PR TITLE
Petit correctif d'alignement de boutons

### DIFF
--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -111,7 +111,7 @@ a[disabled] {
   flex-direction: column;
 }
 
-.justify-content-space-between {
+.rdv-justify-content-space-between {
   justify-content: space-between;
 }
 


### PR DESCRIPTION
J'avais ajouté le préfixe à la classe dans le html mais pas dans le css 🤦 


Avant | Après
:- | -:
<img width="1170" alt="Screenshot 2025-06-20 at 20 15 08" src="https://github.com/user-attachments/assets/53875e6b-3256-4110-bf0c-947de3e27eb3" />|<img width="1197" alt="Screenshot 2025-06-20 at 20 15 42" src="https://github.com/user-attachments/assets/ab8696d2-14e7-434a-8a74-1276b112da91" />
