### PR TITLE
Ajout d'index sur users.pro_connect_openid_sub

### DIFF
--- a/db/migrate/20250623070746_add_users_proconnect_index.rb
+++ b/db/migrate/20250623070746_add_users_proconnect_index.rb
@@ -1,0 +1,7 @@
+class AddUsersProconnectIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :users, :pro_connect_openid_sub, algorithm: :concurrently, unique: true, where: "pro_connect_openid_sub IS NOT NULL"
+  end
+end

--- a/db/migrate/20250623070746_add_users_proconnect_index.rb
+++ b/db/migrate/20250623070746_add_users_proconnect_index.rb
@@ -2,6 +2,6 @@ class AddUsersProconnectIndex < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
-    add_index :users, :pro_connect_openid_sub, algorithm: :concurrently, unique: true, where: "pro_connect_openid_sub IS NOT NULL"
+    add_index :users, :pro_connect_openid_sub, algorithm: :concurrently, where: "pro_connect_openid_sub IS NOT NULL"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_17_121151) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_23_070746) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -842,6 +842,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_17_121151) do
     t.index ["last_name"], name: "index_users_on_last_name"
     t.index ["notification_email"], name: "index_users_on_notification_email", where: "(notification_email IS NOT NULL)"
     t.index ["phone_number_formatted"], name: "index_users_on_phone_number_formatted"
+    t.index ["pro_connect_openid_sub"], name: "index_users_on_pro_connect_openid_sub", unique: true, where: "(pro_connect_openid_sub IS NOT NULL)"
     t.index ["rdv_invitation_token"], name: "index_users_on_rdv_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["responsible_id"], name: "index_users_on_responsible_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -842,7 +842,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_23_070746) do
     t.index ["last_name"], name: "index_users_on_last_name"
     t.index ["notification_email"], name: "index_users_on_notification_email", where: "(notification_email IS NOT NULL)"
     t.index ["phone_number_formatted"], name: "index_users_on_phone_number_formatted"
-    t.index ["pro_connect_openid_sub"], name: "index_users_on_pro_connect_openid_sub", unique: true, where: "(pro_connect_openid_sub IS NOT NULL)"
+    t.index ["pro_connect_openid_sub"], name: "index_users_on_pro_connect_openid_sub", where: "(pro_connect_openid_sub IS NOT NULL)"
     t.index ["rdv_invitation_token"], name: "index_users_on_rdv_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["responsible_id"], name: "index_users_on_responsible_id"


### PR DESCRIPTION
J'avais oublié de mettre ça dans https://github.com/betagouv/rdv-service-public/pull/5423.
Vu qu'on fait un find_by sur cette colonne, on ajoute cet index.

On va vouloir rendre cette valeur unique aussi, mais il faudra modifier la logique du service de merge_user (voir aussi https://github.com/betagouv/rdv-service-public/pull/5442)

Je vais déployer ça entre midi et deux, vu que ça risque d'être un peu long.