### PR TITLE
a11y: ajout de p manquants

### DIFF
--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -40,10 +40,6 @@ a[disabled] {
   font-weight: bold;
 }
 
-.rdv-font-weight-700 {
-  font-weight: 700;
-}
-
 .text-underline {
   text-decoration: underline;
 }

--- a/app/views/search/_nothing_to_show.html.slim
+++ b/app/views/search/_nothing_to_show.html.slim
@@ -2,17 +2,16 @@
   .card-body
     - if context.follow_up?
       - if context.referent_agents.empty?
-        .rdv-font-weight-700 L'agent avec qui vous voulez prendre rendez-vous ne vous est pas assigné comme référent.
+        p.fr-text--bold L'agent avec qui vous voulez prendre rendez-vous ne vous est pas assigné comme référent.
       - else
-        .mb-3.rdv-font-weight-700 Votre référent n'a pas de créneaux disponibles. Voulez-vous prendre rendez-vous avec un autre agent ?
+        p.fr-text--bold.fr-mb-3v Votre référent n'a pas de créneaux disponibles. Voulez-vous prendre rendez-vous avec un autre agent ?
         .float-left
           = render "users/rdvs/prendre_rdv_button"
     - elsif context.invitation?
-      .rdv-font-weight-700 Malheureusement, aucun créneau correspondant à votre invitation n'a été trouvé.
-      .rdv-font-weight-700.mb-2 Toutes nos excuses pour cela.
+      p.fr-text--bold Malheureusement, aucun créneau correspondant à votre invitation n'a été trouvé. Toutes nos excuses pour cela.
       = render "search/nothing_to_show_invitation", context: context
     - else
-      .rdv-font-weight-700
+      p.fr-text--bold.fr-mb-0
         | Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.
       - if context.first_matching_motif&.requires_ants_predemande_number?
         .fr-callout.fr-mt-4w

--- a/app/views/search/_prescription_banner.html.slim
+++ b/app/views/search/_prescription_banner.html.slim
@@ -7,7 +7,7 @@
             .fr-col-lg-7
               h2.rdv-color-text-title-grey.mb-1.pb-0  Nouvelle fonctionnalité&nbsp;:
               h2.rdv-color-text-action-high-blue-ecume.mb-2.pb-0  la prescription dans l'espace agent
-              p.rdv-font-weight-700 Vous souhaitez rediriger un usager vers une organisation différente de la votre ?
+              p.fr-text--bold Vous souhaitez rediriger un usager vers une organisation différente de la votre ?
               p
                 |> Désormais, vous pouvez directement trouver un rendez-vous dans
                 = link_to "votre espace agent #{current_domain.name}", root_path

--- a/app/views/search/_referent_booking_card.html.slim
+++ b/app/views/search/_referent_booking_card.html.slim
@@ -1,15 +1,13 @@
 - unless context.invitation? || current_agent || context.follow_up?
   - if current_user
     - if current_user.referent_agents.any?
-      .fr-callout
-        p.fr-callout__text
-          | Pour prendre un RDV avec un de vos agents référent, allez sur la page de
-          span>
-          = link_to "vos rendez-vous", users_rdvs_path
+      p
+        | Pour prendre un RDV avec un de vos agents référent, allez sur la page de
+        span>
+        = link_to "vos rendez-vous", users_rdvs_path
   - else
     - if context.follow_up_motifs?
-      .fr-callout
-        p.fr-callout__text
-          | Pour prendre un RDV de suivi avec un de vos agents référents,
-          span>
-          = link_to("connectez-vous", users_rdvs_path)
+      p
+        | Pour prendre un RDV de suivi avec un de vos agents référents,
+        span>
+        = link_to("connectez-vous", users_rdvs_path)

--- a/app/views/search/_referent_booking_card.html.slim
+++ b/app/views/search/_referent_booking_card.html.slim
@@ -1,15 +1,15 @@
 - unless context.invitation? || current_agent || context.follow_up?
   - if current_user
     - if current_user.referent_agents.any?
-      .card
-        .m-2
+      .fr-callout
+        p.fr-callout__text
           | Pour prendre un RDV avec un de vos agents référent, allez sur la page de
           span>
           = link_to "vos rendez-vous", users_rdvs_path
   - else
     - if context.follow_up_motifs?
-      .card
-        .m-2
+      .fr-callout
+        p.fr-callout__text
           | Pour prendre un RDV de suivi avec un de vos agents référents,
           span>
           = link_to("connectez-vous", users_rdvs_path)


### PR DESCRIPTION
# Contexte

Suite à l’audit d’accessibilité, il s’est avéré qu’il manque des `<p>` à certains endroits.

# Solution

- On ajoute les p
- On supprime la classe `rdv-font-weight-700` qui fait doublons avec `fr-text--bold`
- On change les `card` Bootstrap par des `callout` DSFR

## Captures d'écran

Avant | Après
:- | -:
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/c28cf11a-41ec-4dfd-84c4-0074033413ec" /> | <img width="1044" alt="image" src="https://github.com/user-attachments/assets/a1529a84-694f-401d-af2b-d8006202afea" />
