### PR TITLE
a11y : ajout du role contentinfo dans les footer

### DIFF
--- a/app/views/layouts/_agent_footer.html.slim
+++ b/app/views/layouts/_agent_footer.html.slim
@@ -1,4 +1,4 @@
-footer.footer#footer
+footer.footer#footer[role="contentinfo"]
   .container-fluid
     .row
       .col-md-12

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -29,5 +29,5 @@ html lang="fr"
                     = yield :breadcrumb
             = yield
 
-        = render "layouts/agent_footer"
+      = render "layouts/agent_footer"
     #modal-holder

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -49,7 +49,7 @@ html lang="fr"
 
     #modal-holder
 
-    footer.fr-footer.main-footer.fr-pb-12w#footer
+    footer.fr-footer.main-footer.fr-pb-12w#footer[role="contentinfo"]
 
       .fr-container
         .fr-footer__body


### PR DESCRIPTION
# Contexte

Suite à l’audit d’accessibilité, il a été relevé que l’attribut `role` était manquant dans les footer.

# Solution

- On ajoute le role contentinfo dans les footer
