### PR TITLE
Permettre la connexion en tant qu'agent et usager en même temps

### DIFF
--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -1,6 +1,5 @@
 class Agents::SessionsController < Devise::SessionsController
   include Admin::WeakPasswordControllerConcern
-  before_action :exclude_signed_in_users, only: [:new]
 
   # Lorsqu'un agent est connecté à une application Oauth via notre application,
   # Il est possible qu'il cherche à se déconnecter alors que sa session a déjà expiré.
@@ -72,16 +71,5 @@ class Agents::SessionsController < Devise::SessionsController
     else
       redirect_to after_sign_out_path_for(:agent)
     end
-  end
-
-  private
-
-  def exclude_signed_in_users
-    return true unless user_signed_in?
-
-    redirect_to(
-      root_path,
-      flash: { error: "Déconnectez-vous d'abord de votre compte usager pour vous connecter en tant qu'agent" }
-    )
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,8 +4,6 @@ class Users::SessionsController < Devise::SessionsController
   include CanHaveRdvWizardContext
   include Admin::WeakPasswordControllerConcern
 
-  before_action :exclude_signed_in_agents, only: [:new]
-
   def new
     # Le flash d'erreur est trop aggressif pour le cas d'un usager non connecté.
     # Un flash de style info est plus adapté.
@@ -52,15 +50,6 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   private
-
-  def exclude_signed_in_agents
-    return true unless agent_signed_in?
-
-    redirect_to(
-      root_path,
-      flash: { error: "Déconnectez-vous d'abord de votre compte agent pour vous connecter en tant qu'utilisateur" }
-    )
-  end
 
   # Copied from devise-4.8.1/app/controllers/devise/sessions_controller.rb
   # We needed to override the call to redirect_to to set `allow_other_host: true`.


### PR DESCRIPTION
On a une vieille restriction sur le fait de pouvoir se connecter en tant qu'agent et usager en même temps. Ça date du tout début de l'application en 2019, et ça avait du sens à l'époque.

Cependant, on permet maintenant la prise de rendez-vous avec des professionnels par ProConnect, et on a un premier cas d'usage pour lequel on voudrait proposer à des gens de se connecter en tant qu'agent et usager : pour les agents qui prennent rdv avec notre équipe pour un rdv d'accompagnement.

Il n'y a pas particulièrement de blocage technique, donc on peut tout simplement supprimer le code qui empêche la double connexion.