### PR TITLE
Ajout d’un attribut pattern sur les input de type tel

### DIFF
--- a/app/views/aide/demandes_support/new.html.slim
+++ b/app/views/aide/demandes_support/new.html.slim
@@ -52,7 +52,7 @@
         .fr-col-12.fr-col-md-6
           = f.dsfr_email_field :email, label: "Votre email", hint: "Format attendu : nom@domaine.fr", required: true, autocomplete: "email"
         .fr-col-12.fr-col-md-6
-          = f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone", hint: "Facultatif", autocomplete: "tel"
+          = f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone", hint: "Facultatif. Format attendu : 0612345678", autocomplete: "tel", pattern: "[+0-9 ]*"
 
       ul.fr-btns-group.fr-btns-group--inline
         li

--- a/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
@@ -14,7 +14,7 @@
             = f.hidden_field :ants_meeting_point_id, value: @rdv_wizard.lieu_id
             .fr-col-12= f.dsfr_text_field :ants_pre_demande_number, required: true, input_html: {style: "text-transform: uppercase;"}
 
-          .fr-col-12= f.dsfr_phone_field :phone_number, label: "Téléphone mobile", hint: "Format attendu : 0639980130. Un SMS de confirmation et un SMS de rappel seront envoyés à ce numéro"
+          .fr-col-12= f.dsfr_phone_field :phone_number, label: "Téléphone mobile", hint: "Format attendu : 0639980130. Un SMS de confirmation et un SMS de rappel seront envoyés à ce numéro", pattern: "[+0-9 ]*"
 
         = render("model_errors", model: @beneficiaire, f: f)
 

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -32,7 +32,7 @@
           .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, required: true, label: "Votre prénom"
           .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, required: true, label: "Votre nom"
           .fr-col-12= f.dsfr_email_field :email, required: true, label: "Votre email professionnel", hint: "Format attendu : prenom.prescripteur@domaine.fr", autocomplete: "email"
-          .fr-col-12= f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone professionnel", hint: "Format attendu : 0122334455", autocomplete: "tel"
+          .fr-col-12= f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone professionnel", hint: "Format attendu : 0122334455", autocomplete: "tel", pattern: "[+0-9 ]*"
 
         .rdv-text-align-right
           = f.submit "Continuer", class: "fr-btn"

--- a/app/views/users/invitations/edit.html.slim
+++ b/app/views/users/invitations/edit.html.slim
@@ -15,6 +15,6 @@
           .fr-col-md-12= f.dsfr_email_field :email, value: resource.email, disabled: true
         - else
           .fr-col-md-12= f.dsfr_email_field :email, required: true, autocomplete: "email"
-        .fr-col-md-12= f.dsfr_phone_field :phone_number, hint: "Saisissez un numéro à 10 chiffres de France métropole ou d’outre-mer, ou bien un numéro international avec le préfixe du pays."
+        .fr-col-md-12= f.dsfr_phone_field :phone_number, hint: "Saisissez un numéro à 10 chiffres de France métropole ou d’outre-mer, ou bien un numéro international avec le préfixe du pays.", pattern: "[+0-9 ]*"
         .fr-col-md-12 = render "common/form/new_password_input", f: f
       .rdv-text-align-center= f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -20,7 +20,7 @@
         .fr-col-6
           = f.dsfr_text_field :last_name, label: "Nom", required: true, autocomplete: "family-name"
       = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr", required: true, autocomplete: "email"
-      = f.dsfr_phone_field :phone_number, label: "Numéro de téléphone", hint: "Facultatif. Vous recevrez les rappels et les informations du RDV sur ce numéro.", autocomplete: "tel"
+      = f.dsfr_phone_field :phone_number, label: "Numéro de téléphone", hint: "Facultatif. Vous recevrez les rappels et les informations du RDV sur ce numéro. Format attendu : 0612345678", autocomplete: "tel", pattern: "[+0-9 ]*"
 
       .form-group
         small

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -27,7 +27,7 @@ ruby:
       / Nous ne voulons pas perdre d'informations si l'utilisateur a déjà un email de notification, donc le champ est requis
       / L'utilisateur peut définir un email de notification s'il n'en a pas encore, mais ce n'est pas obligatoire
       = f.dsfr_email_field :notification_email, required: user.notification_email.present?
-  = f.dsfr_phone_field :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?, autocomplete: "tel"
+  = f.dsfr_phone_field :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?, hint: "Format attendu : 0612345678", autocomplete: "tel", pattern: "[+0-9 ]*"
   - if user.phone_number.present? && !user.phone_number_mobile?
     .fr-alert.fr-alert--warning.fr-mb-1w Vous ne recevrez pas de SMS avec ce numéro non-mobile
   div.mb-2 Préférences de notifications


### PR DESCRIPTION
# Contexte

Lors de l’audit d’accessibilité, on nous a indiqué qu’il était curieux de pouvoir saisir des lettres dans un champ de téléphone. 
Sans JS, il n’est pas possible de restreindre la saisie de certains caractères. En revanche, il est possible en HTML d’indiquer un pattern à respecter pour certains champs, ce qui permet une vérification avant soumission. Cela permet également d’utiliser le comportement natif du navigateur pour indiquer qu’il y a une erreur de saisie.

# Solution

- On rajoute l’attribut `pattern` sur tous les inputs de téléphone en autorisant les chiffres, les espaces et le +
- On en profite pour remettre le format attendu partout, pour que l’usager comprenne ce qui ne va pas si son navigateur lui lève une erreur

<img width="479" alt="image" src="https://github.com/user-attachments/assets/e75b211a-fb39-43ec-894c-5904a50ce888" />

