### PR TITLE
Suppression du creneaux.js.erb

### DIFF
--- a/app/views/users/rdvs/creneaux.js.erb
+++ b/app/views/users/rdvs/creneaux.js.erb
@@ -1,7 +1,0 @@
-<% creneaux_html = render 'creneaux' %>
-(function(){
-  let element = document.querySelector("#creneaux-lieu");
-  if(element) {
-    element.innerHTML = "<%= escape_javascript creneaux_html %>";
-  }
-})();

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -411,14 +411,6 @@ RSpec.describe Users::RdvsController, type: :controller do
 
       it { expect(assigns(:all_creneaux)).to be_empty }
       it { expect(response.body).to include("Malheureusement, tous les créneaux sont pris.") }
-
-      context "for a js request" do
-        subject do
-          get :creneaux, params: { id: rdv.id }, xhr: true
-        end
-
-        it { expect(response.body).to include("Malheureusement, tous les créneaux sont pris.") }
-      end
     end
 
     context "creneaux available" do


### PR DESCRIPTION
# Contexte

En enquêtant sur les `.js.erb` j’ai l’impression que celui-là n’est jamais appelé.
Il semble que depuis cette diff, on ne renvoie que le `slim` : https://github.com/betagouv/rdv-service-public/pull/4466/files#diff-8a89cd703a4c563c49292544ca7b8f70e8c3c44f301fc4a0e4672561d2110077L93

J’ai fais des tests sur les pages utilisant ce path et tout semble ok.

# Solution

On supprime `creaneaux.js.erb`.

