### PR TITLE
Désactivation du prefetch hotwire turbo

### DIFF
--- a/app/views/common/_meta.html.slim
+++ b/app/views/common/_meta.html.slim
@@ -1,5 +1,6 @@
 meta name="viewport" content="width=device-width, initial-scale=1.0"
 meta content="text/html; charset=UTF-8" http-equiv="Content-Type"
+meta name="turbo-prefetch" content="false"
 title
   - if content_for? :title
     - if content_for? :subtitle


### PR DESCRIPTION
# Contexte

Turbo hotwire permet de prefech les pages au survol de la souris sur les liens pour accélérer le chargement au clic. 
Aujourd’hui ce comportement n’est pas actif, car nous avons désactivé Turbo Drive.
En revanche, lorsqu’il y a des Turbo Frame avec des liens, ce comportement se déclenche. Afin d’éviter des comportements inattendus, je préfère que nous désactivions cette fonctionnalité pour le moment et que nous l’activions + tard en connaissance de cause.


