### PR TITLE
Changement de la position de RDV collectifs, fil d’ariane et boutons DSFR

### DIFF
--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -36,7 +36,7 @@
         - if rdv.individuel?
           = link_to t("admin.rdvs.show.duplicate"), admin_organisation_creneaux_search_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "fr-btn fr-btn--secondary fr-btn--sm"
         - else
-          = link_to t("admin.rdvs.show.duplicate"), new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: rdv.motif_id, duplicated_rdv_id: rdv.id), class: "fr-btn fr-btn--secondary fr-btn--sm fr-mb-0"
+          = link_to t("admin.rdvs.show.duplicate"), new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: rdv.motif_id, duplicated_rdv_id: rdv.id), class: "fr-btn fr-btn--secondary fr-btn--sm"
 
   .mx-3
   - if rdv.users.any?

--- a/app/views/admin/rdvs/_rdv_collectif_add_participant.html.slim
+++ b/app/views/admin/rdvs/_rdv_collectif_add_participant.html.slim
@@ -2,10 +2,6 @@
 
 .d-flex.justify-content-start.mb-2
   - if rdv.remaining_seats? && rdv.not_cancelled?
-    = link_to edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "btn btn-outline-primary btn-sm" do
-      span.ml-1
-        i.fa.fa-fw.fa-user-plus>
-      span
-        = "Ajouter un participant"
+    = link_to "Ajouter un participant", edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-user-add-fill"
   .text-muted.align-self-center.ml-2
     = render "admin/rdvs/participants_count", rdv: rdv

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -1,19 +1,20 @@
 - content_for(:menu_item) { @agent ? "menu-agendas" : "menu-rdvs-list" }
 
-- content_for :breadcrumb do
-  ol.breadcrumb.m-0.p-0
+- content_for :fil_ariane do
+  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
+    = b.with_breadcrumb label: "Accueil", href: root_path
     - if @agent
-      li.breadcrumb-item.p-0
-        - if @agent != current_agent
-          = link_to "Agenda de #{@agent.full_name}", admin_organisation_agent_agenda_path(current_organisation, @agent)
-        - else
-          = link_to "Votre agenda", admin_organisation_agent_agenda_path(current_organisation, current_agent)
-    li.breadcrumb-item.p-0.ml-2
-      | RDV
-      |&nbsp;
-      = rdv_title_for_agent(@rdv)
-    li.breadcrumb-item.p-0.ml-2
-      | Modifier
+      - if @agent != current_agent
+        = b.with_breadcrumb label: "Agenda de #{@agent.full_name}", href: admin_organisation_agent_agenda_path(current_organisation, @agent)
+      - else
+        = b.with_breadcrumb label: "Votre agenda", href: admin_organisation_agent_agenda_path(current_organisation, current_agent)
+    - else
+      - if @rdv.collectif?
+        = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)
+      - else
+        = b.with_breadcrumb label: "Liste des RDV", href: admin_organisation_rdvs_path(current_organisation)
+    = b.with_breadcrumb label: "RDV #{rdv_title_for_agent(@rdv)}", href: admin_organisation_rdv_path(current_organisation, @rdv)
+    = b.with_breadcrumb label: "Modifier le RDV"
 
 - content_for :title do
   | Modifier le RDV

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -9,7 +9,10 @@
       - else
         = b.with_breadcrumb label: "Votre agenda", href: admin_organisation_agent_agenda_path(current_organisation, current_agent)
     - else
-      = b.with_breadcrumb label: "Liste des RDV", href: admin_organisation_rdvs_path(current_organisation)
+      - if @rdv.collectif?
+        = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)
+      - else
+        = b.with_breadcrumb label: "Liste des RDV", href: admin_organisation_rdvs_path(current_organisation)
     = b.with_breadcrumb label: "RDV #{rdv_title_for_agent(@rdv)}"
 
 - content_for :title do

--- a/app/views/admin/rdvs_collectifs/_rdv.html.slim
+++ b/app/views/admin/rdvs_collectifs/_rdv.html.slim
@@ -6,8 +6,8 @@
       |&nbsp;
       = I18n.l(rdv.starts_at, format: "%A %d %B à %H:%M").capitalize
     - if current_agent.admin_in_organisation?(current_organisation)
-      div.mr-3= link_to admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: nil), method: :delete, title: t("helpers.delete"), data: { confirm: "Confirmez-vous la suppression de ce rendez-vous collectif ?"} do
-        i.fa.fa-trash-alt
+      div
+        = link_to "Supprimer", admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: nil), method: :delete, data: { confirm: "Confirmez-vous la suppression de ce rendez-vous collectif ?"}, class: "fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-delete-bin-line"
   .card-body
     .row
       .col-md-6

--- a/app/views/admin/rdvs_collectifs/_rdv.html.slim
+++ b/app/views/admin/rdvs_collectifs/_rdv.html.slim
@@ -30,8 +30,4 @@
       .col-md-6
         = render "admin/rdvs_collectifs/participants_info", rdv: rdv
         - if rdv.remaining_seats? && rdv.not_cancelled?
-          = link_to edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "btn btn-outline-primary btn-sm" do
-            span.mr-1
-              i.fa.fa-fw.fa-user-plus>
-            span
-              = "Ajouter un participant"
+          = link_to "Ajouter un participant", edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-user-add-fill"

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -1,5 +1,13 @@
 - content_for(:title) { "Ajouter un participant" }
 
+- content_for :fil_ariane do
+  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
+    = b.with_breadcrumb label: "Accueil", href: root_path
+    = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)
+    = b.with_breadcrumb label: @rdv.motif_name, href: admin_organisation_rdv_path(current_organisation, @rdv)
+    = b.with_breadcrumb label: "Ajouter un participant"
+  end
+
 .row.justify-content-md-center
   .col-md-12.col-lg-8
     = simple_form_for(@rdv, url: admin_organisation_rdvs_collectif_path(current_organisation), method: :put) do |f|

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -1,11 +1,16 @@
 - content_for :title do
-  | RDV Collectifs
+  | RDV collectifs
 
 - content_for(:menu_item) { "menu-rdvs-collectifs-list" }
 
+- content_for :fil_ariane do
+  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
+    = b.with_breadcrumb label: "Accueil", href: root_path
+    = b.with_breadcrumb label: "RDV collectifs"
+
 - content_for :breadcrumb do
   .btn-group
-    = link_to "Nouveau RDV Collectif", admin_organisation_rdvs_collectif_motifs_path(current_organisation), class: "btn btn-primary"
+    = link_to "Nouveau RDV collectif", admin_organisation_rdvs_collectif_motifs_path(current_organisation), class: "fr-btn"
 
 .card
   .card-body
@@ -26,13 +31,13 @@
         .col-md-3.mt-4
           = f.input :with_remaining_seats, as: :boolean, label: "Avec des places disponibles"
         .col-md-1.d-flex-justify-content-end.mt-3
-          = f.submit "Filtrer", class: "btn btn-outline-primary"
+          = f.submit "Filtrer", class: "fr-btn fr-btn--secondary"
 
 .row.justify-content-center.pb-3
   .col-md-12.col-lg-8
     - if @rdvs.any?
       = render(partial: "admin/rdvs_collectifs/rdv", collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :services))
-      .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
+      .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
     - else
       .card
         .card-body

--- a/app/views/admin/rdvs_collectifs/motifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/motifs/index.html.slim
@@ -1,10 +1,10 @@
-- content_for(:title) { "Nouveau RDV Collectif" }
+- content_for(:title) { "Nouveau RDV collectif" }
 
-- content_for :breadcrumb do
-  ol.breadcrumb.m-0
-    li.breadcrumb-item
-      = link_to "RDV Collectifs", admin_organisation_rdvs_collectifs_path(current_organisation)
-    li.breadcrumb-item.active Nouveau RDV Collectif
+- content_for :fil_ariane do
+  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
+    = b.with_breadcrumb label: "Accueil", href: root_path
+    = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)
+    = b.with_breadcrumb label: "Choisir un motif"
 
 .row.justify-content-md-center
   .col-md-12.col-lg-8

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -1,10 +1,10 @@
-- content_for(:title) { "Nouveau RDV Collectif" }
+- content_for(:title) { "Nouveau RDV collectif" }
 
-- content_for :breadcrumb do
-  ol.breadcrumb.m-0
-    li.breadcrumb-item
-      = link_to "RDV Collectifs", admin_organisation_rdvs_collectifs_path(current_organisation)
-    li.breadcrumb-item.active Nouveau RDV Collectif
+- content_for :fil_ariane do
+  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
+    = b.with_breadcrumb label: "Accueil", href: root_path
+    = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)
+    = b.with_breadcrumb label: "Nouveau RDV collectif"
 
 .row.justify-content-md-center
   .col-md-12.col-lg-8

--- a/app/views/admin/territories/motifs/index.html.slim
+++ b/app/views/admin/territories/motifs/index.html.slim
@@ -31,7 +31,7 @@
         label for="collectif"
           | Nombre de participants
         select.select2-input[id="collectif" name="collectif" style="width: 100%"]
-          = options_for_select([["-", ""], ["Collectif", "true"], ["Individuel", "false"]], params[:collectif])
+          = options_for_select([["-", ""], ["collectif", "true"], ["Individuel", "false"]], params[:collectif])
       .form-group.col-md-4
         label for="bookable_by"
           | Réservable par

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -53,8 +53,6 @@ nav.left-side-menu-wrapper
               = active_link_to "Plages d'ouverture", admin_organisation_agent_plage_ouvertures_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
             li
               = active_link_to "Indisponibilités", admin_organisation_agent_absences_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
-            li
-              = active_link_to "RDV collectifs", admin_organisation_rdvs_collectifs_path(current_organisation), class: "side-menu__item side-menu__item--small"
 
         li
           = active_link_to(admin_organisation_users_path(current_organisation), class: "side-menu__item")
@@ -65,6 +63,11 @@ nav.left-side-menu-wrapper
           = active_link_to(admin_organisation_rdvs_path(current_organisation), class: "side-menu__item")
             span.fr-icon-survey-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
             | Liste des RDV
+
+        li
+          = active_link_to(admin_organisation_rdvs_collectifs_path(current_organisation), class: "side-menu__item")
+            span.fr-icon-team-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
+            | RDV collectifs
 
         li
           = active_link_to(admin_organisation_stats_path(current_organisation), class: "side-menu__item")

--- a/app/views/static_pages/cgu_agent.html.slim
+++ b/app/views/static_pages/cgu_agent.html.slim
@@ -44,7 +44,7 @@
 
     p Chaque Agent dispose d’un agenda lui permettant de visualiser ses rendez-vous avec les usagers. Il peut notamment prendre des rendez-vous à la place des usagers en renseignant le motif, ses coordonnées, le nom de l’Agent, l’horaire, le lieu et les préférences de notifications.
 
-    h3 4.3.2 Plage d’ouverture, Indisponibilité et RDV Collectifs
+    h3 4.3.2 Plage d’ouverture, Indisponibilité et RDV collectifs
 
     p L’Agent peut créer une plage d’ouverture en renseignant la description, le lieu, les motifs, la date du premier jour et les horaires de début et de fin.
 

--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Agent can organize a rdv collectif", js: true do
     visit admin_organisation_rdvs_collectifs_path(organisation)
     expect(page).to have_content("Aucun RDV")
 
-    click_link "Nouveau RDV Collectif"
+    click_link "Nouveau RDV collectif"
     expect(page).to have_content("Choisissez un motif")
     click_link "Atelier participatif"
 
@@ -98,7 +98,7 @@ RSpec.describe "Agent can organize a rdv collectif", js: true do
       visit admin_organisation_rdvs_collectifs_path(organisation)
       expect(page).to have_content("Aucun RDV")
 
-      click_link "Nouveau RDV Collectif"
+      click_link "Nouveau RDV collectif"
       expect(page).to have_content("Choisissez un motif")
       click_link "Atelier participatif"
 


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5460.osc-secnum-fr1.scalingo.io/) 

# Contexte

Dans le cadre de l’agenda multi-agents (#5373) nous allons supprimer le deuxième niveau de menu de la section planning.
Les éléments agenda, plages d’ouverture et indisponibilités vont se retrouver dans la partie droite. L’item RDV collectif lui va rester dans le menu latéral au même niveau que « Liste des RDV ». 
Afin d’habituer petit à petit nos agents au changement, je propose via cette PR, de déplacer dès maintenant l’item RDV collectifs.

# Solution

- Déplacement de l’item 
- Corrections de tous les fils d’arianes sur la partie RDV collectifs
- Passage de boutons Bootstrap à des boutons DSFR
- Changement du thème de pagination des RDV collectif au profit de celui du DSFR

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/af19cd8a-8d96-4fd3-b7ed-ba161a9e8228) | ![image](https://github.com/user-attachments/assets/5cd95cbe-7ff6-4c0a-8700-ee2b1f818585)
![image](https://github.com/user-attachments/assets/df3e3266-943a-464e-885f-7e35657edaef) | ![image](https://github.com/user-attachments/assets/d8608561-ff48-4eff-9bd1-d4f0223735ad)

