### PR TITLE
Incitation à la création de motifs et de lieux pour une nouvelle organisation

### DIFF
--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -1,4 +1,12 @@
 module ConfigurationHelper
+  def needs_configuration(organisation)
+    organisation.motifs.none? || needs_lieu(organisation)
+  end
+
+  def needs_lieu(organisation)
+    organisation.motifs.active.where(location_type: :public_office).any? && organisation.lieux.none?
+  end
+
   def territory_navigation(title = nil, previous_links = [])
     content_for(:breadcrumbs) do
       tag.nav class: "configuration-title pb-2 mb-2" do

--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -1,6 +1,6 @@
 module ConfigurationHelper
   def needs_configuration(organisation)
-    organisation.motifs.none? || needs_lieu(organisation)
+    organisation.motifs.active.none? || needs_lieu(organisation)
   end
 
   def needs_lieu(organisation)

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -132,3 +132,12 @@
   justify-content: flex-start;
   text-align: left;
 }
+
+// Une pastille qui reprend la couleur du badge d'info pour guide l'utilisateur vers une page qui comportera ce badge
+.rdv-pastille {
+  background-color: #a9bfff;
+  border-radius: 4px;
+  width: 8px;
+  height: 8px;
+  display: inline-block;
+}

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -79,5 +79,4 @@
     - elsif motif_selected? && params[:commit].present?
       = render partial: "admin/creneaux_search/no_slot_available"
     - else
-      .text-muted= t(".choose_filter_and_refresh")
       = render "admin/creneaux_search/prescription_cta"

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -6,64 +6,67 @@
     - if @form.users.any?
       h6.card-subtitle.mb-2 = t(".search_for_slots_subtitle", users_fullname: @form.users.map(&:full_name).join(" ,"))
   .card-body
-    = simple_form_for(@form, as: "", url: admin_organisation_creneaux_search_path(current_organisation), method: :get) do |f|
-      - @form.user_ids.each do |user_id|
-        = hidden_field_tag "user_ids[]", user_id
-      - if @form.context.present?
-        = hidden_field_tag :context, @form.context
-      .row
-        .col-md-4
-          = f.input :service_id, \
-            collection: @services, \
-            input_html: { \
-              class: "select2-input js-service-filter", \
-              data: { \
-                placeholder: "Sélectionnez un service pour filtrer les motifs", \
-                "select2-config": { disableSearch: true }, \
-              }, \
-            }
-        .col-md-4
-          = f.input :motif_id, \
-            required: true, \
-            include_blank: true, \
-            collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
-            as: :grouped_select, \
-            group_method: :last,
-            label_method: -> { motif_name_and_location_type(_1) }, \
-            input_html: { \
-              data: { placeholder: "Sélectionnez un motif" }, \
-              class: "js-filtered-motifs", \
-            }
-        .col-md-4
-          - input_html = { data: { "min-date": Time.zone.today.strftime("%d/%m/%Y") } } # prevent from selecting past dates
-          = date_input(f, :from_date, "À partir du", input_html: input_html, required: true)
-      .row
-        - if @teams.any?
+    - if @motifs.none?
+      = render "admin/motifs/creation_needed_callout"
+    - else
+      = simple_form_for(@form, as: "", url: admin_organisation_creneaux_search_path(current_organisation), method: :get) do |f|
+        - @form.user_ids.each do |user_id|
+          = hidden_field_tag "user_ids[]", user_id
+        - if @form.context.present?
+          = hidden_field_tag :context, @form.context
+        .row
           .col-md-4
-            = f.input :team_ids, collection: @teams, label: t(".teams"), label_method: :name, input_html: { \
-                multiple: true, \
-                class: "select2-input", \
+            = f.input :service_id, \
+              collection: @services, \
+              input_html: { \
+                class: "select2-input js-service-filter", \
+                data: { \
+                  placeholder: "Sélectionnez un service pour filtrer les motifs", \
+                  "select2-config": { disableSearch: true }, \
+                }, \
               }
+          .col-md-4
+            = f.input :motif_id, \
+              required: true, \
+              include_blank: true, \
+              collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
+              as: :grouped_select, \
+              group_method: :last,
+              label_method: -> { motif_name_and_location_type(_1) }, \
+              input_html: { \
+                data: { placeholder: "Sélectionnez un motif" }, \
+                class: "js-filtered-motifs", \
+              }
+          .col-md-4
+            - input_html = { data: { "min-date": Time.zone.today.strftime("%d/%m/%Y") } } # prevent from selecting past dates
+            = date_input(f, :from_date, "À partir du", input_html: input_html, required: true)
+        .row
+          - if @teams.any?
+            .col-md-4
+              = f.input :team_ids, collection: @teams, label: t(".teams"), label_method: :name, input_html: { \
+                  multiple: true, \
+                  class: "select2-input", \
+                }
 
-        .col-md-4
-          = f.input :agent_ids, collection: @agents, label: t(".agents"), label_method: :reverse_full_name, input_html: { \
-              multiple: true, \
-              class: "select2-input",\
-              data: { \
-                "select2-config": { \
-                  ajax: { \
-                    url: admin_organisation_agents_path(current_organisation),
-                    dataType: "json",
-                    delay: 250, \
+          .col-md-4
+            = f.input :agent_ids, collection: @agents, label: t(".agents"), label_method: :reverse_full_name, input_html: { \
+                multiple: true, \
+                class: "select2-input",\
+                data: { \
+                  "select2-config": { \
+                    ajax: { \
+                      url: admin_organisation_agents_path(current_organisation),
+                      dataType: "json",
+                      delay: 250, \
+                    }, \
                   }, \
                 }, \
-              }, \
-            }
+              }
 
-        .col-md-4
-          = f.input :lieu_ids, collection: @lieux, label: "Lieu(x)", input_html: { multiple: true, class: "select2-input" }
-      .text-right
-        = f.submit "Afficher les créneaux", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux…"}
+          .col-md-4
+            = f.input :lieu_ids, collection: @lieux, label: "Lieu(x)", input_html: { multiple: true, class: "select2-input" }
+        .text-right
+          = f.submit "Afficher les créneaux", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux…"}
 
 #creneaux
   .rdv-text-align-center

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -7,7 +7,7 @@
       h6.card-subtitle.mb-2 = t(".search_for_slots_subtitle", users_fullname: @form.users.map(&:full_name).join(" ,"))
   .card-body
     - if @motifs.none?
-      = render "admin/motifs/creation_needed_callout"
+      = render "admin/motifs/creation_needed_callout", motivation_text: "Pour prendre un rendez-vous, vous devez d'abord créer un motif."
     - else
       = simple_form_for(@form, as: "", url: admin_organisation_creneaux_search_path(current_organisation), method: :get) do |f|
         - @form.user_ids.each do |user_id|

--- a/app/views/admin/lieux/index.html.slim
+++ b/app/views/admin/lieux/index.html.slim
@@ -23,13 +23,11 @@
           = render @lieux
       .d-flex.justify-content-center= paginate @lieux, theme: "twitter-bootstrap-4"
     - else
-      .row.justify-content-md-center
-        .col-md-6.rdv-text-align-center.my-5
-          p.mb-2.fr-text--lead Vous n'avez pas encore ajouté de lieu de consultation.
-          p Les lieux sont les endroits où sont réalisés les RDV. L'adresse du lieu est contenue dans les notifications envoyées à l'usager.
-          span.fa-stack.fa-4x
-            i.fa.fa-circle.fa-stack-2x.text-primary
-            i.fa.fa-building.fa-stack-1x.text-white
+      .fr-grid-row.justify-content-md-center
+        .fr-col-md-6.fr-mt-2w.fr-mb-4w
+          h3.fr-mb-2w Vous n'avez pas encore ajouté de lieu de consultation.
+          p Les lieux sont les endroits où sont réalisés les rendez-vous.
+          p L'adresse du lieu est contenue dans les notifications envoyées à l'usager.
 
     - if @lieux_policy.create?
       .rdv-text-align-center

--- a/app/views/admin/motifs/_creation_needed_callout.html.slim
+++ b/app/views/admin/motifs/_creation_needed_callout.html.slim
@@ -1,7 +1,8 @@
+/# locals: (motivation_text:)
 .fr-callout
   p.fr-callout__text.fr-icon-info-line
     - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
-      = " Pour prendre un rendez-vous, vous devez d'abord créer un motif."
+      = " #{motivation_text}"
       br
       = "Vous pouvez le faire depuis la page "
       = link_to("Configuration > Motifs de rendez-vous", admin_organisation_motifs_path(organisation_id: current_organisation.id))

--- a/app/views/admin/motifs/_creation_needed_callout.html.slim
+++ b/app/views/admin/motifs/_creation_needed_callout.html.slim
@@ -1,0 +1,10 @@
+.fr-callout
+  p.fr-callout__text.fr-icon-info-line
+    - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
+      = " Pour prendre un rendez-vous, vous devez d'abord créer un motif de rendez-vous."
+      br
+      = "Vous pouvez le faire depuis la page "
+      = link_to("Configuration > Motifs de rendez-vous", admin_organisation_motifs_path(organisation_id: current_organisation.id))
+      = "."
+    - else
+      = "Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un."

--- a/app/views/admin/motifs/_creation_needed_callout.html.slim
+++ b/app/views/admin/motifs/_creation_needed_callout.html.slim
@@ -1,7 +1,7 @@
 .fr-callout
   p.fr-callout__text.fr-icon-info-line
     - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
-      = " Pour prendre un rendez-vous, vous devez d'abord créer un motif de rendez-vous."
+      = " Pour prendre un rendez-vous, vous devez d'abord créer un motif."
       br
       = "Vous pouvez le faire depuis la page "
       = link_to("Configuration > Motifs de rendez-vous", admin_organisation_motifs_path(organisation_id: current_organisation.id))

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -80,8 +80,8 @@
         - else
           tr
             td(colspan=6)
-              .row.justify-content-md-center
-                .col-md-6.rdv-text-align-center.my-5
+              .fr-grid-row.justify-content-md-center
+                .fr-col-md-6.fr-mt-2w.fr-mb-4w
                   - if current_organisation.motifs.none?
                     h3.fr-mb-2w Vous n'avez pas encore créé de motif.
                     p Les motifs sont les types de rendez-vous que vous proposez dans votre organisation.

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -42,35 +42,36 @@
             = t("admin.motifs.archiving_explanation")
 
     table.table.table-centered
-      thead
-        tr
-          th
-          th= Motif.human_attribute_name("name")
-          th
-            div
-              = Motif.human_attribute_name("bookable_by")
-            - if @need_search
+      - if current_organisation.motifs.any?
+        thead
+          tr
+            th
+            th= Motif.human_attribute_name("name")
+            th
               div
-                - options = options_for_select(["En ligne", "Hors ligne"], params[:online_filter])
-                = select_tag("online_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
-          - if display_sectorisation_level?
-            th= Motif.human_attribute_name("sectorisation_level")
-          th
-            div
-              = Motif.human_attribute_name("service")
-            - if @need_search
-              div
-                - options = options_from_collection_for_select(current_territory.services, :id, :short_name, params[:service_filter])
-                = select_tag("service_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
-          th
-            div
-              = Motif.human_attribute_name("location_type")
+                = Motif.human_attribute_name("bookable_by")
               - if @need_search
                 div
-                  - options = options_for_select(Motif.location_types.map{|l| [Motif.human_attribute_value(:location_type, l[0]), l[1]] }, params[:location_type_filter])
-                  = select_tag("location_type_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
-          th= Motif.human_attribute_name(:default_duration)
-          th
+                  - options = options_for_select(["En ligne", "Hors ligne"], params[:online_filter])
+                  = select_tag("online_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
+            - if display_sectorisation_level?
+              th= Motif.human_attribute_name("sectorisation_level")
+            th
+              div
+                = Motif.human_attribute_name("service")
+              - if @need_search
+                div
+                  - options = options_from_collection_for_select(current_territory.services, :id, :short_name, params[:service_filter])
+                  = select_tag("service_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
+            th
+              div
+                = Motif.human_attribute_name("location_type")
+                - if @need_search
+                  div
+                    - options = options_for_select(Motif.location_types.map{|l| [Motif.human_attribute_value(:location_type, l[0]), l[1]] }, params[:location_type_filter])
+                    = select_tag("location_type_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
+            th= Motif.human_attribute_name(:default_duration)
+            th
       tbody
         - if @motifs_page.any?
           = render partial: "admin/motifs/motif", collection: @motifs_page, as: :motif
@@ -82,13 +83,11 @@
               .row.justify-content-md-center
                 .col-md-6.rdv-text-align-center.my-5
                   - if current_organisation.motifs.none?
-                    p.mb-2.lead Vous n'avez pas encore créé de motif.
-                    p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc…
+                    h3.fr-mb-2w Vous n'avez pas encore créé de motif.
+                    p Les motifs sont les types de rendez-vous que vous proposez dans votre organisation.
+                    p Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de rendez-vous en ligne activée etc…
                   - else
                     p.mb-2.lead Aucun motif ne correspond à votre filtre
-                  span.fa-stack.fa-4x
-                    i.fa.fa-circle.fa-stack-2x.text-primary
-                    i.far.fa-calendar.fa-stack-1x.text-white
                   - if agent_can_create_motif?
                     .rdv-text-align-center.m-3
                       = link_to t("admin.motifs.actions.new"), new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"

--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -40,7 +40,7 @@
             div.fr-tile__desc
               - if current_organisation.lieux.none?
                 i Aucun lieu
-                - if current_organisation.motifs.active.where(location_type: :public_office).any?
+                - if needs_lieu(current_organisation)
                   br
                   p.fr-badge.fr-badge--info.fr-mt-1w À renseigner
               - else

--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -15,26 +15,14 @@
         .fr-tile__body
           .fr-tile__content
             h3.fr-tile__title
-              = link_to(admin_organisation_agents_path(current_organisation)) do
-                = icon("fr-icon-user-fill",class: "fr-mr-1w")
-                | Agents
-            p.fr-tile__desc
-              = @agents_scope.limit(3).map(&:full_name).join(", ")
-              - if @agents_scope.count > 3
-                - autres_count = @agents_scope.count - 3
-                = " et #{autres_count} #{'autre'.pluralize(autres_count)}"
-
-    .fr-col-12.fr-col-md-4.fr-mb-2w
-      .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
-        .fr-tile__body
-          .fr-tile__content
-            h3.fr-tile__title
               = link_to(admin_organisation_motifs_path(current_organisation)) do
                 = motif_icon(class: "fr-mr-1w")
                 | Motifs de rendez-vous
-            p.fr-tile__desc
+            div.fr-tile__desc
               - if @motif_names.blank?
                 i Aucun motif
+                br
+                p.fr-badge.fr-badge--info.fr-mt-1w À renseigner
               - else
                 = @motif_names[0..2].join(", ")
                 - if @motif_names.count > 3
@@ -49,14 +37,31 @@
               = link_to(admin_organisation_lieux_path(current_organisation)) do
                 = lieu_icon(class: "fr-mr-1w")
                 | Lieux
-            p.fr-tile__desc
+            div.fr-tile__desc
               - if current_organisation.lieux.none?
                 i Aucun lieu
+                - if current_organisation.motifs.active.where(location_type: :public_office).any?
+                  br
+                  p.fr-badge.fr-badge--info.fr-mt-1w À renseigner
               - else
                 = @lieu_names[0..2].join(", ")
                 - if @lieu_names.count > 3
                   - autres_count = @lieu_names.count - 3
                   = " et #{autres_count} #{'autre'.pluralize(autres_count)}"
+
+    .fr-col-12.fr-col-md-4.fr-mb-2w
+      .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
+        .fr-tile__body
+          .fr-tile__content
+            h3.fr-tile__title
+              = link_to(admin_organisation_agents_path(current_organisation)) do
+                = icon("fr-icon-user-fill",class: "fr-mr-1w")
+                | Agents
+            p.fr-tile__desc
+              = @agents_scope.limit(3).map(&:full_name).join(", ")
+              - if @agents_scope.count > 3
+                - autres_count = @agents_scope.count - 3
+                = " et #{autres_count} #{'autre'.pluralize(autres_count)}"
 
     .fr-col-12.fr-col-md-4.fr-mb-2w
       .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -28,17 +28,7 @@
 
 ul.list-group.my-1
   - if @motifs.none?
-    .fr-callout
-      p.fr-callout__text.fr-icon-info-line
-      - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
-        = " Pour ouvrir la réservation en ligne, vous devez d'abord créer un motif de rendez-vous."
-        br
-        = "Vous pouvez le faire depuis la page "
-        = link_to("Configuration > Motifs de rendez-vous", admin_organisation_motifs_path(organisation_id: current_organisation.id))
-        = "."
-      - else
-        = "Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un."
-
+    = render "admin/motifs/creation_needed_callout", motivation_text: "Pour ouvrir la réservation en ligne, vous devez d'abord créer un motif de rendez-vous."
   - @motifs.each do |motif|
     li.card
       .card-header.d-flex.align-items-center

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -27,6 +27,18 @@
       = f.submit "Enregistrer", class: "fr-btn"
 
 ul.list-group.my-1
+  - if @motifs.none?
+    .fr-callout
+      p.fr-callout__text.fr-icon-info-line
+      - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
+        = " Pour ouvrir la réservation en ligne, vous devez d'abord créer un motif de rendez-vous."
+        br
+        = "Vous pouvez le faire depuis la page "
+        = link_to("Configuration > Motifs de rendez-vous", admin_organisation_motifs_path(organisation_id: current_organisation.id))
+        = "."
+      - else
+        = "Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un."
+
   - @motifs.each do |motif|
     li.card
       .card-header.d-flex.align-items-center

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -67,4 +67,13 @@
             .col.text-right
               = f.button :submit, "Créer la plage d'ouverture"
 - else
-  | Aucun motif disponible. Vous ne pouvez pas créer de plage d'ouverture.
+  .fr-callout
+    p.fr-callout__text.fr-icon-info-line
+      - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
+        = " Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."
+        br
+        = "Vous pouvez le faire depuis la page "
+        = link_to("Configuration > Motifs de rendez-vous", admin_organisation_motifs_path(organisation_id: current_organisation.id))
+        = "."
+      - else
+        = "Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un."

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -67,13 +67,4 @@
             .col.text-right
               = f.button :submit, "Créer la plage d'ouverture"
 - else
-  .fr-callout
-    p.fr-callout__text.fr-icon-info-line
-      - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
-        = " Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."
-        br
-        = "Vous pouvez le faire depuis la page "
-        = link_to("Configuration > Motifs de rendez-vous", admin_organisation_motifs_path(organisation_id: current_organisation.id))
-        = "."
-      - else
-        = "Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un."
+  = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -67,4 +67,6 @@
             .col.text-right
               = f.button :submit, "Créer la plage d'ouverture"
 - else
-  = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."
+  .card
+    .card-body
+      = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."

--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -3,17 +3,7 @@
 
 = render "card", rdv_wizard_form: @rdv_wizard, step_title: t(".step_title"), current_step: 1, next_step_title: t("admin.rdv_wizard_steps.step2.step_title")  do
   - if @motifs.none?
-      .fr-callout
-        p.fr-callout__text.fr-icon-info-line
-          - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
-                = "Pour prendre un rendez-vous, vous devez d'abord créer un motif de rendez-vous."
-                br
-                = "Vous pouvez le faire depuis la page "
-                = link_to("Configuration > Motifs de rendez-vous", admin_organisation_motifs_path(organisation_id: current_organisation.id))
-                = "."
-          - else
-           = "Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un."
-
+    = render "admin/motifs/creation_needed_callout"
   - else
     = simple_form_for(@rdv_wizard, as: :rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation), method: :get) do |f|
       = render "model_errors", model: @rdv_wizard

--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -3,13 +3,16 @@
 
 = render "card", rdv_wizard_form: @rdv_wizard, step_title: t(".step_title"), current_step: 1, next_step_title: t("admin.rdv_wizard_steps.step2.step_title")  do
   - if @motifs.none?
-    - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
-      p
-        Vous devez d'abord créer un motif de rendez-vous.
-        Vous pouvez le faire depuis la page Configuration > Motifs de rendez-vous
-
-    - else
-      p Aucun motif ne vous est accessible
+      .fr-callout
+        p.fr-callout__text.fr-icon-info-line
+          - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
+                = "Pour prendre un rendez-vous, vous devez d'abord créer un motif de rendez-vous."
+                br
+                = "Vous pouvez le faire depuis la page "
+                = link_to("Configuration > Motifs de rendez-vous", admin_organisation_motifs_path(organisation_id: current_organisation.id))
+                = "."
+          - else
+           = "Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un."
 
   - else
     = simple_form_for(@rdv_wizard, as: :rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation), method: :get) do |f|

--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -3,7 +3,7 @@
 
 = render "card", rdv_wizard_form: @rdv_wizard, step_title: t(".step_title"), current_step: 1, next_step_title: t("admin.rdv_wizard_steps.step2.step_title")  do
   - if @motifs.none?
-    = render "admin/motifs/creation_needed_callout"
+    = render "admin/motifs/creation_needed_callout", motivation_text: "Pour prendre un rendez-vous, vous devez d'abord créer un motif."
   - else
     = simple_form_for(@rdv_wizard, as: :rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation), method: :get) do |f|
       = render "model_errors", model: @rdv_wizard

--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -2,35 +2,45 @@
 - content_for(:title) { t(".page_title", starts_at: l(@rdv.starts_at, format: :dense)) }
 
 = render "card", rdv_wizard_form: @rdv_wizard, step_title: t(".step_title"), current_step: 1, next_step_title: t("admin.rdv_wizard_steps.step2.step_title")  do
-  = simple_form_for(@rdv_wizard, as: :rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation), method: :get) do |f|
-    = render "model_errors", model: @rdv_wizard
-    = render "hidden_fields", f: f, step: 1, \
-      fields: %i[starts_at lieu_id context service_id], \
-      user_ids: @rdv.user_ids, agent_ids: @rdv.agent_ids,
-      lieu_attributes: @rdv.nested_lieu_attributes
+  - if @motifs.none?
+    - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
+      p
+        Vous devez d'abord créer un motif de rendez-vous.
+        Vous pouvez le faire depuis la page Configuration > Motifs de rendez-vous
 
-    - if @services.count > 1
-      = f.input :service_id, \
-        collection: @services, \
+    - else
+      p Aucun motif ne vous est accessible
+
+  - else
+    = simple_form_for(@rdv_wizard, as: :rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation), method: :get) do |f|
+      = render "model_errors", model: @rdv_wizard
+      = render "hidden_fields", f: f, step: 1, \
+        fields: %i[starts_at lieu_id context service_id], \
+        user_ids: @rdv.user_ids, agent_ids: @rdv.agent_ids,
+        lieu_attributes: @rdv.nested_lieu_attributes
+
+      - if @services.count > 1
+        = f.input :service_id, \
+          collection: @services, \
+          input_html: { \
+            class: "select2-input js-service-filter", \
+            data: { \
+              placeholder: "Sélectionnez un service pour filtrer les motifs", \
+              "select2-config": { disableSearch: true }, \
+            }, \
+          }
+
+      = f.input :motif_id, \
+        label: "Motif du rendez-vous", \
+        required: true, \
+        include_blank: true, \
+        collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
+        as: :grouped_select, \
+        group_method: :last,
+        label_method: -> { motif_name_with_location_and_group_type(_1) }, \
         input_html: { \
-          class: "select2-input js-service-filter", \
-          data: { \
-            placeholder: "Sélectionnez un service pour filtrer les motifs", \
-            "select2-config": { disableSearch: true }, \
-          }, \
+          data: { placeholder: "Sélectionnez un motif", "auto-select-sole-option": true },
+          class: @services.count > 1 ? "js-filtered-motifs" : "select2-input", \
         }
 
-    = f.input :motif_id, \
-      label: "Motif du rendez-vous", \
-      required: true, \
-      include_blank: true, \
-      collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
-      as: :grouped_select, \
-      group_method: :last,
-      label_method: -> { motif_name_with_location_and_group_type(_1) }, \
-      input_html: { \
-        data: { placeholder: "Sélectionnez un motif", "auto-select-sole-option": true },
-        class: @services.count > 1 ? "js-filtered-motifs" : "select2-input", \
-      }
-
-    = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f
+      = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -86,7 +86,8 @@ nav.left-side-menu-wrapper
             = link_to admin_organisation_configuration_path(current_organisation), class: "side-menu__item #{'active' if menu_top_level_item == 'settings'}"
               span.fr-icon-settings-5-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
               | Configuration
-              - if menu_top_level_item != "settings" && needs_configuration(current_organisation)
+              / On ajoute une condition sur la date de création de l'organisation pour éviter de faire des requêtes sur les tables motifs et lieux à chaque chargement de page
+              - if menu_top_level_item != "settings" && current_organisation.created_at > 30.days.ago && needs_configuration(current_organisation)
                 .fr-ml-1w.rdv-pastille
 
         li

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -86,8 +86,8 @@ nav.left-side-menu-wrapper
             = link_to admin_organisation_configuration_path(current_organisation), class: "side-menu__item #{'active' if menu_top_level_item == 'settings'}"
               span.fr-icon-settings-5-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
               | Configuration
-              - if menu_top_level_item != 'settings' && needs_configuration(current_organisation)
-                div.fr-ml-1w[style="background-color: #a9bfff; border-radius: 4px; width: 8px; height: 8px; display: inline-block"]
+              - if menu_top_level_item != "settings" && needs_configuration(current_organisation)
+                .fr-ml-1w.rdv-pastille
 
         li
           = active_link_to admin_organisation_support_path(current_organisation), class: "side-menu__item"

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -86,6 +86,9 @@ nav.left-side-menu-wrapper
             = link_to admin_organisation_configuration_path(current_organisation), class: "side-menu__item #{'active' if menu_top_level_item == 'settings'}"
               span.fr-icon-settings-5-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
               | Configuration
+              - if menu_top_level_item != 'settings' && needs_configuration(current_organisation)
+                div.fr-ml-1w[style="background-color: #a9bfff; border-radius: 4px; width: 8px; height: 8px; display: inline-block"]
+
         li
           = active_link_to admin_organisation_support_path(current_organisation), class: "side-menu__item"
             span.fr-icon-question-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]

--- a/app/views/mailers/agents/territory_creation_request_mailer/accepted.html.slim
+++ b/app/views/mailers/agents/territory_creation_request_mailer/accepted.html.slim
@@ -14,7 +14,7 @@ p
 p Pour bien démarrer, #{link_to("consultez notre tutoriel", tutoriel_url)} pour configurer votre espace, et retrouvez toutes les ressources utiles dans notre #{link_to("centre d'aide", "https://aide.rdv-service-public.fr/")}.
 
 .btn-wrapper
-  = link_to "Accéder à mon espace", admin_organisation_agent_agenda_url(@organisation, @agent),  class: "btn btn-primary"
+  = link_to "Accéder à mon espace", configuration_admin_organisations_url(@organisation, @agent),  class: "btn btn-primary"
 .btn-wrapper
   = link_to "Consulter le tutoriel", tutoriel_url,  class: "btn btn-secondary"
 

--- a/config/locales/views/agent_searches.fr.yml
+++ b/config/locales/views/agent_searches.fr.yml
@@ -2,7 +2,6 @@ fr:
   admin:
     creneaux_search:
       index:
-        choose_filter_and_refresh: Selectionnez des filtres et rafraichissez les résultats
         agents: Agents
         teams: Équipes
         search_for_slots_title: Trouver un RDV

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Admin can configure the organisation" do
     click_link("Supprimer")
 
     expect_page_title("Lieux")
-    expect_page_with_no_record_text("Vous n'avez pas encore ajouté de lieu de consultation.")
+    expect(page).to have_content("Vous n'avez pas encore ajouté de lieu de consultation.")
 
     click_link "Ajouter un lieu", match: :first
 

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
     it "cannot create plage_ouverture" do
       expect_page_title("Plages d’ouverture")
       click_link "Créer une plage d'ouverture", match: :first
-      expect(page).to have_content("Aucun motif disponible. Vous ne pouvez pas créer de plage d'ouverture.")
+      expect(page).to have_content("Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un")
     end
 
     context "with motif for_secretariat" do

--- a/spec/features/spec_to_doc/self_onboarding_spec.rb
+++ b/spec/features/spec_to_doc/self_onboarding_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe "Configuration initiale", js: true do
+  let(:service) { create(:service, name: "Dinum", short_name: "Dinum") }
+  let(:agent) do
+    create(:agent, services: [service], admin_role_in_organisations: [organisation],
+                   first_name: "Francis",
+                   last_name: "Factice",
+                   email: "francis.factice@demo-rdv-service-public.gouv.fr")
+  end
+  let(:organisation) { create(:organisation, name: "Equipe produit de Mon Permis de Construire") }
+
+  before { login_as(agent, scope: :agent) }
+
+  specify do
+    doc = SpecToDoc.start_scenario("Incitation à la création de motifs et de lieux", self)
+
+    doc.start_section("Contexte")
+
+    doc.add_text(<<~TEXT
+      <p>
+        Pour le moment on crée par défaut des motifs "Suivi de dossier" lors de l'ouverture d'un nouvel espace.
+      </p>
+      <p>
+        Cependant, on va bientôt arrêter de le faire, et encourager les agents à créer leur premier motif et leur premier lieu manuellement.
+      </p>
+      <p>
+        Cette documentation montre ce qui se passe pour une nouvelle organisation créée sans motifs.
+      </p>
+    TEXT
+      .html_safe) # rubocop:disable Rails/OutputSafety
+
+    doc.start_section("Redirections vers la création de motif")
+
+    doc.add_text("Voici ce qui s'affiche sur les différentes pages qui nécessitent un motif")
+
+    visit new_admin_organisation_rdv_wizard_step_url(organisation, host: "http://www.rdv-mairie-test.localhost", starts_at: Time.zone.now, agent_ids: [agent.id])
+
+    doc.add_screenshot(page,
+                       text: "Prise de rendez-vous depuis le calendrier",
+                       wait_for: "Nouveau RDV")
+
+    expect(page).to have_content("Pour prendre un rendez-vous, vous devez d'abord créer un motif.")
+
+    visit admin_organisation_creneaux_search_url(organisation, host: "http://www.rdv-mairie-test.localhost")
+
+    doc.add_screenshot(page,
+                       text: "Recherche de créneaux",
+                       wait_for: "Trouver un RDV")
+
+    expect(page).to have_content("Pour prendre un rendez-vous, vous devez d'abord créer un motif.")
+
+    visit new_admin_organisation_agent_plage_ouverture_url(organisation, host: "http://www.rdv-mairie-test.localhost", agent_id: agent.id)
+
+    doc.add_screenshot(page,
+                       text: "Création de plage d'ouverture",
+                       wait_for: "Nouvelle plage d'ouverture")
+
+    expect(page).to have_content("Pour créer une plage d'ouverture, vous devez d'abord créer un motif")
+
+    visit admin_organisation_online_booking_url(organisation, host: "http://www.rdv-mairie-test.localhost")
+
+    scroll_to(find(".fr-callout"))
+
+    doc.add_screenshot(page,
+                       text: "Réservation en ligne",
+                       wait_for: "Permettez à vos usagers de prendre rendez-vous en ligne")
+
+    expect(page).to have_content("Pour ouvrir la réservation en ligne, vous devez d'abord créer un motif de rendez-vous")
+
+    doc.start_section("Configuration")
+
+    visit admin_organisation_configuration_url(organisation, host: "http://www.rdv-mairie-test.localhost")
+
+    doc.add_screenshot(page,
+                       text: "On affiche un badge pour inciter à la création du premier motif",
+                       wait_for: "À renseigner")
+
+    click_on "Motifs de rendez-vous"
+
+    doc.add_screenshot(page,
+                       text: "",
+                       wait_for: "Vous n'avez pas encore créé de motif.")
+
+    click_on "Créer un motif"
+
+    fill_in "Nom du motif", with: "Entretien utilisateur"
+
+    doc.add_screenshot(page, text: "On crée un motif sur place")
+
+    click_on "Créer un motif"
+  end
+end

--- a/spec/features/spec_to_doc/self_onboarding_spec.rb
+++ b/spec/features/spec_to_doc/self_onboarding_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe "Configuration initiale", js: true do
   end
   let(:organisation) { create(:organisation, name: "Equipe produit de Mon Permis de Construire") }
 
-  before { login_as(agent, scope: :agent) }
+  before do
+    organisation.territory.services << service
+    login_as(agent, scope: :agent)
+  end
 
   specify do
     doc = SpecToDoc.start_scenario("Incitation à la création de motifs et de lieux", self)
@@ -72,7 +75,7 @@ RSpec.describe "Configuration initiale", js: true do
 
     doc.add_screenshot(page,
                        text: "On affiche un badge pour inciter à la création du premier motif",
-                       wait_for: "À renseigner")
+                       wait_for: "À RENSEIGNER")
 
     click_on "Motifs de rendez-vous"
 
@@ -80,12 +83,24 @@ RSpec.describe "Configuration initiale", js: true do
                        text: "",
                        wait_for: "Vous n'avez pas encore créé de motif.")
 
-    click_on "Créer un motif"
+    click_on "Créer un motif", match: :first
 
     fill_in "Nom du motif", with: "Entretien utilisateur"
 
     doc.add_screenshot(page, text: "On crée un motif sur place")
 
-    click_on "Créer un motif"
+    click_on "Créer le motif"
+
+    expect(page).to have_content("Motif Entretien utilisateur créé.")
+
+    visit admin_organisation_configuration_url(organisation, host: "http://www.rdv-mairie-test.localhost")
+
+    doc.add_screenshot(page,
+                       text: "La page de configuration m'incite maintenant à créer un lieu",
+                       wait_for: "Aucun lieu")
+
+    click_on "Lieux"
+
+    doc.add_screenshot(page, wait_for: "Les lieux sont les endroits où sont réalisés les rendez-vous.")
   end
 end

--- a/spec/support/spec_to_doc.rb
+++ b/spec/support/spec_to_doc.rb
@@ -23,6 +23,10 @@ class SpecToDoc
         Slim::Template.new(Rails.root.join("spec/support/spec_to_doc/index.html.slim")).render(self).html_safe # rubocop:disable Rails/OutputSafety
       end
     )
+
+    if @scenarios.any?
+      puts "La doc est accessible sur file://#{Rails.root.join('tmp/capybara/spec_to_doc/index.html')}"
+    end
   end
 
   class Scenario


### PR DESCRIPTION
# Contexte

Dans le cadre de l'amélioration de l'embarquement, on veut encourager les nouveaux agents à créer leur premier motif puis leur premier lieu (si nécessaire).

Ça remplacera les motifs "Suivi de dossier" qui sont créés par défaut.

Mais pour le moment cette PR ajoute juste les éléments d'interface qui sont nécessaire, et la documentation pour les récapituler.

Une fois que ça sera complètement validé, on fera la deuxième PR pour  enlever la création de motifs par défaut.

# Solution

Le plus simple est de consulter la documentation ajoutée dans cette PR.

- On ajoute un callout qui redirige vers la création de motif là où c'est nécessaire.
- On change l'ordre des tuiles de la configuration pour metter motifs et lieu en premier, puisque ce sont les plus importantes.
- On ajoute une pastille pour rediriger vers la configuration
- On ajoute des badges pour renvoyer vers la création de lieux et/ou de motifs
- On met à jour les "empty states" des pages lieux et motifs pour les rendre plus claires


