### PR TITLE
Amélioration de l'incitation à créer des motifs avant de faire des plages d'ouverture

### DIFF
--- a/app/views/admin/plage_ouvertures/calendar.html.slim
+++ b/app/views/admin/plage_ouvertures/calendar.html.slim
@@ -11,10 +11,8 @@
   = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)
 
 - content_for :breadcrumb do
-  .fr-btns-group.fr-btns-group--inline
-    = link_to admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, search: params[:search], current_tab: params[:current_tab]), class: "fr-btn fr-btn--secondary" do
-      = icon("fr-icon-list-unordered", class: "fr-mr-1w")
-      span.mr-1= t("admin.plage_ouvertures.index.list_view")
+  .fr-btns-group.fr-btns-group--inline.fr-btns-group--icon-left
+    = link_to t("admin.plage_ouvertures.index.list_view"), admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, search: params[:search], current_tab: params[:current_tab]), class: "fr-btn fr-btn--secondary fr-icon-list-unordered"
     = link_to t("admin.plage_ouvertures.index.create_plage_ouverture"), new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "fr-btn fr-btn--secondary"
 
 #calendar [

--- a/app/views/admin/plage_ouvertures/calendar.html.slim
+++ b/app/views/admin/plage_ouvertures/calendar.html.slim
@@ -11,11 +11,11 @@
   = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)
 
 - content_for :breadcrumb do
-  .text-right
-    = link_to admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, search: params[:search], current_tab: params[:current_tab]), class: "btn btn-outline-primary align-bottom mr-3" do
+  .fr-btns-group.fr-btns-group--inline
+    = link_to admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, search: params[:search], current_tab: params[:current_tab]), class: "fr-btn fr-btn--secondary" do
+      = icon("fr-icon-list-unordered", class: "fr-mr-1w")
       span.mr-1= t("admin.plage_ouvertures.index.list_view")
-      i.fa.fa-calendar-alt
-    = link_to t("admin.plage_ouvertures.index.create_plage_ouverture"), new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-outline-primary align-bottom"
+    = link_to t("admin.plage_ouvertures.index.create_plage_ouverture"), new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "fr-btn fr-btn--secondary"
 
 #calendar [
   data-agent-id="#{@agent.id}"

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -11,11 +11,12 @@
   = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)
 
 - content_for :breadcrumb do
-  .text-right
-    = link_to calendar_admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), class: "btn btn-outline-primary align-bottom mr-3" do
-      span.mr-1= t(".calendar_view")
-      i.fa.fa-calendar-alt
-    = link_to t(".create_plage_ouverture"), new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-outline-primary align-bottom"
+  - if current_organisation.motifs.active.any?
+    .fr-btns-group.fr-btns-group--inline
+      = link_to calendar_admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), class: "fr-btn fr-btn--secondary" do
+        = icon("fr-icon-calendar-fill", class: "fr-mr-1w")
+        = t(".calendar_view")
+      = link_to t(".create_plage_ouverture"), new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "fr-btn fr-btn--secondary"
 
 .card.pb-3
   - if @display_tabs
@@ -47,25 +48,29 @@
     .d-flex.justify-content-center
       = paginate @plage_ouvertures, theme: "twitter-bootstrap-4"
   - else
-    .row.justify-content-md-center.p-2.mt-3
-      .col-md-6.rdv-text-align-center.mb-2
-        p.mb-2.lead
-          - if params[:search].present?
-            = t(".no_results_for_your_search")
+    .fr-grid-row.justify-content-md-center.p-2.mt-3
+      .fr-col-md-6.mb-2
+        - if params[:search].present?
+          h3= t(".no_results_for_your_search")
+        - else
+          - if current_agent == @agent
+            h3= t(".self.not_yet_created_plage_ouverture")
+            p = t(".self.explanation_plage_ouverture")
           - else
-            - if current_agent == @agent
-              = t(".self.not_yet_created_plage_ouverture")
-              p = t(".self.explanation_plage_ouverture")
-            - else
-              = t(".other_agent.not_yet_created_plage_ouverture", full_name: @agent.full_name_or_email)
-              p = t(".other_agent.explanation_plage_ouverture")
+            h3= t(".other_agent.not_yet_created_plage_ouverture", full_name: @agent.full_name_or_email)
+            p = t(".other_agent.explanation_plage_ouverture")
 
+          - if current_organisation.motifs.active.any?
             .mt-3
               = link_to new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-primary" do
                 - if current_agent == @agent
                   = t(".self.create_first_plage_cta")
                 - else
                   = t(".other_agent.create_first_plage_cta", full_name: @agent.full_name_or_email)
+    - if current_organisation.motifs.active.none?
+      .fr-grid-row
+        .fr-col-12
+          = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."
 
   - if params[:current_tab] == "expired"
     .rdv-text-align-center.text-muted = t(".hint_delete_old")

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -12,10 +12,8 @@
 
 - content_for :breadcrumb do
   - if current_organisation.motifs.active.any?
-    .fr-btns-group.fr-btns-group--inline
-      = link_to calendar_admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), class: "fr-btn fr-btn--secondary" do
-        = icon("fr-icon-calendar-fill", class: "fr-mr-1w")
-        = t(".calendar_view")
+    .fr-btns-group.fr-btns-group--inline.fr-btns-group--icon-left
+      = link_to t(".calendar_view"), calendar_admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), class: "fr-btn fr-btn--secondary fr-icon-calendar-fill"
       = link_to t(".create_plage_ouverture"), new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "fr-btn fr-btn--secondary"
 
 .card

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -18,7 +18,7 @@
         = t(".calendar_view")
       = link_to t(".create_plage_ouverture"), new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "fr-btn fr-btn--secondary"
 
-.card.pb-3
+.card
   - if @display_tabs
     ul.nav.nav-tabs.px-2.mt-2
       li.nav-item
@@ -51,7 +51,7 @@
     .fr-grid-row.justify-content-md-center.p-2.mt-3
       .fr-col-md-6.mb-2
         - if params[:search].present?
-          h3= t(".no_results_for_your_search")
+          = t(".no_results_for_your_search")
         - else
           - if current_agent == @agent
             h3= t(".self.not_yet_created_plage_ouverture")
@@ -62,14 +62,14 @@
 
           - if current_organisation.motifs.active.any?
             .mt-3
-              = link_to new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-primary" do
+              = link_to new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "fr-btn" do
                 - if current_agent == @agent
                   = t(".self.create_first_plage_cta")
                 - else
                   = t(".other_agent.create_first_plage_cta", full_name: @agent.full_name_or_email)
     - if current_organisation.motifs.active.none?
       .fr-grid-row
-        .fr-col-12
+        .fr-col-12.fr-px-2w
           = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."
 
   - if params[:current_tab] == "expired"

--- a/spec/features/spec_to_doc/self_onboarding_spec.rb
+++ b/spec/features/spec_to_doc/self_onboarding_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Configuration initiale", js: true do
                        wait_for: "Nouveau RDV")
 
     expect(page).to have_content("Pour prendre un rendez-vous, vous devez d'abord créer un motif.")
+    expect(page).not_to have_content("Vue calendrier")
 
     visit admin_organisation_creneaux_search_url(organisation, host: "http://www.rdv-mairie-test.localhost")
 
@@ -51,11 +52,11 @@ RSpec.describe "Configuration initiale", js: true do
 
     expect(page).to have_content("Pour prendre un rendez-vous, vous devez d'abord créer un motif.")
 
-    visit new_admin_organisation_agent_plage_ouverture_url(organisation, host: "http://www.rdv-mairie-test.localhost", agent_id: agent.id)
+    visit admin_organisation_agent_plage_ouvertures_url(organisation, host: "http://www.rdv-mairie-test.localhost", agent_id: agent.id)
 
     doc.add_screenshot(page,
-                       text: "Création de plage d'ouverture",
-                       wait_for: "Nouvelle plage d'ouverture")
+                       text: "Liste des plages d'ouverture",
+                       wait_for: "Vous n'avez pas encore créé de plage d'ouverture.")
 
     expect(page).to have_content("Pour créer une plage d'ouverture, vous devez d'abord créer un motif")
 


### PR DESCRIPTION
# Contexte

Un premier ajustement suite à https://github.com/betagouv/rdv-service-public/pull/5461 : pour les plages d'ouverture, plutôt que d'abord afficher un "empty state" qui fait croire qu'on peut créer une plage d'ouverture, puis rediriger vers la liste des motifs, on redirige tout de suite vers la liste des motifs

# Solution

J'en profite pour passer certains composants de bootstrap au dsfr

## Captures d'écran

Avant | Après
:- | -:
<img width="1414" alt="Screenshot 2025-06-25 at 17 46 34" src="https://github.com/user-attachments/assets/4e2fcfb7-07be-425c-9908-4adb38ec4327" />|<img width="1422" alt="Screenshot 2025-06-25 at 17 46 11" src="https://github.com/user-attachments/assets/47d41c36-7abc-4c64-a6ee-23099589890b" />
<img width="1417" alt="Screenshot 2025-06-25 at 17 47 52" src="https://github.com/user-attachments/assets/7c21127b-452d-49c8-8e37-307cf7858178" />|<img width="1419" alt="Screenshot 2025-06-25 at 17 48 09" src="https://github.com/user-attachments/assets/3d0f9516-810c-4fd7-a41f-9bc2345d1efd" />
