### PR TITLE
Utilisation du thème DSFR pour toutes les paginations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,6 @@ gem "pg_search"
 gem "strong_migrations"
 # A pagination engine plugin for Rails 4+ and other modern frameworks
 gem "kaminari"
-# Bootstrap 4 styling for Kaminari gem
-gem "bootstrap4-kaminari-views"
 # A Rails engine for creating super-flexible admin dashboards
 gem "administrate"
 # Track changes to your models.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,9 +168,6 @@ GEM
     blueprinter (1.1.0)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
-    bootstrap4-kaminari-views (1.0.1)
-      kaminari (>= 0.13)
-      rails (>= 3.1)
     brakeman (7.0.0)
       racc
     builder (3.3.0)
@@ -780,7 +777,6 @@ DEPENDENCIES
   binding_of_caller
   blueprinter
   bootsnap
-  bootstrap4-kaminari-views
   brakeman
   bullet
   byebug

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -30,7 +30,7 @@
     - elsif @agents.total_pages > 1
       .m-3
         .d-flex.justify-content-center
-          = paginate @agents, theme: "twitter-bootstrap-4"
+          = paginate @agents, theme: "dsfr"
         .rdv-text-align-center= page_entries_info @agents
 
     - if current_agent_can_create_agent_in?(current_organisation)

--- a/app/views/admin/invitations/index.html.slim
+++ b/app/views/admin/invitations/index.html.slim
@@ -29,7 +29,7 @@
     - elsif @invited_agents.total_pages > 1
       .m-3
         .d-flex.justify-content-center
-          = paginate @invited_agents, theme: "twitter-bootstrap-4"
+          = paginate @invited_agents, theme: "dsfr"
         .rdv-text-align-center= page_entries_info @invited_agents
 
     - if current_agent_can_create_agent_in?(current_organisation)

--- a/app/views/admin/lieux/index.html.slim
+++ b/app/views/admin/lieux/index.html.slim
@@ -6,7 +6,7 @@
 
 - if @lieux_policy.create?
   - content_for :breadcrumb do
-    = link_to "Ajouter un lieu", new_admin_organisation_lieu_path(current_organisation), class: "btn btn-outline-primary"
+    = link_to "Ajouter un lieu", new_admin_organisation_lieu_path(current_organisation), class: "fr-btn fr-btn--secondary"
 
 .card
   .card-body
@@ -21,7 +21,7 @@
             th Actions
         tbody
           = render @lieux
-      .d-flex.justify-content-center= paginate @lieux, theme: "twitter-bootstrap-4"
+      .d-flex.justify-content-center= paginate @lieux, theme: "dsfr"
     - else
       .fr-grid-row.justify-content-md-center
         .fr-col-md-6.fr-mt-2w.fr-mb-4w
@@ -31,4 +31,4 @@
 
     - if @lieux_policy.create?
       .rdv-text-align-center
-        = link_to "Ajouter un lieu", new_admin_organisation_lieu_path(current_organisation), class: "btn btn-primary"
+        = link_to "Ajouter un lieu", new_admin_organisation_lieu_path(current_organisation), class: "fr-btn"

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -76,7 +76,7 @@
         - if @motifs_page.any?
           = render partial: "admin/motifs/motif", collection: @motifs_page, as: :motif
           .d-flex.justify-content-center
-            = paginate @motifs_page, theme: "twitter-bootstrap-4"
+            = paginate @motifs_page, theme: "dsfr"
         - else
           tr
             td(colspan=6)
@@ -94,7 +94,7 @@
 
     - if @motifs_page.any?
       .d-flex.justify-content-center
-        = paginate @motifs_page, theme: "twitter-bootstrap-4"
+        = paginate @motifs_page, theme: "dsfr"
       - if agent_can_create_motif? && @current_tab == :active
         .rdv-text-align-center.m-3
           = link_to t("admin.motifs.actions.new"), new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -44,7 +44,7 @@
       tbody
         = render partial: "admin/plage_ouvertures/plage_ouverture", collection: @plage_ouvertures, as: :plage_ouverture
     .d-flex.justify-content-center
-      = paginate @plage_ouvertures, theme: "twitter-bootstrap-4"
+      = paginate @plage_ouvertures, theme: "dsfr"
   - else
     .fr-grid-row.justify-content-md-center.p-2.mt-3
       .fr-col-md-6.mb-2

--- a/app/views/admin/rdvs/a_renseigner.html.slim
+++ b/app/views/admin/rdvs/a_renseigner.html.slim
@@ -16,7 +16,7 @@ p Merci d'indiquer si ces rendez-vous se sont bien passés comme prévu.
         - rdvs.sort_by(&:starts_at).each do |rdv|
           = render "rdv_with_quick_update", rdv: rdv, agent: current_agent
         hr.mb-4
-      .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
+      .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
 - else
   .row.justify-content-center.pb-3
     .col-md-12

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -60,9 +60,9 @@
 
     .fr-grid-row.fr-pb-3w
       .fr-col-12
-        .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
+        .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
         = render(partial: "rdv", collection: @rdvs_in_page, locals: { agent: nil })
-        .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
+        .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
   - else
     .fr-grid-row.fr-py-3w
       .fr-col-12

--- a/app/views/admin/referent_assignations/index.html.slim
+++ b/app/views/admin/referent_assignations/index.html.slim
@@ -46,7 +46,7 @@
   - if @agents.total_pages > 1
     .m-3
       .d-flex.justify-content-center
-        = paginate @agents, theme: "twitter-bootstrap-4"
+        = paginate @agents, theme: "dsfr"
       .rdv-text-align-center= page_entries_info @agents
 
   .m-3

--- a/app/views/admin/territories/agents/index.html.slim
+++ b/app/views/admin/territories/agents/index.html.slim
@@ -32,4 +32,4 @@
                         title: t(".edit_agents") do
                   i.fa.fa-edit
     .d-flex.justify-content-center
-      = paginate @agents, theme: "twitter-bootstrap-4"
+      = paginate @agents, theme: "dsfr"

--- a/app/views/admin/territories/motifs/index.html.slim
+++ b/app/views/admin/territories/motifs/index.html.slim
@@ -77,9 +77,9 @@
             = t("admin.motifs.archiving_explanation")
 
     - if @motifs_page.any?
-      = paginate @motifs_page, theme: "twitter-bootstrap-4"
+      = paginate @motifs_page, theme: "dsfr"
       = render partial: "admin/territories/motifs/motifs_table", locals: { motifs: @motifs_page, display_actions: true, display_checkboxes: @current_tab != :archived }
-      .mt-2 = paginate @motifs_page, theme: "twitter-bootstrap-4"
+      .mt-2 = paginate @motifs_page, theme: "dsfr"
 
     - else
       .rdv-text-align-center

--- a/app/views/admin/territories/teams/index.html.slim
+++ b/app/views/admin/territories/teams/index.html.slim
@@ -34,7 +34,7 @@
                         data: { confirm: "Confirmez-vous la suppression de cette équipe ?"} ) do
                   i.fa.fa-trash-alt
     .d-flex.justify-content-center
-      = paginate @teams, theme: "twitter-bootstrap-4"
+      = paginate @teams, theme: "dsfr"
 
     .text-right
       = link_to t(".create_team"), new_admin_territory_team_path(current_territory), class: "btn btn-outline-primary"

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -49,7 +49,7 @@
     - elsif @users.total_pages > 1
       .m-3
         .d-flex.justify-content-center id="users-pagination"
-          = paginate @users, theme: "twitter-bootstrap-4"
+          = paginate @users, theme: "dsfr"
           .rdv-text-align-center= page_entries_info @users
   - else
     .card-body

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -17,7 +17,7 @@
               .card
                 .card-body
                   = render "rdv", rdv: rdv
-            .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
+            .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
 
       - else
         .card


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5463.osc-secnum-fr1.scalingo.io/) 

# Contexte

À la suite de l’instauration de la pagination au thème DSFR, je propose ici de passer toutes les pagination encore en Bootstrap au thème DSFR et de retirer la Gem `bootstrap4-kaminari-views`.

