### PR TITLE
Incitation à la création de lieux dans le flash de confirmation de la création d'un motif

### DIFF
--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -66,7 +66,7 @@ class Admin::MotifsController < AgentAuthController
     @motif.organisation ||= current_organisation
     authorize(@motif, policy_class: Agent::MotifPolicy)
     if @motif.save
-      flash[:success] = "Motif #{link_to_motif(@motif)} créé."
+      flash[:success] = creation_flash
       redirect_to admin_organisation_motifs_path(@motif.organisation)
     else
       render :new
@@ -113,6 +113,15 @@ class Admin::MotifsController < AgentAuthController
   end
 
   private
+
+  def creation_flash
+    if helpers.needs_lieu(current_organisation)
+      link = helpers.link_to("Configuration > Lieux", admin_organisation_lieux_path(current_organisation))
+      "Motif #{@motif.name} créé. Pour finaliser votre configuration, vous pouvez maintenant ajouter un lieu depuis la page #{link}"
+    else
+      "Motif #{link_to_motif(@motif)} créé."
+    end
+  end
 
   def display_sectorisation_level?
     @display_sectorisation_level ||= current_organisation.motifs.active.where.not(sectorisation_level: Motif::SECTORISATION_LEVEL_DEPARTEMENT).any?

--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -4,7 +4,7 @@ module ConfigurationHelper
   end
 
   def needs_lieu(organisation)
-    organisation.motifs.active.where(location_type: :public_office).any? && organisation.lieux.none?
+    organisation.motifs.active.where(location_type: :public_office).any? && organisation.lieux.enabled.none?
   end
 
   def territory_navigation(title = nil, previous_links = [])

--- a/spec/features/agents/agent_can_crud_motifs_spec.rb
+++ b/spec/features/agents/agent_can_crud_motifs_spec.rb
@@ -219,4 +219,18 @@ RSpec.describe "Agent can CRUD motifs" do
       end
     end
   end
+
+  describe "when the next necessary step is to create a lieu" do
+    let(:motif) { nil } # Pour éviter la création d'un motif par défaut
+
+    it "recommends it in the flash confirmation" do
+      visit new_admin_organisation_motif_path(organisation)
+      fill_in("Nom du motif", with: "Accompagnement")
+      select("PMI", from: "Service associé")
+      fill_in("Couleur associée", with: "#000000")
+      click_on("Créer le motif")
+
+      expect(page).to have_content("Pour finaliser votre configuration, vous pouvez maintenant ajouter un lieu")
+    end
+  end
 end

--- a/spec/features/spec_to_doc/self_onboarding_spec.rb
+++ b/spec/features/spec_to_doc/self_onboarding_spec.rb
@@ -91,7 +91,9 @@ RSpec.describe "Configuration initiale", js: true do
 
     click_on "Créer le motif"
 
-    expect(page).to have_content("Motif Entretien utilisateur créé.")
+    doc.add_screenshot(page,
+                       text: "Le message de confirmation m'incite à créer un lieu parce que le motif est sur place",
+                       wait_for: "vous pouvez maintenant ajouter un lieu")
 
     visit admin_organisation_configuration_url(organisation, host: "http://www.rdv-mairie-test.localhost")
 


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1421" alt="Screenshot 2025-06-26 at 10 23 22" src="https://github.com/user-attachments/assets/d4c62f6a-1e59-4533-a262-ffcd9b36b008" />|<img width="1424" alt="Screenshot 2025-06-26 at 10 26 19" src="https://github.com/user-attachments/assets/51a2cb30-5f3c-4656-8572-47affb51bc4e" />


Une autre amélioration suite à https://github.com/betagouv/rdv-service-public/pull/5461

Le wording est très discutable, je suis preneur de suggestions dessus (on va peut-être itérer dessus avec Mehdi et Téo plus tard)