### PR TITLE
Inciter à la création de motifs depuis la liste de rdv collectifs

### DIFF
--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -13,7 +13,7 @@
     = link_to "Nouveau RDV collectif", admin_organisation_rdvs_collectif_motifs_path(current_organisation), class: "fr-btn"
 
 .card
-  .card-body
+  .card-header
     = simple_form_for(@form, as: "", url: admin_organisation_rdvs_collectifs_path(current_organisation), method: :get) do |f|
       .row
         .col-md-4
@@ -33,18 +33,12 @@
         .col-md-1.d-flex-justify-content-end.mt-3
           = f.submit "Filtrer", class: "fr-btn fr-btn--secondary"
 
-.row.justify-content-center.pb-3
-  .col-md-12.col-lg-8
+  .card-body
     - if @rdvs.any?
       = render(partial: "admin/rdvs_collectifs/rdv", collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :services))
       .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
     - else
-      .card
-        .card-body
-          .row.justify-content-md-center
-            .col-md-6.rdv-text-align-center.my-5
-              p.mb-2.lead
-                | Aucun RDV
-              span.fa-stack.fa-4x
-                i.fa.fa-circle.fa-stack-2x.text-primary
-                i.far.fa-calendar.fa-stack-1x.text-white
+      .row.justify-content-md-center
+        .col-md-6.rdv-text-align-center.my-5
+          p.mb-2.lead
+            | Aucun RDV collectif

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -8,37 +8,43 @@
     = b.with_breadcrumb label: "Accueil", href: root_path
     = b.with_breadcrumb label: "RDV collectifs"
 
+- needs_collectif_motif = current_organisation.motifs.collectif.active.none?
 - content_for :breadcrumb do
-  .btn-group
-    = link_to "Nouveau RDV collectif", admin_organisation_rdvs_collectif_motifs_path(current_organisation), class: "fr-btn"
+  - unless needs_collectif_motif
+    .btn-group
+      = link_to "Nouveau RDV collectif", admin_organisation_rdvs_collectif_motifs_path(current_organisation), class: "fr-btn"
 
 .card
-  .card-header
-    = simple_form_for(@form, as: "", url: admin_organisation_rdvs_collectifs_path(current_organisation), method: :get) do |f|
-      .row
-        .col-md-4
-          = date_input(f, :from_date, label = "À partir du", value: @form.from_date)
-        .col-md-4
-          = f.input :motif_id, \
-            include_blank: true, \
-            collection: @motifs, \
-            as: :select, \
-            label_method: -> { motif_name_and_location_type(_1) }, \
-            input_html: { \
-              data: { placeholder: "Sélectionnez un motif", "allow-clear": true }, \
-              class: "select2-input", \
-            }
-        .col-md-3.mt-4
-          = f.input :with_remaining_seats, as: :boolean, label: "Avec des places disponibles"
-        .col-md-1.d-flex-justify-content-end.mt-3
-          = f.submit "Filtrer", class: "fr-btn fr-btn--secondary"
+  - unless needs_collectif_motif
+    .card-header
+      = simple_form_for(@form, as: "", url: admin_organisation_rdvs_collectifs_path(current_organisation), method: :get) do |f|
+        .row
+          .col-md-4
+            = date_input(f, :from_date, label = "À partir du", value: @form.from_date)
+          .col-md-4
+            = f.input :motif_id, \
+              include_blank: true, \
+              collection: @motifs, \
+              as: :select, \
+              label_method: -> { motif_name_and_location_type(_1) }, \
+              input_html: { \
+                data: { placeholder: "Sélectionnez un motif", "allow-clear": true }, \
+                class: "select2-input", \
+              }
+          .col-md-3.mt-4
+            = f.input :with_remaining_seats, as: :boolean, label: "Avec des places disponibles"
+          .col-md-1.d-flex-justify-content-end.mt-3
+            = f.submit "Filtrer", class: "fr-btn fr-btn--secondary"
 
   .card-body
     - if @rdvs.any?
       = render(partial: "admin/rdvs_collectifs/rdv", collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :services))
       .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
     - else
-      .row.justify-content-md-center
-        .col-md-6.rdv-text-align-center.my-5
-          p.mb-2.lead
-            | Aucun RDV collectif
+      - if current_organisation.motifs.collectif.active.none?
+        = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer un RDV collectif, vous devez d'abord créer un motif de rendez-vous collectif."
+      - else
+        .row.justify-content-md-center
+          .col-md-6.rdv-text-align-center.my-5
+            p.mb-2.lead
+              | Aucun RDV collectif

--- a/spec/features/spec_to_doc/self_onboarding_spec.rb
+++ b/spec/features/spec_to_doc/self_onboarding_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe "Configuration initiale", js: true do
 
     expect(page).to have_content("Pour prendre un rendez-vous, vous devez d'abord créer un motif.")
 
+    visit admin_organisation_rdvs_collectifs_url(organisation, host: "http://www.rdv-mairie-test.localhost", agent_id: agent.id)
+
+    doc.add_screenshot(page,
+                       text: "Liste des RDV collectifs",
+                       wait_for: "Pour créer un RDV collectif")
+
     visit admin_organisation_agent_plage_ouvertures_url(organisation, host: "http://www.rdv-mairie-test.localhost", agent_id: agent.id)
 
     doc.add_screenshot(page,


### PR DESCRIPTION
Une autre amélioration suite à https://github.com/betagouv/rdv-service-public/pull/5461

On adopte le même comportement que pour les plages d'ouverture :
- on indique directement qu'il faut créer un motif
- on cache les filtres s'ils ne sont pas pertinents
- et au passage on met dans les filtres et les résultats dans la même card, parce qu'ils sont liés

### Sans motif collectif

Avant | Après
:- | -:
<img width="1436" alt="Screenshot 2025-06-26 at 14 31 19" src="https://github.com/user-attachments/assets/e9f046fc-9673-4140-96c4-41f0b3b815c1" />|<img width="1432" alt="Screenshot 2025-06-26 at 14 31 32" src="https://github.com/user-attachments/assets/f503556a-f380-4652-aef3-f27ba5b4d68a" />


### Avec motif collectif

Avant | Après
:- | -:
<img width="1436" alt="Screenshot 2025-06-26 at 14 31 19" src="https://github.com/user-attachments/assets/e9f046fc-9673-4140-96c4-41f0b3b815c1" />|<img width="1440" alt="Screenshot 2025-06-26 at 14 35 00" src="https://github.com/user-attachments/assets/fdcda520-17e8-463f-9ca7-bcd0a1ab3eb3" />
