### PR TITLE
Ne plus créer de motifs par défaut

### DIFF
--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -41,8 +41,6 @@ class Compte
       if organisation.ants_connectable
         create_mairie_motifs!
         add_mairie_motifs_categories!
-      else
-        create_example_motifs!
       end
 
       AgentTerritorialRole.create!(agent: agent, territory: territory)

--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -41,6 +41,9 @@ class Compte
       if organisation.ants_connectable
         create_mairie_motifs!
         add_mairie_motifs_categories!
+      elsif OauthApplication.agent_is_verified_by_an_application?(agent)
+        # On ne propose pas encore la création de motifs depuis les intégrations, donc on continue de créer des motifs par défaut dans ce cas
+        create_example_motifs!
       end
 
       AgentTerritorialRole.create!(agent: agent, territory: territory)

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -11,8 +11,6 @@ header.main-content__header
 section.main-content__body
   p
     | Ce formulaire vous permet de créer un espace, une organisation, et un lieu (facultatif) pour un agent qui en sera admin (généralement la personne référente du projet).
-  p
-    | Des motifs "Suivi de dossier" seront créés par défaut
   = simple_form_for([namespace, page.resource], html: { class: "form" }) do |f|
     - if @territory_creation_request
       = f.hidden_field :territory_creation_request_id, value: @territory_creation_request.id

--- a/spec/features/spec_to_doc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/spec_to_doc/rendez_vous_entre_agents_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
       }, current_domain: Domain::RDV_MAIRIE
     ).save!
 
-    Motif.where.not(location_type: :visio).update_all(deleted_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
+    create(:motif, organisation: Organisation.last, location_type: :visio, name: "Suivi de dossier")
   end
 
   specify do

--- a/spec/features/spec_to_doc/self_onboarding_spec.rb
+++ b/spec/features/spec_to_doc/self_onboarding_spec.rb
@@ -20,13 +20,7 @@ RSpec.describe "Configuration initiale", js: true do
 
     doc.add_text(<<~TEXT
       <p>
-        Pour le moment on crée par défaut des motifs "Suivi de dossier" lors de l'ouverture d'un nouvel espace.
-      </p>
-      <p>
-        Cependant, on va bientôt arrêter de le faire, et encourager les agents à créer leur premier motif et leur premier lieu manuellement.
-      </p>
-      <p>
-        Cette documentation montre ce qui se passe pour une nouvelle organisation créée sans motifs.
+        Quand une nouvelle organisation est créée, elle n'a pas encore de motifs. On veut permettre à l'agent d'explorer les différentes pages, mais l'inciter à créer un premier motif.
       </p>
     TEXT
       .html_safe) # rubocop:disable Rails/OutputSafety

--- a/spec/features/super_admin/creating_a_new_account_spec.rb
+++ b/spec/features/super_admin/creating_a_new_account_spec.rb
@@ -66,10 +66,7 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
       longitude: 2.429639
     )
 
-    new_motif = new_organisation.motifs.first
-    expect(new_motif).to have_attributes(
-      name: "Suivi de dossier"
-    )
+    expect(new_organisation.motifs).to be_blank
 
     perform_enqueued_jobs
     invitation_email = ActionMailer::Base.deliveries.last

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
         click_on "Enregistrer"
 
         expect(page).to have_content "Configuration"
+
+        new_motif = Organisation.last.motifs.first
+        expect(new_motif).to have_attributes(
+          name: "Suivi de dossier"
+        )
         expect(agent.reload.organisations.last.name).to eq "CCAS de Montreuil"
       end
     end


### PR DESCRIPTION
L'aboutissement du travail commencé avec https://github.com/betagouv/rdv-service-public/pull/5461 : maintenant qu'on guide correctement à la création de motifs, on ne crée plus les motifs "Suivi de dossier" qui prêtent à confusion.

On les garde juste dans le contexte des intégrations, puisqu'on ne permet pas encore la création de motif "inline" pour les intégrations.

