### PR TITLE
Rendre l'autodoc plus jolie et plus pratique

### DIFF
--- a/spec/support/spec_to_doc/index.html.slim
+++ b/spec/support/spec_to_doc/index.html.slim
@@ -1,10 +1,13 @@
-h1 Documentation
+.fr-grid-row[style="min-height: 400px"]
+  .fr-col-12
+    h1 Documentation de RDV Service Public
 
-p Cette page documente différentes fonctionnalités de RDV Service Public
+    p Cette page documente différentes fonctionnalités de RDV Service Public
+    p Elle est mise à jour automatiquement dès que l'application change.
 
-ul
-- @scenarios.each do |scenario|
-  li
-    a[href='scenario_#{scenario.index}.html'] #{scenario.title}
+    ul
+    - @scenarios.each do |scenario|
+      li
+        a[href='scenario_#{scenario.index}.html'] #{scenario.title}
 
-p Dernière mise à jour le #{I18n.l(Time.zone.now)}
+    p Dernière mise à jour le #{I18n.l(Time.zone.now)}

--- a/spec/support/spec_to_doc/layout.html.slim
+++ b/spec/support/spec_to_doc/layout.html.slim
@@ -1,5 +1,20 @@
-head
-  link href="https://unpkg.com/@gouvfr/dsfr@1.13.2/dist/dsfr.min.css" rel="stylesheet"
-  title Documentation interne - RDV Service Public
-body
-  = yield
+doctype html
+html lang="fr"
+  head
+    link href="https://unpkg.com/@gouvfr/dsfr@1.13.2/dist/dsfr.min.css" rel="stylesheet"
+    title Autodoc de RDV Service Public
+  body
+
+    header[role="banner" class="fr-header"]
+      .fr-header__body
+        .fr-container
+          .fr-header__body-row
+            .fr-header__brand.fr-enlarge-link
+              .fr-header__brand-top
+                .fr-header__service
+                  a[href="index.html" title="Accueil - Autodoc RDV Service Public"]
+                    p.fr-header__service-title = "Autodoc - RDV Service Public"
+
+    main#content[role="main"]
+      .fr-container.fr-pt-2w
+        = yield

--- a/spec/support/spec_to_doc/scenario.html.slim
+++ b/spec/support/spec_to_doc/scenario.html.slim
@@ -1,4 +1,3 @@
-
 .fr-grid-row
   .fr-col-12
     div[style="display: flex; position: sticky; top: 0; background: white;"]

--- a/spec/support/spec_to_doc/scenario.html.slim
+++ b/spec/support/spec_to_doc/scenario.html.slim
@@ -16,6 +16,6 @@
           - if step[:img_src]
             img[src='#{step[:img_src]}' width=800 style='border: solid 2px grey']
             - if step[:text]
-              p.fr-mt-2w = step[:text]
+              p.fr-mt-2w.fr-mb-5w = step[:text]
           - else
-            p[style="min-width: 300px"] = step[:text]
+            p = step[:text]

--- a/spec/support/spec_to_doc/scenario.html.slim
+++ b/spec/support/spec_to_doc/scenario.html.slim
@@ -1,9 +1,16 @@
-.fr-m-2w
-  a[href="index.html"] retour
-  h1 = @title
-  - @sections.each.with_index do |section, index|
-    h2 = "#{index +1}) #{section.title}"
-    div[style="display: flex"]
+
+.fr-grid-row
+  .fr-col-12
+    div[style="display: flex; position: sticky; top: 0; background: white;"]
+      h1 = @title
+      ul.fr-nav__list.fr-ml-4w[style="display: flex;"]
+        - @sections.each.with_index do |section, index|
+          li.fr-nav__item
+            a.fr-nav__link[href="#section_#{index}"] = section.title
+
+    - @sections.each.with_index do |section, index|
+      / le padding-top et margin-top sont pour compenser la hauteur du headeur sticky
+      h2[id="section_#{index}" style="padding-top: 80px; margin-top: -80px;"] = "#{index +1}) #{section.title}"
       - section.steps.each do |step|
         div[style="padding: 8px; display: flex; flex-direction: column; align-items: center"]
           - if step[:img_src]

--- a/spec/support/spec_to_doc/scenario.html.slim
+++ b/spec/support/spec_to_doc/scenario.html.slim
@@ -17,4 +17,4 @@
             - if step[:text]
               p.fr-mt-2w.fr-mb-5w = step[:text]
           - else
-            p = step[:text]
+            div = step[:text]


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1422" alt="Screenshot 2025-06-26 at 17 09 39" src="https://github.com/user-attachments/assets/33588e52-e284-449f-84b3-d56bac816627" />|<img width="1344" alt="Screenshot 2025-06-26 at 17 09 10" src="https://github.com/user-attachments/assets/f5b5cdac-b3d3-4f6d-8227-2a6b146429c6" />

Cette PR rend l'autodoc navigable de manière verticale, et ajoute un layout un tout petit peu plus élégant.
Comme suggéré par @AntoineGirard, on rend les différentes sections navigables avec des anchor.

J'ai pas réussi à faire fonctionner les dsfr view componants avec du slim vanilla, mais on s'en sort avec du htm