### PR TITLE
Retrait de la CPS JS unsafe inline

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -41,15 +41,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src :self, :unsafe_inline, bootstrap_cdn, headway_cnd, unpkg_cdn
   policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
 
-  # La source `unsafe_inline` autorise l'utilisation de js dans un tag `script` dans la page ou dans les attributs onchange, onclick….
-  # Idéalement, on voudrait donc la supprimer, puisque ça ajouterait une couche de protection contre les injections de JS.
-  # On s’en sert encore pour certains attributs `onchange`/`onclick`, mais on pourrait s’en passer en utilisant des événements JS.
-  #
-  # Il semble aussi que dans les tests capybara en js: true, un petit script est injecté pour lequel il faut aussi ajouter une source de type sha.
-  #
-  # Les sources de type sha permettent de s'assurer que seul le script correspondant exactement au sha peut-être chargé.
-  # Cependant, elles ne sont pas prises en compte si la source 'unsafe_inline' est présente
-  policy.script_src :self, :unsafe_inline, headway_cnd, unpkg_cdn
+  policy.script_src :self, headway_cnd, unpkg_cdn, "osjxnKEPL/pQJbFk1dKsF7PYFmTyMWGmVSiL9inhxJY="
 end
 
 # If you are using UJS then enable automatic nonce generation

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -41,7 +41,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src :self, :unsafe_inline, bootstrap_cdn, headway_cnd, unpkg_cdn
   policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
 
-  policy.script_src :self, headway_cnd, unpkg_cdn, "osjxnKEPL/pQJbFk1dKsF7PYFmTyMWGmVSiL9inhxJY="
+  policy.script_src :self, headway_cnd, unpkg_cdn
 end
 
 # If you are using UJS then enable automatic nonce generation


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5470.osc-secnum-fr1.scalingo.io/) 

# Contexte

Afin de renforcer à la sécurité de notre produit, nous avons supprimé les JS inliné ici : 
- https://github.com/betagouv/rdv-service-public/pull/5490
- https://github.com/betagouv/rdv-service-public/pull/5480
- https://github.com/betagouv/rdv-service-public/pull/5473
- https://github.com/betagouv/rdv-service-public/pull/5458
- https://github.com/betagouv/rdv-service-public/pull/5456

On peut donc désormais retirer la CSP correspondante.
