### PR TITLE
Correction de l’affichage à la mise à jour d’un RDV collectif

### DIFF
--- a/app/controllers/admin/participations_controller.rb
+++ b/app/controllers/admin/participations_controller.rb
@@ -13,7 +13,7 @@ class Admin::ParticipationsController < AgentAuthController
     else
       flash.now[:error] = @participation.errors.full_messages.to_sentence
     end
-    render "admin/rdvs/update", locals: { rdv: @rdv, agent: current_agent, quick_update: params[:quick_update] }
+    render "admin/rdvs/update", locals: { rdv: @rdv.reload, agent: current_agent, quick_update: params[:quick_update] }
   end
 
   def destroy

--- a/app/helpers/participations_helper.rb
+++ b/app/helpers/participations_helper.rb
@@ -8,9 +8,8 @@ module ParticipationsHelper
 
   def participation_delete_dropdown_item(participation, agent)
     link_to admin_organisation_rdv_participation_path(participation.rdv.organisation, participation.rdv, participation, agent_id: agent&.id),
-            method: :delete,
             class: "dropdown-item",
-            data: { confirm: t("admin.participations.delete.confirm") } do
+            data: { turbo_method: :delete, confirm: t("admin.participations.delete.confirm") } do
       tag.div(t("admin.participations.delete.title"), class: "text-danger") +
         tag.div(t("admin.participations.delete.details"), class: "text-wrap text-muted")
     end

--- a/app/views/admin/participations/_participation_status_dropdown_item.html.slim
+++ b/app/views/admin/participations/_participation_status_dropdown_item.html.slim
@@ -1,5 +1,5 @@
 = link_to admin_organisation_rdv_participation_path(participation.rdv.organisation, participation.rdv, participation, participation: { status: status }, agent_id: agent&.id),
-  method: :put, class: "dropdown-item", data: { confirm: change_status_confirmation_message(participation.rdv, status) }, remote: remote do
+  class: "dropdown-item", data: { turbo_method: :put, confirm: change_status_confirmation_message(participation.rdv, status) } do
   span
     i class=("fa fa-circle mr-1 rdv-status-#{status}")
     = Participation.human_attribute_value(:status, status, context: :action)


### PR DESCRIPTION
Closes #5278

# Contexte

On corrige l’affichage des status des participations au RDV collectifs.
Il y avait 2 problèmes : 

1. Le problème historique : le RDV n’était pas mis à jour avant d’être envoyé à la vue. Par conséquent, le statut de la participation n’était pas à jour 
2. Depuis le passage à Hotwire, je n’avais pas changé le moyen d’indiquer la méthode. Le retour n’était donc pas traité comme un turbo stream.
