### PR TITLE
Suppression du script inliné Headway

### DIFF
--- a/app/javascript/headway_config.js
+++ b/app/javascript/headway_config.js
@@ -1,0 +1,23 @@
+// @see https://docs.headwayapp.co/widget for more configuration options.
+config = {
+  selector: "#js-headway-anchor", // CSS selector where to inject the badge
+  account:  "7643Dy",
+  trigger:  "#js-headway-anchor",
+  translations: {
+    title: "Nouveautés",
+    readMore: "Voir plus",
+    footer: "Voir tout ↗️"
+  },
+  callbacks: {
+    onWidgetReady: function(widget) {
+      // Ne pas afficher le conteneur du badge avant que le widget soit chargé
+      // pour éviter le mouvement bref de l'élément au chargement.
+      const container = document.querySelector("#HW_badge_cont")
+      if(container) {
+        container.style.display = "block"
+      }
+    },
+  },
+};
+
+Headway.init(config)

--- a/app/views/layouts/_headway_widget.html.erb
+++ b/app/views/layouts/_headway_widget.html.erb
@@ -1,24 +1,2 @@
-<script>
-  // @see https://docs.headwayapp.co/widget for more configuration options.
-  var HW_config = {
-    selector: "#js-headway-anchor", // CSS selector where to inject the badge
-    account:  "7643Dy",
-    trigger:  "#js-headway-anchor",
-    translations: {
-      title: "Nouveautés",
-      readMore: "Voir plus",
-      footer: "Voir tout ↗️"
-    },
-    callbacks: {
-      onWidgetReady: function(widget) {
-        // Ne pas afficher le conteneur du badge avant que le widget soit chargé
-        // pour éviter le mouvement bref de l'élément au chargement.
-        const container = document.querySelector("#HW_badge_cont")
-        if(container) {
-          container.style.display = "block"
-        }
-      },
-    },
-  };
-</script>
-<script async src="https://cdn.headwayapp.co/widget.js"></script>
+<%= javascript_include_tag "https://cdn.headwayapp.co/widget.js"  %>
+<%= javascript_include_tag "headway_config.js" %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -41,12 +41,9 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src :self, :unsafe_inline, bootstrap_cdn, headway_cnd, unpkg_cdn
   policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
 
-  # La source `unsafe_inline` autorise l'utilisation de js dans un tag `script` dans la page.
+  # La source `unsafe_inline` autorise l'utilisation de js dans un tag `script` dans la page ou dans les attributs onchange, onclick….
   # Idéalement, on voudrait donc la supprimer, puisque ça ajouterait une couche de protection contre les injections de JS.
-  # On s'en sert pour deux choses:
-  # - un script de customisation de headway qui est inliné : on pourrait ajouter une source de type sha pour éviter ça
-  # - les mises à jour de statuts de rdvs qui utilisent des forms `js: true` et une view en `js.erb`. Si on pouvait éviter ce fonctionnement
-  # (peut-être en utilisant des turbo-frames), on pourrait s'éviter l'usage de cette source ici.
+  # On s’en sert encore pour certains attributs `onchange`/`onclick`, mais on pourrait s’en passer en utilisant des événements JS.
   #
   # Il semble aussi que dans les tests capybara en js: true, un petit script est injecté pour lequel il faut aussi ajouter une source de type sha.
   #

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
     rdv_plan: "./app/javascript/rdv_plan",
     mail: "./app/javascript/mail",
     instance_name: "./app/javascript/instance_name",
+    headway_config: "./app/javascript/headway_config",
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5473.osc-secnum-fr1.scalingo.io/) 

# Contexte

Afin de pouvoir à terme retirer le unsafe_inline de la CSP, on change la manière donc on charge la config Headway.

# Solution

Utilisation d’un JS séparé plutôt que d’un script inliné.
