### PR TITLE
CI: Retirer le pin v128 de Chrome 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,17 +206,6 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-      # TODO: Remove this workaround that specify the Chrome version used by the CI
-      # inspired by https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2731100953
-      # once the linked issue on selenium would have been fixed
-      - name: Remove image-bundled Chrome
-        run: sudo apt-get purge google-chrome-stable
-      - name: Setup stable Chrome
-        uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: 128
-          install-chromedriver: true
-          install-dependencies: true
       - name: Set up Redis
         uses: zhulik/redis-action@1.1.0
       - name: Cache js dependencies
@@ -288,17 +277,6 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-      # TODO: Remove this workaround that specify the Chrome version used by the CI
-      # inspired by https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2731100953
-      # once the linked issue on selenium would have been fixed
-      - name: Remove image-bundled Chrome
-        run: sudo apt-get purge google-chrome-stable
-      - name: Setup stable Chrome
-        uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: 128
-          install-chromedriver: true
-          install-dependencies: true
       - name: Set up Redis
         uses: zhulik/redis-action@1.1.0
       - name: Cache js dependencies


### PR DESCRIPTION
# Contexte

Dans https://github.com/betagouv/rdv-service-public/pull/5258 on avait mis en place du code pour forcer Chrome v128 pour éviter certaines flaky specs Capybara

Ces deux étapes prennent entre 20s et 1m+ par ex https://github.com/betagouv/rdv-service-public/actions/runs/15979055999/job/45070437250

Ça fait aussi un peu de code supplémentaire dans les github actions déjà un peu dures à lire

# Solution

Je propose de retirer le pinning en 128. Ce n’est pas super clair si le problème a été résolu dans les nouvelles versions de chrome https://github.com/teamcapybara/capybara/issues/2800 

Si jamais on a de nouveaux des problèmes de type `node id not found` je propose d’essayer https://github.com/makandra/capybara-lockstep plutôt que de pinner chrome.

