### PR TITLE
Correctif sur le logout suite à une prise de rdv

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -35,6 +35,7 @@ class Users::SessionsController < Devise::SessionsController
 
     agent_connect_id_token = session.delete(:agent_connect_id_token)
 
+    session.delete(:invitation)
     sign_out(:user)
     set_flash_message!(:notice, :signed_out)
 

--- a/spec/features/users/account/logout_spec.rb
+++ b/spec/features/users/account/logout_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "Déconnexion" do
     first(:link, "11:00").click
 
     # On vérifie que les infos de l'utilisateur n'ont pas été gardées dans la session
-    
     expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer.")
 
     expect(page).not_to have_content(user.first_name)

--- a/spec/features/users/account/logout_spec.rb
+++ b/spec/features/users/account/logout_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe "Déconnexion" do
+  let(:user) { create(:user) }
+  let(:motif) { create(:motif, bookable_by: :everyone, organisation: organisation) }
+  let(:organisation) { create(:organisation) }
+  let(:lieu) { create(:lieu, organisation: organisation) }
+
+  let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: 1.month.from_now, motifs: [motif], lieu: lieu, organisation: organisation) }
+
+  it "fonctionne après une prise de rdv" do
+    visit public_link_to_org_path(organisation_id: organisation.id, org_slug: organisation.slug)
+    click_on motif.name
+    click_on lieu.name
+    first(:link, "11:00").click
+
+    fill_in("Adresse email", with: user.email)
+    fill_in("Mot de passe", with: user.password)
+    find("input[value='Se connecter']").click
+
+    click_button("Continuer")
+    click_button("Continuer")
+    click_link("Confirmer mon RDV")
+    expect(page).to have_content("Votre RDV")
+
+    click_on "Déconnexion"
+
+    visit public_link_to_org_path(organisation_id: organisation.id, org_slug: organisation.slug)
+    click_on motif.name
+    click_on lieu.name
+    first(:link, "11:00").click
+
+    # On vérifie que les infos de l'utilisateur n'ont pas été gardées dans la session
+    
+    expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer.")
+
+    expect(page).not_to have_content(user.first_name)
+  end
+end


### PR DESCRIPTION
# Contexte

J'ai trouvé ça en faisant la recette pour France Connect v2
Voir la fiche notion https://www.notion.so/rdvs/2232b05ced4180818646c7ef0ed14c14

La spec reproduit le bug.

# Solution

La valeur `session[:invitation]` est ajoutée lors de la prise de rdv, mais pas supprimée lors du `sign_out`
Je vais examiner le reste de la logique de plus près, voir s'il y a d'autres soucis.

J'ai l'impression que ça date de https://github.com/betagouv/rdv-service-public/pull/2153
