### PR TITLE
Correctif de la marge entre le contenu et le footer côté agent

### DIFF
--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -13,6 +13,7 @@
     100vh - 73px
   ); // 73px correspond à la taille du header, arrondie au supérieur
   padding-bottom: 73px; //idem
+  margin-bottom: 40px; // cette marge évite que le haut du footer soit au-dessus du contenu
 
   @media (max-height: 800px) {
     min-height: calc(100vh - 49px); // taille du header

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -12,12 +12,10 @@
   min-height: calc(
     100vh - 73px
   ); // 73px correspond à la taille du header, arrondie au supérieur
-  padding-bottom: 73px; //idem
-  margin-bottom: 40px; // cette marge évite que le haut du footer soit au-dessus du contenu
+  padding-bottom: 90px; // taille du footer, plus un peu de marge
 
   @media (max-height: 800px) {
-    min-height: calc(100vh - 49px); // taille du header
-    padding-bottom: 49px; //idem
+    min-height: calc(100vh - 53px); // taille du header
   }
 }
 


### PR DESCRIPTION
Un autre petit correctif suite aux retours qu'on a en ce moment.
Au passage ça évite le scroll vertical sur les pages sur lesquelles il n'y en a pas besoin

## Captures d'écran

Avant | Après
:- | -:
<img width="1416" alt="Screenshot 2025-07-01 at 12 55 25" src="https://github.com/user-attachments/assets/552c70c6-dc04-4a37-a03a-637921a27eff" />|<img width="1420" alt="Screenshot 2025-07-01 at 12 51 57" src="https://github.com/user-attachments/assets/6d3413b9-0ef6-46e7-924a-48cee2230dc5" />
<img width="1207" alt="Screenshot 2025-07-01 at 12 53 35" src="https://github.com/user-attachments/assets/05b65f80-ab6d-45c3-b561-2f936c45fed6" />|<img width="1250" alt="Screenshot 2025-07-01 at 12 53 46" src="https://github.com/user-attachments/assets/f98cc80c-b5f7-42be-b473-d660fc15a6d2" />