### PR TITLE
Suppression onclick bouton impression

### DIFF
--- a/app/javascript/application_agent.js
+++ b/app/javascript/application_agent.js
@@ -43,6 +43,7 @@ import './components/clear-field-on-focus.js'
 import { Application } from "@hotwired/stimulus"
 import CheckboxSelectAll from '@stimulus-components/checkbox-select-all'
 import MotifFormController from './controllers/motif_form_controller'
+import './controllers'
 
 window.Stimulus = Application.start()
 Stimulus.register('checkbox-select-all', CheckboxSelectAll)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import MotifFormController from "./motif_form_controller"
 application.register("motif-form", MotifFormController)
+
+import PrintController from "./print_controller"
+application.register("print", PrintController)

--- a/app/javascript/controllers/print_controller.js
+++ b/app/javascript/controllers/print_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  print() {
+    window.print()
+  }
+}

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -45,7 +45,7 @@
 
             i.fa.fa-download>
 
-          .btn.btn-sm.btn-link.d-print-none role="button" onclick="window.print();return;"
+          .btn.btn-sm.btn-link.d-print-none role="button" data-controller="print" data-action="click->print#print"
             span> Imprimer
             i.fa.fa-print>
 


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5480.osc-secnum-fr1.scalingo.io/) 

# Contexte

Dans le cadre de la suppression de la CSP unsafe inline, nous supprimons les `onchange`/`onclick`. Cette PR a pour but de proposer une première implémentation sur un cas simple avant de reproduire sur les autres cas.
