### PR TITLE
Ne pas afficher une section lieu vide dans les mails pour les plages d'ouverture sans lieu

### DIFF
--- a/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
@@ -4,14 +4,14 @@
     span.title Agent :
     span.float-right= plage_ouverture.agent.full_name
     .clear
-  div.row-result
-    span.title Lieu :
-    span.float-right
-      -if plage_ouverture.lieu.present?
+  -if plage_ouverture.lieu.present?
+    div.row-result
+      span.title Lieu :
+      span.float-right
         = plage_ouverture.lieu_name
         = tag.span("Fermé", class: "badge badge-danger") unless plage_ouverture.lieu_enabled?
         = " (#{plage_ouverture.lieu_address})"
-    .clear
+      .clear
   div.row-result
     span.title Motifs :
     span.float-right


### PR DESCRIPTION
Petit défaut remarqué hier par Yasmina : pour une plage d'ouverture sans lieu, ont affiche l'intitulé "Lieu" même s'il n'y en a pas (par exemple pour une plage d'ouverture uniquement pour des rdvs par téléphone).