### PR TITLE
Correctif de l'alignement des boutons dans la prise de rdv pour les usagers

### DIFF
--- a/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
+++ b/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
@@ -26,6 +26,9 @@ main .fr-btn.fr-btn--secondary:hover {
 main .fr-btn.fr-btn--tertiary:hover {
   color: var(--text-action-high-blue-france);
 }
+main .fr-btn.fr-btn--tertiary-no-outline:hover {
+  color: var(--text-action-high-blue-france);
+}
 main .fr-btn.fr-btn--close:hover {
   color: var(--text-action-high-blue-france);
 }

--- a/app/views/agents/registrations/_form.html.slim
+++ b/app/views/agents/registrations/_form.html.slim
@@ -14,4 +14,4 @@
   = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "current-password"
   .form-text.text-muted.mb-2
     | Renseignez votre mot de passe actuel pour tout changement.
-  .text-right= f.submit "Modifier", class: "btn btn-primary"
+  .text-right= f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/users/rdv_wizard_steps/step1.html.slim
+++ b/app/views/users/rdv_wizard_steps/step1.html.slim
@@ -9,5 +9,3 @@
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body
         = render "users/users/form", user: current_user, rdv_wizard: @rdv_wizard, service: @rdv_wizard.service
-        .col
-          = link_to "Revenir en arrière", prendre_rdv_path(@rdv_wizard.to_query), class: "btn btn-link"

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -24,6 +24,7 @@
 
           .form-group
             = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv_wizard.lieu_id), data: { modal: true }
-          .rdv-text-align-right
-            = link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "fr-btn fr-btn--secondary fr-mr-2w"
-            = f.submit "Continuer", class: "fr-btn"
+          .fr-grid-row.fr-grid-row--gutters.fr-mt-3w
+            .fr-col.rdv-justify-content-space-between.d-flex.flex-row-aligned
+              = dsfr_link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "fr-icon-arrow-left-line fr-link--icon-left"
+              = f.submit "Continuer", class: "fr-btn"

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -25,6 +25,6 @@
           .form-group
             = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv_wizard.lieu_id), data: { modal: true }
           .fr-grid-row.fr-grid-row--gutters.fr-mt-3w
-            .fr-col.rdv-justify-content-space-between.d-flex.flex-row-aligned
-              = dsfr_link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "fr-icon-arrow-left-line fr-link--icon-left"
+            .fr-col.rdv-justify-content-space-between.d-flex
+              = link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "fr-icon-arrow-left-line fr-btn--icon-left fr-btn fr-btn--tertiary-no-outline"
               = f.submit "Continuer", class: "fr-btn"

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -2,20 +2,21 @@
 
 .card
   .card-body
-    - if resource.logged_once_with_franceconnect?
-      .fr-alert.fr-alert--info.fr-mb-3w
-        | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de FranceConnect
-    - if resource.pro_connect_openid_sub
-      .fr-alert.fr-alert--info.fr-mb-3w
-        | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de ProConnect
-    = form_for resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put }, builder: Dsfr::FormBuilder do |f|
-      = f.dsfr_email_field :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), autocomplete: "email"
-      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-        .form-text.rdv-color-text-mention-grey.mb-2
-          | En attente de confirmation pour #{resource.unconfirmed_email}
-      = render "common/form/new_password_input", f:, hint: "Choisissez votre mot de passe ou laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.", password_label: "Nouveau mot de passe"
-      = render "common/form/current_password_input", f: f, name: :current_password, hint: "Renseignez votre mot de passe actuel pour tout changement.", password_label: "Mot de passe actuel"
-      .rdv-text-align-right= f.submit "Enregistrer", class: "fr-btn"
+    - if resource.encrypted_password.present?
+      - if resource.logged_once_with_franceconnect?
+        .fr-alert.fr-alert--info.fr-mb-3w
+          | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de FranceConnect
+      - if resource.pro_connect_openid_sub
+        .fr-alert.fr-alert--info.fr-mb-3w
+          | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de ProConnect
+      = form_for resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put }, builder: Dsfr::FormBuilder do |f|
+        = f.dsfr_email_field :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), autocomplete: "email"
+        - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+          .form-text.rdv-color-text-mention-grey.mb-2
+            | En attente de confirmation pour #{resource.unconfirmed_email}
+        = render "common/form/new_password_input", f:, hint: "Choisissez votre mot de passe ou laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.", password_label: "Nouveau mot de passe"
+        = render "common/form/current_password_input", f: f, name: :current_password, hint: "Renseignez votre mot de passe actuel pour tout changement.", password_label: "Mot de passe actuel"
+        .rdv-text-align-right= f.submit "Modifier", class: "fr-btn"
       .mt-5
         hr
     p Vous souhaitez supprimer votre compte ?

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -2,21 +2,20 @@
 
 .card
   .card-body
-    - if resource.encrypted_password.present?
-      - if resource.logged_once_with_franceconnect?
-        .fr-alert.fr-alert--info.fr-mb-3w
-          | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de FranceConnect
-      - if resource.pro_connect_openid_sub
-        .fr-alert.fr-alert--info.fr-mb-3w
-          | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de ProConnect
-      = form_for resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put }, builder: Dsfr::FormBuilder do |f|
-        = f.dsfr_email_field :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), autocomplete: "email"
-        - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-          .form-text.rdv-color-text-mention-grey.mb-2
-            | En attente de confirmation pour #{resource.unconfirmed_email}
-        = render "common/form/new_password_input", f:, hint: "Choisissez votre mot de passe ou laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.", password_label: "Nouveau mot de passe"
-        = render "common/form/current_password_input", f: f, name: :current_password, hint: "Renseignez votre mot de passe actuel pour tout changement.", password_label: "Mot de passe actuel"
-        .rdv-text-align-right= f.submit "Modifier", class: "fr-btn"
+    - if resource.logged_once_with_franceconnect?
+      .fr-alert.fr-alert--info.fr-mb-3w
+        | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de FranceConnect
+    - if resource.pro_connect_openid_sub
+      .fr-alert.fr-alert--info.fr-mb-3w
+        | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de ProConnect
+    = form_for resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put }, builder: Dsfr::FormBuilder do |f|
+      = f.dsfr_email_field :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), autocomplete: "email"
+      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+        .form-text.rdv-color-text-mention-grey.mb-2
+          | En attente de confirmation pour #{resource.unconfirmed_email}
+      = render "common/form/new_password_input", f:, hint: "Choisissez votre mot de passe ou laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.", password_label: "Nouveau mot de passe"
+      = render "common/form/current_password_input", f: f, name: :current_password, hint: "Renseignez votre mot de passe actuel pour tout changement.", password_label: "Mot de passe actuel"
+      .rdv-text-align-right= f.submit "Enregistrer", class: "fr-btn"
       .mt-5
         hr
     p Vous souhaitez supprimer votre compte ?

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -69,7 +69,7 @@ ruby:
 
     .fr-grid-row.fr-grid-row--gutters.fr-mt-3w
       .fr-col.rdv-justify-content-space-between.d-flex.flex-row-aligned
-        = dsfr_link_to "Revenir en arrière", prendre_rdv_path(rdv_wizard.to_query), class: "fr-icon-arrow-left-line fr-link--icon-left"
+        = link_to "Revenir en arrière", prendre_rdv_path(rdv_wizard.to_query), class: "fr-icon-arrow-left-line fr-btn--icon-left fr-btn fr-btn--tertiary-no-outline"
         = f.submit "Continuer", class: "fr-btn"
 
   - else

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -67,9 +67,12 @@ ruby:
     - rdv_wizard.to_query.each do |wizard_key, wizard_value|
       = hidden_field_tag "rdv[#{wizard_key}]", wizard_value
 
-  .fr-grid-row.fr-grid-row--gutters.fr-mt-3w
-    .fr-col.rdv-justify-content-space-between.d-flex.flex-row-aligned
-      - if rdv_wizard.present?
+    .fr-grid-row.fr-grid-row--gutters.fr-mt-3w
+      .fr-col.rdv-justify-content-space-between.d-flex.flex-row-aligned
         = dsfr_link_to "Revenir en arrière", prendre_rdv_path(rdv_wizard.to_query), class: "fr-icon-arrow-left-line fr-link--icon-left"
+        = f.submit "Continuer", class: "fr-btn"
 
-      = f.submit (rdv_wizard.present? ? "Continuer" : "Enregistrer"), class: "fr-btn"
+  - else
+    .rdv-text-align-right
+      = f.submit "Enregistrer", class: "fr-btn"
+

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -75,4 +75,3 @@ ruby:
   - else
     .rdv-text-align-right
       = f.submit "Enregistrer", class: "fr-btn"
-

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -67,5 +67,9 @@ ruby:
     - rdv_wizard.to_query.each do |wizard_key, wizard_value|
       = hidden_field_tag "rdv[#{wizard_key}]", wizard_value
 
-  .rdv-text-align-right
-    = f.submit (rdv_wizard.present? ? "Continuer" : "Modifier"), class: "fr-btn"
+  .fr-grid-row.fr-grid-row--gutters.fr-mt-3w
+    .fr-col.rdv-justify-content-space-between.d-flex.flex-row-aligned
+      - if rdv_wizard.present?
+        = dsfr_link_to "Revenir en arrière", prendre_rdv_path(rdv_wizard.to_query), class: "fr-icon-arrow-left-line fr-link--icon-left"
+
+      = f.submit (rdv_wizard.present? ? "Continuer" : "Enregistrer"), class: "fr-btn"

--- a/spec/features/agents/account/change_email_spec.rb
+++ b/spec/features/agents/account/change_email_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Agents can change their email" do
     fill_in "Email", with: new_email
     fill_in "Mot de passe actuel", with: "CorrectH0rse!"
 
-    expect { click_button "Modifier" }.not_to change { agent.reload.email }
+    expect { click_button "Enregistrer" }.not_to change { agent.reload.email }
 
     expect(page).to have_content("Votre compte a bien été mis à jour mais nous devons vérifier votre nouvelle adresse email")
     perform_enqueued_jobs

--- a/spec/features/super_admin/use_correct_history_version_spec.rb
+++ b/spec/features/super_admin/use_correct_history_version_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Use correct history version when a super admin is logged in and 
     visit root_path
     click_link "Vos informations"
     fill_in("Téléphone", with: "0612345678")
-    click_on("Modifier")
+    click_on("Enregistrer")
     expect(page).to have_content("Vos informations ont été mises à jour")
 
     expect(user.reload.versions.last.whodunnit).to eq "[Admin] #{super_admin.full_name} pour #{user.full_name}"

--- a/spec/features/users/account/user_can_update_their_information_spec.rb
+++ b/spec/features/users/account/user_can_update_their_information_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "User can update their information" do
       expect(page).not_to have_content "Nombre d'enfants"
       select "MSA", from: "Caisse d'affiliation"
       fill_in "Numéro d'allocataire", with: 123
-      click_on("Modifier")
+      click_on("Enregistrer")
       expect(page).to have_content "Vos informations ont été mises à jour."
       expect(user.reload.affiliation_number).to eq "123"
     end
@@ -34,7 +34,7 @@ RSpec.describe "User can update their information" do
       it "allows changing the notification email" do
         visit users_informations_path
         fill_in("Email de notification", with: "nouvelle.adresse@exemple.fr")
-        click_on("Modifier")
+        click_on("Enregistrer")
         expect(page).to have_content "Vos informations ont été mises à jour."
         expect(user.reload.notification_email).to eq "nouvelle.adresse@exemple.fr"
       end


### PR DESCRIPTION
## Captures d'écran

Avant | Après
:- | -:
<img width="918" height="240" alt="Screenshot 2025-07-10 at 13 03 14" src="https://github.com/user-attachments/assets/e4a9f13a-2f62-4f8a-975c-1c2d09902a09" />|<img width="861" height="299" alt="Screenshot 2025-07-10 at 13 02 59" src="https://github.com/user-attachments/assets/8b8a9e53-8d70-46d6-a206-16ef203f3e48" />

Vu avec Téo ✅ 
On en profite pour aller vers une harmonisation des ctas des étapes de nos wizard.