### PR TITLE
Suppression onchange soumission formulaire

### DIFF
--- a/app/javascript/components/select2-inputs.js
+++ b/app/javascript/components/select2-inputs.js
@@ -25,6 +25,13 @@ class Select2Inputs {
     if (elt.dataset.autoSelectSoleOption) {
       this.autoSelectSoleOption(elt, config)
     }
+    // select2 change le comportement de l’événement change.
+    // Pour pouvoir intercepter l’événement change, grâce à un data-action stimulus, il faut le re-déclencher manuellement.
+    // cf https://psmy.medium.com/rails-6-stimulus-and-select2-de4a4d2b59e4
+    $(elt).on("change", function () {
+      let event = new Event('change')
+      this.dispatchEvent(event);
+    })
   }
 
   getInputConfig = elt => {

--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="form"
+export default class extends Controller {
+  submit() {
+    this.element.requestSubmit()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import FormController from "./form_controller"
+application.register("form", FormController)
+
 import MotifFormController from "./motif_form_controller"
 application.register("motif-form", MotifFormController)
 

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for(form, method: "GET", url: url_for({}), as: "") do |f|
+= simple_form_for(form, method: "GET", url: url_for({}), as: "", data: { controller: "form" }) do |f|
   - if current_agent.multiple_organisations_access?
     .row
       .col-md-6
@@ -7,8 +7,10 @@
                 label: "Organisation", \
                 input_html: { \
                   class: "select2-input", \
-                  onchange: "this.form.submit()", \
                   multiple: true, \
+                  data: { \
+                    action: "change->form#submit", \
+                  },
                 }, \
                 wrapper: "horizontal_form"
     hr

--- a/app/views/users/rdvs/_file_attente.html.slim
+++ b/app/views/users/rdvs/_file_attente.html.slim
@@ -5,10 +5,10 @@
       | Vous souhaitez prendre RDV plus tôt ?
     .fr-ml-4w
       - fa = rdv.file_attentes.where(user: current_user).first || FileAttente.new(user: current_user, rdv: rdv)
-      = simple_form_for fa, url: users_file_attente_path, html: { method: :post, class: "form-inline" }, wrapper: :inline_form, remote: false  do |f|
+      = simple_form_for fa, url: users_file_attente_path, html: { method: :post, class: "form-inline" }, wrapper: :inline_form, remote: false, data: { controller: "form" }  do |f|
         = f.input :id, as: :hidden
         = f.input :rdv_id, as: :hidden
         = f.input :user_id, as: :hidden
         = label_tag "active[0]", class: "pl-1"
-          = check_box "active", "0", { checked: (fa.id.nil? ? false : true), onchange: "this.form.submit()" }
+          = check_box "active", "0", { checked: (fa.id.nil? ? false : true), data: { action: "change->form#submit" } }
           span.fr-ml-1w Je souhaite être prévenu(e) si un créneau se libère.


### PR DESCRIPTION
# Contexte

Dans l’objectif de retirer tous les JS inlinés, on se sépare des attributs `onchange`.

# Solution

Il serait possible de réécrire proprement ces comportements en se séparant des validations de formulaire.
Néanmoins, l’objectif ici n’est pas de tout réécrire tout de suite, mais juste de garder le même comportement qu’avant, sans le JS inliné.

Pour le morceau avec le select2, j’ai été obligé de déclencher l’événement, cette partie est détaillée dans le code.