### PR TITLE
Utilisation des secteurs d'identifications France Connect v2

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -27,4 +27,13 @@ class StaticPagesController < ApplicationController
 
     response.headers["Content-Length"] = response.body.length.to_s
   end
+
+  def france_connect_sector_identifier
+    response.headers["Content-Type"] = "application/json"
+
+    redirect_urls = Domain::ALL.map(&:host_name).map do |host_name|
+      franceconnect_v2_callback_url(host: host_name)
+    end
+    render json: redirect_urls
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   get "franceconnect_v2/auth" => "france_connect_v2#auth"
   get "franceconnect_v2/callback" => "france_connect_v2#callback"
   get "franceconnect_v2/post_logout" => "france_connect_v2#post_logout"
+  get "franceconnect_v2/sector_identifier" => "static_pages#france_connect_sector_identifier"
 
   devise_for :super_admins # necessary for helpers like super_admin_signed_in?
   devise_scope :super_admin do

--- a/spec/requests/france_connect_sector_identifier_spec.rb
+++ b/spec/requests/france_connect_sector_identifier_spec.rb
@@ -1,0 +1,15 @@
+# voir https://docs.partenaires.franceconnect.gouv.fr/fs/fs-technique/fs-technique-sector_identifier/
+# En ayant un même openid sub sur les deux instances, on peut faciliter la migration des usagers d'une instance à l'autre.
+RSpec.describe "Secteur d'identification France Connect V2" do
+  specify do
+    get "/franceconnect_v2/sector_identifier"
+
+    expect(response.parsed_body).to eq %w[
+      http://www.rdv-solidarites-test.localhost/franceconnect_v2/callback
+      http://www.rdv-aide-numerique-test.localhost/franceconnect_v2/callback
+      http://www.rdv-mairie-test.localhost/franceconnect_v2/callback
+    ]
+
+    expect(response.headers["content-type"]).to eq "application/json"
+  end
+end


### PR DESCRIPTION
voir https://docs.partenaires.franceconnect.gouv.fr/fs/fs-technique/fs-technique-sector_identifier/

Les secteurs d'identification permettent de faire que nos applications sur nos différents noms de domaine auront le même sub open_id connect pour la même personne.

Aujourd'hui c'est déjà le cas, puisque nos deux instances utilisent la même application France Connect, mais ça ne sera pas le cas pour France Connect v2  : on aura une appli France Connect vous RDV Service Public, et une autre pour RDV Solidarités.
Ça permet de faire qu'au moment de la connexion, on affiche clairement à quelle application l'usager se connecte.

Pour que ça continue d'être le cas avec ces deux applications, il faut donc qu'on utilise les secteurs d'identification.

Au cas où elle change, voici ce que dit actuellement la documentation France Connect à ce sujet : 

```
Utilisation des secteurs d'identifications
FranceConnect et FranceConnect+ reposent sur le protocole OpenID Connect, qui définit les règles d'identification des utilisateurs via l’attribut sub (subject). Lorsque le type d’identifiant utilisé est pairwise (méchanisme qui fait dépendre le sub du client, empêchant le recoupement en cas de fuite) — ce qui est le cas dans FranceConnect et FranceConnect+ — un identifiant unique par secteur d’identification est généré pour chaque utilisateur.

La spécification OpenID Connect impose alors une restriction importante :

Tous les redirect_uri associés à un même client doivent partager le même nom de domaine ou sous-domaine, sauf si un sector_identifier explicite est défini.

En effet, pour générer de façon cohérente le même identifiant sub pour un utilisateur sur plusieurs applications (ou redirections), il faut que FranceConnect sache qu’elles appartiennent à un même secteur d’identification. Ce secteur est alors défini via une URL spéciale : sector_identifier_url.

👉 Voir la spécification officielle : [OpenID Connect – Sector Identifier Validation](https://openid.net/specs/openid-connect-registration-1_0.html#SectorIdentifierValidation)

C’est cette URL qui permet de centraliser et déclarer les redirect_uris appartenant au même secteur, en contournant la limitation liée à la diversité des noms de domaine.

⚠️ L’utilisation du sector_identifier_url ne dispense pas de déclarer l’ensemble des redirect_uri dans votre espace partenaire FranceConnect. Le fichier référencé par sector_identifier_url vient en complément de cette déclaration, pas en remplacement.

Format attendu du fichier sector_identifier_url [#](https://docs.partenaires.franceconnect.gouv.fr/fs/fs-technique/fs-technique-sector_identifier/#format-attendu-du-fichier-sector-identifier-url)
Le fichier doit :

Être accessible via HTTPS
Contenir une liste JSON des redirect_uris
Être servi avec le type MIME : application/json
```