### PR TITLE
Mise à jour de l'autodoc de la prise de rdv entre agents et correctif pour l'affichage du bouton france connect

### DIFF
--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -4,7 +4,8 @@
   = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard if @rdv_wizard.present?
 
   .card-body
-    = render "common/franceconnect_button"
+    - if @rdv_wizard.nil? || @rdv_wizard.display_france_connect?
+      = render "common/franceconnect_button"
 
     / Contrairement à FranceConnect, on n'affiche pas le bouton ProConnect en dehors de la prise de rendez-vous
     - if display_agent_connect_button? && @rdv_wizard&.display_pro_connect?

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -30,10 +30,16 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
     doc.add_text(<<~TEXT
       <h3>Contexte</h3>
       <p>
-        Je suis un agent du service public, par exemple quelqu'un qui travaille pour une startup d'état de la Dinum.
+        Je souhaite proposer de la prise de rendez-vous à d'autres agents du service public, en leur envoyant un lien avec lequel ils pourront directement prendre rendez-vous.
       </p>
       <p>
-        Je souhaite proposer de la prise de rendez-vous à d'autres agents du service public, en leur envoyant un lien avec lequel ils pourront directement prendre rendez-vous.
+        RDV Service Public peut remplacer des solutions de type Cal.com pour la prise de rendez-vous entre agents de différentes structures.
+      </p>
+      <p>
+        Pour une réunion entre collègues, la prise de rendez-vous via votre calendrier partagé habituel reste plus pratique (par exemple la Suite Numérique, Outlook, Thunderbird…). Si vous avez besoin de proposer des rendez-vous à d'autres agents qui ne sont pas vos collègues, RDV Service Public peut vous aider.
+      </p>
+      <p>
+        Par exemple, pour une équipe produit d'une startup d'état qui veut proposer des entretiens utilisateurs aux agents de mairie qui utilisent le produit, voici comment vous pouvez faire :
       </p>
       <p>
         J'ai un compte sur RDV Service Public, sur lequel j'ai juste un motif "Suivi de dossier" par visio.

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -1,6 +1,11 @@
 RSpec.describe "Prise de rendez-vous entre agents", js: true do
   let(:service) { create(:service, name: "Dinum", short_name: "Dinum") }
 
+  stub_env_with(
+    AGENT_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2",
+    AGENT_CONNECT_RDVS_CLIENT_SECRET: "un faux secret de test",
+    AGENT_CONNECT_RDVS_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
+  )
   before do
     Compte.new(
       {

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
   stub_env_with(
     AGENT_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2",
     AGENT_CONNECT_RDVSP_CLIENT_SECRET: "un faux secret de test",
-    AGENT_CONNECT_RDVSP_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
+    AGENT_CONNECT_RDVSP_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa",
+    FRANCECONNECT_V2_BASE_URL: "https://fcp-low.sbx.dev-franceconnect.fr/api/v2",
+    FRANCECONNECT_V2_CLIENT_ID: "fake_france_connect_v2_client_id",
+    FRANCECONNECT_V2_CLIENT_SECRET: "fake_france_connect_v2_client_secret"
   )
   before do
     Compte.new(
@@ -137,6 +140,8 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
     doc.add_screenshot(page,
                        text: "L'appli me propose de me connecter avec ProConnect",
                        wait_for: "Vous devez vous connecter ou vous inscrire pour continuer.")
+
+    expect(page).not_to have_content("FranceConnect")
 
     expect(page).to have_content("ProConnect")
     # On triche pour faire semblant de faire une connexion via ProConnect

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
         Exemple de cas d’usage
       </h3>
       <p>
-        Vous faites partie de l’équipe produit d’un service public numérique. 
-        Vous souhaitez proposer des entretiens utilisateurs aux agents de mairie qui utilisent votre service. 
+        Vous faites partie de l’équipe produit d’un service public numérique.
+        Vous souhaitez proposer des entretiens utilisateurs aux agents de mairie qui utilisent votre service.
         Voici comment vous pouvez faire :
       </p>
       <p>

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
   stub_env_with(
     AGENT_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2",
-    AGENT_CONNECT_RDVS_CLIENT_SECRET: "un faux secret de test",
-    AGENT_CONNECT_RDVS_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
+    AGENT_CONNECT_RDVSP_CLIENT_SECRET: "un faux secret de test",
+    AGENT_CONNECT_RDVSP_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
   )
   before do
     Compte.new(
@@ -138,6 +138,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
                        text: "L'appli me propose de me connecter avec ProConnect",
                        wait_for: "Vous devez vous connecter ou vous inscrire pour continuer.")
 
+    expect(page).to have_content("ProConnect")
     # On triche pour faire semblant de faire une connexion via ProConnect
     user = create(:user, pro_connect_openid_sub: "fake_sub", first_name: "Camille", last_name: "Exemple", email: "camille.exemple@demo-rdv-service-public.gouv.fr")
     login_as(user, scope: :user)

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -46,8 +46,13 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
       <p>
         Pour une réunion entre collègues, la prise de rendez-vous via votre calendrier partagé habituel reste plus pratique (par exemple la Suite Numérique, Outlook, Thunderbird…). Si vous avez besoin de proposer des rendez-vous à d'autres agents qui ne sont pas vos collègues, RDV Service Public peut vous aider.
       </p>
+      <h3>
+        Exemple de cas d’usage
+      </h3>
       <p>
-        Par exemple, pour une équipe produit d'une startup d'état qui veut proposer des entretiens utilisateurs aux agents de mairie qui utilisent le produit, voici comment vous pouvez faire :
+        Vous faites partie de l’équipe produit d’un service public numérique. 
+        Vous souhaitez proposer des entretiens utilisateurs aux agents de mairie qui utilisent votre service. 
+        Voici comment vous pouvez faire :
       </p>
       <p>
         J'ai un compte sur RDV Service Public, sur lequel j'ai juste un motif "Suivi de dossier" par visio.


### PR DESCRIPTION
Suite à une discussion avec adrien sur la différence entre les rdv entres agent set les réunions entre collègues pour clarifier notre positionnement, on met le résultat de cette explication dans la doc.

J'en profite pour corriger un point assez important de cette doc : le bouton ProConnect n'apparaissait pas.

Et ça m'a permis de réaliser un autre bug: on a perdu la possibilité de cacher le bouton FranceConnect en mergant la pr france connect v2.

En fait la spec d'autodoc est l'endroit le plus pratique pour tester ça, donc j'ajoute l'expect à ce niveau, et je fais le correctif.