### PR TITLE
Permettre la modification de l'email de notification pour les usagers qui utilisent FranceConnect

### DIFF
--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -24,6 +24,7 @@ class Users::UsersController < UserAuthController
       :first_name,
       :last_name,
       :birth_name,
+      :notification_email,
       :phone_number,
       :birth_date,
       :address,

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -27,7 +27,7 @@ ruby:
       / Nous ne voulons pas perdre d'informations si l'utilisateur a déjà un email de notification, donc le champ est requis
       / L'utilisateur peut définir un email de notification s'il n'en a pas encore, mais ce n'est pas obligatoire
       = f.dsfr_email_field :notification_email, required: user.notification_email.present?
-  - elsif user.email.blank? && user.notification_email && user.logged_once_with_franceconnect?
+  - elsif user.email.blank? && user.notification_email && user.connected_with_sso?
     = f.dsfr_email_field :notification_email, label: "Email de notification"
 
   = f.dsfr_phone_field :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?, autocomplete: "tel"

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -28,7 +28,7 @@ ruby:
       / L'utilisateur peut définir un email de notification s'il n'en a pas encore, mais ce n'est pas obligatoire
       = f.dsfr_email_field :notification_email, required: user.notification_email.present?
   - elsif user.email.blank? && user.notification_email && user.logged_once_with_franceconnect?
-    = f.dsfr_email_field :notification_email, label: "Email de notification", disabled: true, hint: "Cet email a été importé via FranceConnect. Vous y recevrez toutes vos notifications."
+    = f.dsfr_email_field :notification_email, label: "Email de notification"
 
   = f.dsfr_phone_field :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?, autocomplete: "tel"
   - if user.phone_number.present? && !user.phone_number_mobile?

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -53,5 +53,15 @@ FactoryBot.define do
       family_situation { nil }
       number_of_children { nil }
     end
+
+    # Correspond à la logique de UpsertUserForFranceconnectService#create_new_user
+    trait :using_france_connect do
+      franceconnect_openid_sub { "fake_sub" }
+      logged_once_with_franceconnect { true }
+      email { nil }
+      notification_email { generate(:user_email) }
+      encrypted_password { "" }
+      phone_number { nil }
+    end
   end
 end

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -150,7 +150,10 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     expect(page).to have_content("ProConnect")
     # On triche pour faire semblant de faire une connexion via ProConnect
-    user = create(:user, pro_connect_openid_sub: "fake_sub", first_name: "Camille", last_name: "Exemple", email: "camille.exemple@demo-rdv-service-public.gouv.fr")
+    user = create(:user, pro_connect_openid_sub: "fake_sub", first_name: "Camille", last_name: "Exemple",
+                         email: nil, encrypted_password: "",
+                         phone_number: nil,
+                         notification_email: "camille.exemple@demo-rdv-service-public.gouv.fr")
     login_as(user, scope: :user)
     find("a[title='Modifier la date du rendez-vous']").click
     click_on "9:00", match: :first
@@ -158,6 +161,8 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
     doc.add_screenshot(page,
                        text: "Mon nom et prénom sont remplis automatiquement, je continue",
                        wait_for: "Vos informations")
+
+    expect(page.body).to include(user.notification_email) # L'email est dans un input, donc on utilise cette méthode plutôt qu'un expect(page).to have_content
 
     click_on "Continuer"
 

--- a/spec/features/users/account/user_can_update_their_information_spec.rb
+++ b/spec/features/users/account/user_can_update_their_information_spec.rb
@@ -1,25 +1,43 @@
 RSpec.describe "User can update their information" do
   let!(:organisation) { create(:organisation, territory: territory) }
   let(:user) { create(:user, organisations: [organisation]) }
+  let(:territory) { create(:territory) }
 
-  let(:territory) do
-    create(:territory, enable_caisse_affiliation_field: true,
-                       enable_affiliation_number_field: true, enable_number_of_children_field: false)
+  before { login_as(user, scope: :user) }
+
+  describe "optional fields" do
+    let(:territory) do
+      create(:territory, enable_caisse_affiliation_field: true,
+                         enable_affiliation_number_field: true, enable_number_of_children_field: false)
+    end
+
+    before do
+      visit root_path
+      click_link "Vos informations"
+    end
+
+    it "shows the user information" do
+      expect(page).to have_content "Mes informations"
+      expect(page).not_to have_content "Nombre d'enfants"
+      select "MSA", from: "Caisse d'affiliation"
+      fill_in "Numéro d'allocataire", with: 123
+      click_on("Modifier")
+      expect(page).to have_content "Vos informations ont été mises à jour."
+      expect(user.reload.affiliation_number).to eq "123"
+    end
   end
 
-  before do
-    login_as(user, scope: :user)
-    visit root_path
-    click_link "Vos informations"
-  end
+  describe "updating notification_email" do
+    context "when the user is connected with FranceConnect" do
+      let(:user) { create(:user, :using_france_connect, organisations: [organisation]) }
 
-  it "shows the user information" do
-    expect(page).to have_content "Mes informations"
-    expect(page).not_to have_content "Nombre d'enfants"
-    select "MSA", from: "Caisse d'affiliation"
-    fill_in "Numéro d'allocataire", with: 123
-    click_on("Modifier")
-    expect(page).to have_content "Vos informations ont été mises à jour."
-    expect(user.reload.affiliation_number).to eq "123"
+      it "allows changing the notification email" do
+        visit users_informations_path
+        fill_in("Email de notification", with: "nouvelle.adresse@exemple.fr")
+        click_on("Modifier")
+        expect(page).to have_content "Vos informations ont été mises à jour."
+        expect(user.reload.notification_email).to eq "nouvelle.adresse@exemple.fr"
+      end
+    end
   end
 end


### PR DESCRIPTION
La recette de France Connect V2 demande que l'adresse email de l'usager soit modifiable, contrairement à ce qu'on croyait pour la première implémentation.

<img width="796" alt="Screenshot 2025-07-08 at 17 54 59" src="https://github.com/user-attachments/assets/e16512ae-5936-47d7-a269-46c42c4d2d09" />

J'en profite pour ajouter le comportement pour les usagers qui utilisent ProConnect