### PR TITLE
corriger le formulaire de fusion d’usagers

### DIFF
--- a/app/javascript/components/merge-users-form.js
+++ b/app/javascript/components/merge-users-form.js
@@ -1,7 +1,7 @@
 class MergeUsersForm {
   constructor() {
     // have to use jQuery here because of select2
-    $(".js-merge-users-user-select").on("change", this.userSelected)
+    $(".js-merge-users-user-select").on("select2:select", this.userSelected)
     $(".js-merge-users-collapse-user").on("click", this.toggleDisabledUserFields)
   }
 

--- a/app/javascript/components/select2-inputs.js
+++ b/app/javascript/components/select2-inputs.js
@@ -27,11 +27,15 @@ class Select2Inputs {
     }
     // select2 change le comportement de l’événement change.
     // Pour pouvoir intercepter l’événement change, grâce à un data-action stimulus, il faut le re-déclencher manuellement.
+    // On ne fait ceci que si il y a un data-action "change->" sur l'élément pour éviter des conflits (notamment avec le formulaire de fusion usagers).
     // cf https://psmy.medium.com/rails-6-stimulus-and-select2-de4a4d2b59e4
     $(elt).on("change", function () {
-      let event = new Event('change')
-      this.dispatchEvent(event);
-    })
+      const action = this.getAttribute("data-action") || "";
+      if (action.includes("change->")) {
+        let event = new Event('change');
+        this.dispatchEvent(event);
+      }
+    });
   }
 
   getInputConfig = elt => {


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5501.osc-secnum-fr1.scalingo.io/) 

# Bug


https://github.com/user-attachments/assets/3c32903b-a317-42d9-a1e5-208002cbf564

cf https://zammad10.ethibox.fr/#ticket/zoom/25390

# Contexte

Il semble que ça soit ce bout de code introduit récemment qui cause la recursion infinie : https://github.com/betagouv/rdv-service-public/blob/production/app/javascript/components/select2-inputs.js#L28-L34

# Solution

?