### PR TITLE
Inputs pseudo-dsfr côté agent

### DIFF
--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -273,7 +273,7 @@ $btn-border-radius-sm: 0;
 
 // Forms
 
-$input-bg: #f9f9f9;
+$input-bg: rgb(238, 238, 238);
 $input-focus-bg: $input-bg;
 $input-padding-y: $input-btn-padding-y;
 $input-padding-x: $input-btn-padding-x;

--- a/app/javascript/stylesheets/components/_forms.scss
+++ b/app/javascript/stylesheets/components/_forms.scss
@@ -12,6 +12,10 @@ input.form-control, select.form-control {
   border-left: none;
   border-right: none;
 
+  &:disabled {
+    color: rgb(146, 146, 146);
+    border-bottom-color: rgb(146, 146, 146);
+  }
 }
 
 .custom-select.is-invalid,

--- a/app/javascript/stylesheets/components/_forms.scss
+++ b/app/javascript/stylesheets/components/_forms.scss
@@ -3,7 +3,8 @@ input.form-control[type="range"] {
   min-height: 39px;
 }
 
-input.form-control, select.form-control {
+input.form-control,
+select.form-control {
   border-radius: 4px 4px 0 0;
   background-color: rgb(238, 238, 238);
   border-bottom-color: rgb(58, 58, 58);

--- a/app/javascript/stylesheets/components/_forms.scss
+++ b/app/javascript/stylesheets/components/_forms.scss
@@ -3,7 +3,7 @@ input.form-control[type="range"] {
   min-height: 39px;
 }
 
-input.form-control {
+input.form-control, select.form-control {
   border-radius: 4px 4px 0 0;
   background-color: rgb(238, 238, 238);
   border-bottom-color: rgb(58, 58, 58);

--- a/app/javascript/stylesheets/components/_forms.scss
+++ b/app/javascript/stylesheets/components/_forms.scss
@@ -3,6 +3,17 @@ input.form-control[type="range"] {
   min-height: 39px;
 }
 
+input.form-control {
+  border-radius: 4px 4px 0 0;
+  background-color: rgb(238, 238, 238);
+  border-bottom-color: rgb(58, 58, 58);
+  border-bottom-width: 2px;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+
+}
+
 .custom-select.is-invalid,
 .form-control.is-invalid,
 .custom-select:invalid,

--- a/app/javascript/stylesheets/components/_select2.scss
+++ b/app/javascript/stylesheets/components/_select2.scss
@@ -83,7 +83,7 @@
 .select2-container--bootstrap4
   .select2-selection--multiple
   .select2-selection__choice {
-    border-radius: 0;
+  border-radius: 0;
 }
 
 .select2-container--bootstrap4 .select2-selection--single.input-sm,
@@ -122,7 +122,6 @@
   .select2-selection--multiple
   .select2-selection__choice {
   border-radius: 0;
-
 }
 
 // Background color overrides

--- a/app/javascript/stylesheets/components/_select2.scss
+++ b/app/javascript/stylesheets/components/_select2.scss
@@ -54,50 +54,60 @@
 
 // Border radius overrides
 // C'est trop compliqué d'utiliser le fichier src plutôt que le dist à cause d'incohérence d'unités entre les px et rem (et de certains calculs sans unités)
-// Le plus simple pour avoir des border-radius de 0 est donc de mettre des override pour toutes les règles de border-radius dans le fichier node_modules/select2-bootstrap4-theme/dist/select2-bootstrap4.css
+// Le plus simple pour avoir des border-radius conformes au dsfr est donc de mettre des override pour toutes les règles de border-radius dans le fichier node_modules/select2-bootstrap4-theme/dist/select2-bootstrap4.css
+
+@mixin dsfr-input-style {
+  border-radius: 4px 4px 0 0;
+  background-color: rgb(238, 238, 238);
+  border-bottom-color: rgb(58, 58, 58);
+  border-bottom-width: 2px;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+}
 
 .select2-container--bootstrap4 .select2-selection {
-  border-radius: 0;
+  @include dsfr-input-style;
 }
 
 .select2-container--bootstrap4 .select2-selection.form-control {
-  border-radius: 0;
+  @include dsfr-input-style;
 }
 
 .select2-container--bootstrap4
   .select2-search--dropdown
   .select2-search__field {
-  border-radius: 0;
+  @include dsfr-input-style;
 }
 
 .select2-container--bootstrap4
   .select2-selection--multiple
   .select2-selection__choice {
-  border-radius: 0;
+  @include dsfr-input-style;
 }
 
 .select2-container--bootstrap4 .select2-selection--single.input-sm,
 .input-group-sm .select2-container--bootstrap4 .select2-selection--single,
 .form-group-sm .select2-container--bootstrap4 .select2-selection--single {
-  border-radius: 0;
+  @include dsfr-input-style;
 }
 
 .select2-container--bootstrap4 .select2-selection--multiple.input-sm,
 .input-group-sm .select2-container--bootstrap4 .select2-selection--multiple,
 .form-group-sm .select2-container--bootstrap4 .select2-selection--multiple {
-  border-radius: 0;
+  @include dsfr-input-style;
 }
 
 .select2-container--bootstrap4 .select2-selection--single.input-lg,
 .input-group-lg .select2-container--bootstrap4 .select2-selection--single,
 .form-group-lg .select2-container--bootstrap4 .select2-selection--single {
-  border-radius: 0;
+  @include dsfr-input-style;
 }
 
 .select2-container--bootstrap4 .select2-selection--multiple.input-lg,
 .input-group-lg .select2-container--bootstrap4 .select2-selection--multiple,
 .form-group-lg .select2-container--bootstrap4 .select2-selection--multiple {
-  border-radius: 0;
+  @include dsfr-input-style;
 }
 
 .select2-container--bootstrap4
@@ -112,6 +122,7 @@
   .select2-selection--multiple
   .select2-selection__choice {
   border-radius: 0;
+  @include dsfr-input-style;
 }
 
 // Background color overrides

--- a/app/javascript/stylesheets/components/_select2.scss
+++ b/app/javascript/stylesheets/components/_select2.scss
@@ -83,31 +83,31 @@
 .select2-container--bootstrap4
   .select2-selection--multiple
   .select2-selection__choice {
-  @include dsfr-input-style;
+    border-radius: 0;
 }
 
 .select2-container--bootstrap4 .select2-selection--single.input-sm,
 .input-group-sm .select2-container--bootstrap4 .select2-selection--single,
 .form-group-sm .select2-container--bootstrap4 .select2-selection--single {
-  @include dsfr-input-style;
+  border-radius: 0;
 }
 
 .select2-container--bootstrap4 .select2-selection--multiple.input-sm,
 .input-group-sm .select2-container--bootstrap4 .select2-selection--multiple,
 .form-group-sm .select2-container--bootstrap4 .select2-selection--multiple {
-  @include dsfr-input-style;
+  border-radius: 0;
 }
 
 .select2-container--bootstrap4 .select2-selection--single.input-lg,
 .input-group-lg .select2-container--bootstrap4 .select2-selection--single,
 .form-group-lg .select2-container--bootstrap4 .select2-selection--single {
-  @include dsfr-input-style;
+  border-radius: 0;
 }
 
 .select2-container--bootstrap4 .select2-selection--multiple.input-lg,
 .input-group-lg .select2-container--bootstrap4 .select2-selection--multiple,
 .form-group-lg .select2-container--bootstrap4 .select2-selection--multiple {
-  @include dsfr-input-style;
+  border-radius: 0;
 }
 
 .select2-container--bootstrap4
@@ -122,7 +122,7 @@
   .select2-selection--multiple
   .select2-selection__choice {
   border-radius: 0;
-  @include dsfr-input-style;
+
 }
 
 // Background color overrides


### PR DESCRIPTION
Pour préparer la migration full dsfr côté agent, on style les inputs bootstrap pour ressemble au dsfr. Ça nous donne plus de cohérence entre les pages qui sont au vrai dsfr et les autres.

Vu avec Téo ✅ 

Avant | Après
:- | -:
<img width="1421" height="599" alt="Screenshot 2025-07-10 at 12 38 28" src="https://github.com/user-attachments/assets/83a26c78-f557-4bb1-826c-f760cd20c7ca" />|<img width="1421" height="596" alt="Screenshot 2025-07-10 at 12 38 43" src="https://github.com/user-attachments/assets/89e0299d-988e-4f1b-b1d6-6d34efcc849f" />
<img width="597" height="348" alt="Screenshot 2025-07-10 at 12 39 27" src="https://github.com/user-attachments/assets/a9596f0c-c078-4899-b785-42132ccec174" />|<img width="601" height="351" alt="Screenshot 2025-07-10 at 12 39 15" src="https://github.com/user-attachments/assets/29a58936-f7ff-480a-ba24-56ede640dd58" />
<img width="1299" height="778" alt="Screenshot 2025-07-10 at 12 40 03" src="https://github.com/user-attachments/assets/355a40a8-344c-4727-bbbf-234bda651c72" />|<img width="1271" height="785" alt="Screenshot 2025-07-10 at 12 40 19" src="https://github.com/user-attachments/assets/1929fd51-53c9-4259-8a48-b34293d0dab3" />
<img width="829" height="370" alt="Screenshot 2025-07-10 at 12 41 55" src="https://github.com/user-attachments/assets/2c755dc2-4071-4571-949a-ec09ec213fb1" />|<img width="830" height="413" alt="Screenshot 2025-07-10 at 12 41 41" src="https://github.com/user-attachments/assets/7923f589-69a6-4f4b-9b46-ba8cd603e1f3" />
