### PR TITLE
Ne pas retry le job d’envoi de SMS lorsqu’il est en modération chez SMS Factor

### DIFF
--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -91,7 +91,7 @@ class SmsSender < BaseService
     if request.success?
       parsed_response = JSON.parse(request.body)
       sms_factor_status = parsed_response["status"]
-      if sms_factor_status == 1
+      if [1, -8].include?(sms_factor_status) # 1 envoyé avec succès, -8 en attente de modération par SMS Factor
         save_receipt(result: :delivered, sms_count: parsed_response["cost"])
         Redis.with_connection do |redis|
           redis.set("SMS_FACTOR_REMAINING_CREDITS", parsed_response["credits"])

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -58,20 +58,41 @@ RSpec.describe SmsSender, type: :service do
     end
 
     context "with smsfactor" do
-      before do
-        stub_sms_factor_ok
-        described_class.perform_with("RdvSoli", "0612345678", "content", "sms_factor", "key", receipt_params)
+      context "when sms is sent successfully" do
+        before do
+          stub_sms_factor_ok
+          described_class.perform_with("RdvSoli", "0612345678", "content", "sms_factor", "key", receipt_params)
+        end
+
+        it do
+          receipt = Receipt.last
+          expect(receipt).not_to be_nil
+          expect(receipt).to have_attributes(event: "rdv_created", rdv: rdv, user: user, content: "content", sms_provider: "sms_factor", sms_count: 1)
+        end
+
+        it "save remaining credits" do
+          Redis.with_connection do |redis|
+            expect(redis.get("SMS_FACTOR_REMAINING_CREDITS")).to eq("42")
+          end
+        end
       end
 
-      it do
-        receipt = Receipt.last
-        expect(receipt).not_to be_nil
-        expect(receipt).to have_attributes(event: "rdv_created", rdv: rdv, user: user, content: "content", sms_provider: "sms_factor")
-      end
+      context "when sms is not sent due to moderation" do
+        before do
+          stub_sms_factor_moderation
+          described_class.perform_with("RdvSoli", "0612345678", "content", "sms_factor", "key", receipt_params)
+        end
 
-      it "save remaining credits" do
-        Redis.with_connection do |redis|
-          expect(redis.get("SMS_FACTOR_REMAINING_CREDITS")).to eq("42")
+        it do
+          receipt = Receipt.last
+          expect(receipt).not_to be_nil
+          expect(receipt).to have_attributes(event: "rdv_created", rdv: rdv, user: user, content: "content", sms_provider: "sms_factor", sms_count: 1)
+        end
+
+        it "save remaining credits" do
+          Redis.with_connection do |redis|
+            expect(redis.get("SMS_FACTOR_REMAINING_CREDITS")).to eq("42")
+          end
         end
       end
     end

--- a/spec/support/sms_stubbing.rb
+++ b/spec/support/sms_stubbing.rb
@@ -19,6 +19,18 @@ def stub_sms_factor_ok
     .to_return(status: 200, body: stubbed_body, headers: {})
 end
 
+def stub_sms_factor_moderation
+  stubbed_body = {
+    status: -8,
+    message: "Votre campagne est en attente de validation",
+    cost: 1,
+    credits: 42,
+  }.to_json
+
+  stub_request(:get, "https://api.smsfactor.com/send?pushtype=alert&sender=RdvSoli&text=content&to=0612345678")
+    .to_return(status: 200, body: stubbed_body, headers: {})
+end
+
 def expect_sms_enqueued(args)
   expect(SmsJob).to have_been_enqueued.with(hash_including(args))
 end


### PR DESCRIPTION
# Contexte

Suite à [cette Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/186863/?referrer=webhooks_plugin), nous nous sommes rendu compte que dans certains cas rares, notre fournisseur fait de la modération sur les SMS envoyés.
Dans ce cas on considère qu’il y a une erreur et on retry. Par conséquent, l’usager se fait spammer…
<img width="741" height="768" alt="image" src="https://github.com/user-attachments/assets/8c236945-24bf-40d4-854d-54bb6b3891e2" />

Ce cas ne s’est produit qu’une fois.

# Solution

Je propose donc qu’on considère le status `-8` comme un succès, qu’on enregistre la communication normalement dans notre base, car il n’y aucune raison que notre communication soit rejetée. 

J’ai testé avec l’API et le body est bien identique à un succès à l’exception du `status` et du `message`.
