### PR TITLE
CronJob::IGNHealthCheckJob ne devrait pas retry + gestion des timeout

### DIFF
--- a/app/jobs/cron_job/ign_health_check_job.rb
+++ b/app/jobs/cron_job/ign_health_check_job.rb
@@ -1,13 +1,19 @@
 class CronJob::IGNHealthCheckJob < CronJob
+  discard_on StandardError # ne jamais retry ce job
+
   # Ce job vérifie que l’API adresse de l’IGN est accessible.
   # Cette API étant utilisée uniquement en front pour l’auto-complétion des adresses, nous n’avions pas de remontée d’erreur
   # lorsqu’elle était en panne.
   # Si l’API est inaccessible, nous incrémentons un compteur dans Redis. Si ce compteur atteint 3, nous envoyons une alerte Sentry.
   # Le job étant exécuté toutes les minutes, la détection de l’indisponibilité se fera 3 minutes après la première erreur.
   def perform
-    response = Faraday.get("https://data.geopf.fr/geocodage/search?q=1+place+de+la+republique+75011+paris&limit=1")
+    begin
+      response = Faraday.get("https://data.geopf.fr/geocodage/search?q=1+place+de+la+republique+75011+paris&limit=1")
+    rescue Faraday::TimeoutError
+      response = nil
+    end
 
-    if response.status != 200
+    if response&.status != 200
       Redis.with_connection do |redis|
         if redis.incr("ign_api_health_check_failures") > 2
           Sentry.capture_message("L'API adresse de l'IGN est inaccessible (HTTP status: #{response.status}). Vérifier l’état du service ici : https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9/7ec26cae-995d-4974-926a-9130b14f77be?SelectedPeriod=Last30Days")

--- a/spec/jobs/cron_job/ign_health_check_job_spec.rb
+++ b/spec/jobs/cron_job/ign_health_check_job_spec.rb
@@ -46,4 +46,16 @@ RSpec.describe CronJob::IGNHealthCheckJob, type: :job do
       expect(Redis.with_connection { |redis| redis.get("ign_api_health_check_failures").to_i }).to eq(3)
     end
   end
+
+  context "quand l’API de l’IGN timeoute" do
+    before do
+      stub_request(:get, "https://data.geopf.fr/geocodage/search?q=1+place+de+la+republique+75011+paris&limit=1")
+        .to_raise(Faraday::TimeoutError)
+    end
+
+    it "incrémente le compteur Redis" do
+      perform_now
+      expect(Redis.with_connection { |redis| redis.get("ign_api_health_check_failures").to_i }).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

https://sentry.incubateur.net/organizations/betagouv/issues/186893/?project=74&referrer=webhooks_plugin

Des timeout génèrent des erreurs sur ce job

# Solution

- Les timeouts devraient être considérés au même titre que des statuts != 200
- Ce job ne devrait jamais retry