### PR TITLE
sélecteur de nombre de RDV affichés par page sur la liste de RDV

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -151,7 +151,7 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def parse_date_from_params(date_param)
-    Date.parse(date_param)
+    Date.parse(date_param) if date_param.present?
   rescue Date::Error
     nil
   end

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -5,16 +5,18 @@ class Admin::RdvsController < AgentAuthController
 
   before_action :set_rdv, :set_optional_agent, except: %i[index a_renseigner export participations_export]
 
+  PERMITTED_PER_PAGE = [10, 25, 50].freeze
+
   def index
     set_scoped_organisations
     @breadcrumb_page = params[:breadcrumb_page]
-
+    per_page = PERMITTED_PER_PAGE.include?(params[:per]&.to_i) ? params[:per].to_i : 10
     order = [{ starts_at: :asc }, { id: :asc }]
     distinct_on = "rdvs.starts_at, rdvs.id" # les clauses ORDER BY et DISTINCT ON doivent utiliser les mêmes colonnes
     @rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope)
       .select("DISTINCT ON (#{distinct_on}) rdvs.*") # dédoublonnage des RDV renvoyés par Agent::RdvPolicy::Scope
       .search_for(@scoped_organisations, parsed_params)
-      .order(order).page(page_number).per(10)
+      .order(order).page(page_number).per(per_page)
 
     # On fait cette requête en deux temps pour éviter de faire un `order` et un `include` sur le même scope,
     # parce que ça fait un sort et beaucoup de left outer joins

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -177,7 +177,7 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def parsed_params
-    params.permit(:organisation_id, :agent_id, :user_id, :status, :start, :end,
+    params.permit(:organisation_id, :agent_id, :user_id, :status, :start, :end, :per,
                   lieu_attributes: %i[name address latitude longitude], motif_ids: [], lieu_ids: [], scoped_organisation_ids: []).to_hash.to_h do |param_name, param_value|
       case param_name
       when "start", "end"

--- a/app/form_models/admin/rdv_search_form.rb
+++ b/app/form_models/admin/rdv_search_form.rb
@@ -2,7 +2,7 @@ class Admin::RdvSearchForm
   include ActiveModel::Model
   include Pundit::Authorization
 
-  attr_accessor :organisation_id, :start, :end, :agent_id, :user_id, :lieu_ids, :status, :motif_ids, :scoped_organisation_ids, :pundit_user
+  attr_accessor :organisation_id, :start, :end, :agent_id, :user_id, :lieu_ids, :status, :motif_ids, :scoped_organisation_ids, :pundit_user, :per
 
   def agent
     @agent ||= agent_scope.find_by(id: agent_id) if agent_id.present?

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -1,6 +1,6 @@
 /# locals: (rdv:, agent:, success_message: nil)
 
-turbo-frame.card[id= "rdv-#{rdv.id}" target="_top"]
+turbo-frame.card.rdv-item[id= "rdv-#{rdv.id}" target="_top"]
   div[id= "rdv-error-message-#{rdv.id}"]
   - if success_message
     .fr-alert.fr-alert--sm.fr-alert--success.fr-pb-1w.fr-mx-3w.fr-my-2w

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -79,4 +79,5 @@
   .d-flex.justify-content-end
     = link_to "Afficher les RDVs du jour", admin_organisation_rdvs_path(current_organisation, start: Time.zone.today, end: Time.zone.today), class: "btn btn-link"
     = link_to "Réinitialiser", admin_organisation_rdvs_path(current_organisation), class: "btn btn-link"
+    = f.hidden_field :per
     input.btn.btn-primary.d-print-none type="submit" value="Rafraîchir la liste"

--- a/app/views/admin/rdvs/_rdv_visibility.html.slim
+++ b/app/views/admin/rdvs/_rdv_visibility.html.slim
@@ -1,2 +1,3 @@
-= dsfr_alert size: :sm, icon_name: "eye-line" do
-  = Agent::RdvPolicy.explain(current_organisation, current_agent)
+.fr-mb-4w
+  = dsfr_alert size: :sm, icon_name: "eye-line" do
+    = Agent::RdvPolicy.explain(current_organisation, current_agent)

--- a/app/views/admin/rdvs/_rdv_visibility.html.slim
+++ b/app/views/admin/rdvs/_rdv_visibility.html.slim
@@ -1,3 +1,2 @@
-.fr-mb-4w
-  = dsfr_alert size: :sm, icon_name: "eye-line" do
-    = Agent::RdvPolicy.explain(current_organisation, current_agent)
+= dsfr_alert size: :sm, icon_name: "eye-line" do
+  = Agent::RdvPolicy.explain(current_organisation, current_agent)

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -52,16 +52,36 @@
   = render "admin/rdvs/rdv_visibility"
 
   - if @rdvs.total_count > 0
-    .mb-2
-      h4>= "#{@rdvs.total_count} rendez-vous"
-      .custom-control.custom-switch
-        input.custom-control-input[type="checkbox" id="show-users-details-switch" data-toggle="collapse" data-target=".users-details"]
-        label.custom-control-label for="show-users-details-switch" Afficher plus de détails usagers
-
-    .fr-grid-row.fr-pb-3w
+    .fr-mb-4w
+      h4.rdv-text-align-center
+        | #{@rdvs.total_count} RDV trouvés par cette recherche
+    .fr-grid-row
       .fr-col-12
         .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
+    .fr-grid-row
+      .fr-col-12
+        .d-flex.justify-content-center.fr-text--sm
+          .custom-control.custom-switch
+            input.custom-control-input[type="checkbox" id="show-users-details-switch" data-toggle="collapse" data-target=".users-details"]
+            label.custom-control-label for="show-users-details-switch" Afficher plus de détails usagers
+
+    .fr-grid-row
+      .fr-col-12
+        .d-flex.justify-content-center.form-group.fr-text--sm
+          = form_with url: request.path,
+            method: :get,
+            html: { class: "form-inline mb-3", data: { controller: "form" } } do |f|
+            = f.label :per, "Nombre de RDV par page :", class: "mr-2"
+            = f.select :per,
+              options_for_select(Admin::RdvsController::PERMITTED_PER_PAGE, params[:per]),
+              {},
+              class: "form-control optional mr-2 form-control-sm",
+              data: { action: "change->form#submit" }
+    .fr-grid-row
+      .fr-col-12
         = render(partial: "rdv", collection: @rdvs_in_page, locals: { agent: nil })
+    .fr-grid-row.fr-pb-3w
+      .fr-col-12
         .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
   - else
     .fr-grid-row.fr-py-3w

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -67,7 +67,7 @@
     .fr-grid-row
       .fr-col-12
         .d-flex.justify-content-center.fr-text--sm
-          span.mr-2 Nombre de RDV par page :
+          span.mr-2.fr-pt-1v Nombre de RDV par page :
           .fr-pagination__list.rdv-per-page-list
             - Admin::RdvsController::PERMITTED_PER_PAGE.each do |per|
               - path = admin_organisation_rdvs_path(current_organisation, @form.to_query.merge(per:, page: params[:page]))

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -60,22 +60,22 @@
 
     .fr-grid-row.fr-pb-3w
       .fr-col-12
-        .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
+        .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr", params: { per: params[:per] }.compact
         = render(partial: "rdv", collection: @rdvs_in_page, locals: { agent: nil })
-        .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
+        .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr", params: { per: params[:per] }.compact
 
     .fr-grid-row
       .fr-col-12
         .d-flex.justify-content-center.fr-text--sm
           span.mr-2 Nombre de RDV par page :
-          .fr-pagination__list
+          .fr-pagination__list.rdv-per-page-list
             - Admin::RdvsController::PERMITTED_PER_PAGE.each do |per|
               - uri = URI(request.path)
               - uri.query = URI.encode_www_form(@form.to_query.merge(per:, page: params[:page]))
-              - if per_page == params.fetch(:per_page, 10).to_i
-                = link_to per_page, uri.to_s, class: "fr-pagination__link fr-pagination__link--current", "aria-current": "page"
+              - if per == params.fetch(:per, 10).to_i
+                = link_to per, uri.to_s, class: "fr-pagination__link fr-pagination__link--current", "aria-current": "page"
               - else
-                = link_to per_page, uri.to_s, class: "fr-pagination__link"
+                = link_to per, uri.to_s, class: "fr-pagination__link"
 
   - else
     .fr-grid-row.fr-py-3w

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -52,37 +52,31 @@
   = render "admin/rdvs/rdv_visibility"
 
   - if @rdvs.total_count > 0
-    .fr-mb-4w
-      h4.rdv-text-align-center
-        | #{@rdvs.total_count} RDV trouvés par cette recherche
-    .fr-grid-row
-      .fr-col-12
-        .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
-    .fr-grid-row
-      .fr-col-12
-        .d-flex.justify-content-center.fr-text--sm
-          .custom-control.custom-switch
-            input.custom-control-input[type="checkbox" id="show-users-details-switch" data-toggle="collapse" data-target=".users-details"]
-            label.custom-control-label for="show-users-details-switch" Afficher plus de détails usagers
+    .mb-2
+      h4>= "#{@rdvs.total_count} rendez-vous"
+      .custom-control.custom-switch
+        input.custom-control-input[type="checkbox" id="show-users-details-switch" data-toggle="collapse" data-target=".users-details"]
+        label.custom-control-label for="show-users-details-switch" Afficher plus de détails usagers
 
-    .fr-grid-row
-      .fr-col-12
-        .d-flex.justify-content-center.form-group.fr-text--sm
-          = form_with url: request.path,
-            method: :get,
-            html: { class: "form-inline mb-3", data: { controller: "form" } } do |f|
-            = f.label :per, "Nombre de RDV par page :", class: "mr-2"
-            = f.select :per,
-              options_for_select(Admin::RdvsController::PERMITTED_PER_PAGE, params[:per]),
-              {},
-              class: "form-control optional mr-2 form-control-sm",
-              data: { action: "change->form#submit" }
-    .fr-grid-row
-      .fr-col-12
-        = render(partial: "rdv", collection: @rdvs_in_page, locals: { agent: nil })
     .fr-grid-row.fr-pb-3w
       .fr-col-12
         .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
+        = render(partial: "rdv", collection: @rdvs_in_page, locals: { agent: nil })
+        .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"
+
+    .fr-grid-row
+      .fr-col-12
+        .d-flex.justify-content-center.fr-text--sm
+          span.mr-2 Nombre de RDV par page :
+          .fr-pagination__list
+            - Admin::RdvsController::PERMITTED_PER_PAGE.each do |per|
+              - uri = URI(request.path)
+              - uri.query = URI.encode_www_form(@form.to_query.merge(per:, page: params[:page]))
+              - if per_page == params.fetch(:per_page, 10).to_i
+                = link_to per_page, uri.to_s, class: "fr-pagination__link fr-pagination__link--current", "aria-current": "page"
+              - else
+                = link_to per_page, uri.to_s, class: "fr-pagination__link"
+
   - else
     .fr-grid-row.fr-py-3w
       .fr-col-12

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -70,12 +70,11 @@
           span.mr-2 Nombre de RDV par page :
           .fr-pagination__list.rdv-per-page-list
             - Admin::RdvsController::PERMITTED_PER_PAGE.each do |per|
-              - uri = URI(request.path)
-              - uri.query = URI.encode_www_form(@form.to_query.merge(per:, page: params[:page]))
+              - path = admin_organisation_rdvs_path(current_organisation, @form.to_query.merge(per:, page: params[:page]))
               - if per == params.fetch(:per, 10).to_i
-                = link_to per, uri.to_s, class: "fr-pagination__link fr-pagination__link--current", "aria-current": "page"
+                = link_to per, path, class: "fr-pagination__link fr-pagination__link--current", "aria-current": "page"
               - else
-                = link_to per, uri.to_s, class: "fr-pagination__link"
+                = link_to per, path, class: "fr-pagination__link"
 
   - else
     .fr-grid-row.fr-py-3w

--- a/spec/features/agents/agent_can_list_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_list_rdvs_spec.rb
@@ -153,4 +153,43 @@ RSpec.describe "Agent can list RDVs" do
       end
     end
   end
+
+  describe "configuration du nombre de RDV par page", js: true do
+    before { create_list(:rdv, 54, organisation:, agents: [current_agent]) }
+
+    it "fonctionne de manière cohérente" do
+      # par défaut la liste affiche 10 RDV par page
+      visit admin_organisation_rdvs_path(organisation, current_agent)
+      expect(page).to have_selector(".rdv-item", count: 10)
+      expect(Rack::Utils.parse_query(URI.parse(first(".fr-pagination__link--last")["href"]).query)["page"].to_i).to eq(6)
+      expect(first(".rdv-per-page-list").find(".fr-pagination__link--current").text.to_i).to eq 10
+      # on passe à 25 par page
+      first(".rdv-per-page-list").find(".fr-pagination__link", text: /25/).click
+      expect(page).to have_selector(".rdv-item", count: 25)
+      expect(Rack::Utils.parse_query(URI.parse(first(".fr-pagination__link--last")["href"]).query)["page"].to_i).to eq(3)
+      expect(first(".rdv-per-page-list").find(".fr-pagination__link--current").text.to_i).to eq 25
+      # on passe à 50 par page
+      first(".rdv-per-page-list").find(".fr-pagination__link", text: /50/).click
+      expect(page).to have_selector(".rdv-item", count: 50)
+      expect(Rack::Utils.parse_query(URI.parse(first(".fr-pagination__link--last")["href"]).query)["page"].to_i).to eq(2)
+      expect(first(".rdv-per-page-list").find(".fr-pagination__link--current").text.to_i).to eq 50
+      # on va à la deuxième page et on vérifie que 50 RDV par page est toujours sélectionné
+      first('.fr-pagination__link[title="Page 2"]').click
+      expect(first(".rdv-per-page-list").find(".fr-pagination__link--current").text.to_i).to eq 50
+      expect(page).to have_selector(".rdv-item", count: 4)
+      # on change un filtre et on vérifie que le nombre de RDV par page est retenu
+      select("Rendez-vous à venir", from: "status")
+      click_on "Rafraîchir la liste"
+      expect(first(".rdv-per-page-list").find(".fr-pagination__link--current").text.to_i).to eq 50
+      # en revanche ça fait revenir à la première page, ce qui est raisonnable
+      expect(first(".fr-pagination__link.fr-pagination__link--current")["title"]).to eq "Page 1"
+      expect(page).to have_selector(".rdv-item", count: 50)
+      # on revient à 10 par page
+      first(".rdv-per-page-list").find(".fr-pagination__link", text: /10/).click
+      expect(page).to have_selector(".rdv-item", count: 10)
+      expect(first(".rdv-per-page-list").find(".fr-pagination__link--current").text.to_i).to eq 10
+      # le filtre sur le statut est bien conservé
+      expect(page).to have_select("status", selected: "Rendez-vous à venir")
+    end
+  end
 end


### PR DESCRIPTION
Review app : https://demo-rdv-solidarites-pr5505.osc-secnum-fr1.scalingo.io/admin/organisations/4/rdvs.4?per=25

# Contexte

https://app.crisp.chat/website/df852917-bfc0-4524-83c8-953865c6465d/inbox/session_a8161488-f71c-4175-b2b8-11838cf27a20/

L’impression des RDV est peu pratique aujourd’hui pour deux raisons principales : 
- on n’affiche que 10 RDV par page : cette PR 💫
- le CSS de l’impression n’est pas idéal : cf autre PR #5507 

# Solution

Je propose de rajouter ce sélecteur de nombre de RDV par page uniquement en bas de page pour l’instant.
Je pense en effet que c’est un bon endroit car tu vas probablement parcourir la liste de 10 RDV avant de te rendre compte qu’il y en a plus à voir.

J’ai réutilisé les composants de pagination du DSFR ce qui est peut-être une mauvaise idée d’UX et/ou d’accessibilité, je ne sais pas. Je suis un peu surpris qu’il n’y ait aucune recommendation à ce sujet dans le DSFR https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pagination

J’ai proposé des évolutions plus larges de l’UI de cette page dans une PR plus spéculative : #5506 

# Captures d’écran

<img width="1285" height="614" alt="image" src="https://github.com/user-attachments/assets/5bf07628-1070-4ba1-9bb4-a42dc04f8461" />


