### PR TITLE
Amélioration du CSS d’impression de la liste des RDV

### DIFF
--- a/app/form_models/admin/rdv_search_form.rb
+++ b/app/form_models/admin/rdv_search_form.rb
@@ -12,9 +12,39 @@ class Admin::RdvSearchForm
     @user ||= user_scope.find_by(id: user_id) if user_id.present?
   end
 
+  def lieux
+    @lieux ||= Agent::LieuPolicy::Scope.new(pundit_user.agent, Lieu.where(id: lieu_ids)).resolve
+  end
+
+  def motifs
+    @motifs ||= Agent::MotifPolicy::ScopeForRdvsList.new(pundit_user.agent, Motif.where(id: motif_ids)).resolve
+  end
+
   def to_query
     %i[organisation_id start end agent_id user_id status lieu_ids motif_ids scoped_organisation_ids]
       .index_with { send(_1) }
+  end
+
+  def self.valid_date?(date)
+    return false if date.blank? || date.to_s.include?("__/__/____")
+
+    Date.parse(date.to_s)
+  rescue Date::Error
+    Sentry.capture_message("invalid date: #{date.inspect}", fingerprint: ["invalid date"])
+    false
+  end
+
+  def applied_filters # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    @applied_filters ||= begin
+      filters = []
+      filters << :agent if agent.present?
+      filters << :user if  user.present?
+      filters << :lieux if lieux.present?
+      filters << :motifs if motifs.present?
+      filters << :status if status.present?
+      filters << :dates if self.class.valid_date?(start) || self.class.valid_date?(send(:end))
+      filters
+    end
   end
 
   private

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -74,9 +74,9 @@ module RdvsHelper
   def dates_interval
     return nil if no_date_filters?
 
-    if valid_date?(params[:start]) && !valid_date?(params[:end])
+    if Admin::RdvSearchForm.valid_date?(params[:start]) && !Admin::RdvSearchForm.valid_date?(params[:end])
       dates_interval_from(params[:start])
-    elsif valid_date?(params[:end]) && !valid_date?(params[:start])
+    elsif Admin::RdvSearchForm.valid_date?(params[:end]) && !Admin::RdvSearchForm.valid_date?(params[:start])
       dates_interval_until(params[:end])
     else
       # Both Dates are valid
@@ -143,17 +143,8 @@ module RdvsHelper
       (rdv.motif.phone? ? " ☎️" : "")
   end
 
-  def valid_date?(date)
-    return false if date.blank? || date.to_s.include?("__/__/____")
-
-    Date.parse(date.to_s)
-  rescue Date::Error
-    Sentry.capture_message("invalid date: #{date.inspect}", fingerprint: ["invalid date"])
-    false
-  end
-
   def no_date_filters?
-    !valid_date?(params[:start]) && !valid_date?(params[:end])
+    !Admin::RdvSearchForm.valid_date?(params[:start]) && !Admin::RdvSearchForm.valid_date?(params[:end])
   end
 
   def dates_interval_from(date)

--- a/app/javascript/stylesheets/components/_rdv_status.scss
+++ b/app/javascript/stylesheets/components/_rdv_status.scss
@@ -30,3 +30,22 @@ $status_colors: (
 .text-primary-blue {
   color: $blue;
 }
+
+.rdv-status-print {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: end;
+}
+.rdv-status-print::before {
+  content: "";
+  display: block;
+  width: 16px;
+  height: 16px;
+  border-radius: 8px;
+}
+@each $status, $color in $status_colors {
+  .rdv-status-print.rdv-status-print-#{$status}::before {
+    background-color: $color;
+  }
+}

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -54,6 +54,10 @@
 
 // FLEX
 
+.rdv-display-flex {
+  display: flex;
+}
+
 .rdv-flex-wrap-wrap {
   flex-wrap: wrap;
 }
@@ -66,12 +70,20 @@
   justify-content: center;
 }
 
+.rdv-justify-content-space-between {
+  justify-content: space-between;
+}
+
 .rdv-align-items-baseline {
   align-items: baseline;
 }
 
 .rdv-gap-1rem {
   gap: 1rem;
+}
+
+.rdv-flex-direction-column {
+  flex-direction: column;
 }
 
 // DIMENSIONS

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -80,31 +80,41 @@
 
 .print-content.px-20
   .fr-grid-row.fr-mb-4w
-    .fr-col-6
-      div #{@rdvs.total_count} RDV au total
-      div #{@rdvs_in_page.count} RDV dans la page courante (p. #{@rdvs.current_page} / #{@rdvs.total_pages})
-    .fr-col-6
-      - if @form.applied_filters.empty?
-        div Aucun filtre appliqué
-      - if @form.agent.present?
-        div Agent: #{@form.agent}
-      - if @form.user.present?
-        div Usager: #{@form.user}
-      - if @form.lieux.present?
-        div
-          |> Lieu#{"x" if @form.lieux.count > 1}
-          | : #{@form.lieux.map(&:name).to_sentence}
-      - if @form.motifs.present?
-        div
-          |> Motif#{"s" if @form.motifs.count > 1}
-          | : #{@form.motifs.map(&:name).to_sentence}
-      - if @form.status.present?
-        div Statut: #{Rdv.human_attribute_value(:status, @form.status)}
-      - if dates_interval.present?
-        div Dates : #{dates_interval}
+    - if @form.applied_filters.any?
+      .fr-col-6
+        div.fr-text--bold Filtres appliqués
+        - if @form.agent.present?
+          div Agent: #{@form.agent}
+        - if @form.user.present?
+          div Usager: #{@form.user}
+        - if @form.lieux.present?
+          div
+            |> Lieu#{"x" if @form.lieux.count > 1}
+            | : #{@form.lieux.map(&:name).to_sentence}
+        - if @form.motifs.present?
+          div
+            |> Motif#{"s" if @form.motifs.count > 1}
+            | : #{@form.motifs.map(&:name).to_sentence}
+        - if @form.status.present?
+          div Statut: #{Rdv.human_attribute_value(:status, @form.status)}
+        - if dates_interval.present?
+          div Dates : #{dates_interval}
+    div[class=(@form.applied_filters.any? ? "fr-col-6": "fr-col-12")]
+      - if @form.applied_filters.any?
+        div.fr-text--bold Résultats
+      - if @rdvs.total_pages > 1
+        div #{@rdvs.total_count} RDV au total
+        div #{@rdvs_in_page.count} RDV dans la page courante (p. #{@rdvs.current_page} / #{@rdvs.total_pages})
+      - else
+        div #{@rdvs.total_count} RDV
 
   - rdvs_collection = @rdvs_in_page.group_by { |rdv| rdv.starts_at.to_date }
   - rdvs_collection.each do |date, rdvs|
-    h3.fr-mb-4w.fr-mt-6w
-      = format_date(date.to_s)
-    = render(partial: "admin/rdvs/print/rdv", collection: rdvs)
+    - first_rdv = rdvs.shift
+    / On veut éviter qu’il y ait un saut de page entre la date et le premier RDV de cette date
+    / on utilise un padding-top plutôt qu’une margin qui se fait « manger » au saut de page
+    .fr-pt-2w[style="break-inside: avoid;"]
+      h3.fr-mb-4w
+        = format_date(date.to_s)
+      = render "admin/rdvs/print/rdv", rdv: first_rdv
+    = render partial: "admin/rdvs/print/rdv", collection: rdvs

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -2,10 +2,7 @@
   - content_for :title do
     .d-print-none Liste des RDV
     .print-context
-      - if @form.agent
-        | Agenda de #{@form.agent.full_name}
-      - else
-        | Agenda de l'organisation #{current_organisation.name}
+      | Liste de RDV de l’organisation #{current_organisation.name}
 
   - content_for(:menu_item) { "menu-rdvs-list" }
 
@@ -82,12 +79,32 @@
                   i.far.fa-calendar.fa-stack-1x.text-white
 
 .print-content.px-20
-  - unless params[:start] == params[:end]
-    h3.fr-mt-4w
-      = dates_interval
+  .fr-grid-row.fr-mb-4w
+    .fr-col-6
+      div #{@rdvs.total_count} RDV au total
+      div #{@rdvs_in_page.count} RDV dans la page courante (p. #{@rdvs.current_page} / #{@rdvs.total_pages})
+    .fr-col-6
+      - if @form.applied_filters.empty?
+        div Aucun filtre appliqué
+      - if @form.agent.present?
+        div Agent: #{@form.agent}
+      - if @form.user.present?
+        div Usager: #{@form.user}
+      - if @form.lieux.present?
+        div
+          |> Lieu#{"x" if @form.lieux.count > 1}
+          | : #{@form.lieux.map(&:name).to_sentence}
+      - if @form.motifs.present?
+        div
+          |> Motif#{"s" if @form.motifs.count > 1}
+          | : #{@form.motifs.map(&:name).to_sentence}
+      - if @form.status.present?
+        div Statut: #{Rdv.human_attribute_value(:status, @form.status)}
+      - if dates_interval.present?
+        div Dates : #{dates_interval}
+
   - rdvs_collection = @rdvs_in_page.group_by { |rdv| rdv.starts_at.to_date }
-  - rdvs_collection.each_with_index do |item, index|
-    - date, rdvs = item
-    h3.fr-mb-4w class=("fr-mt-6w" if index > 0)
+  - rdvs_collection.each do |date, rdvs|
+    h3.fr-mb-4w.fr-mt-6w
       = format_date(date.to_s)
     = render(partial: "admin/rdvs/print/rdv", collection: rdvs)

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -1,6 +1,11 @@
 .web-content
   - content_for :title do
-    | Liste des RDV
+    .d-print-none Liste des RDV
+    .print-context
+      - if @form.agent
+        | Agenda de #{@form.agent.full_name}
+      - else
+        | Agenda de l'organisation #{current_organisation.name}
 
   - content_for(:menu_item) { "menu-rdvs-list" }
 
@@ -77,18 +82,12 @@
                   i.far.fa-calendar.fa-stack-1x.text-white
 
 .print-content.px-20
-  h1
-    - if @form.agent
-      | Agenda de #{@form.agent.full_name}
-    - else
-      | Agenda de l'organisation
-    .mt-2
-      = current_organisation.name
-
-  h3.mt-4
-    = dates_interval unless params[:start] == params[:end]
+  - unless params[:start] == params[:end]
+    h3.fr-mt-4w
+      = dates_interval
   - rdvs_collection = @rdvs_in_page.group_by { |rdv| rdv.starts_at.to_date }
-  - rdvs_collection.each do |date, rdvs|
-    h3.mt-4
+  - rdvs_collection.each_with_index do |item, index|
+    - date, rdvs = item
+    h3.fr-mb-4w class=("fr-mt-6w" if index > 0)
       = format_date(date.to_s)
     = render(partial: "admin/rdvs/print/rdv", collection: rdvs)

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -49,15 +49,15 @@
               = "proche de #{user.responsible}"
           = render "admin/rdvs/print/user_details", user: user
 
-        - if current_organisation.territory.enable_context_field
-          div
-            | Contexte&nbsp;:
-            | &nbsp
-            - if rdv.context.present?
-              = rdv.context
-            - else
-              span.font-weight-light.font-italic.text-muted
-                | Pas de contexte renseigné
+      - if current_organisation.territory.enable_context_field
+        div
+          | Contexte&nbsp;:
+          | &nbsp
+          - if rdv.context.present?
+            = rdv.context
+          - else
+            span.font-weight-light.font-italic.text-muted
+              | Pas de contexte renseigné
 
       div
         - case rdv.motif.location_type.to_sym

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -64,7 +64,8 @@
         - when :visio
           .fa.fa-video-camera>
           |> RDV par visioconférence
-          = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)
+          span[style="line-break: anywhere;"]
+            = rdv.visio_url
         - when :phone
           .fa.fa-phone>
           |> RDV par téléphone

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -1,69 +1,56 @@
-.row
-  .col-md-2.col-sm-2.text-right
-    hr.mt-0
-    .lead.font-weight-bold
-      = rdv_interval(rdv, :time_only)
+.fr-grid-row.fr-mb-4w.fr-text--md.fr-py-1w[style="border-top: 1px solid #ccc; border-bottom: 1px solid #ccc; break-inside: avoid;"]
+  .fr-col-4.fr-px-2w.text-right.rdv-display-flex.rdv-justify-content-space-between.rdv-flex-direction-column
+    div
+      |> de #{l(rdv.starts_at, format: :time_only)}
+      | à #{l(rdv.starts_at + rdv.duration_in_min.minutes, format: :time_only)}
     - if rdv.duration_in_min
       div
-        = "(#{rdv.duration_in_min} minutes)"
-  .col-md-10.col-sm-10
-    .card.rdv-card.rounded-0 style="border-left: 8px solid #{rdv.motif.color}"
-      .d-flex
-        .flex-grow-1.lead.pl-3.pt-2
-          = rdv.motif_name
-        .rdv-status.px-2.py-2 class="rdv-status-#{rdv.status}" id="rdv-#{rdv.id}-status"
-          = rdv.human_attribute_value(:status).upcase
-      - case rdv.motif.location_type.to_sym
-      - when :visio
-        .pl-3.pt-2
-          .fa.fa-video-camera>
-          |> RDV par visioconférence
-          = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)
-      - when :phone
-        .pl-3.pt-2
-          .fa.fa-phone>
-          |> RDV par téléphone
-          - rdv.participations.filter_map { |p| p.user.user_to_notify&.phone_number_formatted }.each do |phone_number|
-            |> -
-            = phone_to(phone_number)
+        | #{rdv.duration_in_min} minutes
+    div
+      .rdv-status-print class="rdv-status-print-#{rdv.status}"
+        = rdv.human_attribute_value(:status)
 
-      .card-body
-        - rdv.participations.each do |participation|
-          ruby:
-            user = participation.user
-            phone_number = user.user_to_notify&.phone_number
-            email = user.user_to_notify&.preferred_email
-          div
-            span.font-weight-bold.lead
-              = user
-            - if user.birth_date
-              span.mx-1
-                = "(né(e) le #{I18n.l(participation.user.birth_date)})"
-            | &nbsp - &nbsp
-            span.mx-1
-              - if email.present?
-                = email
-              - else
-                span.font-weight-light.font-italic.text-muted
-                  | Email non renseigné
-            | &nbsp - &nbsp
-            span.mx-1
-              - if phone_number.present?
-                = phone_number
-              - else
-                span.font-weight-light.font-italic.text-muted
-                  | Téléphone non renseigné
-          .mt-2
-            span.mx-1
-              - if current_organisation.ants_connectable? && user.ants_pre_demande_number.present?
-                = "N° de pré-demande ANTS : #{user.ants_pre_demande_number}"
-          .users-details.collapse
-            - if user.responsible.present?
-              div.mb-2
-                = "proche de #{user.responsible}"
-            = render "admin/rdvs/print/user_details", user: user
+  .fr-col-8.fr-px-2w[style="border-left: 8px solid #{rdv.motif.color}"]
+    .rdv-display-flex.rdv-flex-direction-column.rdv-gap-1rem
+      div= rdv.motif_name
+
+      - rdv.participations.each do |participation|
+        ruby:
+          user = participation.user
+          phone_number = user.user_to_notify&.phone_number
+          email = user.user_to_notify&.preferred_email
+        div
+          = user
+          - if user.birth_date
+            span.fr-mx-1w
+              = "(né(e) le #{I18n.l(participation.user.birth_date)})"
+          | &nbsp - &nbsp
+          span.fr-mx-1w
+            - if email.present?
+              = email
+            - else
+              span.font-weight-light.font-italic.text-muted
+                | Email non renseigné
+          | &nbsp - &nbsp
+          span.fr-mx-1w
+            - if phone_number.present?
+              = phone_number
+            - else
+              span.font-weight-light.font-italic.text-muted
+                | Téléphone non renseigné
+
+        - if current_organisation.ants_connectable? && user.ants_pre_demande_number.present?
+          span.fr-mx-1w
+            = "N° de pré-demande ANTS : #{user.ants_pre_demande_number}"
+
+        .users-details.collapse
+          - if user.responsible.present?
+            div
+              = "proche de #{user.responsible}"
+          = render "admin/rdvs/print/user_details", user: user
+
         - if current_organisation.territory.enable_context_field
-          .mt-2
+          div
             | Contexte&nbsp;:
             | &nbsp
             - if rdv.context.present?
@@ -71,10 +58,24 @@
             - else
               span.font-weight-light.font-italic.text-muted
                 | Pas de contexte renseigné
-        .mt-2
-          i.fa.fa-map-marker-alt>
-          = human_location(rdv)
-        .mt-2
-          | Agent(s)&nbsp;:
-          | &nbsp
-          = agents_to_sentence(rdv.agents)
+
+      div
+        - case rdv.motif.location_type.to_sym
+        - when :visio
+          .fa.fa-video-camera>
+          |> RDV par visioconférence
+          = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)
+        - when :phone
+          .fa.fa-phone>
+          |> RDV par téléphone
+          - rdv.participations.filter_map { |p| p.user.user_to_notify&.phone_number_formatted }.each do |phone_number|
+            |> -
+            = phone_number
+        - else
+            i.fa.fa-map-marker-alt>
+            = human_location(rdv)
+
+      div
+        | Agent(s)&nbsp;:
+        | &nbsp
+        = agents_to_sentence(rdv.agents)

--- a/app/views/admin/rdvs/print/_user_details.html.slim
+++ b/app/views/admin/rdvs/print/_user_details.html.slim
@@ -7,4 +7,3 @@ div= object_attribute_tag(user, :address)
   - if current_territory.attributes.with_indifferent_access[toggle]
     div
       = object_attribute_tag(user, field_name)
-hr


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5507.osc-secnum-fr1.scalingo.io/) 

# Contexte

https://app.crisp.chat/website/df852917-bfc0-4524-83c8-953865c6465d/inbox/session_a8161488-f71c-4175-b2b8-11838cf27a20/

L’impression des RDV est peu pratique aujourd’hui pour deux raisons principales : 
- on n’affiche que 10 RDV par page (cf autre PR #5505)
- le CSS de l’impression n’est pas idéal : cette PR 💫

Aussi, aujourd’hui l’impression d’une liste de RDV en N&B est peu lisible. Ça me paraît être une bonne idée de prendre comme référence la vue N&B, un peu comme on prend la vue mobile comm ref sur le web : il faut que ça fonctionne pour des personnes daltoniennes ou pour des imprimantes sans couleurs.

# Solution


| avant                                | après                                |
| ------------------------------------ | ------------------------------------ |
| <img width="966" height="1432" alt="image" src="https://github.com/user-attachments/assets/31713c96-91e3-4358-9d6b-72a22a63ce5d" /> | <img width="960" height="1418" alt="image" src="https://github.com/user-attachments/assets/f2790504-083e-4787-b834-a53410d35d7c" /> |


Liste des améliorations :

## Général
- passage en 12pt = 16px sur le contenu. Ça semble être une valeur commune pour les impressions
- simplification des cards en blocs avec des bordures horizontales, réduction du padding et des marges internes
- ça ne peut pas couper au milieu d’un bloc de RDV
- ça ne peut pas couper entre le titre de date et le premier bloc de RDV

## Titre
- suppression de « Liste des RDV » qui est redondant
- passage sur une seule ligne « Agenda de X - Orga »
- Amélioration des marges des titres de dates 

## Récap
- Ajout d’un bloc de deux colonnes sous le titre : Liste des filtres appliqués + Nombre de RDV trouvés
- L’info me paraît nécessaire pour savoir ce qu’on est en train d’imprimer et comprendre le contexte quand on lit cette impression.
- On affiche le nombre de résultats totaux et le nombre de RDV dans la page courante imprimée, ça risque de porter confusion avec le numéro de page imprimée mais je ne vois pas trop comment éclaircir ça.

## Heures des RDV
- passage sur une seule ligne
- alignement entre les différentes heures plus consistent

## Statuts des RDV
- Le fond coloré n’est pas lisible et pas pratique pour l’impression
- On passe à une pastille colorée
- On déplace aussi ce statut dans la colonne de gauche en bas, pour gagner un peu d’espace
- On diminue la police et on passe en minuscules pour plus de lisibilité

## Corrections
- L’adresse des RDV apparaissait (comme non-renseignée) même pour les RDV en visio et par téléphone

## Cas par cas des RDV

### Visio

- on affiche l’URL plutôt qu’un lien
- on n’affiche pas l’adresse non renseignée inutile

avant | après
 -- | --
<img width="978" height="430" alt="image" src="https://github.com/user-attachments/assets/dccde588-c47e-407c-b825-ff9c66b5da58" /> | <img width="1040" height="322" alt="image" src="https://github.com/user-attachments/assets/bce5f251-0494-4e65-8aa0-9279e22b212e" />

### Téléphone

- on n’affiche pas l’adresse non renseignée inutile

avant | après 
-|-
<img width="1042" height="368" alt="image" src="https://github.com/user-attachments/assets/0f0ff7f8-959d-4b56-8fc6-e3b6e6c7b36d" /> | <img width="1014" height="284" alt="image" src="https://github.com/user-attachments/assets/1dd54e0a-2bf3-4427-9dad-ca114553f31f" />

### ANTS

avant | après 
-|-
<img width="1012" height="358" alt="image" src="https://github.com/user-attachments/assets/9d72360d-bfaf-4e34-887f-f9e816a9dbe1" /> | <img width="1030" height="354" alt="image" src="https://github.com/user-attachments/assets/4f3f18d2-67ce-4dcb-923a-fd2c7bddf36b" />


### proche (détails usagers activés)

avant | après 
-|-
<img width="1036" height="502" alt="image" src="https://github.com/user-attachments/assets/b5e1f985-65e4-4159-9ab3-ac687d32161b" /> | <img width="1068" height="370" alt="image" src="https://github.com/user-attachments/assets/70a873ed-55b6-472a-ab2a-4a4f92a0fc82" />

### contexte - n/a

avant | après 
-|-
<img width="1032" height="312" alt="image" src="https://github.com/user-attachments/assets/1528731f-4ba6-4dda-98fa-efbc9c55de2e" /> | <img width="1028" height="266" alt="image" src="https://github.com/user-attachments/assets/ae99a7ac-7a84-4073-9b63-ac7c2e8d6cf8" />


### contexte - renseigné

avant | après 
-|-
<img width="1010" height="402" alt="image" src="https://github.com/user-attachments/assets/6b1a2fdd-b675-42bb-afdd-15d0089a59ce" /> | <img width="1018" height="332" alt="image" src="https://github.com/user-attachments/assets/81e4f1ab-487a-477e-ab95-66dbedabf195" />

