### PR TITLE
Fix: lien voir dans l’agenda

### DIFF
--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -30,7 +30,7 @@ turbo-frame.card.rdv-item[id= "rdv-#{rdv.id}" target="_top"]
             = rdv_starts_at_and_duration(rdv, :time_only)
             - if rdv.agents.first
               |&nbsp;
-              = link_to "voir dans l'agenda", admin_organisation_planning_agenda_path(current_organisation, agent_id: rdv.agents.first.id, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
+              = link_to "voir dans l'agenda", admin_organisation_planning_agenda_path(current_organisation, agent_id: rdv.agents.first.id, selected_event_id: rdv.id, date: rdv.starts_at.to_date), data: { turbo: false }
         = render "admin/rdvs/rdv_details", rdv: rdv
 
       ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--right.fr-mb-0


### PR DESCRIPTION
# Contexte

Suite à l’utilisation du turbo frame, le lien pour afficher le RDV sur le calendrier est cassé. 
En effet, ce lien utilisant turbo, le full calendar ne charge pas correctement.

# Solution

Je propose donc d’appliquer la même méthode que sur les autres liens pour le moment, à savoir, désactiver turbo.