### PR TITLE
Fix LAPINS-2XT

### DIFF
--- a/app/policies/agent/agent_agenda_policy.rb
+++ b/app/policies/agent/agent_agenda_policy.rb
@@ -3,7 +3,7 @@ class Agent::AgentAgendaPolicy < ApplicationPolicy
 
   def show?
     current_agent_role = current_agent.roles.find_by(organisation_id: record.organisation_id)
-    other_agent_role = record.agent.roles.find_by(organisation_id: record.organisation_id)
+    other_agent_role = record.agent&.roles&.find_by(organisation_id: record.organisation_id)
 
     return false if current_agent_role.nil? || other_agent_role.nil?
 


### PR DESCRIPTION
# Contexte

Suite à #5497 nous avons quelques agents qui rencontrent une erreur.
Après avoir creusé le problème, il s’agit en fait d’un cas très particulier.

1. Un agent basique crée un RDV pour un agent d’un autre service pour lequel il n’a pas le droit de voir l’agenda.
2. L’agent après confirmation du RDV est normalement redirigé vers l’agenda de l’agent
3. Comme il n’a pas le droit de le voir il devrait normalement avoir un message d’erreur comme ci-dessous et voir son propre agenda. Au lieu de ça, il se prend une 500.

<img width="1288" height="309" alt="image" src="https://github.com/user-attachments/assets/1d23b700-b51a-4224-aab9-dcad7e93b404" />

En réalité, comme nous avons utilisé le scope [Agent::AgentPolicy](https://github.com/betagouv/rdv-service-public/blob/88c60f18a484a5725869db85babbaedb0dfff982/app/controllers/concerns/admin/planning/set_agents_concern.rb#L13) en amont du `authorize` sur la policy [Agent::AgentAgendaPolicy](https://github.com/betagouv/rdv-service-public/blob/88c60f18a484a5725869db85babbaedb0dfff982/app/controllers/admin/planning/agendas_controller.rb#L8), on se retrouve à tester un scope sur un record `nil`.

À noter que cela n’affecte absolument pas la prise de RDV mais cela amène de la confusion pour les agents (d’autant plus qu’ils n’ont pas le droit de voir les agendas de leurs collègues pour vérifier que les RDV sont bien placés)

# Solution

Je serai d’avis de réécrire cela un peu plus proprement, mais j’ai déjà passé beaucoup de temps à retourner le problème et je préfère donc faire ce petit quick fix avant de réécrire cela.

À terme, je ne suis pas sur que ça soit une bonne idée de garder ce `set_agents` qui préscope sur une policy.

Il faudrait peut-être respliter les `set_agents` dans chaque controller, ou ne pas préscoper et laisser le controleur faire le authorize après le `set_agents`.

Voir : https://sentry.incubateur.net/organizations/betagouv/issues/188183/


