### PR TITLE
Corriger l’affichage des restrictions pour les motifs téléphoniques

### DIFF
--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -7,6 +7,7 @@
   p.fr-text--lg = t(".select_lieu")
   p.fr-text--sm = t(".lieu_available", count: context.shown_lieux.count)
   ul.fr-raw-list
+    / similar to app/views/search/_organisation_selection.html.slim:10
     - context.next_availability_by_lieux.each do |lieu, next_availability|
       - motif = next_availability.motif
       - if motif.restriction_for_rdv.blank?

--- a/app/views/search/_organisation_selection.html.slim
+++ b/app/views/search/_organisation_selection.html.slim
@@ -6,12 +6,23 @@
 - else
   p.fr-text--lg Sélectionnez la structure avec laquelle prendre RDV&nbsp;:
   ul.fr-raw-list
+    / similar to app/views/search/_lieu_selection.html.slim:10
     - context.next_availability_by_motifs_organisations.each do |organisation, next_availability|
+      - motif = next_availability.motif
+      - if motif.restriction_for_rdv.blank?
+        - link = link_to organisation.name, prendre_rdv_path(context.query_params.merge(user_selected_organisation_id: organisation.id, date: next_availability.starts_at))
+      - else
+        - link = link_to organisation.name, prendre_rdv_path(context.query_params.merge(user_selected_organisation_id: organisation.id, date: next_availability.starts_at)), "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{organisation.id}" }
+        = render "/common/modal",
+          id: "js-rdv-restriction-motif#{organisation.id}",
+          title: "À lire avant de prendre un rendez-vous",
+          confirm_path: prendre_rdv_path(context.query_params.merge(user_selected_organisation_id: organisation.id, date: next_availability.starts_at)) do
+          = restriction_for_rdv_to_html(motif)
       li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
         .fr-card__body
           .fr-card__content
             .fr-card__title
-              = link_to organisation.name, prendre_rdv_path(context.query_params.merge(user_selected_organisation_id: organisation.id, date: next_availability.starts_at))
+              = link
             .fr-card__end
               = render "search/organisation_card_subtitles", organisation: organisation
               .fr-card__detail

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe "User can search for rdvs" do
       create(:motif, :by_phone, name: "RSA orientation par téléphone", organisation: organisation_without_po, restriction_for_rdv: nil, service: service)
     end
 
-    context "motif téléphonique" do
-      specify js: true do
+    context "when the motif is by phone" do
+      it "can take a RDV in the available organisations", js: true do
         visit root_path
         execute_search
 

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe "User can search for rdvs" do
       create(:motif, :by_phone, name: "RSA orientation par téléphone", organisation: organisation_without_po, restriction_for_rdv: nil, service: service)
     end
 
-    context "when the motif is by phone" do
-      it "can take a RDV in the available organisations", js: true do
+    context "motif téléphonique" do
+      specify js: true do
         visit root_path
         execute_search
 
@@ -108,6 +108,32 @@ RSpec.describe "User can search for rdvs" do
         continue_to_rdv(first_motif)
         add_relative
         confirm_rdv(first_motif)
+      end
+    end
+
+    context "motif téléphonique avec restriction (instruction pré-RDV)" do
+      let!(:first_motif) do
+        create(:motif, :by_phone, name: "RSA orientation par téléphone", organisation: first_organisation_with_po, restriction_for_rdv: "Merci d’apporter les documents nécessaires", service: service)
+      end
+
+      it "oblige à accepter la restriction", js: true do
+        visit root_path
+        execute_search
+
+        ## Motif selection
+        expect(page).to have_content(first_motif.name)
+        click_link(first_motif.name)
+
+        ## Organisation selection
+        click_on first_organisation_with_po.name
+        expect(page).to have_content("Merci d’apporter les documents nécessaires")
+        click_on "Annuler"
+        click_on first_organisation_with_po.name
+        expect(page).to have_content("Merci d’apporter les documents nécessaires")
+        click_on "Accepter"
+
+        ## Sélection créneau
+        expect(page).to have_content("Sélectionnez un créneau")
       end
     end
 


### PR DESCRIPTION
# Contexte

https://app.crisp.chat/website/df852917-bfc0-4524-83c8-953865c6465d/inbox/session_4975e0a2-e56f-4d09-b48c-884362924769/

Les restrictions (indications AVANT la prise de RDV) ne s’affichent pas pour les motifs téléphoniques.

C’est du au fait qu’on ne passe pas par le partial `lieu_selection` pour ces motifs.

# Solution

Reproduction de ce qui est fait dans le partial `lieu_selection` dans `organisation_selection`