### PR TITLE
correction autodoc pour ne pas générer de doc inutilement

### DIFF
--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -9,6 +9,8 @@ class Autodoc
   end
 
   def self.render
+    return if @scenarios.empty?
+
     `mkdir -p tmp/capybara/autodoc`
 
     @scenarios.each do |scenario|


### PR DESCRIPTION
les runs de CI pour les tests unit ou feature génèrent des uploads GH inutiles : des autodoc index.html vides

ex https://github.com/betagouv/rdv-service-public/actions/runs/16363575105/job/46235977763

