### PR TITLE
CI: uploader les logs RSpec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,9 @@ jobs:
         if: always()
         with:
           name: artifacts-capybara-${{ matrix.name }}
-          path: tmp/capybara
+          path: |
+            tmp/capybara
+            tmp/rspec-*
           if-no-files-found: ignore
   test_features_autodoc:
     name: Feature Tests using Autodoc

--- a/.rspec
+++ b/.rspec
@@ -2,6 +2,6 @@
 --order rand
 --require rails_helper
 --format progress
---format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
---format ParallelTests::RSpec::SummaryLogger --out tmp/spec_summary.log
---format ParallelTests::RSpec::FailuresLogger --out tmp/failing_specs.log
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/rspec-parallel_runtime_rspec.log
+--format ParallelTests::RSpec::SummaryLogger --out tmp/rspec-spec_summary.log
+--format ParallelTests::RSpec::FailuresLogger --out tmp/rspec-failing_specs.log


### PR DESCRIPTION
J’aimerais pouvoir vérifier si certains tests spécifiques se sont bien executés sur la CI

précisément `./spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb:90`

```rb
    click_link("Ajouter un participant")
    add_user(user1)
    add_new_user
    click_on "Enregistrer"
    expect(page).to have_content("Participants mis à jour")

    expect(Receipt.where(user_id: user1.id, channel: "sms", result: "delivered").count).to eq 1
    expect(Receipt.where(user_id: user1.id, channel: "mail", result: "processed").count).to eq 1
```

ces tests ne passent pas en local sur production, je ne vois pas trop ce qui devrait déclencher l’envoi de ces notifications, je suspecte que ces tests ne tournent pas du tout.


J’aimerais aussi éventuellement mettre en place une action comme https://github.com/marketplace/actions/publish-test-results pour lire plus facilement les specs ayant échoué