### PR TITLE
WIP correction des specs RDV Collectifs pour les receipts

### DIFF
--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe "Agent can organize a rdv collectif", js: true do
     expect(page).to have_content("Participants mis à jour")
 
     expect(Receipt.where(user_id: user1.id, channel: "sms", result: "delivered").count).to eq 1
+    receipt_sms = Receipt.where(user_id: user1.id, channel: "sms", result: "delivered").first
+    puts "receipt_sms is #{receipt_sms.attributes}"
     expect(Receipt.where(user_id: user1.id, channel: "mail", result: "processed").count).to eq 1
 
     expect(page).to have_content("2 places restantes")

--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe "Agent can organize a rdv collectif", js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   def create_rdv_collectif(lieu_availability)
+    Receipt.delete_all
+
     # Creating a new RDV Collectif
     visit admin_organisation_rdvs_collectifs_path(organisation)
     expect(page).to have_content("Aucun RDV")


### PR DESCRIPTION
en local ces specs sur les receipts ne passent pas

```rb
    click_link("Ajouter un participant")
    add_user(user1)
    add_new_user
    click_on "Enregistrer"
    expect(page).to have_content("Participants mis à jour")

    expect(Receipt.where(user_id: user1.id, channel: "sms", result: "delivered").count).to eq 1
    expect(Receipt.where(user_id: user1.id, channel: "mail", result: "processed").count).to eq 1
```

je ne vois pas trop ce qui devrait déclencher l’envoi de ces notifications, je suspecte que ces tests ne tournent pas comme on l’imagine en prod
