### PR TITLE
Amélioration & générisation des specs avant Playwright

### DIFF
--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "agents page", js: true do
     login_as(agent, scope: :agent)
 
     path = admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
-    expect_page_to_be_axe_clean(path, excluding_selector: ".fc-axis") # Full calendar place une case de tableau vide pour laquelle nous ne voulons pas d’alerte
+    expect_page_to_be_axe_clean(path)
   end
 
   it "agenda with 3 rdvs is accessible" do
@@ -33,7 +33,7 @@ RSpec.describe "agents page", js: true do
     visit path
     expect(page).to have_current_path(path)
     expect(page).to have_content(Rdv.last.users.last.full_name)
-    expect(page).to be_axe_clean.excluding(".fc-axis") # Full calendar place une case de tableau vide pour laquelle nous ne voulons pas d’alerte
+    expect(page).to be_axe_clean
   end
 
   it "admin organisation plage_ouvertures path is accessible" do

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -40,14 +40,17 @@ RSpec.describe "Agent can create a Rdv with wizard" do
     fill_in :user_first_name, with: "Jean-Paul"
     fill_in :user_last_name, with: "Orvoir"
     fill_in :user_email, with: "jporvoir@bidule.com"
-    click_button("Enregistrer")
+    click_button("Enregistrer l'usager")
+    expect(page).to have_content("ORVOIR Jean-Paul")
 
     # create user without email
     click_link("Ajouter")
     click_link("Ajouter un usager")
     fill_in :user_first_name, with: "Jean-Marie"
     fill_in :user_last_name, with: "Lapin"
-    click_button("Enregistrer")
+    click_button("Enregistrer l'usager")
+    expect(page).to have_content("LAPIN Jean-Marie")
+
     sleep(1) # wait for modal to hide completely
     fill_in :rdv_context, with: "RDV très spécial"
     click_button("Continuer")

--- a/spec/features/agents/relatives/agent_can_delete_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_delete_relative_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe "Agent can delete a relative" do
   it "works", js: true do
     login_as(agent, scope: :agent)
     visit admin_organisation_user_path(organisation, relative)
-    click_link("Supprimer")
-    page.driver.browser.switch_to.alert.accept
+    accept_confirm do
+      click_link("Supprimer")
+    end
     expect_page_title "Fiona LEGENDE"
     expect(page).to have_content("L’usager a été supprimé")
     expect(page).to have_content("Aucun proche")

--- a/spec/features/agents/users/agent_can_delete_user_spec.rb
+++ b/spec/features/agents/users/agent_can_delete_user_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe "Agent can delete user" do
   end
 
   it "delete user", js: true do
-    click_link("Supprimer")
-    page.driver.browser.switch_to.alert.accept
+    accept_confirm do
+      click_link("Supprimer")
+    end
     expect_page_title("Usagers")
     expect_page_with_no_record_text("Utilisez le champ de recherche pour trouver un usager")
   end

--- a/spec/features/agents/users/agent_can_merge_users_spec.rb
+++ b/spec/features/agents/users/agent_can_merge_users_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe "Agent can delete user" do
     accept_confirm do
       find("input[type=submit]").click
     end
-    message = page.find("#merge_users_form_phone_number_1").evaluate_script("this.validationMessage") # cf https://stackoverflow.com/a/48206413
-    expect(message).to eq("Please select one of these options.").or(eq("Veuillez sélectionner l'une de ces options."))
+    expect(page).to have_field("merge_users_form_phone_number_1", validation_message: /(Please select one of these options|Veuillez sélectionner l'une de ces options)/)
 
     choose "01 02 03 04 05"
     accept_confirm do

--- a/spec/features/agents/users/agent_can_merge_users_spec.rb
+++ b/spec/features/agents/users/agent_can_merge_users_spec.rb
@@ -48,14 +48,16 @@ RSpec.describe "Agent can delete user" do
     find("label", text: "Locataire").click
 
     # forget to check phone number
-    find("input[type=submit]").click
-    page.driver.browser.switch_to.alert.accept
-    message = page.find("#merge_users_form_phone_number_1").native.attribute("validationMessage") # cf https://stackoverflow.com/a/48206413
+    accept_confirm do
+      find("input[type=submit]").click
+    end
+    message = page.find("#merge_users_form_phone_number_1").evaluate_script("this.validationMessage") # cf https://stackoverflow.com/a/48206413
     expect(message).to eq("Please select one of these options.").or(eq("Veuillez sélectionner l'une de ces options."))
 
     choose "01 02 03 04 05"
-    find("input[type=submit]").click
-    page.driver.browser.switch_to.alert.accept
+    accept_confirm do
+      find("input[type=submit]").click
+    end
 
     expect_page_title("Anna SWAN")
     expect(page).to have_content("Les usagers ont été fusionnés")

--- a/spec/features/territory_admins/can_crud_webhook_spec.rb
+++ b/spec/features/territory_admins/can_crud_webhook_spec.rb
@@ -32,8 +32,9 @@ RSpec.describe "territory admin can crud webhooks endpoints" do
     expect(organisation.reload.webhook_endpoints.first.secret).to eq("XSECRET")
 
     # Delete
-    click_link "Supprimer"
-    page.driver.browser.switch_to.alert.accept
+    accept_confirm do
+      click_link "Supprimer"
+    end
     expect(page).not_to have_content organisation.name
     expect(organisation.reload.webhook_endpoints.count).to eq(0)
   end

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
       # soumission sans numéro ANTS
       click_button "Enregistrer"
       ants_input_elt = find("label", text: /Numéro de pré-demande ANTS/).sibling("input")
-      expect(ants_input_elt.native.evaluate("el => el.validationMessage")).not_to be_empty # client side HTML5 validation
+      expect(page).to have_field(ants_input_elt[:name], validation_message: /Please fill (in|out) this field/)
 
       # soumission avec un numéro invalide
       fill_in "Numéro de pré-demande ANTS", with: "inva lide"

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
       # soumission sans numéro ANTS
       click_button "Enregistrer"
       ants_input_elt = find("label", text: /Numéro de pré-demande ANTS/).sibling("input")
-      expect(ants_input_elt.native.attribute("validationMessage")).not_to be_empty # client side HTML5 validation
+      expect(ants_input_elt.native.evaluate("el => el.validationMessage")).not_to be_empty # client side HTML5 validation
 
       # soumission avec un numéro invalide
       fill_in "Numéro de pré-demande ANTS", with: "inva lide"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -94,7 +94,7 @@ RSpec.configure do |config|
   end
 
   config.around do |example|
-    DatabaseCleaner.strategy = if example.metadata[:js]
+    DatabaseCleaner.strategy = if example.metadata[:js] || ENV["HEADLESS"] == "false"
                                  :truncation
                                else
                                  :transaction

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -64,9 +64,9 @@ class Autodoc
 
       if page_or_email.is_a?(Capybara::Node::Email)
         Capybara.current_session.driver.visit "file://#{page_or_email.save_page}"
-        Capybara.current_session.driver.browser.save_screenshot(path)
+        Capybara.current_session.driver.save_screenshot(path)
       else
-        page_or_email.driver.browser.save_screenshot(path)
+        page_or_email.driver.save_screenshot(path)
       end
 
       img_src = ENV["UPLOAD_TO_GH_PAGES"] ? "/rdv-service-public/#{filename}" : path

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -51,16 +51,11 @@ RSpec.configure do |config|
   end
 end
 
-def expect_page_to_be_axe_clean(path, excluding_selector: nil)
+def expect_page_to_be_axe_clean(path)
   visit path
   expect(page).to have_current_path(path)
   expect_page_to_have_title
-
-  if excluding_selector
-    expect(page).to be_axe_clean.excluding(excluding_selector)
-  else
-    expect(page).to be_axe_clean
-  end
+  expect(page).to be_axe_clean
 end
 
 # Pour des questions d’accessibilité, chaque page doit avoir un titre explicite

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -33,8 +33,6 @@ Capybara.configure do |config|
   config.always_include_port = true
 end
 
-# On force le driver JS lorsqu’on debug des tests E2E, mais ça ne
-# fonctionne pas dans tous les cas, il vaut mieux rajouter manuellement js:true
 if ENV["HEADLESS"] == "false"
   Capybara.default_driver = Capybara.javascript_driver
 end

--- a/spec/support/fill_in_readonly_input_helper.rb
+++ b/spec/support/fill_in_readonly_input_helper.rb
@@ -1,6 +1,6 @@
 module FillInReadOnlyInputHelper
   def fill_in_readonly_input(selector, value)
-    if RSpec.current_example.metadata[:js]
+    if RSpec.current_example.metadata[:js] || ENV["HEADLESS"] == "false"
       find(selector) # so that it waits for the page to load
       page.execute_script("document.querySelector('#{selector}').value = '#{value}'")
     else


### PR DESCRIPTION
PR préliminaire au passage à Playwright https://github.com/betagouv/rdv-service-public/pull/5484

Dans cette PR je backporte les changements permettant de passer à playwright qui peuvent être backportés. 

Il s’agit généralement d’améliorations aux specs existantes ou de manières d’écrire les choses plus génériques (moins selenium-spécifiques donc)

## Simplifier les tests d’accessibilité : ne plus exclure de sélecteurs

on faisait `expect(page).to be_axe_clean(excluding: "some-selector")` à certains endroits, en fait ce n’est plus nécessaire (et ça m’arrange) 👍 

## use accept_confirm + evaluate_script rather than native

générisation

## wait for content in agent_can_create_rdv_with_wizard_spec.rb 

améliore la robustesse en rajoutant un `expect page to have content` après avoir sélectionné un user dans le wizard
je renomme aussi l’appel au bouton « enregistrer » en « enregistrer l’usager »

## call save_screenshot on driver rather than on browser

détail de générisation

##  improve HEADLESS behaviour to debug E2E specs 

`HEADLESS=false bundle exec rspec spec/features/..` permet de lancer la spec avec Chromium visible. C’est utile pour debugger.

Je me demandais par le passé pourquoi ça ne suffisait pas et qu’il fallait rajouter manuellement `js: true` sur certaines specs. J’ai trouvé ici : il fallait harmoniser le comportement lorsque cette variable d’env est présente et quand js: true est présent
