### PR TITLE
correction double titre sur la liste des RDV

### DIFF
--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -1,7 +1,7 @@
 .web-content
   - content_for :title do
     .d-print-none Liste des RDV
-    .print-context
+    .print-content
       | Liste de RDV de l’organisation #{current_organisation.name}
 
   - content_for(:menu_item) { "menu-rdvs-list" }

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -1,8 +1,6 @@
 .web-content
   - content_for :title do
     .d-print-none Liste des RDV
-    .print-content
-      | Liste de RDV de l’organisation #{current_organisation.name}
 
   - content_for(:menu_item) { "menu-rdvs-list" }
 
@@ -92,6 +90,7 @@
                   i.far.fa-calendar.fa-stack-1x.text-white
 
 .print-content.px-20
+  h1 Liste de RDV de l’organisation #{current_organisation.name}
   .fr-grid-row.fr-mb-4w
     - if @form.applied_filters.any?
       .fr-col-6


### PR DESCRIPTION
<img width="3979" height="2138" alt="image" src="https://github.com/user-attachments/assets/2227a9d5-ae27-4e5d-8dc1-1f675b407bc2" />

c’était aussi cassé dans le window.title
