### PR TITLE
Ajout d’avertissements sur la visibilité des remarques sur les usagers

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -117,8 +117,7 @@ module UsersHelper
   end
 
   def formatted_user_annotation(user, current_territory)
-    annotation = user.annotation_for(current_territory)
-    annotation.present? ? simple_format(annotation) : nil
+    user.annotation_for(current_territory)&.gsub(/(\n|\r)/, " ")
   end
 
   def user_soft_delete_confirm_message(user)

--- a/app/views/admin/users/_annotation_visibility_info.html.slim
+++ b/app/views/admin/users/_annotation_visibility_info.html.slim
@@ -1,0 +1,4 @@
+/ locals(territory:)
+
+small.text-muted
+  | Les remarques sont visibles et modifiables par tous les agents du territoire #{territory} mais pas par les usagers

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -42,6 +42,8 @@
         = date_input(f, :birth_date, **input_opts[:relative])
       - if current_territory.enable_notes_field?
         = f.input :annotation_content, **input_opts[:relative].deep_merge(input_html: { rows: 6, value: user.annotation_for(current_territory) })
+        .fr-mb-4w
+         = render "admin/users/annotation_visibility_info", territory: current_territory
 
     - if user.new_record?
       .form-row.mb-2 *div_opts[:relative]

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -62,6 +62,8 @@
 
 - if current_territory.enable_notes_field
   = f.input :annotation_content, **input_opts.deep_merge(input_html: { rows: 6, value: user.annotation_for(current_territory)} )
+  small.form-text.text-muted.fr-mb-4w
+    | ⚠️ les remarques sont visibles et modifiables par tous les agents du territoire #{current_territory} mais pas par les usagers
 
 - if current_territory.enable_caisse_affiliation_field || current_territory.enable_affiliation_number_field
   .form-row

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -62,8 +62,8 @@
 
 - if current_territory.enable_notes_field
   = f.input :annotation_content, **input_opts.deep_merge(input_html: { rows: 6, value: user.annotation_for(current_territory)} )
-  small.form-text.text-muted.fr-mb-4w
-    | ⚠️ les remarques sont visibles et modifiables par tous les agents du territoire #{current_territory} mais pas par les usagers
+  .fr-mb-4w
+    = render "admin/users/annotation_visibility_info", territory: current_territory
 
 - if current_territory.enable_caisse_affiliation_field || current_territory.enable_affiliation_number_field
   .form-row

--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -25,8 +25,8 @@ ul.list-unstyled.mb-5
     .mb-2
       li= object_attribute_tag(user, :annotation_content, formatted_user_annotation(user, current_territory))
       - if @user.annotation_for(current_territory).present?
-        small.form-text.text-muted
-          | ⚠️ les remarques sont visibles et modifiables par tous les agents du territoire #{current_territory} mais pas par les usagers
+        .fr-mb-2w
+          = render "admin/users/annotation_visibility_info", territory: current_territory
 
 - if current_territory.any_social_field_enabled?
   h4.card-title.mb-3 Informations sociales

--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -22,7 +22,11 @@ ul.list-unstyled.mb-5
       | En attente de confirmation pour #{user.unconfirmed_email}
 
   - if current_territory.enable_notes_field?
-    li.mb-2= object_attribute_tag(user, :annotation_content, formatted_user_annotation(user, current_territory))
+    .mb-2
+      li= object_attribute_tag(user, :annotation_content, formatted_user_annotation(user, current_territory))
+      - if @user.annotation_for(current_territory).present?
+        small.form-text.text-muted
+          | ⚠️ les remarques sont visibles et modifiables par tous les agents du territoire #{current_territory} mais pas par les usagers
 
 - if current_territory.any_social_field_enabled?
   h4.card-title.mb-3 Informations sociales

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -51,8 +51,8 @@ ruby:
             - if current_territory.enable_notes_field?
               li= object_attribute_tag(@user, :annotation_content, formatted_user_annotation(@user, current_territory))
               - if @user.annotation_for(current_territory).present?
-                small.form-text.text-muted.fr-mb-4w
-                | ⚠️ les remarques sont visibles et modifiables par tous les agents du territoire #{current_territory} mais pas par les usagers
+                .fr-mb-2w
+                  = render "admin/users/annotation_visibility_info", territory: current_territory
 
         ul.fr-btns-group.fr-btns-group--right.fr-btns-group--inline.fr-btns-group--icon-left.fr-mb-0
           li

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -50,6 +50,9 @@ ruby:
             li= object_attribute_tag(@user, :birth_date, birth_date_and_age(@user))
             - if current_territory.enable_notes_field?
               li= object_attribute_tag(@user, :annotation_content, formatted_user_annotation(@user, current_territory))
+              - if @user.annotation_for(current_territory).present?
+                small.form-text.text-muted.fr-mb-4w
+                | ⚠️ les remarques sont visibles et modifiables par tous les agents du territoire #{current_territory} mais pas par les usagers
 
         ul.fr-btns-group.fr-btns-group--right.fr-btns-group--inline.fr-btns-group--icon-left.fr-mb-0
           li


### PR DESCRIPTION
# Contexte

Je me suis rendu compte qu’on informe peu sur la visibilité des remarques sur les usagers au sein d’un territoire. Je me demande si les agents sont au courant que ces remarques sont visibles et modifiables par tous les agents du territoire courant. 

La fonctionnalité de notes sur les usagers est activée au cas par cas sur certains territoires historiques. Elle ne peut pas être activée manuellement par un territoire. 

Elle est actuellement activée sur : 
- 41/133 territoires sur RDVS/RDVAN 
- 18/462 territoires sur RDVSP

On dit que cette fonctionnalité est « dépréciée » dans le produit mais je ne suis pas si sûr que ce soit le cas, et dans tous les cas elle est actuellement utilisée et c’est la plus susceptible de contenir des données sensibles.

<img width="813" height="647" alt="image" src="https://github.com/user-attachments/assets/fe1a869c-9305-4717-94a1-777494a67267" />


# Solution 


## formulaire de création / édition d’usager responsable

<img width="3081" height="1050" alt="image" src="https://github.com/user-attachments/assets/59b32bd5-a4cc-4bed-814c-7ae77dc0beeb" />

## formulaire de création / édition d’usager proche

<img width="1434" height="460" alt="image" src="https://github.com/user-attachments/assets/b87a5d45-6ad5-483e-8da1-99da7736a6bd" />

## Page d’un usager

si pas de remarque, pas de changement

<img width="515" height="313" alt="image" src="https://github.com/user-attachments/assets/a73192fc-351f-472d-bfdf-831fab29c3cb" />

<img width="2187" height="748" alt="image" src="https://github.com/user-attachments/assets/1c454ed8-92bb-4601-a73e-c2b6c5aa29e2" />
