### PR TITLE
Ajout d’un système de feature flags côté agent

### DIFF
--- a/app/controllers/super_admins/agents_controller.rb
+++ b/app/controllers/super_admins/agents_controller.rb
@@ -62,11 +62,12 @@ module SuperAdmins
 
       agent.toggle_feature!(feature)
 
-      flash[:notice] = if agent.feature_enabled?(feature)
-                         "#{feature} désactivé pour #{agent.email}"
-                       else
-                         "#{feature} activé pour #{agent.email}"
-                       end
+      flash[:notice] =
+        if agent.feature_enabled?(feature)
+          "#{feature} désactivé pour #{agent.email}"
+        else
+          "#{feature} activé pour #{agent.email}"
+        end
 
       redirect_to super_admins_agent_path(agent)
     end

--- a/app/controllers/super_admins/agents_controller.rb
+++ b/app/controllers/super_admins/agents_controller.rb
@@ -54,5 +54,21 @@ module SuperAdmins
         notice: "Invitation envoyée"
       )
     end
+
+    def toggle_feature
+      authorize(:agent, :toggle_feature?, policy_class: SuperAdmin::AgentPolicy)
+      agent = Agent.find(params[:agent_id])
+      feature = params[:feature]
+
+      agent.toggle_feature!(feature)
+
+      flash[:notice] = if agent.feature_enabled?(feature)
+                         "#{feature} désactivé pour #{agent.email}"
+                       else
+                         "#{feature} activé pour #{agent.email}"
+                       end
+
+      redirect_to super_admins_agent_path(agent)
+    end
   end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,6 +1,8 @@
 class SoftDeleteError < StandardError; end
 
 class Agent < ApplicationRecord
+  include Agent::FeatureFlags
+
   # Mixins
   has_paper_trail(
     only: %w[

--- a/app/models/concerns/agent/feature_flags.rb
+++ b/app/models/concerns/agent/feature_flags.rb
@@ -7,6 +7,17 @@ module Agent::FeatureFlags
     feature_flags && feature_flags[feature] == true
   end
 
+  def toggle_feature!(feature)
+    if feature_enabled?(feature)
+      disable_feature(feature)
+    else
+      enable_feature(feature)
+    end
+    update!(feature_flags: feature_flags)
+  end
+
+  private
+
   def enable_feature(feature)
     return unless AVAILABLE_FEATURES.include?(feature)
 
@@ -16,14 +27,5 @@ module Agent::FeatureFlags
 
   def disable_feature(feature)
     self.feature_flags&.delete(feature)
-  end
-
-  def toggle_feature!(feature)
-    if feature_enabled?(feature)
-      disable_feature(feature)
-    else
-      enable_feature(feature)
-    end
-    update!(feature_flags: feature_flags)
   end
 end

--- a/app/models/concerns/agent/feature_flags.rb
+++ b/app/models/concerns/agent/feature_flags.rb
@@ -1,0 +1,29 @@
+module Agent::FeatureFlags
+  extend ActiveSupport::Concern
+
+  AVAILABLE_FEATURES = %w[new_planning].freeze
+
+  def feature_enabled?(feature)
+    feature_flags && feature_flags[feature] == true
+  end
+
+  def enable_feature(feature)
+    return unless AVAILABLE_FEATURES.include?(feature)
+
+    self.feature_flags ||= {}
+    self.feature_flags[feature] = true
+  end
+
+  def disable_feature(feature)
+    self.feature_flags&.delete(feature)
+  end
+
+  def toggle_feature!(feature)
+    if feature_enabled?(feature)
+      disable_feature(feature)
+    else
+      enable_feature(feature)
+    end
+    update!(feature_flags: feature_flags)
+  end
+end

--- a/app/policies/super_admin/agent_policy.rb
+++ b/app/policies/super_admin/agent_policy.rb
@@ -8,4 +8,5 @@ class SuperAdmin::AgentPolicy < DefaultSuperAdminPolicy
   alias edit? team_member?
   alias update? team_member?
   alias destroy? team_member?
+  alias toggle_feature? team_member?
 end

--- a/app/views/super_admins/agents/show.html.slim
+++ b/app/views/super_admins/agents/show.html.slim
@@ -19,3 +19,26 @@ section.main-content__body
         = t( "helpers.label.#{resource_name}.#{attribute.name}", default: attribute.name.titleize)
       dd class=("attribute-data attribute-data--#{attribute.html_class}") = render_field attribute,page: page
   = render partial: "super_admins/history", locals: {resource: page.resource}
+
+  header.main-content__header style="width: 100%;"
+    h2.main-content__page-title
+      | Feature flags
+  section.main-content__body
+    table.table.table-striped
+      thead
+        tr
+          th Fonctionnalité
+          th État
+          th Action
+      tbody
+        - Agent::AVAILABLE_FEATURES.each do |feature|
+          - if page.resource.feature_enabled?(feature)
+            tr
+              td= feature
+              td= "Activée"
+              td= link_to "Désactiver", toggle_feature_super_admins_agent_path(agent_id: page.resource.id, feature: feature), method: :post, class: "button"
+          - else
+            tr
+              td= feature
+              td= "Désactivée"
+              td= link_to "Activer", toggle_feature_super_admins_agent_path(agent_id: page.resource.id, feature: feature), method: :post, class: "button"

--- a/app/views/super_admins/agents/show.html.slim
+++ b/app/views/super_admins/agents/show.html.slim
@@ -22,7 +22,7 @@ section.main-content__body
 
   header.main-content__header style="width: 100%;"
     h2.main-content__page-title
-      | Feature flags
+      | Fonctionnalités en accès limité
   section.main-content__body
     table.table.table-striped
       thead
@@ -35,10 +35,10 @@ section.main-content__body
           - if page.resource.feature_enabled?(feature)
             tr
               td= feature
-              td= "Activée"
+              td Activée
               td= link_to "Désactiver", toggle_feature_super_admins_agent_path(agent_id: page.resource.id, feature: feature), method: :post, class: "button"
           - else
             tr
               td= feature
-              td= "Désactivée"
+              td Désactivée
               td= link_to "Activer", toggle_feature_super_admins_agent_path(agent_id: page.resource.id, feature: feature), method: :post, class: "button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
       get "sign_in_as", on: :member
       post :invite, on: :member
       resources :migrations, only: %i[new create]
+      post :toggle_feature, on: :member, as: :toggle_feature
     end
     resources :agent_roles, only: %i[show edit update destroy]
     resources :agent_territorial_access_rights, only: %i[show edit update]

--- a/db/migrate/20250724145810_add_feature_flags_to_agents.rb
+++ b/db/migrate/20250724145810_add_feature_flags_to_agents.rb
@@ -1,0 +1,5 @@
+class AddFeatureFlagsToAgents < ActiveRecord::Migration[7.1]
+  def change
+    add_column :agents, :feature_flags, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_23_070746) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_24_145810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -235,6 +235,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_23_070746) do
     t.datetime "account_deletion_warning_sent_at", comment: "Quand le compte de l'agent est inactif depuis bientôt deux ans, on lui envoie un mail qui le prévient que sont compte sera bientôt supprimé, et qu'il doit se connecter à nouveau s'il souhaite conserver son compte. On enregistre la date d'envoi de cet email ici pour s'assure qu'on lui laisse un délai d'au moins un mois pour réagir.\n"
     t.boolean "connected_with_agent_connect", default: false, null: false
     t.string "proconnect_siret"
+    t.jsonb "feature_flags", default: {}
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true

--- a/spec/models/concerns/agent/feature_flags_spec.rb
+++ b/spec/models/concerns/agent/feature_flags_spec.rb
@@ -15,18 +15,18 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
     let(:agent) { create(:agent) }
 
     it "active la fonctionnalité" do
-      agent.enable_feature("new_planning")
+      agent.send(:enable_feature, "new_planning")
       expect(agent.feature_enabled?("new_planning")).to be true
     end
 
     it "ne fait rien si la fonctionnalité n’existe pas" do
-      agent.enable_feature("invalid_feature")
+      agent.send(:enable_feature, "invalid_feature")
       expect(agent.feature_enabled?("invalid_feature")).to be false
     end
 
     it "crée le hash si feature_flags est nil" do
       agent.feature_flags = nil
-      agent.enable_feature("new_planning")
+      agent.send(:enable_feature, "new_planning")
       expect(agent.feature_flags).to eq({ "new_planning" => true })
     end
   end
@@ -35,12 +35,12 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
     let(:agent) { create(:agent, feature_flags: { new_planning: true }) }
 
     it "désactive la fonctionnalité" do
-      agent.disable_feature("new_planning")
+      agent.send(:disable_feature, "new_planning")
       expect(agent.feature_enabled?("new_planning")).to be false
     end
 
     it "ne fait rien si on essaye de désactiver une fonctionnalité inexistante" do
-      expect { agent.disable_feature("non_existent_feature") }.not_to raise_error
+      expect { agent.send(:disable_feature, "non_existent_feature") }.not_to raise_error
       expect(agent.feature_flags).to eq({ "new_planning" => true })
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
     end
 
     it "active une fonctionnalité désactivée" do
-      agent.disable_feature("new_planning")
+      agent.send(:disable_feature, "new_planning")
       agent.toggle_feature!("new_planning")
       expect(agent.reload.feature_enabled?("new_planning")).to be true
     end

--- a/spec/models/concerns/agent/feature_flags_spec.rb
+++ b/spec/models/concerns/agent/feature_flags_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe Agent::FeatureFlags, type: :concern do
+  describe "feature_enabled?" do
+    let(:agent) { build(:agent, feature_flags: { new_planning: true }) }
+
+    it "retourne true si la fonctionnalité est activée pour l’agent" do
+      expect(agent.feature_enabled?("new_planning")).to be true
+    end
+
+    it "retourne false si la fonctionnalité n’est pas activée pour l’agent" do
+      expect(agent.feature_enabled?("non_existent_feature")).to be false
+    end
+  end
+
+  describe "enable_feature" do
+    let(:agent) { build(:agent) }
+
+    it "active la fonctionnalité" do
+      agent.enable_feature("new_planning")
+      expect(agent.feature_enabled?("new_planning")).to be true
+    end
+
+    it "ne fait rien si la fonctionnalité n’existe pas" do
+      agent.enable_feature("invalid_feature")
+      expect(agent.feature_enabled?("invalid_feature")).to be false
+    end
+
+    it "crée le hash si feature_flags est nil" do
+      agent.feature_flags = nil
+      agent.enable_feature("new_planning")
+      expect(agent.feature_flags).to eq({ "new_planning" => true })
+    end
+  end
+
+  describe "disable_feature" do
+    let(:agent) { build(:agent, feature_flags: { new_planning: true }) }
+
+    it "désactive la fonctionnalité" do
+      agent.disable_feature("new_planning")
+      expect(agent.feature_enabled?("new_planning")).to be false
+    end
+
+    it "ne fait rien si on essaye de désactiver une fonctionnalité inexistante" do
+      expect { agent.disable_feature("non_existent_feature") }.not_to raise_error
+      expect(agent.feature_flags).to eq({ "new_planning" => true })
+    end
+  end
+
+  describe "toggle_feature!" do
+    let(:agent) { build(:agent, feature_flags: { new_planning: true }) }
+
+    it "désactive une fonctionnalité activée" do
+      agent.toggle_feature!("new_planning")
+      expect(agent.reload.feature_enabled?("new_planning")).to be false
+    end
+
+    it "active une fonctionnalité désactivée" do
+      agent.disable_feature("new_planning")
+      agent.toggle_feature!("new_planning")
+      expect(agent.reload.feature_enabled?("new_planning")).to be true
+    end
+
+    it "ne fait rien si la fonctionnalité n’existe pas" do
+      expect { agent.toggle_feature!("invalid_feature") }.not_to raise_error
+      expect(agent.reload.feature_flags).to eq({ "new_planning" => true })
+    end
+  end
+end

--- a/spec/models/concerns/agent/feature_flags_spec.rb
+++ b/spec/models/concerns/agent/feature_flags_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Agent::FeatureFlags, type: :concern do
   describe "feature_enabled?" do
-    let(:agent) { build(:agent, feature_flags: { new_planning: true }) }
+    let(:agent) { create(:agent, feature_flags: { new_planning: true }) }
 
     it "retourne true si la fonctionnalité est activée pour l’agent" do
       expect(agent.feature_enabled?("new_planning")).to be true
@@ -12,7 +12,7 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
   end
 
   describe "enable_feature" do
-    let(:agent) { build(:agent) }
+    let(:agent) { create(:agent) }
 
     it "active la fonctionnalité" do
       agent.enable_feature("new_planning")
@@ -32,7 +32,7 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
   end
 
   describe "disable_feature" do
-    let(:agent) { build(:agent, feature_flags: { new_planning: true }) }
+    let(:agent) { create(:agent, feature_flags: { new_planning: true }) }
 
     it "désactive la fonctionnalité" do
       agent.disable_feature("new_planning")
@@ -46,7 +46,7 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
   end
 
   describe "toggle_feature!" do
-    let(:agent) { build(:agent, feature_flags: { new_planning: true }) }
+    let(:agent) { create(:agent, feature_flags: { new_planning: true }) }
 
     it "désactive une fonctionnalité activée" do
       agent.toggle_feature!("new_planning")


### PR DESCRIPTION
# Contexte

Dans le cadre de l’arrivée prochaine de l’agenda multi-agent, on souhaiterait mettre en place une phase de beta. 
On souhaiterait également mettre en place ce genre de mécanique pour d’autres fonctionnalités. Je propose une PR assez basique permettant de mettre en place des features flags spécifiques à un agent. 
Dans un premier temps, on pourrait activer/désactiver ces flags directement dans le super admin. À l’avenir, on pourrait imaginer que certains flags puissent être activés directement par les agents eux-mêmes. Dans ce cas, le tableau des flags disponible pourrait devenir un hash avec en attribut une petite description etc.

<img width="1282" height="504" alt="image" src="https://github.com/user-attachments/assets/96b5572d-3d96-4f91-ad01-d0b825ac3b15" />

J’ai fait le choix de ne pas utiliser de Gem tierce pour être le plus flexible possible et rester sur une implémentation très basique.

