### PR TITLE
script pour déplacer une orga dans un autre territoire

### DIFF
--- a/app/services/move_organisation_to_other_territory_service.rb
+++ b/app/services/move_organisation_to_other_territory_service.rb
@@ -30,13 +30,13 @@ class MoveOrganisationToOtherTerritoryService < BaseService
     ActiveRecord::Base.transaction do
       Rails.logger.info("🔄 Début de la migration (dans une transaction)…")
 
-      move_annotations
-      move_motif_categories
-      move_services
-      move_teams
-      move_access_rights
-      move_territorial_roles
-      delete_sectors
+      copy_annotations
+      copy_motif_categories
+      copy_services
+      copy_teams
+      copy_access_rights
+      copy_territorial_roles
+
       move_organisation_record
       suggest_cleanup_origin_territory
       raise "Intentional failure for testing" if @fail_on_purpose
@@ -45,7 +45,7 @@ class MoveOrganisationToOtherTerritoryService < BaseService
     end
   end
 
-  def move_annotations
+  def copy_annotations
     Rails.logger.info("🔄 Migration des annotations…")
     Annotation.where(user_id: @origin_organisation.user_ids, territory: @territory_origin).each do |source_annotation|
       user = source_annotation.user
@@ -56,14 +56,16 @@ class MoveOrganisationToOtherTerritoryService < BaseService
         target_annotation.update!(content: merged_content)
         counters[:annotation_conflicts] += 1
       else
-        Annotation.create!(content: source_annotation.content, user:, territory: @territory_target)
+        new_annotation = source_annotation.dup
+        new_annotation.territory = @territory_target
+        new_annotation.save!
         counters[:annotation_copies] += 1
       end
     end
     Rails.logger.info("  ✅ #{counters[:annotation_copies]} annotations copiées, #{counters[:annotation_conflicts]} fusions effectuées")
   end
 
-  def move_motif_categories
+  def copy_motif_categories
     Rails.logger.info("🔄  Ajout des catégories de motifs manquantes…")
     @territory_origin.motif_categories.each do |motif_category|
       next if @territory_target.motif_categories.include?(motif_category)
@@ -75,7 +77,7 @@ class MoveOrganisationToOtherTerritoryService < BaseService
     Rails.logger.info("  ✅ #{counters[:motif_category_associations]} catégories de motifs ajoutées au territoire cible")
   end
 
-  def move_services
+  def copy_services
     Rails.logger.info("🔄 Ajout des services manquants…")
     @territory_origin.services.each do |service|
       next if @territory_target.services.include?(service)
@@ -87,8 +89,8 @@ class MoveOrganisationToOtherTerritoryService < BaseService
     Rails.logger.info("  ✅ #{counters[:service_associations]} services ajoutés au territoire cible")
   end
 
-  def move_teams
-    Rails.logger.info("🔄 Migration des équipes…")
+  def copy_teams
+    Rails.logger.info("🔄 Copie des équipes…")
     @territory_origin.teams.includes(:agents).each do |team_origin|
       agents = team_origin.agents & @origin_organisation.agents
 
@@ -103,19 +105,21 @@ class MoveOrganisationToOtherTerritoryService < BaseService
             Rails.logger.info("    - Agent #{agent.id} ajouté à l'équipe existante")
           end
         end
-        team_origin.destroy!
         counters[:team_conflicts] += 1
       else
-        team_origin.update!(territory: @territory_target)
-        Rails.logger.info("  ➕ Équipe '#{team_origin.name}' déplacée dans le territoire cible")
-        counters[:team_moves] += 1
+        team_target_new = team_origin.dup
+        team_target_new.territory = @territory_target
+        team_target_new.agents = agents
+        team_target_new.save!
+        Rails.logger.info("  ➕ Équipe '#{team_origin.name}' copiée dans le territoire cible")
+        counters[:team_copies] += 1
       end
     end
-    Rails.logger.info("  ✅ #{counters[:team_moves]} équipes créées, #{counters[:team_conflicts]} fusions effectuées")
+    Rails.logger.info("  ✅ #{counters[:team_copies]} équipes copiées, #{counters[:team_conflicts]} fusions effectuées")
   end
 
-  def move_access_rights
-    Rails.logger.info("🔄 Migration des droits d'accès territoriaux…")
+  def copy_access_rights
+    Rails.logger.info("🔄 Copie des droits d'accès territoriaux…")
     AgentTerritorialAccessRight.where(territory: @territory_origin).each do |access_right_origin|
       agent = access_right_origin.agent
       access_right_target = agent.agent_territorial_access_rights.find_by(territory: @territory_target)
@@ -126,36 +130,32 @@ class MoveOrganisationToOtherTerritoryService < BaseService
           allow_to_manage_access_rights: access_right_target.allow_to_manage_access_rights || access_right_origin.allow_to_manage_access_rights,
           allow_to_invite_agents: access_right_target.allow_to_invite_agents || access_right_origin.allow_to_invite_agents
         )
-        access_right_origin.destroy!
         counters[:access_rights_merges] += 1
       else
-        access_right_origin.update!(territory: @territory_target)
-        counters[:access_rights_moves] += 1
+        new_access_right = access_right_origin.dup
+        new_access_right.territory = @territory_target
+        new_access_right.save!
+        counters[:access_rights_copies] += 1
       end
     end
-    Rails.logger.info("  ✅ #{counters[:access_rights_moves]} droits déplacés, #{counters[:access_rights_merges]} fusions effectuées")
+    Rails.logger.info("  ✅ #{counters[:access_rights_copies]} droits copiés, #{counters[:access_rights_merges]} fusions effectuées")
   end
 
-  def move_territorial_roles
-    Rails.logger.info("🔄 Migration des rôles territoriaux d'agents…")
+  def copy_territorial_roles
+    Rails.logger.info("🔄 Copie des rôles territoriaux d'agents…")
     AgentTerritorialRole.where(territory: @territory_origin).each do |role_origin|
       agent = role_origin.agent
       if agent.territorial_roles.exists?(territory: @territory_target)
-        AgentTerritorialRole.where(id: role_origin.id).delete_all # skip validations
         Rails.logger.info("  ℹ️  Agent #{agent.id} a déjà un rôle territorial dans le territoire cible")
       else
-        role_origin.update!(territory: @territory_target)
-        Rails.logger.info("  ➕ Rôle territorial créé pour l'agent #{agent.id}")
-        counters[:territorial_roles_created] += 1
+        new_role = role_origin.dup
+        new_role.territory = @territory_target
+        new_role.save!
+        Rails.logger.info("  ➕ Rôle territorial copié pour l'agent #{agent.id}")
+        counters[:territorial_roles_copies] += 1
       end
     end
-    Rails.logger.info("  ✅ #{counters[:territorial_roles_created]} nouveaux rôles territoriaux créés")
-  end
-
-  def delete_sectors
-    Rails.logger.info("🔄  Suppression des secteurs…")
-    Sector.where(territory: @territory_origin).each(&:destroy!)
-    Rails.logger.info("  ✅ #{counters[:removed_attributions]} attributions de secteurs supprimées")
+    Rails.logger.info("  ✅ #{counters[:territorial_roles_copies]} nouveaux rôles territoriaux copiés")
   end
 
   def move_organisation_record

--- a/app/services/move_organisation_to_other_territory_service.rb
+++ b/app/services/move_organisation_to_other_territory_service.rb
@@ -139,12 +139,13 @@ class MoveOrganisationToOtherTerritoryService < BaseService
 
   def move_territorial_roles
     Rails.logger.info("🔄 Migration des rôles territoriaux d'agents…")
-    @origin_organisation.agents.each do |agent|
-      existing_role = agent.territorial_roles.find_by(territory: @territory_target)
-      if existing_role
+    AgentTerritorialRole.where(territory: @territory_origin).each do |role_origin|
+      agent = role_origin.agent
+      if agent.territorial_roles.exists?(territory: @territory_target)
+        AgentTerritorialRole.where(id: role_origin.id).delete_all # skip validations
         Rails.logger.info("  ℹ️  Agent #{agent.id} a déjà un rôle territorial dans le territoire cible")
       else
-        AgentTerritorialRole.create!(agent: agent, territory: @territory_target)
+        role_origin.update!(territory: @territory_target)
         Rails.logger.info("  ➕ Rôle territorial créé pour l'agent #{agent.id}")
         counters[:territorial_roles_created] += 1
       end

--- a/app/services/move_organisation_to_other_territory_service.rb
+++ b/app/services/move_organisation_to_other_territory_service.rb
@@ -1,10 +1,11 @@
 class MoveOrganisationToOtherTerritoryService < BaseService
   attr_accessor :counters
 
-  def initialize(origin_organisation:, target_territory:)
+  def initialize(origin_organisation:, target_territory:, fail_on_purpose: false)
     @origin_organisation = origin_organisation
     @territory_origin = origin_organisation.territory
     @territory_target = target_territory
+    @fail_on_purpose = fail_on_purpose
     @counters = Hash.new(0)
   end
 
@@ -38,6 +39,7 @@ class MoveOrganisationToOtherTerritoryService < BaseService
       delete_sectors
       move_organisation_record
       suggest_cleanup_origin_territory
+      raise "Intentional failure for testing" if @fail_on_purpose
 
       Rails.logger.info("✅ MIGRATION TERMINÉE AVEC SUCCÈS!")
     end

--- a/app/services/move_organisation_to_other_territory_service.rb
+++ b/app/services/move_organisation_to_other_territory_service.rb
@@ -9,18 +9,6 @@ class MoveOrganisationToOtherTerritoryService < BaseService
   end
 
   def call
-    check_preconditions
-    move_organisation
-  end
-
-  private
-
-  def check_preconditions
-    raise "Organisation not found" unless @origin_organisation
-    raise "Territory not found" unless @territory_target
-  end
-
-  def move_organisation
     Rails.logger.info("=== MIGRATION D'ORGANISATION VERS UN AUTRE TERRITOIRE ===")
     Rails.logger.info("Organisation: #{@origin_organisation.name} (ID: #{@origin_organisation.id})")
     Rails.logger.info("Territoire source: #{@territory_origin.name} (ID: #{@territory_origin.id})")
@@ -35,14 +23,14 @@ class MoveOrganisationToOtherTerritoryService < BaseService
       copy_teams
       copy_access_rights
       copy_territorial_roles
-
       move_organisation_record
       suggest_cleanup_origin_territory
-      raise "Intentional failure for testing" if @fail_on_purpose
 
       Rails.logger.info("✅ MIGRATION TERMINÉE AVEC SUCCÈS!")
     end
   end
+
+  private
 
   def copy_annotations
     Rails.logger.info("🔄 Migration des annotations…")

--- a/app/services/move_organisation_to_other_territory_service.rb
+++ b/app/services/move_organisation_to_other_territory_service.rb
@@ -1,11 +1,10 @@
 class MoveOrganisationToOtherTerritoryService < BaseService
   attr_accessor :counters
 
-  def initialize(origin_organisation:, target_territory:, fail_on_purpose: false)
+  def initialize(origin_organisation:, target_territory:)
     @origin_organisation = origin_organisation
     @territory_origin = origin_organisation.territory
     @territory_target = target_territory
-    @fail_on_purpose = fail_on_purpose
     @counters = Hash.new(0)
   end
 

--- a/app/services/move_organisation_to_other_territory_service.rb
+++ b/app/services/move_organisation_to_other_territory_service.rb
@@ -117,22 +117,20 @@ class MoveOrganisationToOtherTerritoryService < BaseService
 
   def move_access_rights
     Rails.logger.info("🔄 Migration des droits d'accès territoriaux…")
-    @origin_organisation.agents.includes(:agent_territorial_access_rights).each do |agent|
-      source_right = agent.agent_territorial_access_rights.find_by(territory: @territory_origin)
-      next unless source_right
-
-      target_right = agent.agent_territorial_access_rights.find_by(territory: @territory_target)
-      if target_right
+    AgentTerritorialAccessRight.where(territory: @territory_origin).each do |access_right_origin|
+      agent = access_right_origin.agent
+      access_right_target = agent.agent_territorial_access_rights.find_by(territory: @territory_target)
+      if access_right_target
         Rails.logger.info("  ⚠️  Droits d'accès existants pour l'agent #{agent.id} - fusion des permissions")
-        target_right.update!(
-          allow_to_manage_teams: target_right.allow_to_manage_teams || source_right.allow_to_manage_teams,
-          allow_to_manage_access_rights: target_right.allow_to_manage_access_rights || source_right.allow_to_manage_access_rights,
-          allow_to_invite_agents: target_right.allow_to_invite_agents || source_right.allow_to_invite_agents
+        access_right_target.update!(
+          allow_to_manage_teams: access_right_target.allow_to_manage_teams || access_right_origin.allow_to_manage_teams,
+          allow_to_manage_access_rights: access_right_target.allow_to_manage_access_rights || access_right_origin.allow_to_manage_access_rights,
+          allow_to_invite_agents: access_right_target.allow_to_invite_agents || access_right_origin.allow_to_invite_agents
         )
-        source_right.destroy!
+        access_right_origin.destroy!
         counters[:access_rights_merges] += 1
       else
-        source_right.update!(territory: @territory_target)
+        access_right_origin.update!(territory: @territory_target)
         counters[:access_rights_moves] += 1
       end
     end

--- a/app/services/move_organisation_to_other_territory_service.rb
+++ b/app/services/move_organisation_to_other_territory_service.rb
@@ -35,7 +35,7 @@ class MoveOrganisationToOtherTerritoryService < BaseService
       move_teams
       move_access_rights
       move_territorial_roles
-      delete_sector_attributions
+      delete_sectors
       move_organisation_record
       suggest_cleanup_origin_territory
 
@@ -153,15 +153,9 @@ class MoveOrganisationToOtherTerritoryService < BaseService
     Rails.logger.info("  ✅ #{counters[:territorial_roles_created]} nouveaux rôles territoriaux créés")
   end
 
-  def delete_sector_attributions
-    Rails.logger.info("🔄  Vérification des secteurs…")
-    @origin_organisation.sector_attributions.includes(:sector).each do |attribution|
-      next unless attribution.sector.territory != @territory_target
-
-      Rails.logger.info("  ⚠️  Suppression de l'attribution au secteur '#{attribution.sector.name}' (territoire différent)")
-      attribution.destroy!
-      counters[:removed_attributions] += 1
-    end
+  def delete_sectors
+    Rails.logger.info("🔄  Suppression des secteurs…")
+    Sector.where(territory: @territory_origin).each(&:destroy!)
     Rails.logger.info("  ✅ #{counters[:removed_attributions]} attributions de secteurs supprimées")
   end
 

--- a/app/services/move_organisation_to_other_territory_service.rb
+++ b/app/services/move_organisation_to_other_territory_service.rb
@@ -1,0 +1,185 @@
+class MoveOrganisationToOtherTerritoryService < BaseService
+  attr_accessor :counters
+
+  def initialize(origin_organisation:, target_territory:)
+    @origin_organisation = origin_organisation
+    @territory_origin = origin_organisation.territory
+    @territory_target = target_territory
+    @counters = Hash.new(0)
+  end
+
+  def call
+    check_preconditions
+    move_organisation
+  end
+
+  private
+
+  def check_preconditions
+    raise "Organisation not found" unless @origin_organisation
+    raise "Territory not found" unless @territory_target
+  end
+
+  def move_organisation
+    Rails.logger.info("=== MIGRATION D'ORGANISATION VERS UN AUTRE TERRITOIRE ===")
+    Rails.logger.info("Organisation: #{@origin_organisation.name} (ID: #{@origin_organisation.id})")
+    Rails.logger.info("Territoire source: #{@territory_origin.name} (ID: #{@territory_origin.id})")
+    Rails.logger.info("Territoire cible: #{@territory_target.name} (ID: #{@territory_target.id})")
+
+    ActiveRecord::Base.transaction do
+      Rails.logger.info("🔄 Début de la migration (dans une transaction)…")
+
+      move_annotations
+      move_motif_categories
+      move_services
+      move_teams
+      move_access_rights
+      move_territorial_roles
+      delete_sector_attributions
+      move_organisation_record
+      suggest_cleanup_origin_territory
+
+      Rails.logger.info("✅ MIGRATION TERMINÉE AVEC SUCCÈS!")
+    end
+  end
+
+  def move_annotations
+    Rails.logger.info("🔄 Migration des annotations…")
+    @origin_organisation.users.includes(:annotations).each do |user|
+      source_annotation = user.annotations.find_by(territory: @territory_origin)
+      next unless source_annotation
+
+      target_annotation = user.annotations.find_by(territory: @territory_target)
+      if target_annotation
+        Rails.logger.info("  ⚠️  Conflit d'annotation pour l'utilisateur #{user.id} - fusion du contenu")
+        merged_content = [target_annotation.content, source_annotation.content].compact.join("\n---\n")
+        target_annotation.update!(content: merged_content)
+        source_annotation.destroy!
+        counters[:annotation_conflicts] += 1
+      else
+        source_annotation.update!(territory: @territory_target)
+        counters[:annotation_moves] += 1
+      end
+    end
+    Rails.logger.info("  ✅ #{counters[:annotation_moves]} annotations déplacées, #{counters[:annotation_conflicts]} fusions effectuées")
+  end
+
+  def move_motif_categories
+    Rails.logger.info("🔄  Ajout des catégories de motifs manquantes…")
+    @territory_origin.motif_categories.each do |motif_category|
+      next if @territory_target.motif_categories.include?(motif_category)
+
+      @territory_target.motif_categories << motif_category
+      Rails.logger.info("  ➕ Catégorie de motifs '#{motif_category.name}' ajoutée au territoire cible")
+      counters[:motif_category_associations] += 1
+    end
+    Rails.logger.info("  ✅ #{counters[:motif_category_associations]} catégories de motifs ajoutées au territoire cible")
+  end
+
+  def move_services
+    Rails.logger.info("🔄 Ajout des services manquants…")
+    @territory_origin.services.each do |service|
+      next if @territory_target.services.include?(service)
+
+      TerritoryService.create!(territory: @territory_target, service: service)
+      Rails.logger.info("  ➕ Service '#{service.name}' ajouté au territoire cible")
+      counters[:service_associations] += 1
+    end
+    Rails.logger.info("  ✅ #{counters[:service_associations]} services ajoutés au territoire cible")
+  end
+
+  def move_teams
+    Rails.logger.info("🔄 Migration des équipes…")
+    @territory_origin.teams.includes(:agents).each do |team_origin|
+      agents = team_origin.agents & @origin_organisation.agents
+
+      team_target_existing = @territory_target.teams.find_by(name: team_origin.name)
+      if team_target_existing
+        Rails.logger.info("  ⚠️  Équipe '#{team_origin.name}' existe déjà dans le territoire cible - fusion des agents")
+        agents.each do |agent|
+          if team_target_existing.agents.include?(agent)
+            Rails.logger.info("    - Agent #{agent.id} déjà dans l'équipe cible")
+          else
+            team_target_existing.agents << agent
+            Rails.logger.info("    - Agent #{agent.id} ajouté à l'équipe existante")
+          end
+        end
+        team_origin.destroy!
+        counters[:team_conflicts] += 1
+      else
+        team_origin.update!(territory: @territory_target)
+        Rails.logger.info("  ➕ Équipe '#{team_origin.name}' déplacée dans le territoire cible")
+        counters[:team_moves] += 1
+      end
+    end
+    Rails.logger.info("  ✅ #{counters[:team_moves]} équipes créées, #{counters[:team_conflicts]} fusions effectuées")
+  end
+
+  def move_access_rights
+    Rails.logger.info("🔄 Migration des droits d'accès territoriaux…")
+    @origin_organisation.agents.includes(:agent_territorial_access_rights).each do |agent|
+      source_right = agent.agent_territorial_access_rights.find_by(territory: @territory_origin)
+      next unless source_right
+
+      target_right = agent.agent_territorial_access_rights.find_by(territory: @territory_target)
+      if target_right
+        Rails.logger.info("  ⚠️  Droits d'accès existants pour l'agent #{agent.id} - fusion des permissions")
+        target_right.update!(
+          allow_to_manage_teams: target_right.allow_to_manage_teams || source_right.allow_to_manage_teams,
+          allow_to_manage_access_rights: target_right.allow_to_manage_access_rights || source_right.allow_to_manage_access_rights,
+          allow_to_invite_agents: target_right.allow_to_invite_agents || source_right.allow_to_invite_agents
+        )
+        source_right.destroy!
+        counters[:access_rights_merges] += 1
+      else
+        source_right.update!(territory: @territory_target)
+        counters[:access_rights_moves] += 1
+      end
+    end
+    Rails.logger.info("  ✅ #{counters[:access_rights_moves]} droits déplacés, #{counters[:access_rights_merges]} fusions effectuées")
+  end
+
+  def move_territorial_roles
+    Rails.logger.info("🔄 Migration des rôles territoriaux d'agents…")
+    @origin_organisation.agents.each do |agent|
+      existing_role = agent.territorial_roles.find_by(territory: @territory_target)
+      if existing_role
+        Rails.logger.info("  ℹ️  Agent #{agent.id} a déjà un rôle territorial dans le territoire cible")
+      else
+        AgentTerritorialRole.create!(agent: agent, territory: @territory_target)
+        Rails.logger.info("  ➕ Rôle territorial créé pour l'agent #{agent.id}")
+        counters[:territorial_roles_created] += 1
+      end
+    end
+    Rails.logger.info("  ✅ #{counters[:territorial_roles_created]} nouveaux rôles territoriaux créés")
+  end
+
+  def delete_sector_attributions
+    Rails.logger.info("🔄  Vérification des secteurs…")
+    @origin_organisation.sector_attributions.includes(:sector).each do |attribution|
+      next unless attribution.sector.territory != @territory_target
+
+      Rails.logger.info("  ⚠️  Suppression de l'attribution au secteur '#{attribution.sector.name}' (territoire différent)")
+      attribution.destroy!
+      counters[:removed_attributions] += 1
+    end
+    Rails.logger.info("  ✅ #{counters[:removed_attributions]} attributions de secteurs supprimées")
+  end
+
+  def move_organisation_record
+    Rails.logger.info("🔄 Déplacement de l'organisation…")
+    @origin_organisation.update!(territory: @territory_target)
+    Rails.logger.info("  ✅ Organisation '#{@origin_organisation.name}' déplacée vers le territoire '#{@territory_target.name}'")
+  end
+
+  def suggest_cleanup_origin_territory
+    return if @territory_origin.organisations.any?
+
+    Rails.logger.info("🧹 Le territoire '#{@territory_origin.name}' n'a plus d'organisations.")
+    Rails.logger.info("   Vous devriez envisager de le supprimer ou de transférer ses ressources restantes.")
+    remaining_teams = @territory_origin.teams.count
+    remaining_sectors = @territory_origin.sectors.count
+    remaining_roles = @territory_origin.roles.count
+    Rails.logger.info("   Ressources restantes: #{remaining_teams} équipes, #{remaining_sectors} secteurs, #{remaining_roles} rôles")
+  end
+end

--- a/app/services/move_organisation_to_other_territory_service.rb
+++ b/app/services/move_organisation_to_other_territory_service.rb
@@ -47,23 +47,20 @@ class MoveOrganisationToOtherTerritoryService < BaseService
 
   def move_annotations
     Rails.logger.info("🔄 Migration des annotations…")
-    @origin_organisation.users.includes(:annotations).each do |user|
-      source_annotation = user.annotations.find_by(territory: @territory_origin)
-      next unless source_annotation
-
+    Annotation.where(user_id: @origin_organisation.user_ids, territory: @territory_origin).each do |source_annotation|
+      user = source_annotation.user
       target_annotation = user.annotations.find_by(territory: @territory_target)
       if target_annotation
         Rails.logger.info("  ⚠️  Conflit d'annotation pour l'utilisateur #{user.id} - fusion du contenu")
         merged_content = [target_annotation.content, source_annotation.content].compact.join("\n---\n")
         target_annotation.update!(content: merged_content)
-        source_annotation.destroy!
         counters[:annotation_conflicts] += 1
       else
-        source_annotation.update!(territory: @territory_target)
-        counters[:annotation_moves] += 1
+        Annotation.create!(content: source_annotation.content, user:, territory: @territory_target)
+        counters[:annotation_copies] += 1
       end
     end
-    Rails.logger.info("  ✅ #{counters[:annotation_moves]} annotations déplacées, #{counters[:annotation_conflicts]} fusions effectuées")
+    Rails.logger.info("  ✅ #{counters[:annotation_copies]} annotations copiées, #{counters[:annotation_conflicts]} fusions effectuées")
   end
 
   def move_motif_categories

--- a/scripts/move_organisation_to_other_territory.rb
+++ b/scripts/move_organisation_to_other_territory.rb
@@ -1,0 +1,36 @@
+require "optparse"
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Utilisation : move_organisation_to_other_territory.rb [options]"
+
+  opts.on("--origin_organisation_id ORGANISATION_ID", "ID de l'organisation à déplacer") do |v|
+    options[:origin_organisation_id] = v
+  end
+
+  opts.on("--target_territory_id TERRITORY_ID", "ID du territoire cible") do |v|
+    options[:target_territory_id] = v
+  end
+end.parse!(ARGV)
+
+if options[:origin_organisation_id].nil? || options[:target_territory_id].nil?
+  puts "Les paramètres origin_organisation_id et target_territory_id sont obligatoires."
+  exit 1
+end
+
+origin_organisation = Organisation.find_by(id: options[:origin_organisation_id])
+unless origin_organisation
+  puts "Organisation avec l'ID #{options[:origin_organisation_id]} introuvable."
+  exit 1
+end
+
+target_territory = Territory.find_by(id: options[:target_territory_id])
+unless target_territory
+  puts "Territoire avec l'ID #{options[:target_territory_id]} introuvable."
+  exit 1
+end
+
+MoveOrganisationToOtherTerritoryService.new(
+  origin_organisation: origin_organisation,
+  target_territory: target_territory
+).call

--- a/scripts/move_organisation_to_other_territory.rb
+++ b/scripts/move_organisation_to_other_territory.rb
@@ -30,6 +30,27 @@ unless target_territory
   exit 1
 end
 
+puts <<~INFO
+
+  Ce script va déplacer une organisation vers un autre territoire. Voici comment les différentes données seront traitées :
+
+  - annotations (remarques usagers) : elles seront fusionnées s’il en existe déjà dans le territoire cible
+  - motif_categories : on ajoutera les catégories de motifs manquantes au territoire cible
+  - territory_services : on ajoutera les services manquants au territoire cible
+  - teams : les équipes sont déplacées ; si une équipe existe déjà avec le même nom, elle sera réutilisée
+  - agent territorial access_rights & roles : les droits sont combinés additivement (on ajoute des droits, on n’en retire pas)
+  - sectors : ⚠️ les secteurs existants seront supprimés, ils ne seront pas déplacés
+  - organisation : déplacée vers le territoire cible
+
+  Êtes-vous sûr(e) de vouloir continuer ? (oui/non)
+INFO
+
+response = $stdin.gets.strip.downcase
+unless response == "oui"
+  puts "Opération annulée."
+  exit 0
+end
+
 MoveOrganisationToOtherTerritoryService.new(
   origin_organisation: origin_organisation,
   target_territory: target_territory

--- a/scripts/move_organisation_to_other_territory.rb
+++ b/scripts/move_organisation_to_other_territory.rb
@@ -37,9 +37,9 @@ puts <<~INFO
   - annotations (remarques usagers) : elles seront fusionnées s’il en existe déjà dans le territoire cible
   - motif_categories : on ajoutera les catégories de motifs manquantes au territoire cible
   - territory_services : on ajoutera les services manquants au territoire cible
-  - teams : les équipes sont déplacées ; si une équipe existe déjà avec le même nom, elle sera réutilisée
+  - teams : les équipes sont copiées ; si une équipe existe déjà avec le même nom, elle sera réutilisée
   - agent territorial access_rights & roles : les droits sont combinés additivement (on ajoute des droits, on n’en retire pas)
-  - sectors : ⚠️ les secteurs existants seront supprimés, ils ne seront pas déplacés
+  - sectors : les secteurs existants ne sont pas déplacés, il faudra les recréer si besoin
   - organisation : déplacée vers le territoire cible
 
   Êtes-vous sûr(e) de vouloir continuer ? (oui/non)

--- a/spec/factories/annotations.rb
+++ b/spec/factories/annotations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :annotation do
+    user
+    territory
+    content { "Cet usager est sympa" }
+  end
+end

--- a/spec/factories/territory_service.rb
+++ b/spec/factories/territory_service.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :territory_service do
+    territory
+    service
+  end
+end

--- a/spec/services/move_organisation_to_other_territory_service_spec.rb
+++ b/spec/services/move_organisation_to_other_territory_service_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
     end
   end
 
-  context "avec des rôles territoriaux" do
+  context "gestion des rôles territoriaux" do
     let!(:agent1) { create(:agent, organisations: [organisation]) }
     let!(:agent2) { create(:agent, organisations: [organisation]) }
 
@@ -131,36 +131,14 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
     end
   end
 
-  context "avec des secteurs" do
-    context "quand l'organisation est attribuée à un secteur dans le territoire d'origine" do
-      let!(:sector_in_origin) { create(:sector, territory: territory_origin) }
-      let!(:attribution_to_origin_sector) { create(:sector_attribution, organisation: organisation, sector: sector_in_origin) }
+  context "gestion des secteurs" do
+    let!(:sectors) { create_list(:sector, 2, territory: territory_origin) }
+    let!(:attributions) { create(:sector_attribution, organisation: organisation, sector: sectors[0]) }
 
-      it "supprime l'attribution" do
-        subject.call
-        expect(SectorAttribution.find_by(id: attribution_to_origin_sector.id)).to be_nil
-      end
-    end
-
-    context "quand l'organisation est attribuée à un secteur dans le territoire cible" do
-      let!(:sector_in_target) { create(:sector, territory: territory_target) }
-      let!(:attribution_to_target_sector) { create(:sector_attribution, organisation: organisation, sector: sector_in_target) }
-
-      it "conserve l'attribution" do
-        subject.call
-        expect(attribution_to_target_sector.reload).to be_present
-      end
-    end
-
-    context "quand l'organisation est attribuée à un secteur dans un autre territoire" do
-      let!(:other_territory) { create(:territory) }
-      let!(:sector_in_other) { create(:sector, territory: other_territory) }
-      let!(:attribution_to_other_sector) { create(:sector_attribution, organisation: organisation, sector: sector_in_other) }
-
-      it "supprime l'attribution" do
-        subject.call
-        expect(SectorAttribution.find_by(id: attribution_to_other_sector.id)).to be_nil
-      end
+    specify do
+      subject.call
+      expect(Sector.where(territory: territory_origin)).to be_empty
+      expect(SectorAttribution.where(organisation:)).to be_empty
     end
   end
 end

--- a/spec/services/move_organisation_to_other_territory_service_spec.rb
+++ b/spec/services/move_organisation_to_other_territory_service_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
   end
 
   context "gestion des équipes" do
-    # une équipe à créer + une équipe à fusionner
+    # une équipe à copier + une équipe à fusionner
     let!(:organisation_target) { create(:organisation, territory: territory_target) }
     let!(:agent_origin1) { create(:agent, organisations: [organisation]) }
     let!(:agent_target1) { create(:agent, organisations: [organisation_target]) }
@@ -91,7 +91,8 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
       expect(territory_target.teams.find_by(name: "Agents habilités")).to be_present
       expect(agent_origin1.reload.teams.where(territory: territory_target).map(&:name)).to contain_exactly("Agents habilités", "Visiteur·ices")
       expect(team_visteurices_target.agents).to contain_exactly(agent_origin1, agent_target1)
-      expect(territory_origin.teams).to be_empty
+      expect(team_habilites_origin.reload).to be_present
+      expect(team_visiteurices_origin.reload).to be_present
     end
   end
 
@@ -108,13 +109,13 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
     specify do
       subject.call
       agent_lea.reload
-      expect(agent_lea.agent_territorial_access_rights.where(territory: territory_origin)).to be_empty
-      expect(agent_lea.agent_territorial_access_rights.where(territory: territory_target).count).to eq 1
+      expect(agent_lea.agent_territorial_access_rights.where(territory: territory_origin)).to be_present
+      expect(agent_lea.agent_territorial_access_rights.where(territory: territory_target).count).to eq(1)
       expect(agent_lea.agent_territorial_access_rights.find_by(territory: territory_target).allow_to_manage_teams).to be true
       # jean a un rôle dans les 2 territoires, son nouvel accès combine les droits positifs dans les deux
       agent_jean.reload
-      expect(agent_jean.agent_territorial_access_rights.where(territory: territory_origin)).to be_empty
-      expect(agent_jean.agent_territorial_access_rights.where(territory: territory_target).count).to eq 1
+      expect(agent_jean.agent_territorial_access_rights.where(territory: territory_origin)).to be_present
+      expect(agent_jean.agent_territorial_access_rights.where(territory: territory_target).count).to eq(1)
       expect(agent_jean.agent_territorial_access_rights.find_by(territory: territory_target).allow_to_manage_teams).to be true
       expect(agent_jean.agent_territorial_access_rights.find_by(territory: territory_target).allow_to_invite_agents).to be true
     end
@@ -132,7 +133,7 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
 
     specify do
       subject.call
-      expect(agent1.territorial_roles.where(territory: territory_origin)).to be_empty
+      expect(agent1.territorial_roles.where(territory: territory_origin)).to be_present
       expect(agent1.territorial_roles.where(territory: territory_target)).to be_present
       expect(agent2.territorial_roles.where(territory: territory_target)).to be_present
     end
@@ -144,8 +145,8 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
 
     specify do
       subject.call
-      expect(Sector.where(territory: territory_origin)).to be_empty
-      expect(SectorAttribution.where(organisation:)).to be_empty
+      expect(Sector.where(territory: territory_origin)).not_to be_empty
+      expect(SectorAttribution.where(organisation:)).not_to be_empty
     end
   end
 

--- a/spec/services/move_organisation_to_other_territory_service_spec.rb
+++ b/spec/services/move_organisation_to_other_territory_service_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
       expect(agent_territorial_role.reload.territory).to eq(territory_origin)
       expect(agent_territorial_access_right.reload.territory).to eq(territory_origin)
       expect(team.reload.territory).to eq(territory_origin)
-      expect(Sector.where(territory: territory_origin)).to include(sector)
+      expect(sector.reload.territory).to eq(territory_origin)
     end
   end
 end

--- a/spec/services/move_organisation_to_other_territory_service_spec.rb
+++ b/spec/services/move_organisation_to_other_territory_service_spec.rb
@@ -150,17 +150,17 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
     end
   end
 
-  describe "gestion des erreurs" do
-    subject { described_class.new(origin_organisation: organisation, target_territory: territory_target, fail_on_purpose: true) }
-
+  describe "lorsque une exception est levée" do
     let!(:agent) { create(:agent, organisations: [organisation]) }
     let!(:agent_territorial_role) { create(:agent_territorial_role, agent: agent, territory: territory_origin) }
     let!(:agent_territorial_access_right) { create(:agent_territorial_access_right, agent: agent, territory: territory_origin) }
     let!(:team) { create(:team, name: "Erreur", territory: territory_origin) }
     let!(:sector) { create(:sector, name: "Erreur", territory: territory_origin) }
 
+    before { allow(organisation).to receive(:update!).and_raise(RuntimeError) }
+
     it "lève une exception" do
-      expect { subject.call }.to raise_error(RuntimeError, "Intentional failure for testing")
+      expect { subject.call }.to raise_error(RuntimeError)
       expect(agent_territorial_role.reload.territory).to eq(territory_origin)
       expect(agent_territorial_access_right.reload.territory).to eq(territory_origin)
       expect(team.reload.territory).to eq(territory_origin)

--- a/spec/services/move_organisation_to_other_territory_service_spec.rb
+++ b/spec/services/move_organisation_to_other_territory_service_spec.rb
@@ -141,4 +141,22 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
       expect(SectorAttribution.where(organisation:)).to be_empty
     end
   end
+
+  describe "gestion des erreurs" do
+    subject { described_class.new(origin_organisation: organisation, target_territory: territory_target, fail_on_purpose: true) }
+
+    let!(:agent) { create(:agent, organisations: [organisation]) }
+    let!(:agent_territorial_role) { create(:agent_territorial_role, agent: agent, territory: territory_origin) }
+    let!(:agent_territorial_access_right) { create(:agent_territorial_access_right, agent: agent, territory: territory_origin) }
+    let!(:team) { create(:team, name: "Erreur", territory: territory_origin) }
+    let!(:sector) { create(:sector, name: "Erreur", territory: territory_origin) }
+
+    it "lève une exception" do
+      expect { subject.call }.to raise_error(RuntimeError, "Intentional failure for testing")
+      expect(agent_territorial_role.reload.territory).to eq(territory_origin)
+      expect(agent_territorial_access_right.reload.territory).to eq(territory_origin)
+      expect(team.reload.territory).to eq(territory_origin)
+      expect(Sector.where(territory: territory_origin)).to include(sector)
+    end
+  end
 end

--- a/spec/services/move_organisation_to_other_territory_service_spec.rb
+++ b/spec/services/move_organisation_to_other_territory_service_spec.rb
@@ -22,9 +22,16 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
 
     specify do
       subject.call
-      expect(annotation1_origin.reload.territory).to eq(territory_target)
+      # l’annotation 1 a été copiée vers le territoire cible
+      annotation1_target = Annotation.find_by(user: user1, territory: territory_target)
+      expect(annotation1_target).to be_present
+      expect(annotation1_target.content).to eq("Usager très sympa")
+      # l’annotation 1 existe toujours dans le territoire d’origine
+      expect(annotation1_origin.reload.territory).to eq(territory_origin)
+      # l’annotation 2 cible a été fusionnée
       expect(annotation2_target.reload.content).to eq("Réjouissant\n---\nSuper")
-      expect(Annotation.find_by(id: annotation2_origin.id)).to be_nil
+      # l’annotation 2 d’origine existe toujours
+      expect(annotation2_origin.reload.territory).to eq(territory_origin)
     end
   end
 

--- a/spec/services/move_organisation_to_other_territory_service_spec.rb
+++ b/spec/services/move_organisation_to_other_territory_service_spec.rb
@@ -88,26 +88,28 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
     end
   end
 
-  context "avec des droits d'accès" do
-    let!(:agent) { create(:agent, organisations: [organisation]) }
-    let!(:access_right) { create(:agent_territorial_access_right, agent: agent, territory: territory_origin, allow_to_manage_teams: true) }
+  context "gestion des droits d'accès" do
+    let!(:agent_lea) { create(:agent, organisations: [organisation]) }
+    let!(:agent_jean) { create(:agent, organisations: [organisation]) }
 
-    it "déplace le droit d'accès au territoire cible" do
-      subject.call
-      expect(access_right.reload.territory).to eq(territory_target)
+    before do
+      create(:agent_territorial_access_right, agent: agent_lea, territory: territory_origin, allow_to_manage_teams: true)
+      create(:agent_territorial_access_right, agent: agent_jean, territory: territory_origin, allow_to_manage_teams: true)
+      create(:agent_territorial_access_right, agent: agent_jean, territory: territory_target, allow_to_invite_agents: true)
     end
 
-    context "quand un droit d'accès existe déjà dans le territoire cible" do
-      let!(:target_access_right) do
-        create(:agent_territorial_access_right, agent: agent, territory: territory_target, allow_to_invite_agents: true)
-      end
-
-      it "fusionne les droits d'accès" do
-        subject.call
-        expect(target_access_right.reload.allow_to_manage_teams).to be(true)
-        expect(target_access_right.reload.allow_to_invite_agents).to be(true)
-        expect(AgentTerritorialAccessRight.find_by(id: access_right.id)).to be_nil
-      end
+    specify do
+      subject.call
+      agent_lea.reload
+      expect(agent_lea.agent_territorial_access_rights.where(territory: territory_origin)).to be_empty
+      expect(agent_lea.agent_territorial_access_rights.where(territory: territory_target).count).to eq 1
+      expect(agent_lea.agent_territorial_access_rights.find_by(territory: territory_target).allow_to_manage_teams).to be true
+      # jean a un rôle dans les 2 territoires, son nouvel accès combine les droits positifs dans les deux
+      agent_jean.reload
+      expect(agent_jean.agent_territorial_access_rights.where(territory: territory_origin)).to be_empty
+      expect(agent_jean.agent_territorial_access_rights.where(territory: territory_target).count).to eq 1
+      expect(agent_jean.agent_territorial_access_rights.find_by(territory: territory_target).allow_to_manage_teams).to be true
+      expect(agent_jean.agent_territorial_access_rights.find_by(territory: territory_target).allow_to_invite_agents).to be true
     end
   end
 

--- a/spec/services/move_organisation_to_other_territory_service_spec.rb
+++ b/spec/services/move_organisation_to_other_territory_service_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+RSpec.describe MoveOrganisationToOtherTerritoryService do
+  subject { described_class.new(origin_organisation: organisation, target_territory: territory_target) }
+
+  let!(:territory_origin) { create(:territory, name: "Territoire d'origine") }
+  let!(:territory_target) { create(:territory, name: "Territoire cible") }
+  let!(:organisation) { create(:organisation, territory: territory_origin) }
+
+  context "cas simple" do
+    it "déplace l'organisation vers le territoire cible" do
+      expect { subject.call }.to change { organisation.reload.territory }.from(territory_origin).to(territory_target)
+    end
+  end
+
+  describe "gestion des annotations" do
+    let!(:user1) { create(:user, organisations: [organisation]) }
+    let!(:annotation1_origin) { create(:annotation, user: user1, territory: territory_origin, content: "Usager très sympa") }
+    let!(:user2) { create(:user, organisations: [organisation]) }
+    let!(:annotation2_origin) { create(:annotation, user: user2, territory: territory_origin, content: "Super") }
+    let!(:annotation2_target) { create(:annotation, user: user2, territory: territory_target, content: "Réjouissant") }
+
+    specify do
+      subject.call
+      expect(annotation1_origin.reload.territory).to eq(territory_target)
+      expect(annotation2_target.reload.content).to eq("Réjouissant\n---\nSuper")
+      expect(Annotation.find_by(id: annotation2_origin.id)).to be_nil
+    end
+  end
+
+  describe "gestion des catégories de motifs" do
+    let!(:motif_categories_origin) { create_list(:motif_category, 3, territories: [territory_origin]) }
+    let!(:motif_category_both) { create(:motif_category, name: "Catégorie 2", territories: [territory_origin, territory_target]) }
+    let!(:motif_category_target) { create(:motif_category, name: "Catégorie 3", territories: [territory_target]) }
+    let!(:motif_category_other_territory) { create(:motif_category, name: "Catégorie 4", territories: [create(:territory)]) }
+
+    specify do
+      subject.call
+      motif_categories_origin.each do |motif_category|
+        expect(motif_category.reload.territories).to include(territory_origin, territory_target)
+      end
+      expect(motif_category_both.reload.territories).to include(territory_origin, territory_target)
+      expect(motif_category_target.reload.territories).to include(territory_target)
+      expect(motif_category_target.reload.territories).not_to include(territory_origin)
+      expect(motif_category_other_territory.reload.territories).not_to include(territory_origin)
+      expect(motif_category_other_territory.reload.territories).not_to include(territory_target)
+    end
+  end
+
+  describe "gestion des services" do
+    let!(:service_pmi) { create(:service, name: "PMI") }
+    let!(:territory_service_pmi) { create(:territory_service, territory: territory_origin, service: service_pmi) }
+    let!(:service_justice) { create(:service, name: "Justice") }
+    let!(:territory_service_justice1) { create(:territory_service, service: service_justice, territory: territory_origin) }
+    let!(:territory_service_justice2) { create(:territory_service, service: service_justice, territory: territory_target) }
+    let!(:service_aide) { create(:service, name: "Aide") }
+    let!(:territory_service_aide) { create(:territory_service, service: service_aide, territory: territory_target) }
+
+    specify do
+      subject.call
+      expect(territory_target.reload.services).to include(service_pmi)
+      expect(territory_target.reload.services).to include(service_justice)
+      expect(territory_target.reload.services).to include(service_aide)
+    end
+  end
+
+  context "gestion des équipes" do
+    # une équipe à créer + une équipe à fusionner
+    let!(:organisation_target) { create(:organisation, territory: territory_target) }
+    let!(:agent_origin1) { create(:agent, organisations: [organisation]) }
+    let!(:agent_target1) { create(:agent, organisations: [organisation_target]) }
+    let!(:team_habilites_origin) { create(:team, name: "Agents habilités", territory: territory_origin) }
+    let!(:team_visiteurices_origin) { create(:team, name: "Visiteur·ices", territory: territory_origin) }
+    let!(:team_visteurices_target) { create(:team, name: "Visiteur·ices", territory: territory_target) }
+
+    before do
+      team_habilites_origin.agents << agent_origin1
+      team_visiteurices_origin.agents << agent_origin1
+      team_visteurices_target.agents << agent_target1
+    end
+
+    specify do
+      subject.call
+      expect(territory_target.teams.find_by(name: "Agents habilités")).to be_present
+      expect(agent_origin1.reload.teams.where(territory: territory_target).map(&:name)).to contain_exactly("Agents habilités", "Visiteur·ices")
+      expect(team_visteurices_target.agents).to contain_exactly(agent_origin1, agent_target1)
+      expect(territory_origin.teams).to be_empty
+    end
+  end
+
+  context "avec des droits d'accès" do
+    let!(:agent) { create(:agent, organisations: [organisation]) }
+    let!(:access_right) { create(:agent_territorial_access_right, agent: agent, territory: territory_origin, allow_to_manage_teams: true) }
+
+    it "déplace le droit d'accès au territoire cible" do
+      subject.call
+      expect(access_right.reload.territory).to eq(territory_target)
+    end
+
+    context "quand un droit d'accès existe déjà dans le territoire cible" do
+      let!(:target_access_right) do
+        create(:agent_territorial_access_right, agent: agent, territory: territory_target, allow_to_invite_agents: true)
+      end
+
+      it "fusionne les droits d'accès" do
+        subject.call
+        expect(target_access_right.reload.allow_to_manage_teams).to be(true)
+        expect(target_access_right.reload.allow_to_invite_agents).to be(true)
+        expect(AgentTerritorialAccessRight.find_by(id: access_right.id)).to be_nil
+      end
+    end
+  end
+
+  context "avec des rôles territoriaux" do
+    let!(:agent) { create(:agent, organisations: [organisation]) }
+
+    it "crée un nouveau rôle territorial pour l'agent dans le territoire cible" do
+      subject.call
+      expect(agent.reload.territorial_roles.find_by(territory: territory_target)).to be_present
+    end
+  end
+
+  context "avec des secteurs" do
+    context "quand l'organisation est attribuée à un secteur dans le territoire d'origine" do
+      let!(:sector_in_origin) { create(:sector, territory: territory_origin) }
+      let!(:attribution_to_origin_sector) { create(:sector_attribution, organisation: organisation, sector: sector_in_origin) }
+
+      it "supprime l'attribution" do
+        subject.call
+        expect(SectorAttribution.find_by(id: attribution_to_origin_sector.id)).to be_nil
+      end
+    end
+
+    context "quand l'organisation est attribuée à un secteur dans le territoire cible" do
+      let!(:sector_in_target) { create(:sector, territory: territory_target) }
+      let!(:attribution_to_target_sector) { create(:sector_attribution, organisation: organisation, sector: sector_in_target) }
+
+      it "conserve l'attribution" do
+        subject.call
+        expect(attribution_to_target_sector.reload).to be_present
+      end
+    end
+
+    context "quand l'organisation est attribuée à un secteur dans un autre territoire" do
+      let!(:other_territory) { create(:territory) }
+      let!(:sector_in_other) { create(:sector, territory: other_territory) }
+      let!(:attribution_to_other_sector) { create(:sector_attribution, organisation: organisation, sector: sector_in_other) }
+
+      it "supprime l'attribution" do
+        subject.call
+        expect(SectorAttribution.find_by(id: attribution_to_other_sector.id)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/move_organisation_to_other_territory_service_spec.rb
+++ b/spec/services/move_organisation_to_other_territory_service_spec.rb
@@ -114,11 +114,20 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
   end
 
   context "avec des rôles territoriaux" do
-    let!(:agent) { create(:agent, organisations: [organisation]) }
+    let!(:agent1) { create(:agent, organisations: [organisation]) }
+    let!(:agent2) { create(:agent, organisations: [organisation]) }
 
-    it "crée un nouveau rôle territorial pour l'agent dans le territoire cible" do
+    before do
+      create(:agent_territorial_role, agent: agent1, territory: territory_origin)
+      create(:agent_territorial_role, agent: agent2, territory: territory_origin)
+      create(:agent_territorial_role, agent: agent2, territory: territory_target)
+    end
+
+    specify do
       subject.call
-      expect(agent.reload.territorial_roles.find_by(territory: territory_target)).to be_present
+      expect(agent1.territorial_roles.where(territory: territory_origin)).to be_empty
+      expect(agent1.territorial_roles.where(territory: territory_target)).to be_present
+      expect(agent2.territorial_roles.where(territory: territory_target)).to be_present
     end
   end
 


### PR DESCRIPTION
# Contexte

L’Allier souhaite migrer certaines organisations depuis le territoire des Conseillers Numériques 31 (~= depuis RDVAN) vers des territoires « normaux » de RDVS. 

Ils souhaitent faire ça avant de migrer vers RDVSP.

Il s’agit ici de migration intra instance. Il ne s’agit pas de fusion d’orga mais de déplacement d’un territoire à un autre - c’est plus simple.

# Solution

J’ai greppé `territory_id` dans le schema et j’ai itéré sur les modèles en ayant un : 

| table | notes | 
-|- 
`annotations` | (les remarques usagers) : elles seront fusionnées s’il en existe déjà dans le territoire cible
`motif_categories` | on ajoutera les catégories de motifs manquantes au territoire cible
`territory_services` | idem on ajoutera les services manquants
`teams` | on copie simplement les équipes, si une équipe existe déjà avec le même nom, on la réutilise
`agent_territorial` `access_rights` et `roles` | les droits sont combinés additivement : on ajoute des droits mais on n’en retire pas
`sectors` | ⚠️ le script ne supprime ni ne copie les secteurs existants
`organisation` | 

Disclaimer : je me suis aidé de l’IA pour faire le squelette de ce script et des specs 😓 et je dois dire qu’à ma surprise ça a bien marché. J’ai tout reparcouru et j’ai du réécrire 80% des lignes à ma sauce. 

J’ai envisagé de stocker le changement dans une table `redirections` pour éventuellement rediriger les personnes tentant d’accéder à une URL avec l’ancien `territory_id`. Ce n’est en fait probablement pas nécessaire : 
- les URL agents donneront des 404, ça me paraît acceptable
- les URL usagers, par exemple celles envoyées dans les notifs mail pour les RDV ne contiennent pas le `territory_id`

# Tests

j’ai lancé en local sur un dump de prod : 

`bundle exec rails runner scripts/move_organisation_to_other_territory.rb --origin_organisation_id 845 --target_territory_id 135`

- J’ai parcouru le résultat en tant qu’agent ça a l’air correct
- J’ai aussi réussi à accéder à un RDV en tant qu’usager depuis l’URL envoyée dans une notif SMS avant la migration - j’ai du copier les clés d’encryption depuis la prod car le `invitation_token` est encrypté 