### PR TITLE
Ajout de Notifiers pour les plages d’ouverture et les indispo

### DIFF
--- a/app/controllers/admin/planning/absences_controller.rb
+++ b/app/controllers/admin/planning/absences_controller.rb
@@ -41,7 +41,7 @@ class Admin::Planning::AbsencesController < AgentAuthController
   def create
     authorize(@absence, policy_class: Agent::AbsencePolicy)
     if @absence.save
-      Agents::AbsenceMailer.with(absence: @absence).absence_created.deliver_later if @agent.absence_notification_level == "all"
+      Notifiers::AbsenceCreated.new(@absence).perform
       flash[:success] = t(".absence_created")
       redirect_to admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent_id)
     else
@@ -52,7 +52,7 @@ class Admin::Planning::AbsencesController < AgentAuthController
   def update
     authorize(@absence, policy_class: Agent::AbsencePolicy)
     if @absence.update(absence_params)
-      Agents::AbsenceMailer.with(absence: @absence).absence_updated.deliver_later if @agent.absence_notification_level == "all"
+      Notifiers::AbsenceUpdated.new(@absence).perform
       flash[:success] = t(".absence_updated")
       redirect_to admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent_id)
     else
@@ -63,8 +63,7 @@ class Admin::Planning::AbsencesController < AgentAuthController
   def destroy
     authorize(@absence, policy_class: Agent::AbsencePolicy)
     if @absence.destroy
-      # On passe l'absence au job sous forme sérialisée puisqu'elle n'existe plus en base.
-      Agents::AbsenceMailer.with(absence: Absence.serialize_for_active_job(@absence)).absence_destroyed.deliver_later if @agent.absence_notification_level == "all"
+      Notifiers::AbsenceDestroyed.new(@absence).perform
       flash[:notice] = t(".absence_deleted")
       redirect_to admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent_id)
     else

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -59,8 +59,7 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
     @plage_ouverture.organisation = current_organisation
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
     if @plage_ouverture.save
-
-      Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_created.deliver_later if @agent.plage_ouverture_notification_level == "all"
+      Notifiers::PlageOuvertureCreated.new(@plage_ouverture).perform
       flash[:success] = "Plage d'ouverture créée"
       redirect_to admin_organisation_planning_plage_ouvertures_path(organisation_id: @plage_ouverture.organisation, agent_id: @plage_ouverture.agent_id)
     else
@@ -71,7 +70,7 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
   def update
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
     if @plage_ouverture.update(plage_ouverture_params)
-      Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_updated.deliver_later if @agent.plage_ouverture_notification_level == "all"
+      Notifiers::PlageOuvertureUpdated.new(@plage_ouverture).perform
       flash[:success] = "La plage d'ouverture a été modifiée."
       redirect_to admin_organisation_planning_plage_ouvertures_path(organisation_id: @plage_ouverture.organisation, agent_id: @plage_ouverture.agent_id)
     else
@@ -81,13 +80,8 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
 
   def destroy
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
-    motif_ids = @plage_ouverture.motifs.ids
     if @plage_ouverture.destroy
-      # On passe la plage au job sous forme sérialisée puisqu'elle n'existe plus en base.
-      if @agent.plage_ouverture_notification_level == "all"
-        plage_attributes = PlageOuverture.serialize_for_active_job(@plage_ouverture).merge(motif_ids: motif_ids)
-        Agents::PlageOuvertureMailer.with(plage_ouverture: plage_attributes).plage_ouverture_destroyed.deliver_later
-      end
+      Notifiers::PlageOuvertureDestroyed.new(@plage_ouverture).perform
       flash[:notice] = "La plage d'ouverture a été supprimée."
       redirect_to admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)
     else

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -80,8 +80,9 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
 
   def destroy
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
+    motif_ids = @plage_ouverture.motifs.ids
     if @plage_ouverture.destroy
-      Notifiers::PlageOuvertureDestroyed.new(@plage_ouverture).perform
+      Notifiers::PlageOuvertureDestroyed.new(@plage_ouverture, motif_ids).perform
       flash[:notice] = "La plage d'ouverture a été supprimée."
       redirect_to admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)
     else

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -80,9 +80,9 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
 
   def destroy
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
-    motif_ids = @plage_ouverture.motifs.ids
+    notifier = Notifiers::PlageOuvertureDestroyed.new(@plage_ouverture)
     if @plage_ouverture.destroy
-      Notifiers::PlageOuvertureDestroyed.new(@plage_ouverture, motif_ids).perform
+      notifier.perform
       flash[:notice] = "La plage d'ouverture a été supprimée."
       redirect_to admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)
     else

--- a/app/services/notifiers/absence_base.rb
+++ b/app/services/notifiers/absence_base.rb
@@ -1,0 +1,19 @@
+class Notifiers::AbsenceBase < BaseService
+  def initialize(absence)
+    @absence = absence
+  end
+
+  def perform
+    notify if agent_notifiable?
+  end
+
+  private
+
+  def notify
+    raise NotImplementedError, "Subclasses must implement the notify method"
+  end
+
+  def agent_notifiable?
+    @absence.agent.email.present? && @absence.agent.absence_notification_level == "all"
+  end
+end

--- a/app/services/notifiers/absence_created.rb
+++ b/app/services/notifiers/absence_created.rb
@@ -1,0 +1,7 @@
+class Notifiers::AbsenceCreated < Notifiers::AbsenceBase
+  private
+
+  def notify
+    Agents::AbsenceMailer.with(absence: @absence).absence_created.deliver_later
+  end
+end

--- a/app/services/notifiers/absence_destroyed.rb
+++ b/app/services/notifiers/absence_destroyed.rb
@@ -1,0 +1,8 @@
+class Notifiers::AbsenceDestroyed < Notifiers::AbsenceBase
+  private
+
+  def notify
+    # On passe l'absence au job sous forme sérialisée puisqu'elle n'existe plus en base.
+    Agents::AbsenceMailer.with(absence: Absence.serialize_for_active_job(@absence)).absence_destroyed.deliver_later
+  end
+end

--- a/app/services/notifiers/absence_updated.rb
+++ b/app/services/notifiers/absence_updated.rb
@@ -1,0 +1,7 @@
+class Notifiers::AbsenceUpdated < Notifiers::AbsenceBase
+  private
+
+  def notify
+    Agents::AbsenceMailer.with(absence: @absence).absence_updated.deliver_later
+  end
+end

--- a/app/services/notifiers/plage_ouverture_base.rb
+++ b/app/services/notifiers/plage_ouverture_base.rb
@@ -14,6 +14,6 @@ class Notifiers::PlageOuvertureBase < BaseService
   end
 
   def agent_notifiable?
-    @plage_ouverture.agent&.email.present?
+    @plage_ouverture.agent&.email.present? && @plage_ouverture.agent.plage_ouverture_notification_level == "all"
   end
 end

--- a/app/services/notifiers/plage_ouverture_base.rb
+++ b/app/services/notifiers/plage_ouverture_base.rb
@@ -1,0 +1,19 @@
+class Notifiers::PlageOuvertureBase < BaseService
+  def initialize(plage_ouverture)
+    @plage_ouverture = plage_ouverture
+  end
+
+  def perform
+    notify if agent_notifiable?
+  end
+
+  private
+
+  def notify
+    raise NotImplementedError, "Subclasses must implement the notify method"
+  end
+
+  def agent_notifiable?
+    @plage_ouverture.agent&.email.present?
+  end
+end

--- a/app/services/notifiers/plage_ouverture_created.rb
+++ b/app/services/notifiers/plage_ouverture_created.rb
@@ -1,0 +1,7 @@
+class Notifiers::PlageOuvertureCreated < Notifiers::PlageOuvertureBase
+  private
+
+  def notify
+    Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_created.deliver_later
+  end
+end

--- a/app/services/notifiers/plage_ouverture_destroyed.rb
+++ b/app/services/notifiers/plage_ouverture_destroyed.rb
@@ -1,0 +1,9 @@
+class Notifiers::PlageOuvertureDestroyed < Notifiers::PlageOuvertureBase
+  private
+
+  def notify
+    # On passe la plage au job sous forme sérialisée puisqu'elle n'existe plus en base.
+    plage_attributes = PlageOuverture.serialize_for_active_job(@plage_ouverture).merge(motif_ids: @plage_ouverture.motifs.ids)
+    Agents::PlageOuvertureMailer.with(plage_ouverture: plage_attributes).plage_ouverture_destroyed.deliver_later
+  end
+end

--- a/app/services/notifiers/plage_ouverture_destroyed.rb
+++ b/app/services/notifiers/plage_ouverture_destroyed.rb
@@ -1,9 +1,14 @@
 class Notifiers::PlageOuvertureDestroyed < Notifiers::PlageOuvertureBase
+  def initialize(plage_ouverture, motif_ids)
+    @motif_ids = motif_ids
+    super(plage_ouverture)
+  end
+
   private
 
   def notify
     # On passe la plage au job sous forme sérialisée puisqu'elle n'existe plus en base.
-    plage_attributes = PlageOuverture.serialize_for_active_job(@plage_ouverture).merge(motif_ids: @plage_ouverture.motifs.ids)
+    plage_attributes = PlageOuverture.serialize_for_active_job(@plage_ouverture).merge(motif_ids: @motif_ids)
     Agents::PlageOuvertureMailer.with(plage_ouverture: plage_attributes).plage_ouverture_destroyed.deliver_later
   end
 end

--- a/app/services/notifiers/plage_ouverture_destroyed.rb
+++ b/app/services/notifiers/plage_ouverture_destroyed.rb
@@ -1,14 +1,13 @@
 class Notifiers::PlageOuvertureDestroyed < Notifiers::PlageOuvertureBase
-  def initialize(plage_ouverture, motif_ids)
-    @motif_ids = motif_ids
-    super(plage_ouverture)
+  def initialize(plage_ouverture)
+    super
+    @plage_ouverture_serialized = PlageOuverture.serialize_for_active_job(plage_ouverture).merge(motif_ids: plage_ouverture.motif_ids)
   end
 
   private
 
   def notify
     # On passe la plage au job sous forme sérialisée puisqu'elle n'existe plus en base.
-    plage_attributes = PlageOuverture.serialize_for_active_job(@plage_ouverture).merge(motif_ids: @motif_ids)
-    Agents::PlageOuvertureMailer.with(plage_ouverture: plage_attributes).plage_ouverture_destroyed.deliver_later
+    Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture_serialized).plage_ouverture_destroyed.deliver_later
   end
 end

--- a/app/services/notifiers/plage_ouverture_updated.rb
+++ b/app/services/notifiers/plage_ouverture_updated.rb
@@ -1,0 +1,7 @@
+class Notifiers::PlageOuvertureUpdated < Notifiers::PlageOuvertureBase
+  private
+
+  def notify
+    Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_updated.deliver_later
+  end
+end

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe "Agent can CRUD absences" do
       expect_page_title("Vos indisponibilités")
       expect(page).to have_content("Vous n’avez pas encore créé d’indisponibilité")
 
+      expect { perform_enqueued_jobs }.to change { emails_sent_to(absence.agent.email).size }.by(1)
+      open_email(absence.agent.email)
+      expect(current_email.subject).to eq("RDV Service Public - Indisponibilité supprimée - La belle indisponibilité")
+
       click_link "Créer une indisponibilité", match: :first
 
       expect_page_title("Nouvelle indisponibilité")
@@ -34,6 +38,10 @@ RSpec.describe "Agent can CRUD absences" do
       fill_in "absence[first_day]", with: Time.zone.today
       fill_in "absence[end_day]", with: Time.zone.today + 2
       click_button "Enregistrer"
+
+      expect { perform_enqueued_jobs }.to change { emails_sent_to(absence.agent.email).size }.by(1)
+      open_email(absence.agent.email)
+      expect(current_email.subject).to eq("RDV Service Public - Indisponibilité créée - Nouvelle indisponibilité")
 
       expect_page_title("Vos indisponibilités")
       click_link "Nouvelle indisponibilité"
@@ -61,6 +69,10 @@ RSpec.describe "Agent can CRUD absences" do
       expect_page_title("Indisponibilités de Jane FAROU (PMI)")
       expect(page).to have_content("Jane FAROU n’a pas encore créé d’indisponibilité")
 
+      expect { perform_enqueued_jobs }.to change { emails_sent_to(absence.agent.email).size }.by(1)
+      open_email(absence.agent.email)
+      expect(current_email.subject).to eq("RDV Service Public - Indisponibilité supprimée - La belle indisponibilité")
+
       click_link "Créer une indisponibilité", match: :first
 
       expect_page_title("Nouvelle indisponibilité")
@@ -68,6 +80,10 @@ RSpec.describe "Agent can CRUD absences" do
       fill_in "absence[first_day]", with: Time.zone.today
       fill_in "absence[end_day]", with: Time.zone.today + 2
       click_button "Enregistrer"
+
+      expect { perform_enqueued_jobs }.to change { emails_sent_to(absence.agent.email).size }.by(1)
+      open_email(absence.agent.email)
+      expect(current_email.subject).to eq("RDV Service Public - Indisponibilité créée - Nouvelle indisponibilité")
 
       expect_page_title("Indisponibilités de Jane FAROU (PMI)")
       click_link "Nouvelle indisponibilité"

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -24,9 +24,17 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       fill_in "Libellé (facultatif)", with: "La belle plage"
       click_button("Enregistrer")
 
+      expect { perform_enqueued_jobs }.to change { emails_sent_to(agent.email).size }.by(1)
+      open_email(agent.email)
+      expect(current_email.subject).to eq("RDV Service Public - Plage d’ouverture modifiée - La belle plage")
+
       expect_page_title("Plages d’ouverture")
       click_on("La belle plage")
       click_link("Supprimer")
+
+      expect { perform_enqueued_jobs }.to change { emails_sent_to(agent.email).size }.by(1)
+      open_email(agent.email)
+      expect(current_email.subject).to eq("RDV Service Public - Plage d’ouverture supprimée - La belle plage")
 
       expect_page_title("Plages d’ouverture")
       expect(page).to have_content("Vous n'avez pas encore créé de plage d'ouverture")
@@ -45,6 +53,10 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       click_button "Créer la plage d'ouverture"
       expect(PlageOuverture.last.title).to eq("Accueil")
       expect_page_title("Plages d’ouverture")
+
+      expect { perform_enqueued_jobs }.to change { emails_sent_to(agent.email).size }.by(1)
+      open_email(agent.email)
+      expect(current_email.subject).to eq("RDV Service Public - Plage d’ouverture créée - Accueil")
     end
   end
 

--- a/spec/services/notifiers/absence_base_spec.rb
+++ b/spec/services/notifiers/absence_base_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Notifiers::AbsenceBase, type: :service do
+  describe "perform" do
+    let(:absence) { build(:absence, agent:) }
+
+    context "quand l’agent n’a pas de mail" do
+      let(:agent) { build(:agent, email: nil, absence_notification_level: "all") }
+
+      it "ne notifie pas l’agent" do
+        service = described_class.new(absence)
+        expect(service).not_to receive(:notify)
+        service.perform
+      end
+    end
+
+    context 'quand l’agent a un mail et le niveau de notification est "all"' do
+      let(:agent) { build(:agent, absence_notification_level: "all") }
+
+      it "notifie l’agent" do
+        service = described_class.new(absence)
+        expect(service).to receive(:notify)
+        service.perform
+      end
+    end
+
+    context 'quand l’agent a un mail mais le niveau de notification est à "none"' do
+      let(:agent) { build(:agent, absence_notification_level: "none") }
+
+      it "ne notifie pas l’agent" do
+        service = described_class.new(absence)
+        expect(service).not_to receive(:notify)
+        service.perform
+      end
+    end
+  end
+end

--- a/spec/services/notifiers/plage_ouverture_base_spec.rb
+++ b/spec/services/notifiers/plage_ouverture_base_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Notifiers::PlageOuvertureBase do
+  describe "perform" do
+    let(:plage_ouverture) { build(:plage_ouverture, agent:) }
+
+    context "quand l’agent n’a pas de mail" do
+      let(:agent) { build(:agent, email: nil, plage_ouverture_notification_level: "all") }
+
+      it "ne notifie pas l’agent" do
+        service = described_class.new(plage_ouverture)
+        expect(service).not_to receive(:notify)
+        service.perform
+      end
+    end
+
+    context 'quand l’agent a un mail et le niveau de notification est "all"' do
+      let(:agent) { build(:agent, plage_ouverture_notification_level: "all") }
+
+      it "notifie l’agent" do
+        service = described_class.new(plage_ouverture)
+        expect(service).to receive(:notify)
+        service.perform
+      end
+    end
+
+    context 'quand l’agent a un mail mais le niveau de notification est à "none"' do
+      let(:agent) { build(:agent, plage_ouverture_notification_level: "none") }
+
+      it "ne notifie pas l’agent" do
+        service = described_class.new(plage_ouverture)
+        expect(service).not_to receive(:notify)
+        service.perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Contexte

En analysant [LAPINS-2KF](https://sentry.incubateur.net/organizations/betagouv/issues/179784/) je me suis rendu compte que nous essayons d’envoyer des mails de notification de création/suppression/modification de plage d’ouverture ou absence à des agents intervenants qui n’ont pas d’adresse email.
Une précédente action avait été faite pour ne pas retry les jobs qui ont l’erreur : `SMTP To address may not be blank: []`
Néanmoins, il semble pertinent de ne pas du tout enqueue ces jobs.

# Solution

En m’inspirant de ce qui existait déjà pour les RDV, j’ai donc créé des Notifiers pour les absences et les plages d’ouvertures. Ceux-ci vérifient que l’agent à un mail et qu’il a les bonnes préférences de notification avant de le notifier.