### PR TITLE
Empêcher la détection automatique des numéros de téléphone sur Safari iOS

### DIFF
--- a/app/views/common/_meta.html.slim
+++ b/app/views/common/_meta.html.slim
@@ -1,6 +1,8 @@
 meta name="viewport" content="width=device-width, initial-scale=1.0"
 meta content="text/html; charset=UTF-8" http-equiv="Content-Type"
 meta name="turbo-prefetch" content="false"
+meta name="format-detection" content="telephone=no"
+
 title
   - if content_for? :title
     - if content_for? :subtitle


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5535.osc-secnum-fr1.scalingo.io/) 

# Contexte

sur iOS il arrive que les usagers soient bloqués lorsqu’ils cliquent sur le nom de l’orga dans le parcours de prise de RDV.

Cela semble arriver uniquement lorsque plusieurs organisations ayant des numéros de téléphone proposent le même motif téléphonique

<img width="440" height="953" alt="image" src="https://github.com/user-attachments/assets/ad57e970-a171-4030-a8e1-a3dec00decbe" />


# Solution

Il semblerait que ça soit une fonctionnalité un peu intrusive de Safari iOS qui cause ça.  Je propose de la désactiver complètement sur tout RDVS, agent et usager.

ça n’empêche pas du tout les lien `href=tel:xxx`, ça empeche uniquement la detection automatique au milieu du texte.

Je n’ai pas compris pourquoi ça se produit uniquement dans ce cas précis. 

La désactivation de cette fonctionnalité a l’air de corriger le problème, j’ai réussi à reproduire en local : 
- je me suis mis dans la situation problématique
- j’ai utilisé un émulateur iOS via xCode
- j’arrive a reproduire un problème similaire cf screenshot plus bas
- en passant sur la branche le problème n’apparaît plus 🤷 

<img width="778" height="1606" alt="image" src="https://github.com/user-attachments/assets/bc10036d-354d-4bbc-b218-66b7dafdc5f6" />
