### PR TITLE
Correction du service de déplacement d’orga

### DIFF
--- a/app/services/move_organisation_to_other_territory_service.rb
+++ b/app/services/move_organisation_to_other_territory_service.rb
@@ -107,7 +107,9 @@ class MoveOrganisationToOtherTerritoryService < BaseService
 
   def copy_access_rights
     Rails.logger.info("🔄 Copie des droits d'accès territoriaux…")
-    AgentTerritorialAccessRight.where(territory: @territory_origin).each do |access_right_origin|
+    AgentTerritorialAccessRight
+      .where(territory: @territory_origin, agent_id: @origin_organisation.agent_ids)
+      .each do |access_right_origin|
       agent = access_right_origin.agent
       access_right_target = agent.agent_territorial_access_rights.find_by(territory: @territory_target)
       if access_right_target
@@ -130,7 +132,9 @@ class MoveOrganisationToOtherTerritoryService < BaseService
 
   def copy_territorial_roles
     Rails.logger.info("🔄 Copie des rôles territoriaux d'agents…")
-    AgentTerritorialRole.where(territory: @territory_origin).each do |role_origin|
+    AgentTerritorialRole
+      .where(territory: @territory_origin, agent_id: @origin_organisation.agent_ids)
+      .each do |role_origin|
       agent = role_origin.agent
       if agent.territorial_roles.exists?(territory: @territory_target)
         Rails.logger.info("  ℹ️  Agent #{agent.id} a déjà un rôle territorial dans le territoire cible")

--- a/spec/services/move_organisation_to_other_territory_service_spec.rb
+++ b/spec/services/move_organisation_to_other_territory_service_spec.rb
@@ -99,11 +99,15 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
   context "gestion des droits d'accès" do
     let!(:agent_lea) { create(:agent, organisations: [organisation]) }
     let!(:agent_jean) { create(:agent, organisations: [organisation]) }
+    let!(:other_orga) { create(:organisation, territory: territory_origin) }
+    let!(:agent_wu) { create(:agent, organisations: [other_orga]) }
 
     before do
       create(:agent_territorial_access_right, agent: agent_lea, territory: territory_origin, allow_to_manage_teams: true)
       create(:agent_territorial_access_right, agent: agent_jean, territory: territory_origin, allow_to_manage_teams: true)
       create(:agent_territorial_access_right, agent: agent_jean, territory: territory_target, allow_to_invite_agents: true)
+      # Wu a des accès au territoire d’origine mais n’appartient pas à l’orga d’origine
+      create(:agent_territorial_access_right, agent: agent_wu, territory: territory_origin, allow_to_invite_agents: true)
     end
 
     specify do
@@ -118,17 +122,24 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
       expect(agent_jean.agent_territorial_access_rights.where(territory: territory_target).count).to eq(1)
       expect(agent_jean.agent_territorial_access_rights.find_by(territory: territory_target).allow_to_manage_teams).to be true
       expect(agent_jean.agent_territorial_access_rights.find_by(territory: territory_target).allow_to_invite_agents).to be true
+      agent_wu.reload
+      expect(agent_wu.agent_territorial_access_rights.where(territory: territory_origin)).to be_present
+      expect(agent_wu.agent_territorial_access_rights.where(territory: territory_target)).not_to be_present
     end
   end
 
   context "gestion des rôles territoriaux" do
     let!(:agent1) { create(:agent, organisations: [organisation]) }
     let!(:agent2) { create(:agent, organisations: [organisation]) }
+    let!(:other_orga) { create(:organisation, territory: territory_origin) }
+    let!(:agent_wu) { create(:agent, organisations: [other_orga]) }
 
     before do
       create(:agent_territorial_role, agent: agent1, territory: territory_origin)
       create(:agent_territorial_role, agent: agent2, territory: territory_origin)
       create(:agent_territorial_role, agent: agent2, territory: territory_target)
+      # Wu a un rôle dans le territoire d’origine mais n’appartient pas à l’orga d’origine
+      create(:agent_territorial_role, agent: agent_wu, territory: territory_origin)
     end
 
     specify do
@@ -136,6 +147,8 @@ RSpec.describe MoveOrganisationToOtherTerritoryService do
       expect(agent1.territorial_roles.where(territory: territory_origin)).to be_present
       expect(agent1.territorial_roles.where(territory: territory_target)).to be_present
       expect(agent2.territorial_roles.where(territory: territory_target)).to be_present
+      expect(agent_wu.territorial_roles.where(territory: territory_origin)).to be_present
+      expect(agent_wu.territorial_roles.where(territory: territory_target)).not_to be_present
     end
   end
 


### PR DESCRIPTION
# Contexte

Après avoir lancé le script de déplacement d’une orga de l’espace Conseillers Numérique vers un autre espace, je me suis rendu compte avec stupeur que j’avais copié tous les droits territoriaux des nombreux agents de l’espace CN vers le nouvel espace 😨 

J’ai corrigé le problème manuellement en retirant les droits des agents « en trop » 

# Solution

Je propose ici de scoper les rôles et droits territoriaux copiés à ceux concernant des agents qui appartiennent à l’organisation déplacée. 

Ce n’est pas 100% correct : certains agents qui étaient admin du territoire d’origine mais n’avaient pas accès à l’orga déplacée vont « perdre » leurs droits sur cette orga une fois qu’elle sera déplacée. Mais c’est moins dangereux dans ce sens 🤷 