### PR TITLE
Fix LetterOpener CSP

### DIFF
--- a/config/initializers/letter_opener.rb
+++ b/config/initializers/letter_opener.rb
@@ -7,4 +7,12 @@ Rails.application.config.after_initialize do
       original_adjust_link_targets(contents).gsub(".localhost/", ".localhost:3000/")
     end
   end
+
+  # Nous appliquons des règles strictes au niveau de nos CSP, notamment sur l’exécution du JS.
+  # Depuis la mise en place de ces règles Letter Opener ne fonctionne plus correctement, spécifiquement car il utilise du JS
+  # inliné. Étant donné qu’il s’agit d’un outil utilisé uniquement en développement, on désactive les CSP dans son controller
+  # pour ne pas perturber son fonctionnement.
+  LetterOpenerWeb::ApplicationController.class_eval do
+    content_security_policy false
+  end
 end


### PR DESCRIPTION
# Contexte

Voir commentaire dans le code.

# Solution

J’ai choisi de désactiver complètement les CSP pour letter opener, car il s’agit d’un outil de dev uniquement.
