### PR TITLE
Ignore RailsEOL brakeman rule (7.1)

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,25 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.1.5.1 ends on 2025-10-01",
+      "file": "Gemfile.lock",
+      "line": 513,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Nous savons que nous devons effectuer la mise à jour Rails 7.2. Nous allons avancer sur ce sujet mais nous ignorons cette règle pour le moment pour ne pas bloquer la CI."
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "5e49c97564dd5bd05b5bc9a38faaf23c0c404cc707b798d4632845745720d0a4",


### PR DESCRIPTION
# Contexte

La date de fin de maintien de Rails 7.1 approchant (- de 2 mois), brakeman nous lève un warning depuis ce matin.
Cela nous rappelle de reprendre les travaux de passage à la configuration par défaut 7.1 de Rails puis de migration vers la 7.2.
Néanmoins, pour ne pas bloquer la CI je propose d’ignorer la règle.

