### PR TITLE
Suppression d'une méthode inutilisée

### DIFF
--- a/app/services/users/geo_search.rb
+++ b/app/services/users/geo_search.rb
@@ -36,10 +36,6 @@ class Users::GeoSearch
     @matching_sectors ||= Sector.where(id: matching_zones&.pluck(:sector_id))
   end
 
-  def available_services
-    @available_services ||= Service.where(id: available_motifs.pluck(:service_id).uniq)
-  end
-
   def available_motifs
     @available_motifs ||= available_motifs_arels.reduce(:or).ordered_by_name
   end

--- a/spec/services/users/geo_search_cases_spec.rb
+++ b/spec/services/users/geo_search_cases_spec.rb
@@ -19,12 +19,11 @@ RSpec.describe Users::GeoSearch, type: :service_model do
     let!(:plage_ouverture_service2) { create(:plage_ouverture, motifs: [motif_service2], organisation: organisation1) }
     let!(:plage_ouverture_orga2) { create(:plage_ouverture, motifs: [motif_orga2], organisation: organisation2) }
 
-    it "filters available motifs and services" do
+    it "filters available motifs" do
       expect(subject.available_motifs).to include(motif_ok)
       expect(subject.available_motifs).to include(motif_service2)
       expect(subject.available_motifs).to include(motif_orga2)
       expect(subject.available_motifs).not_to include(motif_no_plage_ouverture)
-      expect(subject.available_services).to include(service1, service2)
     end
   end
 
@@ -76,7 +75,6 @@ RSpec.describe Users::GeoSearch, type: :service_model do
       expect(subject.available_motifs).to include(motifs_orga1[4])
       expect(subject.available_motifs).to include(motifs_orga2[0])
       expect(subject.available_motifs).not_to include(motifs_orga2[1]) # no plage ouvertures
-      expect(subject.available_services).to include(service1)
     end
   end
 

--- a/spec/services/users/geo_search_spec.rb
+++ b/spec/services/users/geo_search_spec.rb
@@ -290,43 +290,4 @@ RSpec.describe Users::GeoSearch, type: :service_model do
       it { is_expected.to contain_exactly(motif_organisation, motif_agent, motif_departement) }
     end
   end
-
-  describe "#available_services" do
-    subject { described_class.new(departement: "62", city_code: "62100").available_services }
-
-    context "organisation exist but no sectors" do
-      let!(:organisation) { create(:organisation, territory: territory62, name: "MDS Arques") }
-
-      it { is_expected.to be_empty }
-    end
-
-    context "matching sector with 2 motifs with POs from different services" do
-      let!(:organisation) { create(:organisation, territory: territory62, name: "MDS Arques") }
-      let!(:service1) { create(:service) }
-      let!(:service2) { create(:service) }
-      let!(:motif1) { create(:motif, :sectorisation_level_organisation, organisation: organisation, service: service1) }
-      let!(:plage_ouverture1) { create(:plage_ouverture, motifs: [motif1], organisation: organisation) }
-      let!(:motif2) { create(:motif, :sectorisation_level_organisation, organisation: organisation, service: service2) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation) }
-      let!(:sector) { create(:sector, territory: territory62, name: "Arques VILLE", human_id: "arques") }
-      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
-      let!(:attribution) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation) }
-
-      it { is_expected.to contain_exactly(service1, service2) }
-    end
-
-    context "matching sector with 2 motifs with POs from same service" do
-      let!(:organisation) { create(:organisation, territory: territory62, name: "MDS Arques") }
-      let!(:service) { create(:service) }
-      let!(:motif1) { create(:motif, :sectorisation_level_organisation, organisation: organisation, service: service) }
-      let!(:plage_ouverture1) { create(:plage_ouverture, motifs: [motif1], organisation: organisation) }
-      let!(:motif2) { create(:motif, :sectorisation_level_organisation, organisation: organisation, service: service) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation) }
-      let!(:sector) { create(:sector, territory: territory62, name: "Arques VILLE", human_id: "arques") }
-      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
-      let!(:attribution) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation) }
-
-      it { is_expected.to contain_exactly(service) } # we expect no duplicates
-    end
-  end
 end


### PR DESCRIPTION
Dans le cadre de la préparation des motifs sans services, j'ai été amené à relire le code du geosearch, et je me suis rendu compte que cette méthode est inutlisée.

Il y a peut-être d'autres refactors à faire sur ce service, mais je préfère ne pas me lancer là dedans pour le moment.