### PR TITLE
Petits correctifs cosmétiques sur la recherche de créneaux côté agents

### DIFF
--- a/app/views/admin/creneaux_search/_lieu_search_results.html.slim
+++ b/app/views/admin/creneaux_search/_lieu_search_results.html.slim
@@ -3,8 +3,7 @@
     .row
       .col-md
         h4.card-title.mb-3.mt-0.text-success.font-weight-bold= next_availability.lieu.name
-        h5.card-subtitle.text-black-50.mb-2 = @form.motif.service_name
-        h6.card-subtitle.text-black-50= next_availability.lieu.address
+        p.card-subtitle.text-black-50= next_availability.lieu.address
       .col-md.align-self-center.pt-3.pt-md-0.position-static
         = link_to admin_organisation_creneaux_search_selection_creneaux_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [next_availability.lieu.id])),
                 class: "d-block stretched-link" do

--- a/app/views/admin/creneaux_search/_lieu_search_results.html.slim
+++ b/app/views/admin/creneaux_search/_lieu_search_results.html.slim
@@ -9,7 +9,7 @@
                 class: "d-block stretched-link" do
           .row
             .col
-              | Prochaine disponibilité le
+              | Prochain créneau le
               br
               strong= l(next_availability.starts_at, format: :human)
             .col-auto.align-self-center

--- a/app/views/admin/creneaux_search/_prescription_cta.html.slim
+++ b/app/views/admin/creneaux_search/_prescription_cta.html.slim
@@ -1,5 +1,5 @@
 - if show_agent_prescription_feature?(user_provided: @form.user_ids.any?)
-  .rdv-text-align-center.my-4
+  .rdv-text-align-center.fr-my-4v
     p
       | Vous pouvez aussi élargir votre recherche aux créneaux ouverts à la prescription dans d'autres organisations.
       br

--- a/app/views/admin/creneaux_search/_prescription_cta.html.slim
+++ b/app/views/admin/creneaux_search/_prescription_cta.html.slim
@@ -1,8 +1,9 @@
 - if show_agent_prescription_feature?(user_provided: @form.user_ids.any?)
-  .rdv-text-align-center.mt-2.mb-4
+  .rdv-text-align-center.my-4
     p
       | Vous pouvez aussi élargir votre recherche aux créneaux ouverts à la prescription dans d'autres organisations.
-      span  Plus d'informations dans
+      br
+      = "Plus d'informations dans "
       = link_to "la documentation", "https://rdvs.notion.site/Prescription-f1c857697c68421d91592ae88364c05d", target: "_blank"
     p
-      = link_to("Élargir la recherche", search_creneau_admin_organisation_prescription_path(user_ids: @form.user_ids, departement: current_territory.departement_number), class: "btn btn-outline-primary")
+      = link_to("Élargir la recherche", search_creneau_admin_organisation_prescription_path(user_ids: @form.user_ids, departement: current_territory.departement_number), class: "fr-btn fr-btn--secondary")

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -66,7 +66,7 @@
           .col-md-4
             = f.input :lieu_ids, collection: @lieux, label: "Lieu(x)", input_html: { multiple: true, class: "select2-input" }
         .text-right
-          = f.submit "Afficher les créneaux", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux…"}
+          = f.submit "Afficher les créneaux", class: "fr-btn", data: { disable_with: "Récupération des créneaux…"}
 
 #creneaux
   .rdv-text-align-center

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -71,11 +71,10 @@
 #creneaux
   .rdv-text-align-center
     - if @next_availabilities&.any?
-      .container
-        h3.font-weight-bold= t(".available_places_with_slots", count: @next_availabilities.length)
-        - @next_availabilities.each do |next_availability|
-          = render "lieu_search_results", next_availability: next_availability
-        = render "admin/creneaux_search/prescription_cta"
+      h3.font-weight-bold= t(".available_places_with_slots", count: @next_availabilities.length)
+      - @next_availabilities.each do |next_availability|
+        = render "lieu_search_results", next_availability: next_availability
+      = render "admin/creneaux_search/prescription_cta"
     - elsif motif_selected? && params[:commit].present?
       = render partial: "admin/creneaux_search/no_slot_available"
     - else

--- a/app/views/admin/creneaux_search/selection_creneaux.html.slim
+++ b/app/views/admin/creneaux_search/selection_creneaux.html.slim
@@ -1,5 +1,5 @@
 - if @search_result.present?
-  .card
+  .card.mt-2
     .card-header
      .d-flex.justify-content-between.flex-wrap
        span

--- a/app/views/admin/creneaux_search/selection_creneaux.html.slim
+++ b/app/views/admin/creneaux_search/selection_creneaux.html.slim
@@ -1,5 +1,5 @@
 - if @search_result.present?
-  .card.mt-2
+  .card.fr-mt-2v
     .card-header
      .d-flex.justify-content-between.flex-wrap
        span

--- a/config/locales/views/agent_searches.fr.yml
+++ b/config/locales/views/agent_searches.fr.yml
@@ -7,9 +7,9 @@ fr:
         search_for_slots_title: Trouver un RDV
         search_for_slots_subtitle: pour %{users_fullname}
         available_places_with_slots:
-          zero: Aucun lieu ne propose de disponibilité
-          one: "Un lieu propose des disponibilités :"
-          other: "%{count} lieux proposent des disponibilités :"
+          zero: Aucun lieu ne propose de créneau
+          one: "Un lieu propose des créneaux :"
+          other: "%{count} lieux proposent des créneaux :"
       selection_creneaux:
         place_index: Revenir aux filtres
         available_slots_title_html: Créneaux disponibles pour <strong>%{motif}</strong>

--- a/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
+++ b/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe "Agent can find a creneau for a rdv collectif" do
       select "Atelier participatif", from: "Motif"
       click_button "Afficher les créneaux"
 
-      expect(page).to have_content("2 lieux proposent des disponibilités")
-      click_link("Prochaine disponibilité", match: :first)
+      expect(page).to have_content("2 lieux proposent des créneaux")
+      click_link("Prochain créneau", match: :first)
 
       expect(page).to have_content("Créneaux disponibles pour atelier participatif")
     end


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1402" height="947" alt="Screenshot 2025-08-05 at 11 24 39" src="https://github.com/user-attachments/assets/a49a03fd-470c-43e2-ae4f-1dc91c1d7320" />|<img width="1396" height="911" alt="Screenshot 2025-08-05 at 11 24 05" src="https://github.com/user-attachments/assets/cc692fab-f2e8-410c-98a7-565d8dea898c" />

Dans le cadre du travail sur les motifs sans service, je me suis rendu compte que pour la recherche de créneaux côté agents, on affiche le nom du service du motif entre le nom et l'adresse de chaque lieu, ce qui n'a pas de sens.

Le but premier de cette PR était donc de supprimer ce nom de service qui n'a pas de sens, et j'en ai profité pour ajouter d'autres petits correctifs :
- des parties de cet écran utilisent le terme "créneaux" (par exemple le CTA "Afficher les créneaux"), et d'autres utilisent "disponibilités" de manière synonymes. J'ai tout uniformisé vers créneaux, puisque c'est le terme le plus utilisé dans ce parcours (on s'en sert aussi sur l'écran suivant). Par ailleurs, disponibilité est parfois utilisé comme synonyme de "plage d'ouverture", alors que le créneau est bien le résultat des plages d'ouvertures auxquelles on enlève les indispos et les rdvs déjà pris.
- Petits correctifs de marges
- Passages de boutons au dsfr

