### PR TITLE
Motifs sans service

### DIFF
--- a/app/controllers/admin/territories/motifs_controller.rb
+++ b/app/controllers/admin/territories/motifs_controller.rb
@@ -37,13 +37,19 @@ class Admin::Territories::MotifsController < Admin::Territories::BaseController
     custom_cancel_warning_message
   ].freeze
 
-  def batch_update # rubocop:disable Metrics/PerceivedComplexity
+  def batch_update # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
     @motifs = Motif.where(id: params[:motif_ids])
     @motifs.each do |motif|
       authorize(motif, :update?, policy_class: Agent::MotifPolicy)
     end
 
     permitted_params = params.permit(*UPDATABLE_ATTRS).compact_blank
+
+    # Pour permettre d'effacer les services de motifs
+    if params[:service_id] == ""
+      permitted_params[:service_id] = nil
+    end
+
     Motif.transaction do
       @motifs.each do |motif|
         motif.update(permitted_params)

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -11,7 +11,9 @@ class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
                end
     end
 
-    motifs = motifs.where(service_id: params[:service_id]) if params[:service_id].present?
+    if params.key?(:service_id) # Il est possible de filtrer les motifs sans service
+      motifs = motifs.where(service_id: params[:service_id].presence)
+    end
 
     motifs = motifs.with_motif_category_short_name(@params[:motif_category_short_name]) if params[:motif_category_short_name].present?
 

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -1,4 +1,13 @@
 module MotifsHelper
+  def sort_motifs_by_service(motifs_by_service)
+    motifs_by_service.sort_by do |service_and_motifs|
+      service, _motifs = service_and_motifs
+      service ? I18n.transliterate(service.name.downcase) : ""
+    end.sort_by do |service, _motifs|
+      service.present? ? 1 : 0 # Permet de mettre les motifs sans service au début de la liste
+    end
+  end
+
   def motif_name_and_location_type(motif)
     "#{motif.name} (#{motif.human_attribute_value(:location_type)})"
   end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -94,7 +94,7 @@ class Motif < ApplicationRecord
     available_motifs = if agent.admin_in_organisation?(organisation)
                          all
                        else
-                         where(service: agent.services)
+                         where(service: (agent.services + [nil]))
                        end
 
     if agent.secretaire?

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -36,7 +36,7 @@ class Motif < ApplicationRecord
 
   # Relations
   belongs_to :organisation
-  belongs_to :service
+  belongs_to :service, optional: true
   belongs_to :motif_category, optional: true
   has_many :rdvs, dependent: :restrict_with_exception
   has_many :motifs_plage_ouvertures, dependent: :delete_all
@@ -53,7 +53,7 @@ class Motif < ApplicationRecord
 
   # Delegates
   delegate :service_social?, to: :service
-  delegate :name, :short_name, to: :service, prefix: true
+  delegate :name, :short_name, to: :service, prefix: true, allow_nil: true
 
   # Validation
   validates :visibility_type, inclusion: { in: VISIBILITY_TYPES }
@@ -296,11 +296,13 @@ class Motif < ApplicationRecord
 
   def unique_in_org
     if Motif.active.where.not(id: id).exists?(organisation_id:, name:, service_id:, location_type:)
-      errors.add(
-        :base,
-        :duplicate_detected,
-        message: %(Il existe déjà dans #{organisation.name} un motif #{human_attribute_value(:location_type)} nommé "#{name}" pour le service #{service.name})
-      )
+      error_message = if service.present?
+                        %(Il existe déjà dans #{organisation.name} un motif #{human_attribute_value(:location_type)} nommé "#{name}" pour le service #{service.name})
+                      else
+                        %(Il existe déjà dans #{organisation.name} un motif #{human_attribute_value(:location_type)} nommé "#{name}" ouvert à tous les agents)
+                      end
+
+      errors.add(:base, :duplicate_detected, message: error_message)
     end
   end
 end

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -5,6 +5,7 @@ class Agent::MotifPolicy < ApplicationPolicy
 
   def self.agent_can_use_motif?(motif, agent)
     return false unless motif.organisation.in?(agent.organisations)
+    return true if motif.service.blank?
 
     agent.secretaire? ||
       agent_can_manage_motif?(motif, agent) ||
@@ -49,7 +50,7 @@ class Agent::MotifPolicy < ApplicationPolicy
       if current_agent.secretaire?
         scope.where(organisation_id: current_agent.organisation_ids)
       else
-        scope.where(organisation: current_agent.basic_orgs, service: current_agent.services)
+        scope.where(organisation: current_agent.basic_orgs, service: (current_agent.services + [nil]))
           .or(scope.where(organisation: current_agent.admin_orgs))
       end
     end

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -129,10 +129,14 @@ class Agent::RdvPolicy < ApplicationPolicy
     when AgentRole::ACCESS_LEVEL_ADMIN
       true
     when AgentRole::ACCESS_LEVEL_BASIC
-      same_service? || current_agent.secretaire?
+      same_service? || rdv_without_service? || current_agent.secretaire?
     else
       false
     end
+  end
+
+  def rdv_without_service?
+    @record.motif.service_id.nil?
   end
 
   class Scope < Scope
@@ -149,6 +153,7 @@ class Agent::RdvPolicy < ApplicationPolicy
           .joins(:motif, :agents_rdvs)
           .where(
             "agents_rdvs.agent_id = ?
+              OR motifs.service_id is null
               OR (motifs.service_id IN (?) AND agent_roles.access_level = 'basic')
               OR (agent_roles.access_level = 'admin')",
             current_agent.id, current_agent.service_ids

--- a/app/services/agent_prescription_search_context.rb
+++ b/app/services/agent_prescription_search_context.rb
@@ -33,7 +33,7 @@ class AgentPrescriptionSearchContext < WebSearchContext
 
   def filter_motifs(available_motifs)
     motifs = super
-    restrict_agent_services? ? motifs.where(service: @agent_prescripteur.services) : motifs
+    restrict_agent_services? ? motifs.where(service: @agent_prescripteur.services + [nil]) : motifs
   end
 
   def restrict_agent_services?

--- a/app/services/creneau_wizard_for_users/steps/motif_selection.rb
+++ b/app/services/creneau_wizard_for_users/steps/motif_selection.rb
@@ -8,7 +8,11 @@ class CreneauWizardForUsers::Steps::MotifSelection
   end
 
   def services
-    @services ||= @context.matching_motifs.includes(:service).map(&:service).uniq.sort_by { |service| I18n.transliterate(service.name.downcase) }
+    @services ||= @context.matching_motifs.includes(:service).map(&:service).uniq.sort_by do |service|
+      service ? I18n.transliterate(service.name.downcase) : "Autres"
+    end.sort_by do |service|
+      service.present? ? 0 : 1 # Cette ligne permet de mettre les motifs sans service à la fin de la liste
+    end
   end
 
   def follow_up_motifs?

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -29,9 +29,10 @@
             = f.input :motif_id, \
               required: true, \
               include_blank: true, \
-              collection: @motifs.includes(:service).to_a.group_by(&:service_name), \
+              collection: sort_motifs_by_service(@motifs.to_a.group_by(&:service)), \
               as: :grouped_select, \
               group_method: :last,
+              group_label_method: -> { _1.first&.name },
               label_method: -> { motif_name_and_location_type(_1) }, \
               input_html: { \
                 data: { placeholder: "Sélectionnez un motif" }, \

--- a/app/views/admin/motifs/form/_configuration_principale.html.slim
+++ b/app/views/admin/motifs/form/_configuration_principale.html.slim
@@ -22,11 +22,11 @@ p
             option= org_name
     .form-row
       .col-md-12
-        = f.association :service, label: fake_required_label("Service associé"), collection: current_territory.services.reject(&:secretariat?), required: false, input_html: { \
+        = f.association :service, label: "Service associé", collection: current_territory.services.reject(&:secretariat?), required: false, input_html: { \
           class: "select2-input", \
           data: { \
             placeholder: "Sélectionnez le service auquel le motif sera associé", \
-            "select2-config": { disableSearch: true }, \
+            "select2-config": { disableSearch: true, allowClear: true }, \
             "auto-select-sole-option": true,
           }, \
         }

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -12,7 +12,10 @@
     .card.mt-2
       .card-body
         = motif_attribute_row(Motif.human_attribute_name(:name), @motif.name)
-        = motif_attribute_row(Motif.human_attribute_name(:service), @motif.service_name)
+        = motif_attribute_row(Motif.human_attribute_name(:service)) do
+          = @motif.service_name
+          - if @motif.service.blank?
+            span.text-muted= I18n.t("admin.motifs.motif_without_service_explanation")
         - if @motif.motif_category.present?
           = motif_attribute_row(MotifCategory.model_name.human, @motif.motif_category.name)
         = motif_attribute_row \

--- a/app/views/admin/planning/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_form.html.slim
@@ -15,11 +15,15 @@
             = collapsible_form_fields_for_warnings(plage_ouverture) do
               = f.hidden_field :agent_id
               - motifs_by_services = plage_ouverture.available_motifs.group_by(&:service)
-              - motifs_by_services.each do |service, motifs|
+              - sort_motifs_by_service(motifs_by_services).each do |service, motifs|
                 .form-group data-controller="checkbox-select-all"
                   label.h4.d-flex
                     input.mr-1 type="checkbox" data-checkbox-select-all-target="checkboxAll"
-                    span.cursor-pointer Motifs de #{service.name}
+                    span.cursor-pointer
+                      - if service
+                        | Motifs de #{service.name}
+                      - else
+                        | Motifs ouverts à tous les agents
                   - motifs.each do |motif|
                     .pl-4
                       = f.check_box :motif_ids, { multiple: true, class: "form-check-input #{motif.location_type}", data: { checkbox_select_all_target: "checkbox" } }, motif.id, false

--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -27,9 +27,10 @@
         label: "Motif du rendez-vous", \
         required: true, \
         include_blank: true, \
-        collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
+        collection: sort_motifs_by_service(@motifs.to_a.group_by(&:service)), \
         as: :grouped_select, \
         group_method: :last,
+        group_label_method: -> { _1.first&.name },
         label_method: -> { motif_name_with_location_and_group_type(_1) }, \
         input_html: { \
           data: { placeholder: "Sélectionnez un motif", "auto-select-sole-option": true },

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -61,7 +61,7 @@
     .col-md-6
       = f.input :motif_ids,
             label: "Motifs",
-            collection: @motifs.includes(:service).to_a.group_by { _1.service.name },
+            collection: @motifs.includes(:service).to_a.group_by(&:service_name), \
             as: :grouped_select,
             group_method: :last,
             label_method: ->(motif) { motif_name_with_location_type_and_status(motif) },

--- a/app/views/admin/territories/motifs/batch_edit.html.slim
+++ b/app/views/admin/territories/motifs/batch_edit.html.slim
@@ -36,11 +36,11 @@ h1 Modification en masse de #{@motifs.size} motifs
         p.mb-1 Ces motifs sont associés à des services différents :
         ul.mt-0
           - unique_values.sort_by(&:last).reverse.each do |value, nb_of_occurrences|
-            li #{value.name} (#{nb_of_occurrences})
+            li #{value&.name || "Pas de service"} (#{nb_of_occurrences})
       - else
         small.form-text.text-muted.mb-2 Ces #{@motifs.size} motifs sont associés au même service
       .input-group
-        = f.select :service_id, current_territory.services.reject(&:secretariat?).map { [_1.name, _1.id] }, { selected: (unique_values.size > 1 ? "" : unique_values.keys.first.id), include_blank: true, required: true }, { class: "custom-select" }
+        = f.select :service_id, current_territory.services.reject(&:secretariat?).map { [_1.name, _1.id] } + [["Pas de service", nil]], { selected: (unique_values.size > 1 ? "" : unique_values.keys.first&.id || ""), include_blank: true, required: true }, { class: "custom-select" }
         .input-group-append
           = f.submit "Appliquer à ces #{@motifs.size} motifs", class: "fr-btn"
 

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -2,17 +2,14 @@
 
 - content_for :title, "Sélectionnez le service"
 
-- if motif_selection_service.unique_motifs_by_name_and_location_type.empty?
-  = render "search/nothing_to_show", context: context
-- else
-  p.fr-text--lg Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
-  // Nous n’utilisons pas le composant du DSFR view component car nous avons changé la typo des titres d’accordéon
-  .fr-accordions-group.fr-mb-5w[data-fr-group="true"]
-    - motif_selection_service.services.each do |service|
-      section.fr-accordion
-        h2.fr-accordion__title
-          button.fr-accordion__btn.fr-text--lead type="button" aria-expanded="false" aria-controls="fr-accordion-#{service.id}" = service.name
-        .fr-collapse id="fr-accordion-#{service.id}"
-          ul.fr-raw-list
-            - motif_selection_service.motifs_grouped_by_service_id[service.id].uniq(&:name_with_location_type).sort_by { |motif| I18n.transliterate(motif.name.downcase)}.each do |motif|
-              = render "search/motif_card", context: context, motif: motif
+p.fr-text--lg Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
+// Nous n’utilisons pas le composant du DSFR view component car nous avons changé la typo des titres d’accordéon
+.fr-accordions-group.fr-mb-5w[data-fr-group="true"]
+  - motif_selection_service.services.each do |service|
+    section.fr-accordion
+      h2.fr-accordion__title
+        button.fr-accordion__btn.fr-text--lead type="button" aria-expanded="false" aria-controls="fr-accordion-#{service&.id || "all"}" = service&.name || "Autres"
+      .fr-collapse id="fr-accordion-#{service&.id || "all"}"
+        ul.fr-raw-list
+          - motif_selection_service.motifs_grouped_by_service_id[service&.id].uniq(&:name_with_location_type).sort_by { |motif| I18n.transliterate(motif.name.downcase)}.each do |motif|
+            = render "search/motif_card", context: context, motif: motif

--- a/config/locales/views/admin_motifs.fr.yml
+++ b/config/locales/views/admin_motifs.fr.yml
@@ -9,6 +9,7 @@ fr:
         agents_and_prescripteurs_and_invited_users: Par les agents, prescripteurs et les usagers sur invitation
         everyone: Par les agents, prescripteurs et les usagers
       archiving_explanation: "Nouveau : vous pouvez désormais archiver les motifs que vous ne souhaitez plus utiliser. Un motif archivé ne sera plus proposé lors de la prise de RDV. Il peut être réactivé à tout moment ou supprimé définitivement si aucun RDV n'est rattaché."
+      motif_without_service_explanation: "Ce motif n'est pas limité à un service en particulier, et peut donc être utilisé par n'importe quel agent de votre organisation."
       actions:
         new: Créer un motif
         batch_edit: Modifier les motifs

--- a/spec/controllers/admin/api/agenda/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/api/agenda/rdvs_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Admin::Api::Agenda::RdvsController, type: :controller do
         it "does not show any info about the RDV and does not provide a link" do
           other_org = create(:organisation)
           given_agent = create(:agent, basic_role_in_organisations: [organisation, other_org], service: current_agent.services.first)
-          motif_of_other_org = create(:motif, organisation: other_org, service: current_agent.services.first)
+          motif_of_other_org = create(:motif, organisation: other_org)
           rdv_of_another_org_same_service = create(:rdv, agents: [given_agent], organisation: other_org, starts_at: aujourdhui_lundi_15h, motif: motif_of_other_org)
           get :index, params: fullcalendar_time_range_params.merge(agent_id: given_agent.id, organisation_id: organisation.id, format: :json)
           expect(response.parsed_body.size).to eq(1)

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
 
   factory :motif do
     organisation { association(:organisation) }
-    service { association(:service) }
     motif_category { association(:motif_category) }
 
     name { generate(:motif_name) }
@@ -17,6 +16,10 @@ FactoryBot.define do
 
     trait :at_home do
       location_type { :home }
+    end
+
+    trait :with_service do
+      service { association(:service) }
     end
 
     trait :at_public_office do

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe "public pages", driver: :playwright_bypass_csp, js: true do
           service_id: motif.service_id
         )
         visit path
-        expect(page).to have_content("Sélectionnez le motif de votre RDV")
+
+        expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV :")
 
         expect_page_to_be_axe_clean(path)
       end
@@ -161,7 +162,7 @@ RSpec.describe "public pages", driver: :playwright_bypass_csp, js: true do
             service_id: motif.service_id
           )
           visit path
-          expect(page).to have_content("Sélectionnez le motif de votre RDV")
+          expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
 
           expect_page_to_be_axe_clean(path)
         end

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
     let!(:lieu) { create(:lieu, organisation: organisation) }
     let!(:motif) { create(:motif, service: agent.services.first, organisation: organisation) }
     let!(:motif2) { create(:motif, service: agent.services.first, organisation: organisation) }
+    let!(:motif_without_service) { create(:motif, service: nil, organisation: organisation) }
     let!(:another_service) { create(:service) }
     let!(:another_agent) { create(:agent, service: another_service, basic_role_in_organisations: [organisation]) }
     let!(:another_lieu) { create(:lieu, organisation: organisation) }
@@ -147,6 +148,22 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
       let!(:motif) { create(:motif, :at_home, service: agent.services.first, organisation: organisation) }
 
       it_behaves_like "book a rdv without a lieu"
+    end
+  end
+
+  context "when the motif doesn't have a service" do
+    let!(:motif) { create(:motif, service: nil, organisation: organisation) }
+    let!(:motif2) { create(:motif, service: agent.services.first, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, motifs: [motif], agent: agent, organisation: organisation) }
+
+    it "displays lieux and allow filtering on lieux" do
+      visit admin_organisation_creneaux_search_path(organisation)
+      expect(page).to have_content("Trouver un RDV")
+      select(motif.name, from: "motif_id")
+      click_button("Afficher les créneaux")
+
+      # Display results for both lieux
+      expect(page).to have_content(plage_ouverture.lieu_address)
     end
   end
 end

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -224,4 +224,19 @@ RSpec.describe "Agent can create a Rdv with wizard" do
       expect(page).to have_content("Le rendez-vous a été créé.")
     end
   end
+
+  describe "with a motif without a service" do
+    let!(:motif) { create(:motif, :collectif, :at_public_office, service: nil, organisation: organisation, name: "Super Motif") }
+
+    it "works", js: true do
+      step1
+      step2
+      step3(:enabled)
+      step4
+      expect(page).to have_content("Le rendez-vous a été créé.")
+
+      rdv = user.rdvs.first
+      expect(rdv.motif).to eq(motif)
+    end
+  end
 end

--- a/spec/features/agents/agent_can_crud_motifs_spec.rb
+++ b/spec/features/agents/agent_can_crud_motifs_spec.rb
@@ -8,39 +8,71 @@ RSpec.describe "Agent can CRUD motifs" do
     login_as(agent, scope: :agent)
   end
 
-  it "works" do
-    visit authenticated_agent_root_path
-    click_link "Configuration"
-    click_link "Motifs"
-    expect_page_title("Motifs de rendez-vous")
-    click_link motif.name
+  context "with a service" do
+    it "works" do
+      visit authenticated_agent_root_path
+      click_link "Configuration"
+      click_link "Motifs"
+      expect_page_title("Motifs de rendez-vous")
+      click_link motif.name
 
-    expect(page).to have_content(motif.name)
-    click_link "Modifier"
+      expect(page).to have_content(motif.name)
+      click_link "Modifier"
 
-    expect_page_title("Modifier le motif")
-    fill_in "Nom", with: "Suivi bonsoir"
-    click_button("Enregistrer")
+      expect_page_title("Modifier le motif")
+      fill_in "Nom", with: "Suivi bonsoir"
+      click_button("Enregistrer")
 
-    expect(page).to have_content("Suivi bonsoir (PMI)")
-    click_link("Archiver")
-    expect(page).to have_content("Suivi bonsoir (PMI) (archivé)")
-    click_link("Supprimer")
+      expect(page).to have_content("Suivi bonsoir (PMI)")
+      click_link("Archiver")
+      expect(page).to have_content("Suivi bonsoir (PMI) (archivé)")
+      click_link("Supprimer")
 
-    expect_page_title("Motifs de rendez-vous")
-    expect(page).to have_content("Vous n'avez pas encore créé de motif.")
-    click_link "Créer un motif", match: :first
+      expect_page_title("Motifs de rendez-vous")
+      expect(page).to have_content("Vous n'avez pas encore créé de motif.")
+      click_link "Créer un motif", match: :first
 
-    expect_page_title("Créer un motif")
-    ## Check secretariat is unavailable
-    expect(page.all("select#motif_service_id option").map(&:value)).to contain_exactly("", service.id.to_s)
-    find("#motif_service_id").find(:option, service.name).select_option
-    fill_in "Nom", with: "Suivi bonne nuit"
-    fill_in "Couleur associée", with: "#000"
-    click_button "Créer le motif"
+      expect_page_title("Créer un motif")
+      ## Check secretariat is unavailable
+      expect(page.all("select#motif_service_id option").map(&:value)).to contain_exactly("", service.id.to_s)
+      find("#motif_service_id").find(:option, service.name).select_option
+      fill_in "Nom", with: "Suivi bonne nuit"
+      fill_in "Couleur associée", with: "#000"
+      click_button "Créer le motif"
 
-    expect_page_title("Motifs de rendez-vous")
-    expect(page).to have_content("Suivi bonne nuit")
+      expect_page_title("Motifs de rendez-vous")
+      expect(page).to have_content("Suivi bonne nuit")
+    end
+  end
+
+  context "without a service" do
+    let!(:motif) { nil }
+
+    it "works" do
+      visit new_admin_organisation_motif_path(organisation_id: organisation.id)
+
+      expect_page_title("Créer un motif")
+
+      fill_in "Nom", with: "Demande de permis de construire"
+      fill_in "Couleur associée", with: "#000"
+      click_button "Créer le motif"
+
+      expect_page_title("Motifs de rendez-vous")
+
+      expect(organisation.motifs.count).to eq 1
+      expect(page).to have_content("Demande de permis de construire")
+
+      click_link "Modifier"
+
+      expect_page_title("Modifier le motif")
+      fill_in "Nom", with: "Renouvellement de permis de construire"
+      click_button("Enregistrer")
+
+      expect(page).to have_content("Renouvellement de permis de construire")
+      click_link("Archiver")
+      expect(page).to have_content("Renouvellement de permis de construire (archivé)")
+      click_link("Supprimer")
+    end
   end
 
   describe "new" do
@@ -48,7 +80,6 @@ RSpec.describe "Agent can CRUD motifs" do
       visit new_admin_organisation_motif_path(organisation_id: organisation.id)
       click_on "Créer le motif"
       expect(page).to have_content("Nom doit être rempli(e)")
-      expect(page).to have_content("Service doit exister")
     end
   end
 
@@ -56,10 +87,8 @@ RSpec.describe "Agent can CRUD motifs" do
     it "displays errors when name and service are missing" do
       visit edit_admin_organisation_motif_path(organisation_id: organisation.id, id: motif.id)
       fill_in "Nom", with: ""
-      select "", from: "Service associé"
       click_on "Enregistrer"
       expect(page).to have_content("Nom doit être rempli(e)")
-      expect(page).to have_content("Service doit exister")
     end
 
     it "unchecks for_secretariat when checking followup", js: true do

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
 
       it_behaves_like "can crud own plage ouvertures"
     end
+
+    context "for a motif without a service" do
+      let!(:motif) { create(:motif, name: "Suivi bonjour", service: nil, organisation: organisation) }
+
+      it_behaves_like "can crud own plage ouvertures"
+    end
   end
 
   context "for a secretaire" do

--- a/spec/features/agents/agent_can_duplicate_motif_spec.rb
+++ b/spec/features/agents/agent_can_duplicate_motif_spec.rb
@@ -2,14 +2,12 @@ RSpec.describe "agent can duplicate motif" do
   let(:territory) { create(:territory).tap { _1.motif_categories << create(:motif_category, name: "Cat de motif") } }
   let(:organisation) { create(:organisation, territory: territory) }
   let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-  let(:motif_service) { create(:service, name: "Service du motif à dupliquer") }
 
   let(:existing_motif) do
     create(
       :motif,
       organisation: organisation,
       motif_category: territory.motif_categories.first,
-      service: motif_service,
       name: "Motif à créer 18 fois",
       default_duration_in_min: 28,
       color: "#00ffff",
@@ -25,10 +23,6 @@ RSpec.describe "agent can duplicate motif" do
       instruction_for_rdv: "Venez très très très tôt",
       custom_cancel_warning_message: "Êtes-vous sûr d'être certain ?"
     )
-  end
-
-  before do
-    organisation.territory.services << motif_service
   end
 
   it "works" do
@@ -52,7 +46,7 @@ RSpec.describe "agent can duplicate motif" do
   context "when agent is in multiple organisations" do
     let(:other_organisation) { create(:organisation, name: "Mon autre orga", territory: territory) }
     let!(:motif_in_other_orga) do
-      create(:motif, organisation: other_organisation, name: existing_motif.name, service: existing_motif.service, location_type: existing_motif.location_type)
+      create(:motif, organisation: other_organisation, name: existing_motif.name, location_type: existing_motif.location_type)
     end
 
     before do

--- a/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe "Agent can manage recurrence on plage d'ouverture" do
   let!(:organisation) { create(:organisation) }
-  let!(:service) { create(:service) }
-  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
-  let!(:motif) { create(:motif, name: "Suivi bonjour", organisation: organisation, service: service, location_type: :phone) }
+  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+  let!(:motif) { create(:motif, name: "Suivi bonjour", organisation: organisation, location_type: :phone) }
   let!(:plage_ouverture) { create(:plage_ouverture, agent: agent, organisation: organisation, first_day: Time.zone.local(2019, 12, 3)) }
 
   before do

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -391,6 +391,23 @@ RSpec.describe "agents can prescribe rdvs" do
         expect(page).to have_content(service_rsa.name)
         expect(page).not_to have_content(service_autre.name)
       end
+
+      context "and the motif doesn't have a service" do
+        let!(:motif_sans_service) { create(:motif, organisation: org_mds, service: nil) }
+
+        before do
+          next_month = (now + 1.month).to_date
+          create(:plage_ouverture, :weekdays, first_day: next_month, motifs: [motif_sans_service], lieu: mds_paris_nord, organisation: org_mds)
+        end
+
+        it "shows the motif" do
+          go_to_prescription_page
+          expect(page).to have_content(motif_sans_service.name)
+
+          expect(page).to have_content(service_rsa.name)
+          expect(page).not_to have_content(service_autre.name)
+        end
+      end
     end
   end
 end

--- a/spec/features/agents/agent_can_see_users_rdv_spec.rb
+++ b/spec/features/agents/agent_can_see_users_rdv_spec.rb
@@ -1,10 +1,8 @@
 RSpec.describe "can see users' RDV" do
   context "with no RDV" do
     let!(:organisation) { create(:organisation) }
-    let!(:service) { create(:service) }
-    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:user) { create(:user, first_name: "Tanguy", last_name: "Laverdure", organisations: [organisation]) }
-    let!(:motif) { create(:motif, organisation: organisation, service: service) }
 
     it do
       login_as(agent, scope: :agent)
@@ -19,7 +17,7 @@ RSpec.describe "can see users' RDV" do
     let!(:service) { create(:service) }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
     let!(:user) { create(:user, first_name: "Tanguy", last_name: "Laverdure", organisations: [organisation]) }
-    let!(:motif) { create(:motif, organisation: organisation, service: service) }
+    let!(:motif) { create(:motif, organisation: organisation) }
 
     let!(:rdv) { create :rdv, :future, users: [user], organisation: organisation, motif: motif, agents: [agent] }
 

--- a/spec/features/agents/agent_can_update_rdv_spec.rb
+++ b/spec/features/agents/agent_can_update_rdv_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe "Agent can update a RDV", js: true do
   let(:rdv) do
     create(:rdv, organisation: organisation, motif: motif, agents: [agent_shiraz], lieu: lieu, starts_at:, ends_at:)
   end
-  let!(:service) { create(:service, name: "Urbanisme") }
-  let!(:agent_shiraz) { create(:agent, first_name: "Shiraz", last_name: "NADIR", email: "shiraz@angouleme.fr", service:, basic_role_in_organisations: [organisation]) }
-  let!(:motif) { create(:motif, service: service, organisation: organisation) }
+  let!(:agent_shiraz) { create(:agent, first_name: "Shiraz", last_name: "NADIR", email: "shiraz@angouleme.fr", basic_role_in_organisations: [organisation]) }
+  let!(:motif) { create(:motif, organisation: organisation) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let(:starts_at) { 1.hour.from_now }
   let(:ends_at) { starts_at + 1.hour }
@@ -79,7 +78,7 @@ RSpec.describe "Agent can update a RDV", js: true do
   end
 
   context "ajout d’un agent au RDV" do
-    let!(:agent_jungyoon) { create(:agent, first_name: "Jung Yoon", last_name: "Han", email: "jungyoon@angouleme.fr", service:, basic_role_in_organisations: [organisation]) }
+    let!(:agent_jungyoon) { create(:agent, first_name: "Jung Yoon", last_name: "Han", email: "jungyoon@angouleme.fr", basic_role_in_organisations: [organisation]) }
 
     it "envoie un email à l’agent ajouté", skip: "cf PR #5399" do # rubocop:disable RSpec/Pending
       visit edit_admin_organisation_rdv_path(organisation, rdv)
@@ -102,7 +101,7 @@ RSpec.describe "Agent can update a RDV", js: true do
 
       it "affiche un avertissement, une fois contourné l’agent est bien ajouté" do
         visit edit_admin_organisation_rdv_path(organisation, rdv)
-        select("Jung Yoon HAN (Urbanisme)", from: "rdv_agent_ids")
+        select("Jung Yoon HAN", from: "rdv_agent_ids")
         click_button "Enregistrer"
         expect(page).to have_content "Ce rendez-vous en chevauche un autre"
         expect(rdv.reload.agents).to contain_exactly(agent_shiraz)

--- a/spec/features/agents/disabled_fields_spec.rb
+++ b/spec/features/agents/disabled_fields_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe "some fields that are specific to a certain domain can be disabled and hidden from the interface" do
   let!(:organisation) { create(:organisation, territory: territory) }
-  let!(:service) { create(:service) }
-  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
   let!(:user) { create(:user, organisations: [organisation]) }
   let(:territory) do
     create(:territory, enable_affiliation_number_field: true)

--- a/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
+++ b/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
@@ -1,10 +1,9 @@
 RSpec.describe "Agent can find a creneau for a rdv collectif" do
-  let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:motif) do
-    create(:motif, :collectif, name: "Atelier participatif", organisation: organisation, service: service)
+    create(:motif, :collectif, name: "Atelier participatif", organisation: organisation)
   end
   let(:organisation) { create(:organisation) }
-  let!(:service) { create(:service) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:rdv) do
     create(:rdv, motif: motif, organisation: organisation, agents: [agent], max_participants_count: 5, lieu: lieu)

--- a/spec/features/agents/rdv_details_spec.rb
+++ b/spec/features/agents/rdv_details_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Agent can see RDV details correctly" do
 
   context "Motif is not collective" do
     let(:user) { create(:user, organisations: [organisation]) }
-    let(:motif) { create(:motif, service: service, name: "Renseignements", organisation:) }
+    let(:motif) { create(:motif, name: "Renseignements", organisation:) }
     let(:rdv) { create(:rdv, agents: [agent], users: [user], motif: motif, organisation: organisation, starts_at: starts_at) }
     let!(:receipt) { create(:receipt, rdv: rdv, result: :sent, content: "Vous avez rendez-vous!") }
     let(:prescripteur) { create(:prescripteur, first_name: "Jean", last_name: "Valjean") }
@@ -119,7 +119,7 @@ RSpec.describe "Agent can see RDV details correctly" do
     let(:user) { create(:user, organisations: [organisation]) }
     let(:user2) { create(:user, organisations: [organisation]) }
     let(:user3) { create(:user, organisations: [organisation]) }
-    let(:motif) { create(:motif, :collectif, service: service, name: "Atelier Colectif", organisation:) }
+    let(:motif) { create(:motif, :collectif, name: "Atelier Colectif", organisation:) }
     let(:rdv) { create(:rdv, agents: [agent], users: [user, user2, user3], motif: motif, organisation: organisation, starts_at: starts_at, max_participants_count: 3) }
     let!(:receipt) { create(:receipt, rdv: rdv, result: :sent, content: "Vous avez rendez-vous!") }
 
@@ -147,7 +147,7 @@ RSpec.describe "Agent can see RDV details correctly" do
   end
 
   context "when the rdv is by visio" do
-    let(:motif) { create(:motif, service: service, location_type: :visio, organisation:) }
+    let(:motif) { create(:motif, location_type: :visio, organisation:) }
     let(:user) { create(:user, organisations: [organisation]) }
 
     context "when the agent participates in the rdv" do

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
@@ -2,9 +2,8 @@ RSpec.describe "Agent can create a Rdv collectif from the agenda" do
   include UsersHelper
 
   let!(:organisation) { create(:organisation) }
-  let!(:service) { create(:service) }
-  let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", email: "alain@tiptop.fr", service: service, basic_role_in_organisations: [organisation]) }
-  let!(:motif) { create(:motif, :collectif, name: "Atelier administratif", service: service, organisation: organisation) }
+  let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", email: "alain@tiptop.fr", basic_role_in_organisations: [organisation]) }
+  let!(:motif) { create(:motif, :collectif, name: "Atelier administratif", organisation: organisation) }
 
   let!(:user1) { create(:user, organisations: [organisation]) }
   let!(:user2) { create(:user, organisations: [organisation]) }

--- a/spec/features/agents/rdvs_collectifs/agent_can_edit_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_edit_rdv_collectif_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe "Agent can edit a Rdv collectif" do
   let!(:organisation) { create(:organisation) }
-  let!(:service) { create(:service) }
-  let!(:agent) { create(:agent, service: service, admin_role_in_organisations: [organisation]) }
-  let!(:motif) { create(:motif, :collectif, service: service, organisation: organisation, name: "Atelier Collectif") }
+  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+  let!(:motif) { create(:motif, :collectif, organisation: organisation, name: "Atelier Collectif") }
   let(:rdv) do
     create(:rdv,
            :without_users,

--- a/spec/features/agents/rdvs_collectifs/duplicating_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/duplicating_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe "Agent can duplicate a Rdv collectif" do
   let!(:organisation) { create(:organisation) }
-  let!(:service) { create(:service) }
-  let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", service: service, admin_role_in_organisations: [organisation]) }
-  let!(:motif) { create(:motif, :collectif, service: service, organisation: organisation, name: "Atelier Collectif") }
+  let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", admin_role_in_organisations: [organisation]) }
+  let!(:motif) { create(:motif, :collectif, organisation: organisation, name: "Atelier Collectif") }
 
   let(:original_rdv) do
     create(:rdv, motif: motif, organisation: organisation, agents: [agent], name: "Traitement de texte", context: "Apportez votre ordinateur")
@@ -34,7 +33,7 @@ RSpec.describe "Agent can duplicate a Rdv collectif" do
 
   describe "when trying to duplicate a RDV the agent doesn't have access to" do
     let(:other_organisation) { create(:organisation) }
-    let!(:motif_other_organisation) { create(:motif, :collectif, service: service, organisation: other_organisation, name: "Atelier Collectif") }
+    let!(:motif_other_organisation) { create(:motif, :collectif, organisation: other_organisation, name: "Atelier Collectif") }
     let(:rdv_for_other_organisation) do
       create(:rdv, motif: motif_other_organisation, organisation: other_organisation, name: "Traitement de texte")
     end

--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -1,10 +1,9 @@
 RSpec.describe "Agent can organize a rdv collectif", js: true do
-  let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service, first_name: "Alain", last_name: "DIALO") }
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation], first_name: "Alain", last_name: "DIALO") }
   let!(:motif) do
-    create(:motif, :collectif, name: "Atelier participatif", organisation: organisation, service: service)
+    create(:motif, :collectif, name: "Atelier participatif", organisation: organisation)
   end
   let(:organisation) { create(:organisation) }
-  let!(:service) { create(:service) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
 
   let!(:user1) { create(:user, organisations: [organisation]) }

--- a/spec/features/agents/renseigner_rdv_spec.rb
+++ b/spec/features/agents/renseigner_rdv_spec.rb
@@ -1,9 +1,8 @@
 RSpec.describe "Les agents peuvent renseigner le statut des rendez-vous pour nous permettre de mesurer notre impact" do
   let(:agent) { create(:agent, basic_role_in_organisations: [organisation], services: [service]) }
   let(:organisation) { create(:organisation) }
-  let(:service) { create(:service) }
   let!(:rdv) do
-    create(:rdv, :past, status: :unknown, agents: [agent], motif: create(:motif, service: service, organisation:), organisation: organisation)
+    create(:rdv, :past, status: :unknown, agents: [agent], motif: create(:motif, organisation:), organisation: organisation)
   end
 
   before { login_as(agent, scope: :agent) }

--- a/spec/features/agents/renseigner_rdv_spec.rb
+++ b/spec/features/agents/renseigner_rdv_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Les agents peuvent renseigner le statut des rendez-vous pour nous permettre de mesurer notre impact" do
-  let(:agent) { create(:agent, basic_role_in_organisations: [organisation], services: [service]) }
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let(:organisation) { create(:organisation) }
   let!(:rdv) do
     create(:rdv, :past, status: :unknown, agents: [agent], motif: create(:motif, organisation:), organisation: organisation)

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
   end
 
   it "adds validation when trying to create a rdv without email or phone number", js: true do
-    motif = create(:motif, organisation: organisation, location_type: :visio, service: service, name: "Accompagnement RSA")
+    motif = create(:motif, organisation: organisation, location_type: :visio, name: "Accompagnement RSA")
 
     visit new_admin_organisation_rdv_wizard_step_path(organisation_id: organisation.id)
     select(motif.name, from: "Motif du rendez-vous")

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_in_rdv_mairie_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_in_rdv_mairie_spec.rb
@@ -3,12 +3,11 @@ RSpec.describe "prescripteur can create RDV for a user" do
 
   let(:now) { Time.zone.parse("2021-12-13 8:00") }
   let!(:organisation) { create(:organisation, :with_contact, ants_connectable: true) }
-  let(:service) { create(:service) }
   let!(:cni_motif) do
-    create(:motif, name: "Carte d'identité", organisation: organisation, restriction_for_rdv: nil, service: service, motif_category: cni_motif_category)
+    create(:motif, name: "Carte d'identité", organisation: organisation, restriction_for_rdv: nil, motif_category: cni_motif_category)
   end
   let!(:passport_motif) do
-    create(:motif, name: "Passeport", organisation: organisation, restriction_for_rdv: nil, service: service, motif_category: passport_motif_category)
+    create(:motif, name: "Passeport", organisation: organisation, restriction_for_rdv: nil, motif_category: passport_motif_category)
   end
 
   let!(:cni_motif_category) { create(:motif_category, name: Api::Ants::EditorController::CNI_MOTIF_CATEGORY_NAME) }

--- a/spec/features/territory_admins/territory_admin_can_manage_motifs_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_motifs_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe "territory admin can manage motifs", type: :feature do
   describe "Listing motifs" do
     let!(:org_arques) { create(:organisation, name: "Arques", territory: territory) }
     let!(:org_bapaume) { create(:organisation, name: "Bapaume", territory: territory) }
-    let!(:motif_consultation_prenatale) { create(:motif, name: "Consultation prénatale", organisation: org_arques) }
-    let!(:motif_suivi_apres_naissance) { create(:motif, name: "Suivi après naissance", organisation: org_bapaume) }
+    let!(:motif_consultation_prenatale) { create(:motif, name: "Consultation prénatale", organisation: org_arques, service: pmi) }
+    let!(:motif_suivi_apres_naissance) { create(:motif, name: "Suivi après naissance", organisation: org_bapaume, service: pmi) }
+    let!(:motif_sans_service) { create(:motif, name: "Orientation", organisation: org_bapaume, service: nil) }
+    let(:pmi) { create(:service, name: "PMI") }
 
     before do
       agent.roles.create!(organisation: org_arques, access_level: AgentRole::ACCESS_LEVEL_ADMIN)
@@ -201,6 +203,22 @@ RSpec.describe "territory admin can manage motifs", type: :feature do
           click_on "Appliquer"
           expect(motif_a.reload.service).to eq(service_social)
           expect(motif_b.reload.service).to eq(service_social)
+        end
+      end
+
+      describe "removing the service" do
+        let(:motif_sans_service) { create(:motif, organisation: organisation_a, service: nil) }
+
+        it "works" do
+          visit batch_edit_admin_territory_motifs_path(territory_id: territory.id, motif_ids: [motif_a.id, motif_b.id, motif_sans_service.id])
+
+          within("#service_form") do
+            select "Pas de service", from: "Service"
+            click_on "Appliquer"
+            expect(motif_a.reload.service).to be_nil
+            expect(motif_b.reload.service).to be_nil
+            expect(motif_sans_service.reload.service).to be_nil
+          end
         end
       end
     end

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -445,6 +445,24 @@ RSpec.describe "User can search for rdvs" do
     end
   end
 
+  context "pour un motif sans service" do
+    let!(:motif) { create(:motif, name: "Vaccination", organisation: organisation, service: nil, location_type: Motif.location_types[:visio]) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [motif], organisation: organisation) }
+    let(:organisation) { create(:organisation) }
+
+    it "permet de prendre rendez-vous" do
+      visit public_link_to_org_path(organisation_id: organisation.id)
+      click_on "Vaccination"
+      click_on "Prochaine disponibilité"
+      first(:link, "08:00").click
+      sign_up
+      click_on "Continuer"
+      click_on "Continuer"
+      click_on "Confirmer"
+      expect(page).to have_content "Votre rendez vous a été confirmé."
+    end
+  end
+
   private
 
   def execute_search

--- a/spec/features/users/online_booking/motif_selection_spec.rb
+++ b/spec/features/users/online_booking/motif_selection_spec.rb
@@ -51,4 +51,29 @@ RSpec.describe "Motif selection" do
       expect(page).to have_content("Sélectionnez le motif")
     end
   end
+
+  context "un motif avec service et un motif sans service" do
+    let(:organisation) { create(:organisation) }
+    let(:service) { create(:service, name: "Action Sociale") }
+    let(:lieu) { create(:lieu, organisation: organisation, name: "MDS Centre") }
+    let!(:motif_avec_service) { create(:motif, name: "RSA", organisation: organisation, service: service) }
+    let!(:motif_sans_service) { create(:motif, name: "Orientation", organisation: organisation, service: nil) }
+    let!(:plage_ouverture) do
+      create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [motif_avec_service, motif_sans_service], lieu: lieu, organisation: organisation)
+    end
+
+    it "permet d'ouvrir et de fermer l'accordéon", js: true do
+      visit prendre_rdv_path(departement: organisation.territory.departement_number)
+      expect(page).not_to have_content("Orientation")
+      click_on("Autres")
+      sleep 0.5 # Pour attendre le temps de l'animation css
+
+      expect(page).to have_content("Orientation")
+
+      click_on("Autres")
+      sleep 0.5 # Pour attendre le temps de l'animation css
+
+      expect(page).not_to have_content("Orientation")
+    end
+  end
 end

--- a/spec/features/users/user_can_manage_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_rdv_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "User can manage their rdvs" do
           # User change the date
           click_link("Déplacer le RDV")
           first(:link, "11:00").click
-          expect(page).to have_content("Vous allez modifier votre RDV #{motif.name} - #{motif.service.name} qui a lieu le #{I18n.l(rdv.starts_at, format: :human)}")
+          expect(page).to have_content("Vous allez modifier votre RDV #{motif.name} qui a lieu le #{I18n.l(rdv.starts_at, format: :human)}")
           click_link("Confirmer le nouveau créneau")
           expect(rdv.reload.starts_at).not_to eq(original_date)
 

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     describe "using the agent domain's branding" do
       let(:rdv) { create(:rdv, motif: motif, organisation: organisation) }
       let(:motif) do
-        create(:motif, service: create(:service), organisation: organisation)
+        create(:motif, organisation: organisation)
       end
 
       context "when the organisation uses the rdv_solidarites verticale" do

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -103,38 +103,39 @@ RSpec.describe Motif, type: :model do
     let!(:motif3) { create(:motif, :for_secretariat, service: service, organisation: organisation) }
     let!(:motif4) { create(:motif, service: service, organisation: create(:organisation)) }
     let!(:motif5) { create(:motif, service: create(:service), organisation: organisation) }
+    let!(:motif_without_service) { create(:motif, service: nil, organisation: organisation) }
     let(:plage_ouverture) { build(:plage_ouverture, agent: agent, organisation: organisation) }
 
     describe "for secretaire" do
       let(:agent) { create(:agent, :secretaire, basic_role_in_organisations: [organisation]) }
 
-      it { is_expected.to contain_exactly(motif3) }
+      it { is_expected.to contain_exactly(motif3, motif_without_service) }
 
       context "when the agent is also part of another service" do
         before do
           agent.services << service
         end
 
-        it { is_expected.to contain_exactly(motif, motif2, motif3) }
+        it { is_expected.to contain_exactly(motif, motif2, motif3, motif_without_service) }
       end
     end
 
     describe "for other service" do
       let(:agent) { create(:agent, service: service, basic_role_in_organisations: [organisation]) }
 
-      it { is_expected.to contain_exactly(motif, motif2, motif3) }
+      it { is_expected.to contain_exactly(motif, motif2, motif3, motif_without_service) }
     end
 
     describe "for admin" do
       let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
 
-      it { is_expected.to contain_exactly(motif, motif2, motif3, motif5) }
+      it { is_expected.to contain_exactly(motif, motif2, motif3, motif5, motif_without_service) }
     end
 
     describe "for secretary admin" do
       let(:agent) { create(:agent, :secretaire, admin_role_in_organisations: [organisation]) }
 
-      it { is_expected.to contain_exactly(motif, motif2, motif3, motif5) }
+      it { is_expected.to contain_exactly(motif, motif2, motif3, motif5, motif_without_service) }
     end
   end
 
@@ -163,6 +164,12 @@ RSpec.describe Motif, type: :model do
       let!(:agent_pmi3) { create(:agent, basic_role_in_organisations: [org2], service: service_pmi) }
 
       it { is_expected.not_to include(agent_pmi3) }
+    end
+
+    context "for motif without service" do
+      let!(:motif) { create(:motif, service: nil, organisation: org1) }
+
+      it { is_expected.to contain_exactly(agent_pmi1, agent_pmi2, intervenant_pmi, agent_secretariat1) }
     end
   end
 

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe Motif, type: :model do
       expect(subject.errors.details).to eq({ base: [{ error: :duplicate_detected }] })
       expect(subject.errors.full_messages.to_sentence).to eq(%(Il existe déjà dans Mon orga un motif À domicile nommé "name" pour le service PMI))
     end
+
+    context "without a service" do
+      let(:motif) { create(:motif, name: "name", location_type: :home, service: nil, organisation: organisation) }
+
+      specify do
+        expect(subject).not_to be_valid
+        expect(subject.errors.details).to eq({ base: [{ error: :duplicate_detected }] })
+        expect(subject.errors.full_messages.to_sentence).to eq(%(Il existe déjà dans Mon orga un motif À domicile nommé "name" ouvert à tous les agents))
+      end
+    end
   end
 
   describe ".create when associated with secretariat" do

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -112,18 +112,20 @@ RSpec.describe PlageOuverture, type: :model do
     let!(:motif2) { create(:motif, name: "Suivi", service: service, organisation: organisation) }
     let!(:motif3) { create(:motif, :for_secretariat, name: "Test", service: service, organisation: organisation) }
     let!(:motif4) { create(:motif, name: "other orga", service: service, organisation: orga2) }
+    let!(:motif_sans_service) { create(:motif, service: nil, organisation: organisation) }
+
     let(:plage_ouverture) { build(:plage_ouverture, agent: agent, organisation: organisation, motifs: [motif]) }
 
     describe "for secretaire" do
       let(:agent) { create(:agent, :secretaire, basic_role_in_organisations: [organisation]) }
 
-      it { is_expected.to contain_exactly(motif3) }
+      it { is_expected.to contain_exactly(motif3, motif_sans_service) }
     end
 
     describe "for other service" do
       let(:agent) { create(:agent, service: service, basic_role_in_organisations: [organisation]) }
 
-      it { is_expected.to contain_exactly(motif, motif2, motif3) }
+      it { is_expected.to contain_exactly(motif, motif2, motif3, motif_sans_service) }
     end
   end
 

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -74,7 +74,14 @@ RSpec.describe Stat, type: :model do
       service = create(:service, name: "PMI")
       home_motif = create(:motif, location_type: :home, service: service, organisation:)
       create(:rdv, motif: home_motif, created_at: now, organisation:)
+
+      motif_sans_service = create(:motif, service: nil, organisation:)
+      create(:rdv, motif: motif_sans_service, created_at: now, organisation:)
+
       stats = described_class.new(rdvs: Rdv.all)
+
+      # Pour le moment on ne comptabilise pas les motifs sans service dans ce compte.
+      # On peut changer ce comportement si on en trouve un qui a plus de sens.
       expect(stats.rdvs_group_by_service).to eq({ ["PMI", "23/01/2022"] => 1 })
     end
   end

--- a/spec/policies/agent/motif_policy_spec.rb
+++ b/spec/policies/agent/motif_policy_spec.rb
@@ -1,10 +1,30 @@
 RSpec.describe Agent::MotifPolicy do
   subject { described_class }
 
-  let!(:motif) { create(:motif) }
+  let!(:motif) { create(:motif, service: service) }
+  let(:service) { create(:service) }
 
   context "for a basic agent of the same service" do
     let(:agent) { create(:agent, basic_role_in_organisations: [motif.organisation], service: motif.service) }
+
+    it "allows seeing but not modifying the motif" do
+      policy = described_class.new(agent, motif)
+      expect(policy.show?).to be_truthy
+
+      expect(policy.new?).to be_falsey
+      expect(policy.create?).to be_falsey
+      expect(policy.edit?).to be_falsey
+      expect(policy.update?).to be_falsey
+      expect(policy.destroy?).to be_falsey
+
+      expect(policy.versions?).to be_falsey
+    end
+  end
+
+  context "for a basic agent when the motif doesn't have a service" do
+    let(:agent) { create(:agent, basic_role_in_organisations: [motif.organisation], service: service) }
+
+    let!(:motif) { create(:motif, service: nil) }
 
     it "allows seeing but not modifying the motif" do
       policy = described_class.new(agent, motif)
@@ -69,6 +89,23 @@ RSpec.describe Agent::MotifPolicy do
 
       expect(policy.versions?).to be_truthy
     end
+
+    context "when the motif doesn't have a service" do
+      let!(:motif) { create(:motif, service: nil) }
+
+      it "allows seeing and modifying the motif" do
+        policy = described_class.new(agent, motif)
+        expect(policy.show?).to be_truthy
+
+        expect(policy.new?).to be_truthy
+        expect(policy.create?).to be_truthy
+        expect(policy.edit?).to be_truthy
+        expect(policy.update?).to be_truthy
+        expect(policy.destroy?).to be_truthy
+
+        expect(policy.versions?).to be_truthy
+      end
+    end
   end
 
   context "for the admin of a different organisation" do
@@ -85,6 +122,19 @@ RSpec.describe Agent::MotifPolicy do
       expect(policy.destroy?).to be_falsey
 
       expect(policy.versions?).to be_falsey
+    end
+  end
+
+  describe Agent::MotifPolicy::Scope do
+    context "for a basic agent" do
+      let(:agent) { create(:agent, basic_role_in_organisations: [motif.organisation], service: motif.service) }
+      let!(:motif_without_service) { create(:motif, service: nil, organisation: motif.organisation) }
+      let!(:motif_from_other_service) { create(:motif, service: create(:service), organisation: motif.organisation) }
+
+      it "returns the motifs of the agent's service and the motifs without services" do
+        visible_motifs = described_class.new(agent, Motif.all).resolve
+        expect(visible_motifs).to contain_exactly(motif, motif_without_service)
+      end
     end
   end
 end

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     end
   end
 
+  context "existing RDV from other agent on a motif without service" do
+    let(:organisation) { create(:organisation) }
+    let(:agents) { create_list(:agent, 2, organisations: [organisation]) }
+    let(:motif) { create(:motif, organisation: organisation, service: nil) }
+    let(:rdv) { create(:rdv, agents: [agents[0]], motif: motif, organisation: organisation) }
+    let(:pundit_context) { AgentOrganisationContext.new(agents[1], organisation) }
+
+    it_behaves_like "permit actions", :rdv, :show?, :edit?, :update?
+    it_behaves_like "not permit actions", :rdv, :destroy?
+    it_behaves_like "included in scope"
+  end
+
   context "existing RDV from other agent from same service" do
     let(:organisation) { create(:organisation) }
     let(:service) { create(:service) }

--- a/spec/policies/user/participation_policy_spec.rb
+++ b/spec/policies/user/participation_policy_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe User::ParticipationPolicy, type: :policy do
   end
 
   let!(:organisation) { create(:organisation) }
-  let!(:service) { create(:service) }
-  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:user) { create(:user) }
   let!(:user2) { create(:user) }
   let!(:pundit_context) { user }

--- a/spec/policies/user/rdv_policy_spec.rb
+++ b/spec/policies/user/rdv_policy_spec.rb
@@ -14,9 +14,8 @@ RSpec.describe User::RdvPolicy, type: :policy do
   end
 
   let(:organisation) { create(:organisation) }
-  let(:service) { create(:service) }
-  let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
-  let(:motif) { create(:motif, organisation: organisation, service: service) }
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+  let(:motif) { create(:motif, organisation: organisation) }
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
   let(:pundit_context) { user }
@@ -46,7 +45,7 @@ RSpec.describe User::RdvPolicy, type: :policy do
   end
 
   context "Rdv belongs to user but motif is not visible" do
-    let(:motif) { create(:motif, organisation: organisation, service: service, visibility_type: Motif::INVISIBLE) }
+    let(:motif) { create(:motif, organisation: organisation, visibility_type: Motif::INVISIBLE) }
 
     it_behaves_like "not included in scope"
     it_behaves_like "not permit actions", :rdv, :show?, :edit?, :update?, :cancel?, :creneaux?, :can_change_participants?

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Available Creneaux Count for Invitation" do
           min_public_booking_delay: 3.days,
           max_public_booking_delay: 1.month,
           bookable_by: "agents_and_prescripteurs_and_invited_users",
-          name: "RSA orientation",
+          name: "RSA orientation suivi",
           motif_category: rsa_orientation,
           organisation: organisation1
         )

--- a/spec/requests/api/v1/swagger_doc/motifs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/motifs_request_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
 
       parameter name: :active, in: :query, type: :boolean, description: "filtre sur les motifs actifs", required: false
       parameter name: :bookable_publicly, in: :query, type: :boolean, description: "filtre sur les motifs réservables en ligne", required: false
-      parameter name: :service_id, in: :query, type: :integer, description: "filtre sur les services", example: "1", required: false
+      parameter name: :service_id, in: :query, type: :integer,
+                description: "filtre sur les services. Il est possible de passer ce parametre avec une valeur vide pour filtrer les motifs sans services", example: "1", required: false
 
       with_examples
 
@@ -134,11 +135,22 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
           let!(:another_service) { create(:service) }
           let!(:motif1) { create(:motif, organisation: organisation, service: service) }
           let!(:motif2) { create(:motif, organisation: organisation, service: another_service) }
+          let!(:motif_sans_service) { create(:motif, organisation: organisation, service: nil) }
           let(:service_id) { service.id }
 
           run_test!
 
           it { expect(parsed_response_body["motifs"].pluck("id")).to contain_exactly(motif1.id) }
+        end
+
+        response 200, "Renvoie les motifs sans services si on passe un service_id vide", document: false do
+          let!(:motif1) { create(:motif, organisation: organisation, service: service) }
+          let!(:motif_sans_service) { create(:motif, organisation: organisation, service: nil) }
+          let(:service_id) { "" }
+
+          run_test!
+
+          it { expect(parsed_response_body["motifs"].pluck("id")).to contain_exactly(motif_sans_service.id) }
         end
       end
     end

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -96,10 +96,12 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
       let!(:motifA2) { create(:motif, service: service2, organisation: organisationA) }
       let!(:motifB1) { create(:motif, service: service, organisation: organisationB) }
       let!(:motifB2) { create(:motif, service: service2, organisation: organisationB) }
+      let!(:motif_sans_service) { create(:motif, service: nil, organisation: organisationA) }
 
       let!(:rdv) { create(:rdv, organisation: organisationA, motif: motifA1, starts_at: "2022-01-01 09:00:00 +0200") }
       let!(:rdv2) { create(:rdv, organisation: organisationB, motif: motifB1, starts_at: "2023-01-01 09:00:00 +0200") }
       let!(:rdv3) { create(:rdv, organisation: organisationA, motif: motifA2, starts_at: "2024-01-01 09:00:00 +0200") }
+      let!(:rdv_sans_service) { create(:rdv, organisation: organisationA, motif: motif_sans_service, starts_at: "2024-01-01 09:00:00 +0200") }
 
       let!(:basic_agent) { create(:agent, basic_role_in_organisations: [organisationA], service: service) }
       let(:organisation_id) { organisationA.id }
@@ -110,8 +112,8 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
         run_test!
 
         it "returns policy scoped RDVs" do
-          expect(response.parsed_body["rdvs"].pluck("id")).to contain_exactly(rdv.id)
-          expect(response.parsed_body["rdvs"].pluck("created_by")).to contain_exactly("agent")
+          expect(response.parsed_body["rdvs"].pluck("id")).to contain_exactly(rdv.id, rdv_sans_service.id)
+          expect(response.parsed_body["rdvs"].pluck("created_by").uniq).to contain_exactly("agent")
         end
       end
 
@@ -149,7 +151,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
 
           run_test!
 
-          it { expect(response.parsed_body["rdvs"].pluck("id")).to contain_exactly(rdv2020.id, rdv2021.id, rdv.id) }
+          it { expect(response.parsed_body["rdvs"].pluck("id")).to contain_exactly(rdv2020.id, rdv2021.id, rdv.id, rdv_sans_service.id) }
         end
 
         response 200, "returns policy scoped RDVs filtered with starts_before only", document: false do
@@ -186,7 +188,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
 
         run_test!
 
-        it { expect(response.parsed_body["rdvs"].pluck("id")).to contain_exactly(rdv.id, rdv3.id) }
+        it { expect(response.parsed_body["rdvs"].pluck("id")).to contain_exactly(rdv.id, rdv3.id, rdv_sans_service.id) }
       end
 
       it_behaves_like "an endpoint that returns 401 - unauthorized"

--- a/spec/requests/participations_spec.rb
+++ b/spec/requests/participations_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Participations", type: :request do
   let(:service) { create(:service) }
   let(:organisation) { create(:organisation) }
   let(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
-  let(:motif) { create(:motif, :collectif, organisation: organisation, service: service) }
+  let(:motif) { create(:motif, :collectif, organisation: organisation) }
   let(:rdv) { create(:rdv, organisation: organisation, motif: motif, agents: [agent]) }
   let(:user1) { create(:user) }
   let(:user2) { create(:user, :without_devise_email, :with_no_phone_number) }

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -40,11 +40,6 @@ RSpec.describe "Search", type: :request do
       let(:other_motif) { create(:motif, organisation: organisation) }
       let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif, other_motif], organisation: organisation) }
 
-      it "show text to invite to select motif" do
-        get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
-        expect(response.body).to include("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
-      end
-
       context "lorsqu’il n’y a pas de motif de suivi associé aux services" do
         it "n’affiche pas l’invitation à se connecter pour prendre un RDV de suivi" do
           get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
@@ -78,11 +73,6 @@ RSpec.describe "Search", type: :request do
       let(:motif) { create(:motif, organisation: organisation) }
       let(:other_motif) { create(:motif, organisation: organisation, service: motif.service) }
       let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif, other_motif], organisation: organisation) }
-
-      it "show text to invite to select motif" do
-        get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
-        expect(response.body).to include("Sélectionnez le motif de votre RDV")
-      end
 
       context "lorsqu’il n’y a pas de motif de suivi associé aux services" do
         it "n’affiche pas l’invitation à se connecter" do

--- a/spec/services/creneau_wizard_for_users/steps/motif_selection_spec.rb
+++ b/spec/services/creneau_wizard_for_users/steps/motif_selection_spec.rb
@@ -27,6 +27,31 @@ RSpec.describe CreneauWizardForUsers::Steps::MotifSelection do
     end
   end
 
+  context "when there are only motifs without services" do
+    let(:motif_a) { create(:motif, service: nil) }
+    let(:motif_b) { create(:motif, service: nil) }
+    let(:matching_motifs) { Motif.where(id: [motif_a.id, motif_b.id]) }
+
+    it "considers that there is a selected service and returns the motifs" do
+      expect(motif_selection.services).to eq [nil]
+      expect(motif_selection.service_selected?).to be true
+    end
+  end
+
+  context "when there are motifs with and without services" do
+    let(:motif_a) { create(:motif, service: service_a) }
+    let(:motif_b) { create(:motif, service: service_b) }
+    let(:motif_c) { create(:motif, service: nil) }
+    let(:service_b) { create(:service, name: "B") }
+    let(:service_a) { create(:service, name: "A") }
+    let(:matching_motifs) { Motif.where(id: [motif_a.id, motif_b.id, motif_c.id]) }
+
+    it "sorts the services properly" do
+      expect(motif_selection.services).to eq [service_a, service_b, nil]
+      expect(motif_selection.service_selected?).to be false
+    end
+  end
+
   describe "#services" do
     context "when there are two motifs for the same service" do
       let(:matching_motifs) { Motif.where(id: [motif.id, autre_motif.id]) }

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -41,19 +41,29 @@ RSpec.describe Users::RdvSms, type: :service do
       subject { described_class.rdv_created(rdv, user, token).content }
 
       let(:rdv_name) { "Super Atelier" }
-      let(:rdv) { build(:rdv, :collectif, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 123, name: rdv_name) }
+      let(:rdv) { build(:rdv, :collectif, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 123, name: rdv_name, motif: motif) }
+      let(:motif) { build(:motif, :collectif, service:) }
+      let(:service) { build(:service, short_name: "Action Sociale") }
       let(:user) { build(:user) }
       let(:token) { "12345" }
 
       it "contains rdv title" do
-        expect(subject).to include("RDV #{rdv.service.name} : Super Atelier, vendredi 10/12 13h10.")
+        expect(subject).to include("RDV Action Sociale : Super Atelier, vendredi 10/12 13h10.")
       end
 
       context "with a blank name" do
         let(:rdv_name) { "    " }
 
         it "contains rdv title but not the blank name" do
-          expect(subject).to include("RDV #{rdv.service.name} vendredi 10/12 13h10.")
+          expect(subject).to include("RDV Action Sociale vendredi 10/12 13h10.")
+        end
+
+        context "whent the motif doesn't have a service" do
+          let(:motif) { build(:motif, service: nil) }
+
+          it "doesn't have a specific title" do
+            expect(subject).to include("RDV  vendredi 10/12 13h10.")
+          end
         end
       end
 
@@ -61,7 +71,7 @@ RSpec.describe Users::RdvSms, type: :service do
         let(:rdv_name) { "Organiser ses fichiers et ses dossiers sur son ordinateur" }
 
         it "truncates it too avoid sending too many sms and costing too much money" do
-          expect(subject).to include("RDV #{rdv.service.name} : Organiser ses fichiers et ses dossiers sur son ord..., vendredi 10/12 13h10.")
+          expect(subject).to include("RDV #{rdv.service.short_name} : Organiser ses fichiers et ses dossiers sur son ord..., vendredi 10/12 13h10.")
         end
       end
     end


### PR DESCRIPTION
Pour le contexte, voir l'issue https://github.com/betagouv/rdv-service-public/issues/5559

## Périmètre de cette PR

Cette PR propose uniquement de faire fonctionner les motifs sans service, puisque c'est déjà un assez gros changement. 

On ne change quasiment pas le formulaire de motif, donc la fonctionnalité est assez cachée.

On fera un remaniement du formulaire de motif pour rendre la fonctionnalité plus facile à découvrir quand on aura aussi les agents sans services.

## Changements de comportements

Chacun de ces changements correspond à un des commits. Pour faciliter la relecture, vous pouvez les lire en parallèle.

### Formulaire de motif

Depuis le formulaire  de motif, on peut supprimer le service (ou ne pas le remplir)
Avant | Après
:- | -:
<img width="786" height="250" alt="Screenshot 2025-08-08 at 15 02 19" src="https://github.com/user-attachments/assets/418af5c2-0864-49ac-a7c5-1d46482e5760" />|<img width="777" height="242" alt="Screenshot 2025-08-08 at 15 02 30" src="https://github.com/user-attachments/assets/5c37e188-db03-4745-99c5-b278351bbf8b" />
<img width="983" height="243" alt="Screenshot 2025-08-08 at 15 04 52" src="https://github.com/user-attachments/assets/85c67411-3eeb-46a8-ba3f-e56841d8f8d0" />|<img width="984" height="281" alt="Screenshot 2025-08-08 at 15 05 13" src="https://github.com/user-attachments/assets/51a8089c-6f55-43f2-940e-5ee11a699b4d" />

### Plages d'ouvertures pour des motifs sans services

Avant | Après
:- | -:
<img width="899" height="463" alt="Screenshot 2025-08-08 at 15 31 18" src="https://github.com/user-attachments/assets/7d97d62d-1641-460f-a531-3afb199043b0" />|<img width="938" height="571" alt="Screenshot 2025-08-08 at 15 30 20" src="https://github.com/user-attachments/assets/55cfdcbf-683a-428c-8545-92e61da5e441" />


### Prise de rendez-vous sans service côté agent

C'est surtout des modifications des policies. La seule partie visible est le select de motifs en début de parcours :

#### Dans la recherche de créneaux
<img width="878" height="621" alt="Screenshot 2025-08-08 at 16 21 05" src="https://github.com/user-attachments/assets/b0d05565-b2c4-4cc3-b317-9da2d8b010ed" />

#### Depuis le calendrier
<img width="807" height="501" alt="Screenshot 2025-08-08 at 16 22 10" src="https://github.com/user-attachments/assets/8f993043-d232-4b66-bc21-7dae1a831a7c" />


### Prise de rendez-vous sans service pour les usagers (ou les prescripteurs)

Si aucun motif n'a de service, l'interface ne change pas.
Si on est dans un cas où on a un mélange de motifs avec ou sans services, les motifs sans services sont groupés dans la catégorie "Autres". C'est pas parfait, mais ça semble raisonnable pour une première version, et de toutes façons je pense que c'est plus probable qu'on ai soit des service pour tous les motifs soit pour aucun motif.

Ça valait le coup de faire le refacto de https://github.com/betagouv/rdv-service-public/pull/5548, puisque ça a rendu ce changement beaucoup plus facile à écrire et tester.

<img width="1248" height="729" alt="Screenshot 2025-08-11 at 10 36 12" src="https://github.com/user-attachments/assets/cc9e15a2-5857-4527-a3d8-3c653bcea222" />

### Modification en masse de motifs sans service

On arrive sur les fonctionnalités beaucoup moins centrales de l'application.
Depuis l'interface de l'espace admin ça ressemble à ça : 

<img width="1130" height="276" alt="Screenshot 2025-08-11 at 10 41 42" src="https://github.com/user-attachments/assets/846c9ca9-1e46-4512-b491-b990d4c2536e" />

### Filtre par absence de motif dans l'api.

L'endpoint de liste des motifs permet de filtrer par service_id, on permet maintenant d'en passer un blank pour filtrer les motifs sans service.

### Tests

Le dernier commit fait une mise à jour de la factory et des tests. Maintenant, la factory par défaut des motifs n'utilise pas de services. Ça permet aussi de simplifier le setup de pas mals de tests, parce que maintenant on n'a pas besoin de s'assurer que le service de l'agent et du motif correspondent.

J'ai fais le tour de tous les test qui utilisaient des services pour voir s'ils étaient impactés par ce changement (ça a pris du temps). Je suis assez confiant sur la couverture de tests qu'on a au final.