### PR TITLE
Fix - Affichage du champ contexte dans l’édition de RDV

### DIFF
--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -28,7 +28,8 @@
           = collapsible_form_fields_for_warnings(@rdv_form) do
             = hidden_field_tag :agent_id, @agent&.id
             = f.association :motif, collection: [@rdv_form.motif], disabled: true
-            = f.input :context, input_html: { rows: 3 }
+            - if @rdv_form.organisation.territory.enable_context_field
+              = f.input :context, input_html: { rows: 3 }
             .form-row
               .col-md-6 data={ "controller": "past-date-alert" }
                 = datetime_input(f, :starts_at, input_html: { data: { "past-date-alert-target": "date-input" } })

--- a/spec/features/agents/agent_can_update_rdv_spec.rb
+++ b/spec/features/agents/agent_can_update_rdv_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe "Agent can update a RDV", js: true do
-  let!(:organisation) { create(:organisation) }
+  let(:territory) { create(:territory) }
+  let!(:organisation) { create(:organisation, territory:) }
   let(:rdv) do
     create(:rdv, organisation: organisation, motif: motif, agents: [agent_shiraz], lieu: lieu, starts_at:, ends_at:)
   end
@@ -185,6 +186,30 @@ RSpec.describe "Agent can update a RDV", js: true do
           visit admin_organisation_rdv_path(organisation, rdv)
           expect(page).not_to have_link("Salle d’attente")
         end
+      end
+    end
+  end
+
+  describe "edition du contexte" do
+    context "l’option de contexte est activée" do
+      let(:territory) { create(:territory, enable_context_field: true) }
+
+      it "permet de modifier le contexte du RDV" do
+        visit edit_admin_organisation_rdv_path(organisation, rdv)
+        fill_in "Contexte", with: "Besoin d'aide pour la déclaration d'impôts"
+        click_button "Enregistrer"
+
+        expect(page).to have_content("Le rendez-vous a été modifié.")
+        expect(rdv.reload.context).to eq("Besoin d'aide pour la déclaration d'impôts")
+      end
+    end
+
+    context "l’option de contexte n’est pas activée" do
+      let(:territory) { create(:territory, enable_context_field: false) }
+
+      it "n'affiche pas le champ de contexte" do
+        visit edit_admin_organisation_rdv_path(organisation, rdv)
+        expect(page).not_to have_field("Contexte")
       end
     end
   end


### PR DESCRIPTION
# Contexte

En traitant un ticket de support, j’ai été confronté à un agent qui voulait avoir le contexte sur la liste imprimable. Hors le contexte est déjà affiché. Cela a mis en avant le fait que les agents peuvent modifier le contexte dans le formulaire d’édition de RDV que l’option soit activée ou non.

# Solution

On corrige l’affichage du champ dans le formulaire d’édition de RDV, uniquement si est activé au niveau du territoire.
En explorant les données, on s’est aperçu qu’on avait une petite dizaine de territoire sur RDVSP et RDVS qui ont des RDV avec des contextes alors que l’option n’est pas activée.
Cela va peut-être générer quelques retours au support pour 2 ou 3 territoires côté RDVS qu’on gérera au cas par cas.
Côté RDVSP, on a fait une passe pour activer l’option sur les territoires qui ont + de 100 RDV avec des contextes et qui n’ont pas précédemment désactivé l’option.
