### PR TITLE
Correctif pour la prise de rdv en interne en cas d'expiration de la session

### DIFF
--- a/app/controllers/admin/prescription_controller.rb
+++ b/app/controllers/admin/prescription_controller.rb
@@ -4,11 +4,12 @@ class Admin::PrescriptionController < AgentAuthController
 
   def search_creneau
     skip_authorization
-    session[:agent_prescripteur_organisation_id] = params[:organisation_id]
     @context = AgentPrescriptionSearchContext.new(
       user: user,
-      query_params: search_context_params.merge(prescripteur: Prescripteur::INTERNE),
-      current_organisation: current_organisation,
+      query_params: search_context_params.merge(
+        prescripteur: Prescripteur::INTERNE,
+        current_organisation: current_organisation
+      ),
       agent_prescripteur: current_agent
     )
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -33,8 +33,8 @@ class SearchController < ApplicationController
   # rubocop:disable Metrics/PerceivedComplexity
   def search_rdv
     # TODO : public_link_organisation_id has to work if agent is logged in ?
-    if current_agent && params[:prescripteur] == Prescripteur::INTERNE && session[:agent_prescripteur_organisation_id]
-      redirect_to search_creneau_admin_organisation_prescription_path(session[:agent_prescripteur_organisation_id], agent_search_params)
+    if current_agent && params[:prescripteur] == Prescripteur::INTERNE && params[:current_organisation]
+      redirect_to search_creneau_admin_organisation_prescription_path(params[:current_organisation], agent_search_params)
     else
       @context = if invitation&.to_take_rdv?
                    WebInvitationSearchContext.new(user: current_user, query_params: search_params.merge(invitation.query_params))

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -70,10 +70,10 @@ module SearchContextHelper
       :prescripteur,
       :duration,
       :current_organisation,
+      *AgentPrescriptionSearchContext::STARTING_CONDITIONS_PARAMS,
       {
         referent_ids: [],
         external_organisation_ids: [],
-        user_ids: [], # utilisés par les agents prescripteurs en prescription interne
       },
     ]
   end

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -69,6 +69,7 @@ module SearchContextHelper
       :public_link_organisation_id,
       :prescripteur,
       :duration,
+      :current_organisation,
       {
         referent_ids: [],
         external_organisation_ids: [],

--- a/app/services/agent_prescription_search_context.rb
+++ b/app/services/agent_prescription_search_context.rb
@@ -1,12 +1,12 @@
 class AgentPrescriptionSearchContext < WebSearchContext
+  STARTING_CONDITIONS_PARAMS = [:current_organisation, { user_ids: [] }].freeze
+
   STRONG_PARAMS_LIST = [
     *WebSearchContext::ADDRESS_SELECTION_PARAMS,
     *WebSearchContext::USER_CHOICE_PARAMS,
     :date, :motif_category_short_name, :prescripteur,
-    :context, :current_organisation,
-    { # Paramètre supplémentaire qui n'apparait pas dans le WebSearchContext
-      user_ids: [],
-    },
+    :context,
+    *STARTING_CONDITIONS_PARAMS,
   ].freeze
 
   def initialize(user:, agent_prescripteur:, query_params: {})

--- a/app/services/agent_prescription_search_context.rb
+++ b/app/services/agent_prescription_search_context.rb
@@ -3,15 +3,15 @@ class AgentPrescriptionSearchContext < WebSearchContext
     *WebSearchContext::ADDRESS_SELECTION_PARAMS,
     *WebSearchContext::USER_CHOICE_PARAMS,
     :date, :motif_category_short_name, :prescripteur,
-    :context,
+    :context, :current_organisation,
     { # Paramètre supplémentaire qui n'apparait pas dans le WebSearchContext
       user_ids: [],
     },
   ].freeze
 
-  def initialize(user:, current_organisation:, agent_prescripteur:, query_params: {})
+  def initialize(user:, agent_prescripteur:, query_params: {})
     super(user: user, query_params: query_params)
-    @current_organisation = current_organisation
+    @current_organisation = query_params[:current_organisation]
     @agent_prescripteur = agent_prescripteur
   end
 


### PR DESCRIPTION
Correctif pour https://sentry.incubateur.net/organizations/betagouv/issues/192174/?project=74&referrer=webhooks_plugin

### Description du bug :

Lors d'une prescription interne, la session a expiré, et donc on n'a pas fait la redirection correctement.

On peut reproduire le bug en local en commentant le ` && session[:agent_prescripteur_organisation_id]`.

Fun fact : ce bug existait avant le refactor de https://github.com/betagouv/rdv-service-public/pull/5548, mais à la place de lever une 500, il redirigeait l'agent vers la connexion côté usagers.

### Correctif

On balade cette info dans les params plutôt que dans la session (et en bonus on permet de faire deux prises de rdv en parallèle dans deux onglets).
