### PR TITLE
Rails 7.2: active_job.enqueue_after_transaction_commit

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -32,7 +32,7 @@
 # backends that use the same database as Active Record as a queue, hence they
 # don't need this feature.
 #++
-# Rails.application.config.active_job.enqueue_after_transaction_commit = :default
+Rails.application.config.active_job.enqueue_after_transaction_commit = :default
 
 ###
 # Enable validation of migration timestamps. When set, an ActiveRecord::InvalidMigrationTimestampError


### PR DESCRIPTION
# Contexte

Ce paramètre ne devrait rien changer. Actuellement, c’est déjà GoodJob qui a la main sur ce paramètre, car en l’absence de valeur, on tombe déjà dans le cas par défaut, c'est-à-dire utiliser la config de l’adapter.

Le paramètre par défaut de GoodJob est de ne pas enqueue après la transaction. Le code de l’enqueue est donc exécuté immédiatement, mais comme GoodJob utilise la même base, si la transaction n’est pas commit, le job n’est pas enqueue. 

```
lapin(dev)* Rdv.transaction do
lapin(dev)*   CronJob::IGNHealthCheckJob.perform_later
lapin(dev)*   pp Time.now
lapin(dev)*   raise ActiveRecord::Rollback
lapin(dev)> end
[ActiveJob] Enqueued CronJob::IGNHealthCheckJob (Job ID: acfb38d5-3a70-4709-a9a5-998aead7487c) to GoodJob(latency_whenever)
2025-08-08 00:29:14.235626 +0200
=> nil
lapin(dev)> GoodJob::Job.last.created_at
=> Fri, 08 Aug 2025 00:17:20.832804000 CEST +02:00
```

Voir également : https://github.com/bensheldon/good_job/pull/1311