### PR TITLE
Rails 7.2: active_storage.web_image_content_types

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -35,14 +35,6 @@
 # Rails.application.config.active_job.enqueue_after_transaction_commit = :default
 
 ###
-# Adds image/webp to the list of content types Active Storage considers as an image
-# Prevents automatic conversion to a fallback PNG, and assumes clients support WebP, as they support gif, jpeg, and png.
-# This is possible due to broad browser support for WebP, but older browsers and email clients may still not support
-# WebP. Requires imagemagick/libvips built with WebP support.
-#++
-# Rails.application.config.active_storage.web_image_content_types = %w[image/png image/jpeg image/gif image/webp]
-
-###
 # Enable validation of migration timestamps. When set, an ActiveRecord::InvalidMigrationTimestampError
 # will be raised if the timestamp prefix for a migration is more than a day ahead of the timestamp
 # associated with the current time. This is done to prevent forward-dating of migration files, which can


### PR DESCRIPTION
# Contexte

À ce jour nous n’utilisons pas ActiveStorage, on supprime donc cette config.
