### PR TITLE
Rails 7.2: active_record.validate_migration_timestamps

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -43,7 +43,7 @@
 # Applications with existing timestamped migrations that do not adhere to the
 # expected format can disable validation by setting this config to `false`.
 #++
-# Rails.application.config.active_record.validate_migration_timestamps = true
+Rails.application.config.active_record.validate_migration_timestamps = true
 
 ###
 # Controls whether the PostgresqlAdapter should decode dates automatically with manual queries.


### PR DESCRIPTION
# Contexte

Complètement safe. Nous utilisons le generator de Rails pour générer les migrations et nous n’avons pas de raison de mettre des timestamp dans le futur.
