### PR TITLE
Préparation de l'affichage des motifs sans services

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -21,7 +21,7 @@ module MotifsHelper
   end
 
   def motif_name_and_service(motif)
-    "#{motif.name} - #{motif.service_name}"
+    [motif.name, motif.service_name].compact.join(" - ")
   end
 
   def motif_name_with_special_location_type(motif)

--- a/app/services/participation_exporter.rb
+++ b/app/services/participation_exporter.rb
@@ -76,7 +76,7 @@ module ParticipationExporter
       Rdv.human_attribute_value(:created_by_type, rdv.created_by_type),
       I18n.l(rdv.starts_at.to_date, format: "%d/%m/%Y"),
       I18n.l(rdv.starts_at, format: :time_only),
-      rdv.motif.service_name,
+      rdv.service_name,
       rdv.motif_name,
       rdv.context,
       Rdv.human_attribute_value(:status, participation.temporal_status, disable_cast: true),

--- a/app/services/rdv_exporter.rb
+++ b/app/services/rdv_exporter.rb
@@ -70,7 +70,7 @@ module RdvExporter
       Rdv.human_attribute_value(:created_by_type, rdv.created_by_type, disable_cast: true),
       I18n.l(rdv.starts_at.to_date, format: "%d/%m/%Y"),
       I18n.l(rdv.starts_at, format: :time_only),
-      rdv.motif.service_name,
+      rdv.service_name,
       rdv.motif_name,
       rdv.context,
       Rdv.human_attribute_value(:status, rdv.temporal_status, disable_cast: true),

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -4,7 +4,7 @@ class Users::RdvSms < Users::BaseSms
 
   def rdv_title(rdv)
     if rdv.collectif? && rdv.name.present?
-      "#{rdv.service_short_name} : #{truncated_rdv_name},"
+      [rdv.service_short_name, truncated_rdv_name].compact.join(" : ")
     else
       rdv.service_short_name
     end
@@ -49,7 +49,7 @@ class Users::RdvSms < Users::BaseSms
   MAX_RDV_NAME_LENGTH = 50
 
   def truncated_rdv_name
-    self.class.truncated_rdv_name(@rdv.name)
+    "#{self.class.truncated_rdv_name(@rdv.name)},"
   end
 
   def self.truncated_rdv_name(name)

--- a/app/views/admin/creneaux_search/selection_creneaux.html.slim
+++ b/app/views/admin/creneaux_search/selection_creneaux.html.slim
@@ -3,7 +3,7 @@
     .card-header
      .d-flex.justify-content-between.flex-wrap
        span
-         h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
+         h3= t(".available_slots_title_html", motif: motif_name_and_service(@form.motif))
          - if @form.motif.requires_lieu?
            = t(".place_informations_html", place_name: @search_result.lieu.name, place_address: @search_result.lieu.address)
          - else

--- a/app/views/admin/motifs/edit.html.slim
+++ b/app/views/admin/motifs/edit.html.slim
@@ -1,7 +1,9 @@
 - content_for :title do
   / Cette partial est rendue lorsque l'update est invalide, il faut alors afficher
   / le nom et service du motif tels qu'ils étaient avant la tentative de modif.
-  | Modifier le motif "#{@motif.name_was}" (#{Service.find(@motif.service_id_was).short_name})
+  | Modifier le motif "#{@motif.name_was}"
+  - if @motif.service_id_was.present?
+    |  (#{Service.find(@motif.service_id_was)&.short_name})
 
 = render "admin/motifs/fil_ariane", current_page_title: content_for(:title)
 - content_for(:menu_item) { "menu-settings" }

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -1,4 +1,8 @@
-- content_for :title, "#{@motif.name} (#{@motif.service.short_name}) #{'(archivé)' if @motif.archived?}"
+- title = @motif.name
+- title += " (#{@motif.service_short_name})" if @motif.service_short_name
+- title += " (archivé)" if @motif.archived?
+
+- content_for :title, title
 
 = render "admin/motifs/fil_ariane", current_page_title: content_for(:title)
 - content_for(:menu_item) { "menu-settings" }
@@ -8,7 +12,7 @@
     .card.mt-2
       .card-body
         = motif_attribute_row(Motif.human_attribute_name(:name), @motif.name)
-        = motif_attribute_row(Motif.human_attribute_name(:service), @motif.service.name)
+        = motif_attribute_row(Motif.human_attribute_name(:service), @motif.service_name)
         - if @motif.motif_category.present?
           = motif_attribute_row(MotifCategory.model_name.human, @motif.motif_category.name)
         = motif_attribute_row \

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -22,10 +22,11 @@
       - else
         = rdv.motif_name
     .clear
-  div.row-result
-    span.title Service :
-    span.float-right= rdv.motif.service_name
-    .clear
+  - if rdv.service_name
+    div.row-result
+      span.title Service :
+      span.float-right= rdv.service_name
+      .clear
   - if rdv.follow_up?
     div.row-result
       span.title Référent&nbsp;:

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -74,7 +74,7 @@ org_arques = human_id_map["1030"][:organisation]
 
 # SERVICES
 
-service_pmi = Service.create!(name: "PMI (Protection Maternelle Infantile)", short_name: "PMI")
+service_pmi = Service.create!(name: "Protection Maternelle Infantile", short_name: "PMI")
 service_social = Service.create!(name: "Service social", short_name: "Service Social")
 service_secretariat = Service.create!(name: Service::SECRETARIAT, short_name: "Secrétariat")
 territory62.services << [service_pmi, service_social, service_secretariat]

--- a/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
+++ b/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Agent can find a creneau for a rdv collectif" do
     click_button "Afficher les créneaux"
 
     # The rdv collectif appears in the search results
-    expect(page).to have_content("Créneaux disponibles pour atelier participatif")
+    expect(page).to have_content("Créneaux disponibles pour Atelier participatif")
     expect(page).to have_content("1 participant")
     expect(page).to have_content("4 places restantes")
 
@@ -44,7 +44,7 @@ RSpec.describe "Agent can find a creneau for a rdv collectif" do
       expect(page).to have_content("2 lieux proposent des créneaux")
       click_link("Prochain créneau", match: :first)
 
-      expect(page).to have_content("Créneaux disponibles pour atelier participatif")
+      expect(page).to have_content("Créneaux disponibles pour Atelier participatif")
     end
   end
 end


### PR DESCRIPTION
Cette PR est une autre petite extraction pour préparer https://github.com/betagouv/rdv-service-public/pull/5549

Pour faciliter la lecture de cette plus grosse PR, on fait ici plusieurs petites modifications qui rendront possible l'affichage de motifs sans service.

Le premier commit fait juste une petite modification des seeds : le nom `PMI (Protection Maternelle Infantile)` m'a fait croire qu'on utilisait une méthode du genre `"#{service.short_name} (#{service.name})"`, alors que c'était juste `service.name` (en production il me semble qu'on a un service avec `name == "Protection Maternelle Infantile" && short_name == "PMI"`.