### PR TITLE
Suppression de la contrainte de db sur motifs.service_id

### DIFF
--- a/db/migrate/20250317162909_allow_nil_motifs_service_id.rb
+++ b/db/migrate/20250317162909_allow_nil_motifs_service_id.rb
@@ -1,0 +1,5 @@
+class AllowNilMotifsServiceId < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :motifs, :service_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -432,7 +432,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_24_145810) do
     t.integer "min_public_booking_delay", default: 1800, null: false, comment: "Permet de savoir combien de secondes il y aura au minimum entre la prise de rdv par un usager ou un prescripteur et le début du rdv. Par exemple si la valeur est 1800, et qu'il est 10h, le premier rdv qui pourra être pris (s'il y a une plage d'ouverture libre) sera à 10h30, puisque 1800 = 30 x 60. Cela permet à l'agent d'être prévenu suffisamment à l'avance.\n"
     t.integer "max_public_booking_delay", default: 7889238, null: false, comment: "Permet de savoir combien de temps à l'avance il est possible de prendre rdv pour un usager ou un prescripteur. Le délai est mesuré en secondes. Cela évite que des gens prennent des rdv dans trop longtemps, et évite aux agents de s'engager à assurer des rdv alors qu'ils ne connaissent pas leur emploi du temps suffisamment à l'avance.\n"
     t.datetime "deleted_at", comment: "Permet de savoir à quelle date le motif a été soft-deleted\n"
-    t.bigint "service_id", null: false
+    t.bigint "service_id"
     t.text "restriction_for_rdv", comment: "Instructions à accepter avant la prise du rendez-vous par l'usager\n"
     t.text "instruction_for_rdv", comment: "Indications affichées à l'usager après la confirmation du rendez-vous. Apparait dans le mail de confirmation pour l'usager.\n"
     t.boolean "for_secretariat", default: false, comment: "Permet aux agents du secrétariat d'assurer des rdv pour ce motif\n"


### PR DESCRIPTION
Extraction de https://github.com/betagouv/rdv-service-public/pull/5549

Pour la mise en production de la grosse PR sur les motifs sans service, ça sera pratique de pouvoir faire un revert si jamais il y a un bug.
Le problème est que si on a une migration qui enlève la contrainte nullable sur `motifs.service_id`, on ne pourra pas la rollback. On met donc la migration dans cette PR, et on pourra faire un rollback beaucoup plus facilement (même s'il faudra sans doute quand même ajouter manuellement des ids sur des services).

On garde la validation active record, mais on supprime la contrainte au niveau de la db pour les motifs sans service. Ça ne posera donc pas de problème (d'ailleurs cette contrainte avait été ajoutée plusieurs années après la mise en place de la colonne).