### PR TITLE
Suppression de la contrainte non-nullable sur motifs.service_id dans le schema de l'api

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -366,7 +366,7 @@ RSpec.configure do |config|
               motif_category: { "$ref" => "#/components/schemas/motif_category" },
               bookable_publicly: { type: "boolean" },
               bookable_by: { type: "string", enum: %w[agents agents_and_prescripteurs agents_and_prescripteurs_and_invited_users everyone] },
-              service_id: { type: "integer" },
+              service_id: { type: "integer", nullable: true },
             },
             required: %w[id deleted_at location_type name organisation_id bookable_publicly bookable_by service_id],
           },

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -688,7 +688,8 @@
             ]
           },
           "service_id": {
-            "type": "integer"
+            "type": "integer",
+            "nullable": true
           }
         },
         "required": [


### PR DESCRIPTION
Un peu comme https://github.com/betagouv/rdv-service-public/pull/5557, cette PR est une préparation/extraction pour https://github.com/betagouv/rdv-service-public/pull/5549.

On enlève simplement la contrainte dans les définitions du schema de l'api.

On pourrait voir ça comme une manière de prévenir les clients de notre api que ce paramètre va évoluer, mais je pense pas qu'il y ai grand monde qui surveille ça.
Concrètement, ça ne change aucun comportement, ça évitera juste que des specs échouent dans l'autre PR, et ça diminue le diff de la PR principale.