### PR TITLE
Autorisation des scripts swagger dans les CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -24,6 +24,9 @@ headway_widget = "headway-widget.net"
 # Metabase permet d’embedder des rapports dans l’application
 metabase = "rdv-service-public-metabase.osc-secnum-fr1.scalingo.io"
 
+# Utilisés par swagger pour la documentation de l'api
+swagger_shas = ["'sha256-j4Lx1FqFgvYDBEjW7NQaEY7/HhCi8WVsLWkqC4+wJ3w='", "'sha256-JHKToH7KbGJj6TloPeWnKnbImDel00Whl1rRnBiTYuQ='"]
+
 # Tant qu'on utilise les Turbolinks, c'est très difficile d'avoir des CSP différentes pour chaque pages,
 # puisque les CSP sont uniquement chargées lors de la première requête qui charle le premier document,
 # et pas lors des appels XHR fait par les turbolinks.
@@ -41,7 +44,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src :self, :unsafe_inline, bootstrap_cdn, headway_cnd, unpkg_cdn
   policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
 
-  policy.script_src :self, headway_cnd, unpkg_cdn
+  policy.script_src :self, headway_cnd, unpkg_cdn, *swagger_shas
 end
 
 # If you are using UJS then enable automatic nonce generation


### PR DESCRIPTION
Un petit correctif suite à https://github.com/betagouv/rdv-service-public/pull/5470 : pour l'affichage de la documentation, swagger utilise des scripts inline qu'il faut autoriser via la CSP

pour tester l'avant/après en local : http://www.rdv-solidarites.localhost:3000/api-docs/index.html