### PR TITLE
Fix locals magic comments

### DIFF
--- a/app/views/admin/users/_create_user_cta.html.slim
+++ b/app/views/admin/users/_create_user_cta.html.slim
@@ -1,4 +1,4 @@
-/ locals(path:)
+/# locals: (path:)
 span.small.text-muted
   | Vous ne trouvez pas l'usager ?&nbsp;
   = link_to("Ajouter un usager", path, data: { modal: true }, class: "fr-btn fr-btn--sm fr-btn--tertiary-no-outline")

--- a/app/views/agents/rdv_plans/_calendar.html.slim
+++ b/app/views/agents/rdv_plans/_calendar.html.slim
@@ -1,4 +1,4 @@
-/ locals(rdv_plan:, single_day: false)
+/# locals: (rdv_plan:, single_day: false)
 ruby:
   organisation = current_agent.organisations.first
   event_sources = [

--- a/app/views/agents/rdv_plans/_header.html.slim
+++ b/app/views/agents/rdv_plans/_header.html.slim
@@ -1,4 +1,4 @@
-/ locals(rdv_plan:, current_step:, step_title:, next_step_title:)
+/# locals: (rdv_plan:, current_step:, step_title:, next_step_title:)
 - content_for(:additional_scripts) { javascript_include_tag "rdv_plan", "data-turbolinks-track": "reload" }
 - content_for(:additional_stylesheets) { stylesheet_link_tag "rdv_plan", media: "all", "data-turbolinks-track": "reload" }
 h1.fr-h2

--- a/app/views/agents/rdv_plans/summary/_location_type.html.slim
+++ b/app/views/agents/rdv_plans/summary/_location_type.html.slim
@@ -1,4 +1,4 @@
-/ locals(rdv_plan:)
+/# locals: (rdv_plan:)
 br
 - if rdv_plan.public_office?
   = lieu_icon(class: "fr-mr-1w")

--- a/app/views/agents/rdv_plans/summary/_motif.html.slim
+++ b/app/views/agents/rdv_plans/summary/_motif.html.slim
@@ -1,4 +1,4 @@
-/ locals(rdv_plan:)
+/# locals: (rdv_plan:)
 br
 = motif_icon(class: "fr-mr-1w")
 = rdv_plan.motif.name

--- a/app/views/agents/rdv_plans/summary/_starts_at.html.slim
+++ b/app/views/agents/rdv_plans/summary/_starts_at.html.slim
@@ -1,4 +1,4 @@
-/ locals(rdv_plan:)
+/# locals: (rdv_plan:)
 span.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
 = "#{l(rdv_plan.starts_at, format: :human)} (#{rdv_plan.duration_in_minutes} minutes)"
 = link_to "modifier", edit_starts_at_agents_rdv_plan_path(rdv_plan), class: "fr-ml-2w"

--- a/app/views/layouts/_rdv_a_renseigner.html.slim
+++ b/app/views/layouts/_rdv_a_renseigner.html.slim
@@ -1,4 +1,4 @@
-/ locals(organisation: nil)
+/# locals: (organisation: nil)
 - if current_agent.unknown_past_rdv_count > 0 && !current_agent.conseiller_numerique? # See https://github.com/betagouv/rdv-solidarites.fr/issues/2245
   / la condition ci-dessous permet de gérer les cas où le compteur en cache unknown_past_rdv_count
   / est supérieur 0 mais qu’on ne retrouve aucun RDV effectivement à renseigner

--- a/app/views/search/_motif_card.html.slim
+++ b/app/views/search/_motif_card.html.slim
@@ -1,4 +1,4 @@
-/ locals(context:, motif:)
+/# locals: (context:, motif:)
 
 li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
   .fr-card__body


### PR DESCRIPTION
# Contexte

Je me suis aperçu [ici](https://github.com/betagouv/rdv-service-public/pull/5548#discussion_r2259640699) que nous n’utilisons parfois pas la bonne syntaxe pour les magic comments qui définissent les locals.
Je propose que nous les fixions tous d’un coup à travers cette PR


