### PR TITLE
Mise en place de données de test pour l'équipe Justice.fr

### DIFF
--- a/app/controllers/api/justice/lieux_controller.rb
+++ b/app/controllers/api/justice/lieux_controller.rb
@@ -1,4 +1,5 @@
-class Api::Justice::LieuxController < ActionController::Base
+class Api::Justice::LieuxController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  # Cet endpoint renvoie des données publiques similaire à l'annuaire des services publics, donc on n'a pas besoin d'authentification
   def index
     lieux = []
 

--- a/app/controllers/api/justice/lieux_controller.rb
+++ b/app/controllers/api/justice/lieux_controller.rb
@@ -1,0 +1,22 @@
+class Api::Justice::LieuxController < ActionController::Base
+  def index
+    lieux = []
+
+    # Des données de test pour l'équipe tech de l'appli Justice.fr
+    if ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
+      lieux << {
+        ee_id: "612f2ed9b473e40555def46c",
+        reservation_en_ligne: false,
+        url: "https://demo.rdv.anct.gouv.fr/prendre_rdv?departement=&public_link_organisation_id=877",
+      }
+
+      lieux << {
+        ee_id: "612f2ed9b473e40555def46e",
+        reservation_en_ligne: true,
+        url: "https://demo.rdv.anct.gouv.fr/prendre_rdv?departement=&public_link_organisation_id=878",
+      }
+    end
+
+    render json: { lieux: }
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -28,6 +28,10 @@ namespace :api do
     get "searchApplicationIds", to: "editor#search_application_ids"
   end
 
+  namespace :justice do
+    get "lieux", to: "lieux#index"
+  end
+
   namespace :rdvinsertion do
     resources :invitations, only: [] do
       get "creneau_availability", to: "invitations#creneau_availability", on: :collection


### PR DESCRIPTION
# Contexte

On prépare une intégration avec l'application mobile Justice.fr qui permettra de prendre rendez-vous en ligne avec un CDAD.

Le fonctionnement est assez simple : depuis la page de détails d'un établissement du cdad, on ajoute un lien "Prendre rendez-vous" qui bascule vers notre parcours de prise de rendez-vous.

On espère que ce fonctionnement sera repris sur la version web de justice.fr.

# Solution

On a donc besoin de retrouver le lien de prise de rendez-vous pour chaque établissement. Il nous faut un référentiel commun, et on va donc utiliser celui que l'équipe de Justice.fr utilise déjà, et qui est extrait d'un autre outil en amont qui gère "officiellement" la liste des établissements: https://git.easter-eggs.org/cc-data/mj-update/-/raw/main/justice-mobile.csv?ref_type=heads

Ça a l'air d'être les mêmes données que l'annuaire de la justice : https://www.justice.gouv.fr/annuaire

La réconciliation des données est un sujet un peu plus complexe qui est exploré dans cette autre pr : https://github.com/betagouv/rdv-service-public/pull/5563


On s'est mis d'accord avec l'équipe technique qui gère Justice.fr pour l'api proposée ici.

Pour qu'ils puissent commencer le développement, ils ont besoin d'une première version de l'endpoint avec des fausses données de tests, d'où cette première PR.

voir le pad : https://pad.numerique.gouv.fr/qO8k3TtdQhORCZcoveIHzg

