### PR TITLE
Ajout des references externes pour les usagers

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -71,6 +71,18 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
 
     permitted_params = params.permit(*attrs, organisation_ids: [])
 
+    if params[:external_reference].present?
+      attributes_from_params = params.require(:external_reference).permit(:external_id, :external_url)
+
+      territory_id = Organisation.find_by(id: params[:organisation_ids])&.territory_id
+      permitted_params.merge!(
+        external_references_attributes: [attributes_from_params.merge(
+          oauth_application: doorkeeper_token&.application,
+          territory_id: territory_id
+        )]
+      )
+    end
+
     return permitted_params unless params.key?(:referent_agent_ids)
 
     referents_i_can_modify = Agent::AgentPolicy::Scope.new(pundit_user, @user.referent_agents).resolve

--- a/app/models/external_reference.rb
+++ b/app/models/external_reference.rb
@@ -1,0 +1,11 @@
+class ExternalReference < ApplicationRecord
+  belongs_to :item, polymorphic: true
+  belongs_to :oauth_application, class_name: "Doorkeeper::Application"
+  belongs_to :territory
+
+  # Permet de rendre les créations d'objets idempotentes
+  validates :external_id, uniqueness: { scope: %i[item_type oauth_application_id territory] }
+
+  # Evite que le même item ai deux ids différents dans le même système
+  validates :item_id, uniqueness: { scope: %i[item_type oauth_application_id territory] }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,7 @@ class User < ApplicationRecord
   has_many :file_attentes, dependent: :destroy
   has_many :receipts, dependent: :destroy
   has_many :annotations, dependent: :destroy
+  has_many :external_references, as: :item, dependent: :destroy
 
   # Through relations
   # we specify dependent: :destroy because by default user_profiles and referent_assignations
@@ -68,7 +69,7 @@ class User < ApplicationRecord
   has_many :webhook_endpoints, through: :organisations
   has_many :rdvs, through: :participations
 
-  accepts_nested_attributes_for :user_profiles
+  accepts_nested_attributes_for :user_profiles, :external_references
 
   include User::ResponsabilityConcern # relies on belongs_to :responsible
 

--- a/app/policies/agent/external_reference_policy.rb
+++ b/app/policies/agent/external_reference_policy.rb
@@ -1,0 +1,19 @@
+class Agent::ExternalReferencePolicy < ApplicationPolicy
+  alias current_agent pundit_user
+
+  def show?
+    record.territory_id.in?(@pundit_user.agent_territorial_access_rights.select(:territory_id)) &&
+      record.oauth_application.in?(OauthApplication.joins(:access_tokens).merge(@pundit_user.access_tokens))
+  end
+
+  class Scope < Scope
+    alias current_agent pundit_user
+
+    def resolve
+      scope.where(territory_id: @pundit_user.agent_territorial_access_rights.select(:territory_id))
+        .joins(:oauth_application).merge(
+          OauthApplication.joins(:access_tokens).merge(current_agent.access_tokens)
+        )
+    end
+  end
+end

--- a/app/policies/agent/external_reference_policy.rb
+++ b/app/policies/agent/external_reference_policy.rb
@@ -1,16 +1,11 @@
 class Agent::ExternalReferencePolicy < ApplicationPolicy
   alias current_agent pundit_user
 
-  def show?
-    record.territory_id.in?(@pundit_user.agent_territorial_access_rights.select(:territory_id)) &&
-      record.oauth_application.in?(OauthApplication.joins(:access_tokens).merge(@pundit_user.access_tokens))
-  end
-
   class Scope < Scope
     alias current_agent pundit_user
 
     def resolve
-      scope.where(territory_id: @pundit_user.agent_territorial_access_rights.select(:territory_id))
+      scope.where(territory_id: @pundit_user.organisations.select(:territory_id))
         .joins(:oauth_application).merge(
           OauthApplication.joins(:access_tokens).merge(current_agent.access_tokens)
         )

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -51,6 +51,11 @@ ruby:
             - if current_territory.enable_notes_field?
               li= object_attribute_tag(@user, :annotation_content, formatted_user_annotation(@user, current_territory))
 
+        - references = Agent::ExternalReferencePolicy::Scope.new(current_agent, @user.external_references.where(territory: current_territory)).resolve
+        - if references.present?
+          - references.each do |reference|
+            = link_to("Voir sur #{reference.oauth_application.name}", reference.external_url, target: :_blank, class: "fr-mb-2w")
+
         ul.fr-btns-group.fr-btns-group--right.fr-btns-group--inline.fr-btns-group--icon-left.fr-mb-0
           li
             - if @user.can_be_soft_deleted_from_organisation?(current_organisation)

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -467,3 +467,10 @@ tables:
       - created_at
       - updated_at
       - location_type
+  - table_name: external_references
+    anonymized_column_names:
+      - external_url
+      - external_id
+    non_anonymized_column_names:
+      - item_type
+      - item_id

--- a/db/migrate/20250811132916_create_external_references.rb
+++ b/db/migrate/20250811132916_create_external_references.rb
@@ -1,0 +1,18 @@
+class CreateExternalReferences < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    create_table :external_references do |t|
+      t.string :item_type, null: false
+      t.bigint :item_id, null: false
+      t.references :oauth_application, null: false, index: false, foreign_key: true
+      t.references :territory, null: false, index: false, foreign_key: true
+      t.bigint :external_id, null: false
+      t.text :external_url
+
+      t.timestamps
+    end
+
+    add_index :external_references, %i[item_id item_type oauth_application_id territory_id], algorithm: :concurrently, unique: true
+  end
+end

--- a/db/migrate/20250811132916_create_external_references.rb
+++ b/db/migrate/20250811132916_create_external_references.rb
@@ -7,12 +7,13 @@ class CreateExternalReferences < ActiveRecord::Migration[7.2]
       t.bigint :item_id, null: false
       t.references :oauth_application, null: false, index: false, foreign_key: true
       t.references :territory, null: false, index: false, foreign_key: true
-      t.bigint :external_id, null: false
+      t.text :external_id, null: false
       t.text :external_url
 
       t.timestamps
     end
 
+    add_index :external_references, %i[external_id item_type oauth_application_id territory_id], algorithm: :concurrently, unique: true
     add_index :external_references, %i[item_id item_type oauth_application_id territory_id], algorithm: :concurrently, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_24_145810) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_13_133437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -292,6 +292,18 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_24_145810) do
     t.index ["expires_at"], name: "index_exports_on_expires_at"
   end
 
+  create_table "external_references", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.bigint "oauth_application_id", null: false
+    t.bigint "territory_id", null: false
+    t.bigint "external_id", null: false
+    t.text "external_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id", "item_type", "oauth_application_id", "territory_id"], name: "idx_on_item_id_item_type_oauth_application_id_terri_6db34b5548", unique: true
+  end
+
   create_table "file_attentes", force: :cascade do |t|
     t.bigint "rdv_id", null: false
     t.bigint "user_id", null: false
@@ -389,6 +401,13 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_24_145810) do
     t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
+  end
+
+  create_table "justice_lieux_matches", force: :cascade do |t|
+    t.string "ee_id", null: false
+    t.bigint "lieu_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "lieux", force: :cascade do |t|
@@ -901,6 +920,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_24_145810) do
   add_foreign_key "annotations", "users"
   add_foreign_key "api_calls", "agents"
   add_foreign_key "exports", "agents"
+  add_foreign_key "external_references", "oauth_applications"
+  add_foreign_key "external_references", "territories"
   add_foreign_key "file_attentes", "rdvs"
   add_foreign_key "file_attentes", "users"
   add_foreign_key "lieux", "organisations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_13_133437) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_11_132916) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -297,10 +297,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_13_133437) do
     t.bigint "item_id", null: false
     t.bigint "oauth_application_id", null: false
     t.bigint "territory_id", null: false
-    t.bigint "external_id", null: false
+    t.text "external_id", null: false
     t.text "external_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["external_id", "item_type", "oauth_application_id", "territory_id"], name: "idx_on_external_id_item_type_oauth_application_id_t_09b6418013", unique: true
     t.index ["item_id", "item_type", "oauth_application_id", "territory_id"], name: "idx_on_item_id_item_type_oauth_application_id_terri_6db34b5548", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -404,13 +404,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_11_132916) do
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 
-  create_table "justice_lieux_matches", force: :cascade do |t|
-    t.string "ee_id", null: false
-    t.bigint "lieu_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "lieux", force: :cascade do |t|
     t.string "name", null: false
     t.bigint "organisation_id", null: false

--- a/spec/factories/access_token.rb
+++ b/spec/factories/access_token.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :access_token, class: Doorkeeper::AccessToken do
     scopes { ["write"] }
+    application { create(:oauth_application) }
   end
 end

--- a/spec/factories/external_reference.rb
+++ b/spec/factories/external_reference.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     external_url { "monsuivisocial.anct.gouv.fr/users/#{generate(:external_id_in_url)}" }
     oauth_application
     territory
+    item { create(:user) }
   end
 end

--- a/spec/factories/external_reference.rb
+++ b/spec/factories/external_reference.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  sequence(:external_id)
+  sequence(:external_id_in_url)
+
+  factory :external_reference do
+    external_id {  generate(:external_id) }
+    external_url { "monsuivisocial.anct.gouv.fr/users/#{generate(:external_id_in_url)}" }
+    oauth_application
+    territory
+  end
+end

--- a/spec/features/agents/users/agent_can_display_user_spec.rb
+++ b/spec/features/agents/users/agent_can_display_user_spec.rb
@@ -33,4 +33,18 @@ RSpec.describe "Agent can display user" do
       expect(page).to have_content("Cet usager a reçu une invitation via un partenaire de RDV Solidarités (ex : rdv-insertion).")
     end
   end
+
+  context "when the user has an external reference visible for the agent" do
+    let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
+    let!(:user) { create(:user, organisations: [organisation]) }
+    let(:application) { create(:oauth_application, name: "Démarches Simplifiées") }
+    let!(:external_reference) do
+      create(:external_reference, oauth_application: application, territory: organisation.territory, item: user)
+    end
+
+    it "shows a link to the external reference" do
+      visit admin_organisation_user_path(organisation, user)
+      expect(page).to have_content("Voir sur Démarches Simplifiées")
+    end
+  end
 end

--- a/spec/requests/api/v1/api_call_logging_spec.rb
+++ b/spec/requests/api/v1/api_call_logging_spec.rb
@@ -1,21 +1,12 @@
 RSpec.describe "On enregistre les appels à l'api pour mieux comprendre qui s'en sert et comment" do
   context "with OAuth authentication" do
-    let!(:oauth_token) do
-      create(:access_token, resource_owner_id: agent.id, application:)
-    end
-    let(:headers) do
-      {
-        "Content-Type": "application/json",
-        Authorization: "Bearer #{oauth_token.plaintext_token}",
-      }
-    end
-    let(:application) { create(:oauth_application) }
+    let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id) }
     let(:agent) do
       create(:agent, basic_role_in_organisations: [create(:organisation)])
     end
 
     it "records the correct authentication type" do
-      get "/api/v1/absences", headers: headers, as: :json
+      get "/api/v1/absences", headers: oauth_client_headers(oauth_token), as: :json
       expect(ApiCall.last.authentication_type).to eq "OAuth"
     end
   end

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -1,12 +1,8 @@
 RSpec.describe "RDV Plan API" do
+  let(:headers) { oauth_client_headers(oauth_token) }
+
   let!(:oauth_token) do
     create(:access_token, resource_owner_id: agent.id, application:)
-  end
-  let(:headers) do
-    {
-      "Content-Type": "application/json",
-      Authorization: "Bearer #{oauth_token.plaintext_token}",
-    }
   end
   let(:application) do
     create(:oauth_application,

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -2,7 +2,10 @@ RSpec.describe "/api/v1/users" do
   let(:my_organisation) { create(:organisation) }
   let(:myself) { create(:agent, basic_role_in_organisations: [my_organisation]) }
 
-  let(:headers) { api_auth_headers_for_agent(myself) }
+  let(:headers) do
+    oauth_client_headers(oauth_token)
+  end
+  let(:oauth_token) { create(:access_token, resource_owner_id: myself.id) }
 
   describe "POST #create" do
     context "simple case, create a user in my org" do
@@ -47,6 +50,54 @@ RSpec.describe "/api/v1/users" do
       it "agent ids outside my orgs are ignored" do
         post "/api/v1/users", headers:, params:, as: :json
         expect(User.last.referent_agents).to eq([myself])
+      end
+    end
+
+    describe "external references" do
+      let(:params) do
+        {
+          first_name: "Francis",
+          last_name: "Factice",
+          organisation_ids: [my_organisation.id],
+          external_reference: {
+            external_id: "123456",
+            external_url: "monsuivisocial.anct.gouv.fr/users/123456",
+          },
+        }
+      end
+
+      it "stores the external reference" do
+        post "/api/v1/users", headers:, params:, as: :json
+        references = User.last.external_references
+
+        expect(references.count).to eq 1
+        expect(references.last).to have_attributes(
+          external_id: "123456",
+          external_url: "monsuivisocial.anct.gouv.fr/users/123456",
+          territory_id: my_organisation.territory.id,
+          oauth_application_id: oauth_token.application_id
+        )
+      end
+
+      context "when another user already exists with this external reference" do
+        before do
+          ExternalReference.create(
+            item: create(:user),
+            external_id: "123456",
+            external_url: "monsuivisocial.anct.gouv.fr/users/123456",
+            territory_id: my_organisation.territory.id,
+            oauth_application_id: oauth_token.application_id
+          )
+        end
+
+        it "doesn't create a new user, and returns an error" do
+          expect do
+            post "/api/v1/users", headers:, params:, as: :json
+          end.not_to change(User, :count)
+
+          expect(parsed_response_body["error_messages"]).to eq ["external_references.external_id est déjà utilisé"]
+          expect(response.status).to eq 422
+        end
       end
     end
   end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -1,4 +1,11 @@
 module ApiSpecHelper
+  def oauth_client_headers(oauth_token)
+    {
+      "Content-Type": "application/json",
+      Authorization: "Bearer #{oauth_token.plaintext_token}",
+    }
+  end
+
   def api_auth_headers_for_agent(agent)
     # inspired by https://devise-token-auth.gitbook.io/devise-token-auth/usage/testing
     agent_with_token_auth = AgentWithTokenAuth.find(agent.id)


### PR DESCRIPTION
# Contexte

préparation pour https://github.com/betagouv/rdv-service-public/pull/5562

Pour faire migrer les conums depuis RDV Aide Numérique vers RDV Service Public, on a besoin de copier les usagers depuis l'ancienne instance vers la nouvelle.
Pour éviter de créer des doublons s'il y a plusieurs copies successives, on a besoin de savoir quels usagers viennent d'une copie, et à quel profil de base ils correspondent.

Ça serait aussi pratique de pouvoir retrouver un usager dans RDV Aide Numérique depuis RDV Service Public, par exemple pour consulter son historique de rendez-vous.

Pour les autres intégrations ça serait aussi une fonctionnalité intéressante : par exemple pour Mon Suivi Social, ça serait pratique de pouvoir retrouver la fiche du bénéficiaire dans MSS depuis RDV SP.

On pose aussi les bases des migrations des CDAD depuis RDV Solidarités vers RDV Service Public

# Solution

On introduit une nouvelle table ExternalReferences. 
Pour le moment elle ne peut référencer que les users, mais on fait une association polymorphique parce qu'on compte bientôt avoir le même système pour les objets de configuration d'un espace.

On scope cette table par territoire pour permettre à deux conums dans deux territoires différents de copier le même usager chacun de leur côté.
