### PR TITLE
Agents sans services

### DIFF
--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -20,7 +20,9 @@ class Agents::RdvPlansController < AgentAuthController
     redirect_to edit_modalites_agents_rdv_plan_path(@rdv_plan)
   end
 
-  def edit_modalites; end
+  def edit_modalites
+    @available_location_types = available_motifs(@rdv_plan).pluck(:location_type)
+  end
 
   def update_modalites
     rdv_plan_params = params.require(:rdv_plan).permit(:starts_at, :modalite)
@@ -33,11 +35,7 @@ class Agents::RdvPlansController < AgentAuthController
   end
 
   def edit_motif
-    @motifs = current_agent.motifs.individuel.where(
-      organisation_id: current_agent.roles.select(:organisation_id),
-      location_type: @rdv_plan.location_type,
-      service: @rdv_plan.rdv_agent.services
-    )
+    @motifs = available_motifs(@rdv_plan).ordered_by_name
     if @motifs.count == 1
       @rdv_plan.motif_id ||= @motifs.first.id
     end
@@ -86,6 +84,18 @@ class Agents::RdvPlansController < AgentAuthController
   end
 
   private
+
+  def available_motifs(rdv_plan)
+    motif_scope = Agent::MotifPolicy::Scope.new(
+      current_agent,
+      Motif.individuel.active
+    ).resolve
+
+    motif_scope.where(
+      service: rdv_plan.rdv_agent.services + [nil],
+      organisation_id: rdv_plan.rdv_agent.roles.select(:organisation_id)
+    )
+  end
 
   def find_rdv_plan
     @rdv_plan = RdvPlan.find(params[:id])

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -100,8 +100,4 @@ module AgentsHelper
       tag.div(class: "pt-2 pr-2 pb-2 pl-3", &block)
     end
   end
-
-  def access_level_label(access_level)
-    AgentRole.human_attribute_value(:access_level, access_level, context: :explanation).html_safe # rubocop:disable Rails/OutputSafety
-  end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -85,7 +85,6 @@ class Agent < ApplicationRecord
   has_many :services, through: :agent_services
   has_many :teams, through: :agent_teams
   has_many :lieux, through: :plage_ouvertures
-  has_many :motifs, through: :services
   has_many :rdvs, dependent: :restrict_with_error, through: :agents_rdvs
   has_many :territories, through: :territorial_roles
   has_many :organisations_of_territorial_roles, source: :organisations, through: :territories

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -108,7 +108,6 @@ class Agent < ApplicationRecord
   # * it validates :email (the invite_key) specifically with Devise.email_regexp.
   validates :first_name, presence: true, unless: -> { allow_blank_name || is_an_intervenant? }
   validates :last_name, presence: true, unless: -> { allow_blank_name }
-  validates :agent_services, presence: true, unless: -> { roles.none? }
 
   # Hooks
   before_destroy :prevent_destroy_if_rdvs
@@ -120,28 +119,25 @@ class Agent < ApplicationRecord
     where("invitation_sent_at IS NULL OR invitation_accepted_at IS NOT NULL")
   }
   scope :active, -> { where(deleted_at: nil) }
-  scope :in_any_of_these_services, lambda { |services|
-    joins(:agent_services).where(agent_services: { service_id: services.select(:id) })
-  }
 
   ## -
 
   delegate :name, to: :domain, prefix: true
 
   def confrere_of?(other_agent)
-    services.to_set.intersect?(other_agent.services.to_set)
+    services.to_set.intersect?(other_agent.services.to_set) || other_agent.services.none?
   end
 
   def confreres
-    Agent.in_any_of_these_services(services)
+    Agent.left_outer_joins(:agent_services).where(agent_services: { service_id: services.select(:id) + [nil] })
   end
 
   def reverse_full_name_and_service
-    services.present? ? "#{reverse_full_name_or_email} (#{services_short_names})" : full_name
+    services.present? ? "#{reverse_full_name_or_email} (#{services_short_names})" : reverse_full_name
   end
 
   def full_name_and_service
-    services.present? ? "#{full_name_or_email} (#{services_short_names})" : full_name
+    services.present? ? "#{full_name_or_email} (#{services_short_names})" : full_name_or_email
   end
 
   def services_short_names

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -26,10 +26,6 @@ class Service < ApplicationRecord
 
   ## -
 
-  def self.secretariat
-    find_by!(name: SECRETARIAT)
-  end
-
   def secretariat?
     name == SECRETARIAT
   end

--- a/app/services/admin_changes_agent_services.rb
+++ b/app/services/admin_changes_agent_services.rb
@@ -7,16 +7,9 @@ class AdminChangesAgentServices
     @new_services = Service.where(id: new_service_ids)
   end
 
-  validate :at_least_one_service
   validate :removed_services_dont_have_plages
 
   private
-
-  def at_least_one_service
-    if @new_services.empty?
-      errors.add(:service_ids, "Un agent doit avoir au moins un service")
-    end
-  end
 
   def removed_services_dont_have_plages
     removed_services.each do |removed_service|

--- a/app/sms/users/file_attente_sms.rb
+++ b/app/sms/users/file_attente_sms.rb
@@ -2,6 +2,12 @@ class Users::FileAttenteSms < Users::BaseSms
   include Rails.application.routes.url_helpers
 
   def new_creneau_available(rdv, _user, token)
-    @content = "RDV #{rdv.motif&.service&.short_name}: des créneaux se sont libérés.\nPour voir les disponibilités: #{creneaux_users_rdv_short_url(rdv, tkn: token, host: domain_host)}"
+    @content = if rdv.service_short_name
+                 "RDV #{rdv.motif&.service&.short_name}: des créneaux se sont libérés."
+               else
+                 "Des créneaux se sont libérés pour votre RDV."
+               end
+
+    @content += "\nPour voir les disponibilités: #{creneaux_users_rdv_short_url(rdv, tkn: token, host: domain_host)}"
   end
 end

--- a/app/views/admin/agents/edit.html.slim
+++ b/app/views/admin/agents/edit.html.slim
@@ -37,7 +37,7 @@
           = f.simple_fields_for @agent_role do |ff|
             = ff.input :access_level,
               collection: @roles,
-              label_method: -> { render("admin/agents/role_labels/#{_1}") },
+              label_method: -> { render("admin/agents/role_labels/#{_1}", { services: @agent.services }) },
               hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations.count > 1),
               as: :radio_buttons
 

--- a/app/views/admin/agents/edit.html.slim
+++ b/app/views/admin/agents/edit.html.slim
@@ -15,12 +15,15 @@
           = render "model_errors", model: @agent
 
           p
-            - if @agent.services.count == 1
-              | #{@agent.full_name} appartient à un seul service :
+            - if @agent.services.count == 0
+              | #{@agent.full_name_or_email} n'appartient à aucun service
+            - elsif @agent.services.count == 1
+              = "#{@agent.full_name_or_email} appartient au service "
+              b #{@agent.services.first.name}
             - else
-              | #{@agent.full_name} appartient à #{@agent.services.count} services :
-            ul.fr-pl-2w
-            - @agent.services.each do |service|
+              | #{@agent.full_name_or_email} appartient à #{@agent.services.count} services :
+              ul.fr-pl-2w
+              - @agent.services.each do |service|
               li.rdv-font-weight-bold= service.name
 
           - if Agent::TerritoryPolicy.new(current_agent, current_territory).allow_to_manage_access_rights?

--- a/app/views/admin/agents/edit.html.slim
+++ b/app/views/admin/agents/edit.html.slim
@@ -35,13 +35,11 @@
           hr
 
           = f.simple_fields_for @agent_role do |ff|
-            - # rubocop:disable Rails/OutputSafety
-            = ff.input :access_level, \
-              collection: @roles, \
-              label_method: -> { AgentRole.human_attribute_value(:access_level, _1, context: :explanation).html_safe }, \
-              hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
+            = ff.input :access_level,
+              collection: @roles,
+              label_method: -> { render("admin/agents/role_labels/#{_1}") },
+              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations.count > 1),
               as: :radio_buttons
-          - # rubocop:enable Rails/OutputSafety
 
           / allow turning an intervenant into an agent with an account
           - if AgentRole.find(@agent_role.id).access_level == "intervenant"

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -17,7 +17,7 @@
               | Quel type d'agent souhaitez-vous ajouter ?
             = ff.input :access_level,
               collection: @roles,
-              label_method: -> { render("admin/agents/role_labels/#{_1}") },
+              label_method: -> { render("admin/agents/role_labels/#{_1}", { services: @services }) },
               hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations.count > 1),
               as: :radio_buttons,
               label: "",

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -17,8 +17,8 @@
               | Quel type d'agent souhaitez-vous ajouter ?
             = ff.input :access_level,
               collection: @roles,
-              label_method: -> { access_level_label(_1) },
-              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if @current_territory.organisations.count > 1),
+              label_method: -> { render("admin/agents/role_labels/#{_1}") },
+              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations.count > 1),
               as: :radio_buttons,
               label: "",
               html: { class: "mt-4" }

--- a/app/views/admin/agents/role_labels/_admin.html.slim
+++ b/app/views/admin/agents/role_labels/_admin.html.slim
@@ -1,0 +1,6 @@
+i.fa.fa-user-cog.fr-mr-1w
+| Administrateur
+br
+ul
+  li Peut consulter et modifier l'agenda de tous les agents de l'organisation
+  li Peut gérer la configuration

--- a/app/views/admin/agents/role_labels/_basic.html.slim
+++ b/app/views/admin/agents/role_labels/_basic.html.slim
@@ -1,6 +1,11 @@
+/# locals: (services:)
 i.fa.fa-user.fr-mr-1w
 | Basique
 br
 ul
-  li Peut consulter et modifier son agenda et celui des agents de son service
-  li Service secrétariat: peut consulter et modifier les agendas de tous les agents de l'organisation
+  - if services.any?
+    li Peut consulter et modifier son agenda et celui des agents de son service
+  - else
+    li Peut consulter et modifier son agenda et celui de ses collègues
+  - if services.any?(&:secretariat?)
+    li Service secrétariat: peut consulter et modifier les agendas de tous les agents de l'organisation

--- a/app/views/admin/agents/role_labels/_basic.html.slim
+++ b/app/views/admin/agents/role_labels/_basic.html.slim
@@ -1,0 +1,6 @@
+i.fa.fa-user.fr-mr-1w
+| Basique
+br
+ul
+  li Peut consulter et modifier son agenda et celui des agents de son service
+  li Service secrétariat: peut consulter et modifier les agendas de tous les agents de l'organisation

--- a/app/views/admin/agents/role_labels/_intervenant.html.slim
+++ b/app/views/admin/agents/role_labels/_intervenant.html.slim
@@ -1,0 +1,7 @@
+i.fa.fa-user-lock.fr-mr-1w
+| Intervenant
+br
+ul
+  li Ne nécessite pas d'email et ne peut donc pas se connecter
+  li Ne peut pas modifier son agenda
+  li Ne reçoit aucune notification

--- a/app/views/agents/rdv_plans/_modalites_field.html.slim
+++ b/app/views/agents/rdv_plans/_modalites_field.html.slim
@@ -1,10 +1,8 @@
-- available_location_types = rdv_plan.rdv_agent.motifs.individuel.active.where(organisation_id: rdv_plan.rdv_agent.roles.select(:organisation_id)).pluck(:location_type)
-
 fieldset[class="fr-fieldset" id="rdv_plan[modalite]" aria-labelledby="radio-rich-no-pictogram-inline-legend radio-rich-no-pictogram-inline-messages"]
   legend[class="fr-fieldset__legend--regular fr-fieldset__legend" id="radio-rich-no-pictogram-inline-legend"]
     | Comment souhaitez-vous faire le rendez-vous ?
 
-  - if available_location_types.include?("public_office")
+  - if @available_location_types.include?("public_office")
     - lieux = policy_scope(Lieu.enabled, policy_scope_class: Agent::LieuPolicy::Scope)
     - lieux.each do |lieu|
       .fr-fieldset__element
@@ -16,7 +14,7 @@ fieldset[class="fr-fieldset" id="rdv_plan[modalite]" aria-labelledby="radio-rich
               = " Sur place à #{lieu.name}"
             span.fr-hint-text = lieu.address
 
-  - if available_location_types.include?("phone")
+  - if @available_location_types.include?("phone")
     .fr-fieldset__element
       .fr-radio-group.fr-radio-rich
         input[value="phone" type="radio" id="rdv_plan_modalite_phone" name="rdv_plan[modalite]" required]
@@ -25,7 +23,7 @@ fieldset[class="fr-fieldset" id="rdv_plan[modalite]" aria-labelledby="radio-rich
             = phone_icon
             = " Par téléphone"
 
-  - if available_location_types.include?("visio")
+  - if @available_location_types.include?("visio")
     .fr-fieldset__element
       .fr-radio-group.fr-radio-rich
         input[value="visio" type="radio" id="rdv_plan_modalite_visio" name="rdv_plan[modalite]" required]
@@ -36,7 +34,7 @@ fieldset[class="fr-fieldset" id="rdv_plan[modalite]" aria-labelledby="radio-rich
           span.fr-hint-text
             | Nous vous fournirons un lien de visio
 
-  - if available_location_types.include?("home")
+  - if @available_location_types.include?("home")
     .fr-fieldset__element
       .fr-radio-group.fr-radio-rich
         input[value="home" type="radio" id="rdv_plan_modalite_home" name="rdv_plan[modalite]" required]

--- a/app/views/agents/rdv_plans/_modalites_field.html.slim
+++ b/app/views/agents/rdv_plans/_modalites_field.html.slim
@@ -1,3 +1,5 @@
+/# locals: (rdv_plan:)
+
 fieldset[class="fr-fieldset" id="rdv_plan[modalite]" aria-labelledby="radio-rich-no-pictogram-inline-legend radio-rich-no-pictogram-inline-messages"]
   legend[class="fr-fieldset__legend--regular fr-fieldset__legend" id="radio-rich-no-pictogram-inline-legend"]
     | Comment souhaitez-vous faire le rendez-vous ?

--- a/config/locales/models/agent_role.fr.yml
+++ b/config/locales/models/agent_role.fr.yml
@@ -10,10 +10,6 @@ fr:
         basic: Basique
         admin: Administrateur
         intervenant: Intervenant
-      agent_role/access_levels/explanation:
-        basic: "<i class='far fa-user'></i> Basique<br><ul><li>Peut consulter et modifier son agenda et celui des agents de son service</li><li>Service secrétariat: peut consulter et modifier les agendas de tous les agents de l'organisation</li></ul>"
-        admin: <i class='fa fa-user-cog'></i> Administrateur<br><ul><li>Peut consulter et modifier l'agenda des agents de tous les services</li><li>Peut créer, modifier et supprimer des lieux, des motifs et des agents</li></ul>
-        intervenant: <i class="fas fa-user-lock"></i> Intervenant<br><ul><li>Ne nécessite pas d'email et donc ne peut pas se connecter</li><li>Ne peut pas modifier son agenda</li><li>Ne reçoit aucune notification</li></ul>
     warnings:
       models:
         agent_role:

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Admin::AgentsController, type: :controller do
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
   let!(:agent1) { create(:agent, admin_role_in_organisations: [organisation], invitation_sent_at: 3.days.ago, invitation_accepted_at: nil) }
   let!(:organisation2) { create(:organisation) }
-  let(:service_id) { agent.services.first.id }
 
   before do
     request.env["devise.mapping"] = Devise.mappings[:agent]
@@ -82,7 +81,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
           organisation_id: organisation.id,
           agent: {
             email: "hacker@renard.com",
-            service_ids: [service_id],
+            service_ids: [],
             agent_role: {
               access_level: "basic",
             },
@@ -103,7 +102,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
           organisation_id: organisation2.id,
           agent: {
             email: "hacker@renard.com",
-            service_ids: [service_id],
+            service_ids: [],
             agent_role: { access_level: "basic" },
           },
         }
@@ -123,7 +122,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
           organisation_id: organisation.id,
           agent: {
             email: "hacker@renard.com",
-            service_ids: [service_id],
+            service_ids: [],
             agent_role: { access_level: "basic", organisation_id: organisation2.id },
           },
         }
@@ -148,7 +147,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
       end
 
       before do
-        agent.services.first.update!(name: Service::CONSEILLER_NUMERIQUE)
+        agent.services << create(:service, name: Service::CONSEILLER_NUMERIQUE)
       end
 
       it "creates a new basic agent instead of an admin" do
@@ -188,7 +187,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
           organisation_id: organisation.id,
           agent: {
             email: "michel@lapin.com",
-            service_ids: [service_id],
+            service_ids: [],
             agent_role: { access_level: "basic" },
           },
         }
@@ -210,7 +209,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
           organisation_id: organisation.id,
           agent: {
             email: "aa@hhh",
-            service_ids: [service_id],
+            service_ids: [],
             agent_role: {
               access_level: "basic",
             },
@@ -231,7 +230,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
           organisation_id: organisation.id,
           agent: {
             email: existing_agent.email,
-            service_ids: [service_id],
+            service_ids: [],
             agent_role: {
               access_level: "basic",
             },
@@ -293,7 +292,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
           organisation_id: organisation.id,
           agent: {
             email: "MARCO@demo.rdv-solidarites.fr",
-            service_ids: [service_id],
+            service_ids: [],
             agent_role: { access_level: "basic" },
           },
         }
@@ -310,7 +309,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
         params = { organisation_id: organisation.id,
                    agent: {
                      email: "hacker@renard.com",
-                     service_ids: [service_id],
+                     service_ids: [],
                      agent_role: { access_level: "basic" },
                    }, }
         expect do
@@ -325,7 +324,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
         params = { organisation_id: organisation.id,
                    agent: {
                      email: "hacker@renard.com",
-                     service_ids: [service_id],
+                     service_ids: [],
                      agent_role: { access_level: "basic" },
                    }, }
         expect do

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -10,25 +10,27 @@ FactoryBot.define do
     confirmed_at { Time.zone.parse("2020-07-30 10:30").in_time_zone }
     invitation_accepted_at { Time.zone.parse("2020-07-30 10:30").in_time_zone }
 
-    transient do
-      service { build(:service) }
-      no_services { false }
-
-      trait :no_services do
-        no_services { true }
-      end
+    trait :with_service do
+      service { association(:service) }
     end
-    after(:build) do |agent, evaluator|
-      next if evaluator.no_services
-      next if agent.agent_services.any?
-      next if agent.services.any?
+    transient do
+      services { [] }
+      service { nil }
+    end
 
-      if agent.agent_services.empty? && agent.services.empty?
-        agent.services = if evaluator.service
-                           [evaluator.service]
-                         else
-                           [build(:service)]
-                         end
+    trait :secretaire do
+      services { [Service.find_by(name: Service::SECRETARIAT) || build(:service, :secretariat)] }
+    end
+    trait :cnfs do
+      services { [Service.find_by(name: Service::CONSEILLER_NUMERIQUE) || build(:service, :conseiller_numerique)] }
+    end
+
+    after(:build) do |agent, evaluator|
+      if evaluator.service
+        agent.agent_services << build(:agent_service, service: evaluator.service, agent:)
+      end
+      evaluator.services.each do |service|
+        agent.agent_services << build(:agent_service, service:, agent:)
       end
     end
 
@@ -83,12 +85,6 @@ FactoryBot.define do
       invitation_sent_at { 2.days.ago }
       invitation_accepted_at { nil }
       confirmed_at { nil }
-    end
-    trait :secretaire do
-      services { [Service.find_by(name: Service::SECRETARIAT) || build(:service, :secretariat)] }
-    end
-    trait :cnfs do
-      services { [Service.find_by(name: Service::CONSEILLER_NUMERIQUE) || build(:service, :conseiller_numerique)] }
     end
     trait :intervenant do
       email { nil }

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 
   context "when there are multiple plage d'ouverture and lieux" do
-    let!(:motif) { create(:motif, service: agent.services.first, organisation: organisation) }
+    let!(:motif) { create(:motif, organisation: organisation) }
     let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, motifs: [motif], agent: agent, organisation: organisation) }
     let!(:plage_ouverture2) { create(:plage_ouverture, :weekdays, motifs: [motif], organisation: organisation) }
 
@@ -32,6 +32,7 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
   end
 
   context "when there is only one option for service and motif selector", js: true do
+    let!(:agent) { create(:agent, :with_service, basic_role_in_organisations: [organisation]) }
     let!(:motif) { create(:motif, name: "Mon unique motif", service: agent.services.first, organisation: organisation) }
     let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, motifs: [motif], agent: agent, organisation: organisation) }
 
@@ -44,7 +45,7 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
   end
 
   context "when there is more than one option for lieux, services and motifs selector", js: true do
-    let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+    let!(:agent) { create(:agent, :with_service, admin_role_in_organisations: [organisation]) }
     let!(:lieu) { create(:lieu, organisation: organisation) }
     let!(:motif) { create(:motif, service: agent.services.first, organisation: organisation) }
     let!(:motif2) { create(:motif, service: agent.services.first, organisation: organisation) }
@@ -67,8 +68,8 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
     before { travel_to(Date.new(2023, 5, 2)) }
 
     let(:first_day_of_plages) { 2.weeks.from_now.beginning_of_week.to_date }
-    let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation], service: agent.services.first) }
-    let!(:motif) { create(:motif, service: agent.services.first, organisation: organisation) }
+    let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+    let!(:motif) { create(:motif, organisation: organisation) }
     let!(:plage_ouverture1) { create(:plage_ouverture, motifs: [motif], first_day: first_day_of_plages, agent: agent, organisation: organisation) }
     let!(:plage_ouverture2) do
       create(:plage_ouverture, motifs: [motif], first_day: first_day_of_plages, agent: other_agent, organisation: organisation, lieu: plage_ouverture1.lieu)
@@ -88,7 +89,7 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
   end
 
   context "when there are multiple plages from the same agent in the same lieu" do
-    let!(:motif) { create(:motif, service: agent.services.first, organisation: organisation) }
+    let!(:motif) { create(:motif, organisation: organisation) }
     let!(:plage_ouverture1) { create(:plage_ouverture, motifs: [motif], agent: agent, organisation: organisation) }
     let!(:plage_ouverture2) do
       create(:plage_ouverture, motifs: [motif], agent: agent, organisation: organisation, lieu: plage_ouverture1.lieu,
@@ -107,7 +108,7 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
   end
 
   context "when the motif is bookable online and the next creneau is after the max booking delay" do
-    let!(:motif) { create(:motif, name: "Vaccination", organisation: organisation, max_public_booking_delay: 7.days, service: agent.services.first) }
+    let!(:motif) { create(:motif, name: "Vaccination", organisation: organisation, max_public_booking_delay: 7.days) }
     let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: 8.days.since, motifs: [motif], organisation: organisation) }
 
     it "still allows the agent to book a rdv, because the booking delays should only apply to agents" do
@@ -139,13 +140,13 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
     end
 
     context "when the motif is by phone and there is a plage d'ouverture without lieu" do
-      let!(:motif) { create(:motif, :by_phone, service: agent.services.first, organisation: organisation) }
+      let!(:motif) { create(:motif, :by_phone, organisation: organisation) }
 
       it_behaves_like "book a rdv without a lieu"
     end
 
     context "when the motif is at home and there is a plage d'ouverture without lieu" do
-      let!(:motif) { create(:motif, :at_home, service: agent.services.first, organisation: organisation) }
+      let!(:motif) { create(:motif, :at_home, organisation: organisation) }
 
       it_behaves_like "book a rdv without a lieu"
     end
@@ -153,7 +154,7 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
 
   context "when the motif doesn't have a service" do
     let!(:motif) { create(:motif, service: nil, organisation: organisation) }
-    let!(:motif2) { create(:motif, service: agent.services.first, organisation: organisation) }
+    let!(:motif2) { create(:motif, organisation: organisation) }
     let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, motifs: [motif], agent: agent, organisation: organisation) }
 
     it "displays lieux and allow filtering on lieux" do

--- a/spec/features/agents/agent_can_list_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_list_rdvs_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Agent can list RDVs" do
   let!(:organisation) { create(:organisation) }
-  let!(:current_agent) { create(:agent, organisations: [organisation]) }
+  let!(:current_agent) { create(:agent, organisations: [organisation], service: create(:service)) }
   let!(:user) { create(:user) }
 
   def user_profile_path(user)
@@ -25,7 +25,7 @@ RSpec.describe "Agent can list RDVs" do
 
   describe "RDV visibility within organisation" do
     let!(:agent_from_same_service) { create(:agent, organisations: [organisation], service: current_agent.services.first) }
-    let!(:agent_from_other_service) { create(:agent, organisations: [organisation]) }
+    let!(:agent_from_other_service) { create(:agent, organisations: [organisation], service: create(:service)) }
 
     before do
       [current_agent, agent_from_same_service, agent_from_other_service].each do |agent|

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -5,15 +5,15 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
   before do
     first_day = Date.parse("2023/08/01")
     travel_to(first_day.beginning_of_day)
-    motif = create(:motif, organisation: organisation, service: agent.services.first, name: "Accompagnement Formation")
+    motif = create(:motif, organisation: organisation, name: "Accompagnement Formation")
     motif.plage_ouvertures << create(:plage_ouverture, first_day: first_day, organisation: organisation, agent: agent)
   end
 
   it "shows the online booking forms, until the creneau selection" do
     login_as(agent, scope: :agent)
     visit public_link_to_org_path(organisation_id: organisation.id)
-    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
-    find("button", text: agent.services.first.name).click
+
+    expect(page).to have_content("Sélectionnez le motif de votre RDV :")
     click_link("Accompagnement Formation")
     expect(page).to have_content("Sélectionnez un lieu de RDV")
     click_on(organisation.lieux.first.name)
@@ -23,6 +23,6 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
   it "works on the RDV_MAIRIE domain" do
     login_as(agent, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/#{public_link_to_org_path(organisation_id: organisation.id)}"
-    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
+    expect(page).to have_content("Sélectionnez le motif de votre RDV :")
   end
 end

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
   let!(:agent) do
     create(:agent, basic_role_in_organisations: [organisation], rdv_notifications_level: :all)
   end
-  let!(:motif) { create(:motif, service: agent.services.first, organisation: organisation, location_type: :public_office) }
+  let!(:motif) { create(:motif, organisation: organisation, location_type: :public_office) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
 
   let!(:user) do

--- a/spec/features/autodoc/creation_espace_spec.rb
+++ b/spec/features/autodoc/creation_espace_spec.rb
@@ -1,7 +1,7 @@
 # Les captures d'écran des emails dans autodoc causent des erreurs JS à cause d'images qui ne chargent pas correctement
 # donc on désactive cette vérification pour ces specs
 RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
-  let!(:agent) { create(:agent, :no_services, first_name: "Francis", last_name: "Factice", password: "c0rrecThorse!") }
+  let!(:agent) { create(:agent, first_name: "Francis", last_name: "Factice", password: "c0rrecThorse!") }
 
   around { |example| perform_enqueued_jobs { example.run } }
 

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
   end
 
   context "quand l'agent a déjà été créé via une connexion ProConnect" do
-    let(:agent) { create(:agent, :no_services, email: "francis@factice.org", proconnect_siret: "13002526500013") }
+    let(:agent) { create(:agent, email: "francis@factice.org", proconnect_siret: "13002526500013") }
 
     before do
       AnnuaireServicePublicStubs.stub_siret_as_anct(agent.proconnect_siret, self)

--- a/spec/features/territory_admins/territory_admin_can_manage_agents_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_agents_spec.rb
@@ -122,13 +122,6 @@ RSpec.describe "territory admin can manage agents", type: :feature do
       expect { click_on "Enregistrer les services" }.not_to change { edited_agent.reload.services.to_set }
       expect(page).to have_content("Le retrait du service n'a pu aboutir car l'agent a toujours des plages d'ouverture actives sur le service : B")
     end
-
-    it "forbids removing last service" do
-      unselect service_a.name, from: "Services"
-      unselect service_b.name, from: "Services"
-      expect { click_on "Enregistrer les services" }.not_to change { edited_agent.reload.services.to_set }
-      expect(page).to have_content("Un agent doit avoir au moins un service")
-    end
   end
 
   describe "un agent appartient à un service désactivé" do

--- a/spec/form_models/compte_spec.rb
+++ b/spec/form_models/compte_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Compte do
   context "when the agent already has an account because they logged in with ProConnect" do
-    let!(:agent) { create(:agent, :no_services) }
+    let!(:agent) { create(:agent) }
     let(:super_admin) { create(:super_admin) }
     let(:service) { create(:service) }
 

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     it "body contains cancelled confirmation with motif's service name" do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
-      rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user], motif: build(:motif, :with_service))
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
       expect(mail.html_part.body).to match(rdv.motif.service_name)

--- a/spec/models/agent_role_spec.rb
+++ b/spec/models/agent_role_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe AgentRole, type: :model do
     end
 
     context "basic access_level, but agent is secretaire" do
-      let(:agent) { build(:agent, :secretaire) }
-      let(:agent_role) { build(:agent_role, agent: agent) }
+      let(:agent) { create(:agent, :secretaire) }
+      let(:agent_role) { create(:agent_role, agent: agent) }
 
-      it { is_expected.to be_truthy }
+      it { expect(subject).to be_truthy }
     end
 
     context "basic access_level" do

--- a/spec/policies/agent/agent_policy_spec.rb
+++ b/spec/policies/agent/agent_policy_spec.rb
@@ -112,23 +112,20 @@ RSpec.describe Agent::AgentPolicy::Scope, type: :policy do
       let!(:organisations) { create_list(:organisation, 4) }
       let!(:agent) do
         create(
-          :agent,
+          :agent, :with_service,
           basic_role_in_organisations: [organisations[0]],
           admin_role_in_organisations: [organisations[1], organisations[2]]
         )
       end
-      let!(:other_agent1) { create(:agent, basic_role_in_organisations: [organisations[0]]) }
-      let!(:other_agent2) { create(:agent, basic_role_in_organisations: [organisations[1]]) }
-      let!(:other_agent3) { create(:agent, basic_role_in_organisations: [organisations[2]]) }
-      let!(:other_agent4) { create(:agent, basic_role_in_organisations: [organisations[3]]) }
-      let!(:other_agent5) { create(:agent, admin_role_in_organisations: [organisations[2]]) }
+      # TODO: ajouter une spec pour un agent sans service
+      let!(:other_agent1) { create(:agent, :with_service, basic_role_in_organisations: [organisations[0]]) }
+      let!(:other_agent2) { create(:agent, :with_service, basic_role_in_organisations: [organisations[1]]) }
+      let!(:other_agent3) { create(:agent, :with_service, basic_role_in_organisations: [organisations[2]]) }
+      let!(:other_agent4) { create(:agent, :with_service, basic_role_in_organisations: [organisations[3]]) }
+      let!(:other_agent5) { create(:agent, :with_service, admin_role_in_organisations: [organisations[2]]) }
 
-      it do
-        expect(subject).not_to include(other_agent1)
-        expect(subject).to include(other_agent2)
-        expect(subject).to include(other_agent3)
-        expect(subject).not_to include(other_agent4)
-        expect(subject).to include(other_agent5)
+      specify do
+        expect(subject).to contain_exactly(agent, other_agent2, other_agent3, other_agent5)
       end
     end
 
@@ -138,7 +135,7 @@ RSpec.describe Agent::AgentPolicy::Scope, type: :policy do
       let!(:other_territory_organisations) { create_list(:organisation, 3, territory: territories[1]) }
       let!(:agent) do
         create(
-          :agent,
+          :agent, :with_service,
           basic_role_in_organisations: [same_territory_organisations[0], other_territory_organisations[0]],
           admin_role_in_organisations: [same_territory_organisations[1], other_territory_organisations[1]],
           role_in_territories: [territories[0]]
@@ -147,17 +144,19 @@ RSpec.describe Agent::AgentPolicy::Scope, type: :policy do
       let!(:other_agent_same_territory1) { create(:agent, basic_role_in_organisations: [same_territory_organisations[0]]) }
       let!(:other_agent_same_territory2) { create(:agent, basic_role_in_organisations: [same_territory_organisations[1]]) }
       let!(:other_agent_same_territory3) { create(:agent, basic_role_in_organisations: [same_territory_organisations[2]]) }
-      let!(:other_agent_different_territory1) { create(:agent, basic_role_in_organisations: [other_territory_organisations[0]]) }
+      # TODO: ajouter un agent sans service
+      let!(:other_agent_different_territory1) { create(:agent, :with_service, basic_role_in_organisations: [other_territory_organisations[0]]) }
       let!(:other_agent_different_territory2) { create(:agent, basic_role_in_organisations: [other_territory_organisations[1]]) }
       let!(:other_agent_different_territory3) { create(:agent, basic_role_in_organisations: [other_territory_organisations[2]]) }
 
       it do
-        expect(subject).to include(other_agent_same_territory1)
-        expect(subject).to include(other_agent_same_territory2)
-        expect(subject).to include(other_agent_same_territory3)
-        expect(subject).not_to include(other_agent_different_territory1)
-        expect(subject).to include(other_agent_different_territory2)
-        expect(subject).not_to include(other_agent_different_territory3)
+        expect(subject).to contain_exactly(
+          agent,
+          other_agent_same_territory1,
+          other_agent_same_territory2,
+          other_agent_same_territory3,
+          other_agent_different_territory2
+        )
       end
     end
   end

--- a/spec/policies/agent/plage_ouverture_policy_spec.rb
+++ b/spec/policies/agent/plage_ouverture_policy_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Agent::PlageOuverturePolicy, type: :policy do
     end
 
     context "when she belongs to the plage's organisation as basic member" do
-      let(:agent) { create(:agent, basic_role_in_organisations: [plage_ouverture.organisation]) }
+      let(:agent) { create(:agent, :with_service, basic_role_in_organisations: [plage_ouverture.organisation]) }
 
       context "when she shares a service with the plage's agent" do
         before do
@@ -112,6 +112,8 @@ RSpec.describe Agent::PlageOuverturePolicy, type: :policy do
       end
 
       context "when she shares no service with the plage's agent" do
+        let(:plage_ouverture) { create(:plage_ouverture, agent: create(:agent, :with_service)) }
+
         before do
           expect(agent.services.to_set.intersection(plage_ouverture.agent.services.to_set)).to be_empty # rubocop:disable RSpec/ExpectInHook
         end

--- a/spec/requests/api/v1/swagger_doc/absences_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/absences_request_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe "Absence authentified API", swagger_doc: "v1/api.json" do
       let!(:organisation1) { create(:organisation) }
       let!(:organisation2) { create(:organisation) }
       let!(:organisation3) { create(:organisation) }
-      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation1, organisation2]) }
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation1, organisation2], service: create(:service)) }
       let!(:agent1) { create(:agent, basic_role_in_organisations: [organisation1], service: agent.services.first) }
-      let!(:agent2) { create(:agent, basic_role_in_organisations: [organisation2]) }
+      let!(:agent2) { create(:agent, :with_service, basic_role_in_organisations: [organisation2]) }
       let!(:agent3) { create(:agent, basic_role_in_organisations: [organisation3]) }
       let!(:absence1) { create(:absence, agent: agent1) }
       let!(:absence2) { create(:absence, agent: agent2) }

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe "Search", type: :request do
 
       context "with agent_id params" do
         it "render motif_selection template" do
-          motif = create(:motif, service: agent.services.first, follow_up: true, organisation: organisation)
+          motif = create(:motif, follow_up: true, organisation: organisation)
           create(:plage_ouverture, agent: agent, motifs: [motif], organisation: organisation)
-          get prendre_rdv_url(referent_ids: [agent.id], service: agent.services.first.id, departement: organisation.territory.departement_number, host: "www.rdv-solidarites-test.localhost")
+          get prendre_rdv_url(referent_ids: [agent.id], departement: organisation.territory.departement_number, host: "www.rdv-solidarites-test.localhost")
           expect(response).to render_template("search/_motif_selection")
         end
       end

--- a/spec/services/admin_creates_agent_spec.rb
+++ b/spec/services/admin_creates_agent_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe AdminCreatesAgent do
   context "when inviting an agent that doesn't have any services" do
     let(:agent) do
-      create(:agent, :no_services, organisations: [])
+      create(:agent, organisations: [])
     end
     let(:service1) { create(:service) }
     let(:service2) { create(:service) }

--- a/spec/sms/users/file_attente_sms_spec.rb
+++ b/spec/sms/users/file_attente_sms_spec.rb
@@ -8,9 +8,19 @@ RSpec.describe Users::FileAttenteSms, type: :service do
     let(:token) { "12324" }
 
     it do
-      expect(subject).to include("RDV Service 1: des créneaux se sont libérés")
+      expect(subject).to include("Des créneaux se sont libérés pour votre RDV")
       expect(subject).to include("Pour voir les disponibilités")
       expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/82/cr?tkn=12324")
+    end
+
+    context "with a service" do
+      let(:rdv) { build(:rdv, id: 82, organisation: organisation, motif: create(:motif, :with_service)) }
+
+      it do
+        expect(subject).to include("RDV Service 1: des créneaux se sont libérés")
+        expect(subject).to include("Pour voir les disponibilités")
+        expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/82/cr?tkn=12324")
+      end
     end
   end
 end


### PR DESCRIPTION
Pour le contexte, voir l'issue https://github.com/betagouv/rdv-service-public/issues/5559

Cette PR est la suite des motifs sans services (https://github.com/betagouv/rdv-service-public/pull/5549)

# Changements fonctionnels

Si on continue d'utiliser des services, rien ne change.

Il est maintenant possible pour un agent de ne pas avoir de service.
-  tous les agents peuvent voir les agendas des agents sans service de leurs organisations.
- les agents sans service peuvent uniquement utiliser les motifs sans services

# Changements d'interface

Au final c'est juste dans les formulaires d'agents que l'interface change vraiment :


Avant | Après
:- | -:
<img width="1420" height="488" alt="Screenshot 2025-08-15 at 15 06 50" src="https://github.com/user-attachments/assets/7fbf353d-8430-4657-b896-a5567dba1f7b" />|<img width="1421" height="422" alt="Screenshot 2025-08-15 at 15 08 03" src="https://github.com/user-attachments/assets/66c23538-106c-48e2-9992-4d09a454665c" />

On fait aussi une mise à jour des textes explicatifs des différents niveaux de permission, en gérant les différent cas.

Avant | Après
:- | -:
<img width="1426" height="770" alt="Screenshot 2025-08-15 at 15 11 27" src="https://github.com/user-attachments/assets/a1f437d3-1538-446e-bdea-5de86e340a5b" />|<img width="1421" height="773" alt="Screenshot 2025-08-15 at 15 09 39" src="https://github.com/user-attachments/assets/1b5801e8-3002-466b-b52e-de71a322166c" />

La ligne sur le service secrétariat ne s'affiche que si ce service est activé pour ce territoire.

# Découpage en commits


Une lecture commit par commit facilitera la review. J'ai préfixé le messages de commits pour aider à comprendre le but de chacun d'entre eux.

- On commence par deux commits de refacto (qui aurait pu être extrait dans des PR préliminaires, mais ça me semblait acceptable de les mettre ici).
  - Le premier est juste la suppression d'une méthode unitilisée.
  - Le deuxième est un léger changement sur comment on charge les motifs pour les rdv_plans : on utilisait l'assocation `Agent.has_many :motifs, through: :services`, mais cette association n'a pas vraiment de sens, et d'ailleurs elle cause un bug pour la prise de rdv par intégration pour les motifs sans service. Par ailleurs, les règles métiers de quels motifs sont accessibles pour la prise de rdv par intégration sont légèrement différentes de l'interface normale, principalement parce qu'on ne filtre pas par organisation, et que donc le scope est beaucoup plus difficile à écrire.

Le troisième commit est le coeur de la PR : on supprime les règles de validation et on met à jour les policies.

Ensuite les commits suivants sont des mises à jour de l'interface pour gérer le cas des agents sans service.

Les deux derniers commits sont des mises à jour des specs.

