### PR TITLE
Petits correctifs visuels

### DIFF
--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -135,8 +135,6 @@ ruby:
             = link_to "Voir tous les RDV de l’usager", admin_organisation_rdvs_path(current_organisation, user_id: @user.id), class: "fr-btn fr-btn--tertiary fr-btn--sm", title: "Voir tous les RDV de l’usager #{@user.full_name}"
       .card-body
         .row
-          .fr-mb-2v
-            = render "admin/rdvs/rdv_visibility"
           .col-lg-6
             - %i[seen excused revoked noshow].each do |temporal_status|
               = render "stats/rdv_counter_with_link", \
@@ -150,6 +148,7 @@ ruby:
                 count: @participations.joins(:rdv).status(temporal_status).count,
                 path: admin_organisation_rdvs_path(current_organisation, status: temporal_status, user_id: @user.id, breadcrumb_page: "user")
       .card-footer
+        = render "admin/rdvs/rdv_visibility"
         = dsfr_alert type: :info, size: :sm
           | Les RDV sont supprimés au bout de 2 ans.
 

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -45,7 +45,7 @@ nav.left-side-menu-wrapper
             - agent_for_left_menu = @agent&.persisted? ? @agent : current_agent
             - path_helper_name = content_for(:menu_agent_select_path_helper_name) || :admin_organisation_planning_agenda_path
             li
-              form.my-2.pl-2
+              form.fr-my-3v
                 = planning_agent_select(agent_for_left_menu, path_helper_name)
             li
               = active_link_to "Agenda", admin_organisation_planning_agenda_path(current_organisation, agent_id: agent_for_left_menu), class: "side-menu__item side-menu__item--small"

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -27,7 +27,7 @@ nav.left-side-menu-wrapper
                   i.fa.fa-angle-down.menu-arrow.mt-1
           = render "layouts/left_menu/organisation_switcher"
 
-        li
+        li.fr-pb-0
           a.side-menu__item[
             data-toggle="collapse"
             href=".left-submenu-planning"
@@ -44,7 +44,7 @@ nav.left-side-menu-wrapper
           ]
             - agent_for_left_menu = @agent&.persisted? ? @agent : current_agent
             - path_helper_name = content_for(:menu_agent_select_path_helper_name) || :admin_organisation_planning_agenda_path
-            li
+            li.fr-pb-0
               form.fr-my-3v
                 = planning_agent_select(agent_for_left_menu, path_helper_name)
             li
@@ -54,38 +54,38 @@ nav.left-side-menu-wrapper
             li
               = active_link_to "Indisponibilités", admin_organisation_planning_absences_path(current_organisation, agent_id: agent_for_left_menu), class: "side-menu__item side-menu__item--small"
 
-        li
+        li.fr-pb-0
           = active_link_to(admin_organisation_users_path(current_organisation), class: "side-menu__item")
             span.fr-icon-group-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
             | Usagers
 
-        li
+        li.fr-pb-0
           = active_link_to(admin_organisation_rdvs_path(current_organisation), class: "side-menu__item")
             span.fr-icon-survey-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
             | Liste des RDV
 
-        li
+        li.fr-pb-0
           = active_link_to(admin_organisation_rdvs_collectifs_path(current_organisation), class: "side-menu__item")
             span.fr-icon-team-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
             | RDV collectifs
 
-        li
+        li.fr-pb-0
           = active_link_to(admin_organisation_stats_path(current_organisation), class: "side-menu__item")
             span.fr-icon-bar-chart-box-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
             | Statistiques
 
         - unless current_agent_role.admin?
-          li
+          li.fr-pb-0
             = active_link_to admin_organisation_lieux_path(current_organisation), class: "side-menu__item"
               = lieu_icon(class: "fr-icon--sm fr-mr-1w")
               | Lieux
-          li
+          li.fr-pb-0
             = active_link_to admin_organisation_motifs_path(current_organisation), class: "side-menu__item"
               = motif_icon(class: "fr-icon--sm fr-mr-1w")
               | Motifs
 
         - if current_agent_role.admin?
-          li
+          li.fr-pb-0
             = link_to admin_organisation_configuration_path(current_organisation), class: "side-menu__item #{'active' if menu_top_level_item == 'settings'}"
               span.fr-icon-settings-5-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
               | Configuration
@@ -93,7 +93,7 @@ nav.left-side-menu-wrapper
               - if menu_top_level_item != "settings" && current_organisation.created_at > 30.days.ago && needs_configuration(current_organisation)
                 .fr-ml-1w.rdv-pastille
 
-        li
+        li.fr-pb-0
           = active_link_to admin_organisation_support_path(current_organisation), class: "side-menu__item"
             span.fr-icon-question-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
             | Support

--- a/app/views/stats/_rdv_counter_with_link.html.slim
+++ b/app/views/stats/_rdv_counter_with_link.html.slim
@@ -7,5 +7,3 @@
   .flex-grow-1.rdv-text-align-right
     span.text-bold>= count
     span RDV
-    span.pl-2
-      i.fa.fa-eye


### PR DESCRIPTION
Cette PR propose des tout petits correctifs sur des détails visuels repéré en bossant sur autre chose

### Alignement du picker d'agent avec les sous-menus

Avant | Après
:- | -:
<img width="312" height="576" alt="Screenshot 2025-08-15 at 15 51 05" src="https://github.com/user-attachments/assets/84319a29-a33a-40e2-b081-5990e2f611eb" />|<img width="304" height="547" alt="Screenshot 2025-08-15 at 15 49 56" src="https://github.com/user-attachments/assets/ba52be66-7ef1-464d-a781-a1127ae2638d" />

Les sous-menus dépendent de l'agent sélectionné, donc ils doivent être indentés à droite.

### Remaniement des stats de rdv par statut sur la page de détails d'un usager

Avant | Après
:- | -:
<img width="582" height="571" alt="Screenshot 2025-08-15 at 15 52 21" src="https://github.com/user-attachments/assets/da68d18c-8f38-40ae-b6e9-52857f9b5a2f" />|<img width="590" height="570" alt="Screenshot 2025-08-15 at 15 52 42" src="https://github.com/user-attachments/assets/095ed751-fce1-4ba1-8b02-28ea30867ab1" />


- La marge foireuse sur le premier encart d'info était ma principale motivation à commencer cette PR.
- On en profite pour regroupe les infos ensemble.
- Les icônes d'yeux étaient nécessaire pour éviter la confusion au moment de la refonte de cette interface il y a 4 ans, mais plus maintenant (voir https://github.com/betagouv/rdv-service-public/pull/1167)