### PR TITLE
Simplification des champs motif et lieu pour la prise de rdv pour les agents

### DIFF
--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -33,7 +33,7 @@
         group_label_method: -> { _1.first&.name },
         label_method: -> { motif_name_with_location_and_group_type(_1) }, \
         input_html: { \
-          data: { placeholder: "Sélectionnez un motif", "auto-select-sole-option": true },
+          data: { placeholder: "Sélectionnez un motif", "auto-select-sole-option": true, "select2-config": { disableSearch: @motifs.count <= 5  } },
           class: @services.count > 1 ? "js-filtered-motifs" : "select2-input", \
         }
 

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -20,9 +20,10 @@ ruby:
         .form-group data=controller_data
           = f.label :lieu, required: true
           fieldset
-            = f.association :lieu, collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name, label_method: :full_name,
+            - lieux = Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name
+            = f.association :lieu, collection: lieux, label_method: :full_name,
               label: false,  include_blank: true,  required: false,
-              input_html: { class: "select2-input", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true} }
+              input_html: { class: "select2-input", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true, "select2-config": { disableSearch: lieux.count <= 5  } } }
             small.form-text.text-muted data={"rdv-lieu-target": "new_lieu_link"}
               = t(".single_use_lieu_hint_html")
           fieldset data={ "rdv-lieu-target": "new_lieu_fieldset" }


### PR DESCRIPTION
Avant | Après
:- | -:
_mettre un screenshot ici_ | _et ici_
<img width="815" height="503" alt="Screenshot 2025-08-19 at 10 17 18" src="https://github.com/user-attachments/assets/a285e3a3-84bf-4197-8270-b61dc2c149ef" />|<img width="832" height="479" alt="Screenshot 2025-08-19 at 10 17 05" src="https://github.com/user-attachments/assets/daae1feb-2c67-46b5-926f-7844126c017c" />
<img width="830" height="545" alt="Screenshot 2025-08-19 at 10 20 23" src="https://github.com/user-attachments/assets/42f5a30a-3feb-418f-abd8-6ec3fd36521f" />|<img width="851" height="539" alt="Screenshot 2025-08-19 at 10 21 16" src="https://github.com/user-attachments/assets/a58afeee-3fd5-4f46-b98a-c66bf3a0fe1e" />

C'est juste une PR de simplification pour proposer une interface moins lourde quand c'est possible : on enlève la recherche sur les champs motif et lieux pour la prise de rdv pour les agents. Quand on a 5 éléments ou moins, ça sert à rien de proposer une recherche de texte.
