### PR TITLE
Clarification de la recherche des usagers

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,8 +23,11 @@ class Admin::UsersController < AgentAuthController
     agent_id = params[:agent_id]
     search_params = params[:search]
 
+    @search_needed = agent_id.blank? && search_params.blank?
+
     @users = policy_scope(User, policy_scope_class: Agent::UserPolicy::Scope)
-    @users = @users.none if agent_id.blank? && search_params.blank?
+
+    @users = @users.none if @search_needed
     @users = @users.merge(Agent.find(agent_id).users) if agent_id.present?
     @users = @users.search_by_text(search_params) if search_params.present?
     @users = @users.ordered_by_last_name.page(page_number)

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -27,8 +27,8 @@
       input.btn.btn-primary.d-print-none type="submit" value="Rechercher"
 
       - if @search_needed
-        p.fr-mt-2w.text-muted
-          = icon("fr-icon-lock-line", class: "fr-mr-1w")
+        p.fr-mt-4w.text-muted.fr-mb-0.fr-text--sm
+          = icon("fr-icon-lock-line", class: "fr-mr-1w fr-mb-1w")
           | Pour protéger la confidentialité de vos usagers, ils sont accessibles uniquement via une recherche, et pas directement en liste.
           br
           | Lancez une recherche pour trouver des usagers.

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -27,9 +27,11 @@
       input.btn.btn-primary.d-print-none type="submit" value="Rechercher"
 
       - if @search_needed
-      .fr-grid-row
-        .fr-col-12.rdv-text-align-center
-          p Utilisez le champ de recherche pour trouver&nbsp;un&nbsp;usager
+        p.fr-mt-2w.text-muted
+          = icon("fr-icon-lock-line", class: "fr-mr-1w")
+          | Pour protéger la confidentialité de vos usagers, ils sont accessibles uniquement via une recherche, et pas directement en liste.
+          br
+          | Lancez une recherche pour trouver des usagers.
 
   - if @users.any? && !@search_needed
     .table-responsive
@@ -55,7 +57,3 @@
         .d-flex.justify-content-center id="users-pagination"
           = paginate @users, theme: "dsfr"
           .rdv-text-align-center= page_entries_info @users
-
-- if @search_needed
-  = dsfr_alert type: :info, size: :sm, html_attributes: { class: "fr-mb-2v" } do
-    |< Pour protéger la confidentialité de vos usagers, ils sont accessibles uniquement via une recherche, et pas directement en liste.

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -8,26 +8,30 @@
 
 - content_for :breadcrumb do
   .btn-group
-    = link_to "Fusionner deux usagers", new_admin_organisation_merge_users_path(current_organisation), class: "btn btn-outline-primary mr-1"
-    = link_to "Ajouter un usager", new_admin_organisation_user_path(current_organisation), class: "btn btn-outline-primary"
+    = link_to "Fusionner deux usagers", new_admin_organisation_merge_users_path(current_organisation), class: "fr-btn fr-btn--secondary mr-1"
+    = link_to "Ajouter un usager", new_admin_organisation_user_path(current_organisation), class: "fr-btn"
 
-.card
+.card[class="#{"fr-mt-6w" if @search_needed}"]
   .card-body
     = form_with url: admin_organisation_users_path(current_organisation), method: :get  do |f|
       .row
-        .col-md-6
+        .col-md-8
           .form-group.string.optional._search
             = label_tag :search, "Recherche", {class: "form-control-label string optional"}
             = text_field_tag :search, {}, {placeholder: "Prénom, Nom, Email, Téléphone", autocomplete: "off", class: "form-control string optional search-form-control", value: params[:search] }
-        .col-md-6
+        .col-md-4
           .form-group.string.optional._search
             = f.label :agent_id, "Agent référent", {class: "form-control-label select optional"}
             = f.select :agent_id, [], {}, { class: "form-control select optional select2-input", data: { "select2-config": { ajax: { url: admin_organisation_agents_path(current_organisation), dataType: "json", delay: 250 } } } }
 
       input.btn.btn-primary.d-print-none type="submit" value="Rechercher"
 
-.card
-  - if @users.any? || params[:search].present? || params[:agent_id].present?
+      - if @search_needed
+      .fr-grid-row
+        .fr-col-12.rdv-text-align-center
+          p Utilisez le champ de recherche pour trouver&nbsp;un&nbsp;usager
+
+  - if @users.any? && !@search_needed
     .table-responsive
       table.table
         thead
@@ -51,14 +55,7 @@
         .d-flex.justify-content-center id="users-pagination"
           = paginate @users, theme: "dsfr"
           .rdv-text-align-center= page_entries_info @users
-  - else
-    .card-body
-      .row.justify-content-md-center
-        .col-md-6.rdv-text-align-center.my-5
-          p.mb-2.fr-text--lead Utilisez le champ de recherche pour trouver&nbsp;un&nbsp;usager
-          span.fa-stack.fa-4x
-            i.fa.fa-circle.fa-stack-2x.text-primary
-            i.fa.fa-users.fa-stack-1x.text-white
 
-  .m-3.rdv-text-align-center
-    = link_to "Ajouter un usager", new_admin_organisation_user_path(current_organisation), class: "btn btn-primary"
+- if @search_needed
+  = dsfr_alert type: :info, size: :sm, html_attributes: { class: "fr-mb-2v" } do
+    |< Pour protéger la confidentialité de vos usagers, ils sont accessibles uniquement via une recherche, et pas directement en liste.

--- a/spec/features/agents/users/agent_can_delete_user_spec.rb
+++ b/spec/features/agents/users/agent_can_delete_user_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe "Agent can delete user" do
       click_link("Supprimer")
     end
     expect_page_title("Usagers")
-    expect_page_with_no_record_text("Utilisez le champ de recherche pour trouver un usager")
+    expect(organisation.users).to be_empty
   end
 end


### PR DESCRIPTION
### Contexte

Cette PR est la suite très tardive de https://github.com/betagouv/rdv-service-public/issues/1348 : on reste sur la décision initiale de ne pas montrer la liste des usagers (ce qui est une bonne chose aussi pour éviter de devenir un crm), mais on explique ce fonctionnement dans l'interface.

On change aussi l'ui pour éviter de donner cette impression de "liste vide", en enlevant ces éléments :
- la grande card vide
- l'illustration associée aux empty states
- le cta principal dans cette card qui donne l'impression qu'on va ajouter un premier élément dans cette liste.

Et on descend un peu le champs de recherche pour qu'il soit mieux compris comme l'élément principal de la page (une implémentation plus poussée aurait été de mettre une liste "floutée" derrière la card du champs de recherche pour bien faire comprendre cette idée).

En bonus, quand on a des résultats de recherche, on met tout dans la même card, puisque le champs contrôle les résultats.



Avant | Après
:- | -:
<img width="1401" height="906" alt="Screenshot 2025-08-18 at 17 07 07" src="https://github.com/user-attachments/assets/5e6e0271-5d01-41e7-bb0e-52c4655a74e6" />|<img width="1438" height="775" alt="Screenshot 2025-08-18 at 18 13 47" src="https://github.com/user-attachments/assets/99ee4af6-50a4-4ec1-980f-1df8d776fac7" />
<img width="1435" height="785" alt="Screenshot 2025-08-18 at 17 08 31" src="https://github.com/user-attachments/assets/a84c4cc6-36b3-4ae9-a327-5bd01fde1950" />|<img width="1421" height="782" alt="Screenshot 2025-08-18 at 17 08 47" src="https://github.com/user-attachments/assets/c3b3d8ec-b83f-4f1d-9bdc-3d44fcc07bf9" />


historique : https://github.com/betagouv/rdv-service-public/issues/1348