### PR TITLE
Correctif pour la recherche de créneaux avec un motif sans service

### DIFF
--- a/app/controllers/admin/creneaux_search_controller.rb
+++ b/app/controllers/admin/creneaux_search_controller.rb
@@ -60,7 +60,8 @@ class Admin::CreneauxSearchController < AgentAuthController
   def prepare_form
     @motifs = Agent::MotifPolicy::Scope.apply(current_agent, current_organisation.motifs).active.ordered_by_name
     @services = Service.where(id: @motifs.map(&:service_id).uniq)
-    @form.service_id = @services.first.id if @services.count == 1
+
+    @form.service_id = @services.first.id if @services.count == 1 && @motifs.where(service_id: nil).none?
     @teams = Agent::TeamPolicy::Scope.apply(current_agent, current_territory.teams)
     @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
       .joins(:organisations).where(organisations: { id: current_organisation.id })

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -22,7 +22,7 @@
                 class: "select2-input js-service-filter", \
                 data: { \
                   placeholder: "Sélectionnez un service pour filtrer les motifs", \
-                  "select2-config": { disableSearch: true }, \
+                  "select2-config": { disableSearch: true, allowClear: true }, \
                 }, \
               }
           .col-md-4

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
     end
   end
 
+  context "when there is one motif with service and one without", js: true do
+    let!(:agent) { create(:agent, :with_service, basic_role_in_organisations: [organisation]) }
+    let!(:motif) { create(:motif, service: agent.services.first, organisation: organisation) }
+    let!(:motif_without_service) { create(:motif, service: nil, name: "Orientation", organisation:) }
+
+    it "allows selecting the motif without service" do
+      visit admin_organisation_creneaux_search_path(organisation)
+      expect(page).to have_content("Trouver un RDV")
+
+      select("Orientation", from: "motif_id")
+    end
+  end
+
   context "when there is more than one option for lieux, services and motifs selector", js: true do
     let!(:agent) { create(:agent, :with_service, admin_role_in_organisations: [organisation]) }
     let!(:lieu) { create(:lieu, organisation: organisation) }


### PR DESCRIPTION
Cette PR corrige un petit bug introduit dans https://github.com/betagouv/rdv-service-public/pull/5549

Si on a un seul service activé, et un mélange de motifs avec et sans service, les motifs sans service n'étaient pas disponibles dans la recherche de créneaux.

On ajoute donc une spec et un correctif.