### PR TITLE
Ouverture de comptes sans service

### DIFF
--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -100,21 +100,18 @@ class Compte
   end
 
   def create_mairie_motifs!
-    service = Service.find_by(name: Service::MAIRIE)
-
     create_mairie_motif!(service, "Carte d'identité", Api::Ants::EditorController::CNI_MOTIF_CATEGORY_NAME)
     create_mairie_motif!(service, "Passeport", Api::Ants::EditorController::PASSPORT_MOTIF_CATEGORY_NAME)
     create_mairie_motif!(service, "Passeport et carte d'identité", Api::Ants::EditorController::CNI_AND_PASSPORT_MOTIF_CATEGORY_NAME)
   end
 
-  def create_mairie_motif!(service, name, motif_category_name)
+  def create_mairie_motif!(name, motif_category_name)
     Motif.create!(
       name: name,
       color: "#99CC99",
       default_duration_in_min: 15,
       location_type: :public_office,
       organisation: organisation,
-      service: service,
       motif_category: MotifCategory.find_by(name: motif_category_name),
       bookable_by: :everyone
     )
@@ -133,7 +130,6 @@ class Compte
       color: "#99CC99",
       default_duration_in_min: 30,
       bookable_by: :agents,
-      service: agent.services.first,
     }
     Motif.create!(default_motif_attributes.merge(location_type: :phone))
     Motif.create!(default_motif_attributes.merge(location_type: :visio))

--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -100,9 +100,9 @@ class Compte
   end
 
   def create_mairie_motifs!
-    create_mairie_motif!(service, "Carte d'identité", Api::Ants::EditorController::CNI_MOTIF_CATEGORY_NAME)
-    create_mairie_motif!(service, "Passeport", Api::Ants::EditorController::PASSPORT_MOTIF_CATEGORY_NAME)
-    create_mairie_motif!(service, "Passeport et carte d'identité", Api::Ants::EditorController::CNI_AND_PASSPORT_MOTIF_CATEGORY_NAME)
+    create_mairie_motif!("Carte d'identité", Api::Ants::EditorController::CNI_MOTIF_CATEGORY_NAME)
+    create_mairie_motif!("Passeport", Api::Ants::EditorController::PASSPORT_MOTIF_CATEGORY_NAME)
+    create_mairie_motif!("Passeport et carte d'identité", Api::Ants::EditorController::CNI_AND_PASSPORT_MOTIF_CATEGORY_NAME)
   end
 
   def create_mairie_motif!(name, motif_category_name)

--- a/app/models/territory_creation_request.rb
+++ b/app/models/territory_creation_request.rb
@@ -3,7 +3,7 @@ class TerritoryCreationRequest < ApplicationRecord
 
   belongs_to :agent
 
-  validates :organisation_name, :territory_name, :service_name, presence: true
+  validates :organisation_name, :territory_name, presence: true
   validates :agent_id, uniqueness: true
   validate :can_only_have_one_response
 

--- a/app/views/agents/territory_creation_requests/new.html.slim
+++ b/app/views/agents/territory_creation_requests/new.html.slim
@@ -6,6 +6,5 @@
         = form_for @territory_creation_request, url: agents_territory_creation_requests_path, builder: Dsfr::FormBuilder do |f|
           = f.dsfr_text_field :territory_name, hint: "par exemple : Commune de Montreuil, Préfecture de Seine-Saint-Denis", required: true
           = f.dsfr_text_field :organisation_name, hint: "par exemple : CCAS de Montreuil, Bureau de Bobigny", autocomplete: "organization", required: true
-          = f.dsfr_text_field :service_name, label: "Pour quel service souhaitez-vous gérer des rendez-vous ?", hint: "par exemple : Action Sociale, Ressources Humaines", required: true
 
           = f.submit "Envoyer la demande", class: "fr-btn float-right"

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -43,7 +43,7 @@ section.main-content__body
         = ff.input :last_name, label: "Nom"
         = ff.input :email, label: "Adresse mail", hint: "Une invitation sera envoyée automatiquement"
       = ff.input :service_ids, label: "Service", required: false, collection: Service.all, hint: sanitize("Si nécessaire, vous pouvez #{link_to('créer un nouveau service', new_super_admins_service_path, target: :blank)}")
-      - if @territory_creation_request
+      - if @territory_creation_request&.service_name
         .form-text.text-muted[style="margin-bottom: 12px"]
           = "L'agent a indiqué travailler pour le service "
           b #{@territory_creation_request.service_name}

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -42,7 +42,7 @@ section.main-content__body
         = ff.input :first_name, label: "Prénom"
         = ff.input :last_name, label: "Nom"
         = ff.input :email, label: "Adresse mail", hint: "Une invitation sera envoyée automatiquement"
-      = ff.input :service_ids, label: "Service", collection: Service.all, hint: sanitize("Si nécessaire, vous pouvez #{link_to('créer un nouveau service', new_super_admins_service_path, target: :blank)}")
+      = ff.input :service_ids, label: "Service", required: false, collection: Service.all, hint: sanitize("Si nécessaire, vous pouvez #{link_to('créer un nouveau service', new_super_admins_service_path, target: :blank)}")
       - if @territory_creation_request
         .form-text.text-muted[style="margin-bottom: 12px"]
           = "L'agent a indiqué travailler pour le service "

--- a/spec/features/autodoc/creation_espace_spec.rb
+++ b/spec/features/autodoc/creation_espace_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
 
     fill_in("Nom de l’espace", with: "Commune de Montreuil")
     fill_in("Nom de votre première organisation", with: "CCAS de Montreuil")
-    fill_in("Pour quel service souhaitez-vous gérer des rendez-vous ?", with: "Action Sociale")
 
     doc.add_screenshot(page,
                        text: "Je remplis le formulaire puis je valide")

--- a/spec/features/super_admin/creating_a_new_account_spec.rb
+++ b/spec/features/super_admin/creating_a_new_account_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
   before do
     stub_request(:get, "https://data.geopf.fr/geocodage/search/?q=Place%20de%20la%20mairie,%20Romainville,%2093230")
       .to_return(status: 200, body: autocomplete_response, headers: {})
-
-    create(:service, name: "Urbanisme")
   end
 
   it "creates a new organisation" do
@@ -36,7 +34,6 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
     fill_in("Prénom", with: "Francis")
     fill_in(:compte_agent_last_name, with: "Factice") # Plusieurs champs ont le label "Nom", donc on utilise le name de l'input
     fill_in("Adresse mail", with: "francis@factice.org")
-    select("Urbanisme", from: "Service")
 
     click_button("Enregistrer")
     expect(page).to have_content("Le nouvel espace a été créé, et une invitation a été envoyée à francis@factice.org")
@@ -50,9 +47,9 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
       category: "Commune"
     )
 
-    new_agent = new_territory.admin_agents.first
+    new_territory.admin_agents.first
 
-    expect(new_territory.services).to eq new_agent.services
+    expect(new_territory.services).to be_empty
 
     new_organisation = new_territory.organisations.first
     expect(new_organisation).to have_attributes(
@@ -81,7 +78,6 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
     let!(:cni_motif_category) { create(:motif_category, name: Api::Ants::EditorController::CNI_MOTIF_CATEGORY_NAME) }
     let!(:passport_motif_category) { create(:motif_category, name: Api::Ants::EditorController::PASSPORT_MOTIF_CATEGORY_NAME) }
     let!(:cni_passport_motif_category) { create(:motif_category, name: Api::Ants::EditorController::CNI_AND_PASSPORT_MOTIF_CATEGORY_NAME) }
-    let!(:service) { create(:service, name: "Mairie") }
 
     it "crée un espace avec une organisation qui a les catégories de motif pour se brancher à l'ANTS" do
       login_as(super_admin, scope: :super_admin)
@@ -105,7 +101,6 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
       fill_in("Prénom", with: "Francis")
       fill_in(:compte_agent_last_name, with: "Factice") # Plusieurs champs ont le label "Nom", donc on utilise le name de l'input
       fill_in("Adresse mail", with: "francis@factice.org")
-      select("Mairie", from: "Service")
 
       find(:label, text: "Autoriser le branchement au moteur de recherche de l'ANTS").click
 

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
 
         fill_in("Nom de l’espace", with: "Commune de Montreuil")
         fill_in("Nom de votre première organisation", with: "CCAS de Montreuil")
-        fill_in("Pour quel service souhaitez-vous gérer des rendez-vous ?", with: "Action Sociale")
         click_on "Envoyer la demande"
 
         expect(page).to have_content("Votre demande a bien été enregistrée. Notre équipe va l'étudier et revenir vers vous dans les meilleurs délais")
@@ -63,7 +62,6 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
 
         select "Commune", from: "Catégorie de l'espace"
 
-        select "Service social", from: "Service"
         click_on "Enregistrer"
         expect(page).to have_content "Le nouvel espace a été créé"
 


### PR DESCRIPTION
Suite de https://github.com/betagouv/rdv-service-public/pull/5570 / https://github.com/betagouv/rdv-service-public/issues/5559

Avant | Après
:- | -:
<img width="1259" height="775" alt="Screenshot 2025-08-18 at 17 57 35" src="https://github.com/user-attachments/assets/8db9074f-b18d-449c-98ef-d9ed26daf74b" />|<img width="1261" height="767" alt="Screenshot 2025-08-18 at 17 57 02" src="https://github.com/user-attachments/assets/64f7d8ea-e881-482e-a730-35bf428c251c" />

Le service pour l'ouverture d'un nouveau compte devient facultatif, ce qui enlève un frein à la demande de création de compte, et qui évite les distractions pour cette notion qui n'est pas utile au début de l'utilisation de l'application.

Une prochaine étape possible pourrait être de permettre la création de compte directe pour les agents dont on est sûrs qu'ils travaillent pour le service public.