### PR TITLE
Correctif pour l'édition d'un agent avec plusieurs services

### DIFF
--- a/app/views/admin/agents/edit.html.slim
+++ b/app/views/admin/agents/edit.html.slim
@@ -24,7 +24,7 @@
               | #{@agent.full_name_or_email} appartient à #{@agent.services.count} services :
               ul.fr-pl-2w
               - @agent.services.each do |service|
-              li.rdv-font-weight-bold= service.name
+                li.rdv-font-weight-bold= service.name
 
           - if Agent::TerritoryPolicy.new(current_agent, current_territory).allow_to_manage_access_rights?
             = link_to "Ajouter ou retirer des services", edit_admin_territory_agent_path(territory_id: current_territory.id, agent_id: @agent.id), class: "fr-link fr-icon-pencil-line fr-link--icon-left"

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -146,4 +146,23 @@ RSpec.describe "Agents can be managed by organisation admins" do
       expect(Agent.last.services.first).to eq(new_service)
     end
   end
+
+  describe "editing an agent with multiple services" do
+    before do
+      login_as(organisation_admin, scope: :agent)
+      visit admin_organisation_agents_path(organisation1)
+    end
+
+    let!(:other_agent) do
+      create(:agent, basic_role_in_organisations: [organisation1], services: [pmi, other_service])
+    end
+
+    it "works" do
+      visit edit_admin_organisation_agent_path(organisation1, other_agent)
+      find("label", text: "Administrateur").click
+      click_on "Enregistrer"
+      expect(page).to have_content "Agents"
+      expect(other_agent.reload.roles.last.access_level).to eq "admin"
+    end
+  end
 end


### PR DESCRIPTION
Un bug d'indentation introduit dans https://github.com/betagouv/rdv-service-public/pull/5569

Le fix est trivial, mais il nous manquait de la couverture de tests là dessus.
Ce qui est plus inquiétant, c'est que je l'ai appris via crisp, et que je ne retrouve pas les erreurs dans Sentry. Je vais essayer de comprendre pourquoi.