### PR TITLE
Correctif pour les données de test pour l'intégration avec Justice.fr

### DIFF
--- a/app/controllers/api/justice/lieux_controller.rb
+++ b/app/controllers/api/justice/lieux_controller.rb
@@ -8,13 +8,13 @@ class Api::Justice::LieuxController < ActionController::Base # rubocop:disable R
       lieux << {
         ee_id: "612f2ed9b473e40555def46c",
         reservation_en_ligne: false,
-        url: "https://demo.rdv.anct.gouv.fr/prendre_rdv?departement=&public_link_organisation_id=877",
+        url: "https://demo.rdv.anct.gouv.fr/org/877/ccas-de-lille",
       }
 
       lieux << {
         ee_id: "612f2ed9b473e40555def46e",
         reservation_en_ligne: true,
-        url: "https://demo.rdv.anct.gouv.fr/prendre_rdv?departement=&public_link_organisation_id=878",
+        url: "https://demo.rdv.anct.gouv.fr/org/878/ccas-de-montreuil",
       }
     end
 


### PR DESCRIPTION
L'url renvoyée par l'endpoint était `https://demo.rdv.anct.gouv.fr/prendre_rdv?departement=\u0026public_link_organisation_id=877` (avec un `\u0026` en trop), ce qui empêchait de voir les créneaux, ce qui bloque l'équipe tech qui bosse sur l'appli mobile justice.fr pour faire une démo au ministère.
Je fais ici un correctif rapide : j'utilise plutôt l'url canonique, sur laquelle on n'a pas ce problème.