### PR TITLE
Fix ETL sync (ajout good_job_batches)

### DIFF
--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -8,7 +8,20 @@ tables:
   - table_name: good_job_settings
     truncated: true
   - table_name: good_job_batches
-    truncated: true
+    anonymized_column_names:
+      - description
+      - serialized_properties
+      - on_finish
+      - on_success
+      - on_discard
+    non_anonymized_column_names:
+      - created_at
+      - updated_at
+      - finished_at
+      - discarded_at
+      - enqueued_at
+      - callback_queue_name
+      - callback_priority
   - table_name: good_job_processes
     truncated: true
   - table_name: annotations


### PR DESCRIPTION
# Contexte

La table `good_job_batches` était truncated jusqu’à présent. En lisant le code de l’ETL, on se rend compte que celui-ci fait un dump de base sans tenir compte des tables `truncated`. Or, nous avons rajouté [ici](https://github.com/betagouv/rdv-service-public/pull/5568/files#diff-9fd0442614d0f4ad794cf5db2da507157102856b1b7725b14d2d4c1362c11e58R10) une référence à la table `good_job_baches` ce qui a pour conséquence de faire planter l’ETL.

```
2025-08-21 16:27:26.722274915 +0200 CEST [one-off-8094] Command was: ALTER TABLE ONLY public.instance_exports
2025-08-21 16:27:26.722260054 +0200 CEST [one-off-8094] pg_restore: error: could not execute query: ERROR:  relation "public.good_job_batches" does not exist
2025-08-21 16:27:26.722275864 +0200 CEST [one-off-8094] ADD CONSTRAINT fk_rails_42e39d0765 FOREIGN KEY (good_job_batch_id) REFERENCES public.good_job_batches(id);
2025-08-21 16:28:37.961903068 +0200 CEST [one-off-8094] pg_restore: warning: errors ignored on restore: 1
2025-08-21 16:28:37.966527310 +0200 CEST [one-off-8094] /app/lib/utils.rb:30:in `block in run_command': Command failed (RuntimeError)
2025-08-21 16:28:37.966536149 +0200 CEST [one-off-8094] 	from /app/lib/utils.rb:28:in `run_command'
2025-08-21 16:28:37.966537461 +0200 CEST [one-off-8094] 	from main.rb:77:in `<main>'
2025-08-21 16:28:37.966537011 +0200 CEST [one-off-8094] 	from /app/lib/etl.rb:76:in `run'
2025-08-21 16:28:37.966535388 +0200 CEST [one-off-8094] 	from /app/lib/utils.rb:23:in `log_around'
```

# Solution

On ajoute la table `good_job_batches` pour éviter de faire trop de modifications dans le code de l’ETL.
