### PR TITLE
Début de données pour l'intégration Justice.fr

### DIFF
--- a/app/controllers/api/justice/lieux_controller.rb
+++ b/app/controllers/api/justice/lieux_controller.rb
@@ -53,6 +53,7 @@ class Api::Justice::LieuxController < ActionController::Base # rubocop:disable R
     )
   end
 
+  # Cette liste est générée manuellement à partir d'un dump de données de prods en utilisant un script
   def matches
     {
       "612f2ebab473e40555dee806": 2098,

--- a/app/controllers/api/justice/lieux_controller.rb
+++ b/app/controllers/api/justice/lieux_controller.rb
@@ -16,8 +16,55 @@ class Api::Justice::LieuxController < ActionController::Base # rubocop:disable R
         reservation_en_ligne: true,
         url: "https://demo.rdv.anct.gouv.fr/org/878/ccas-de-montreuil",
       }
+    else
+      # Il y a beaucoup de requêtes N+1 dans ce code, mais c'est acceptable tant que c'est derrière un cache
+      # et qu'on a relativement peu de lieux concernées
+      lieux = Rails.cache.fetch("justice/lieux_controller", expires_in: 1.hour) do
+        matches.map do |ee_id, lieu_id|
+          lieu = Lieu.find_by(id: lieu_id)
+          next unless lieu
+
+          {
+            ee_id: ee_id,
+            reservation_en_ligne: reservation_en_ligne(lieu),
+            url: url(lieu),
+          }
+        end.compact
+      end
     end
 
     render json: { lieux: }
+  end
+
+  private
+
+  def reservation_en_ligne(lieu)
+    lieu.plage_ouvertures.joins(:motifs).where(
+      motifs: { bookable_by: :everyone },
+      plage_ouvertures: { expired_cached: false }
+    ).any?
+  end
+
+  def url(lieu)
+    Rails.application.routes.url_helpers.public_link_to_org_url(
+      organisation_id: lieu.organisation_id,
+      org_slug: lieu.organisation.slug,
+      host: "rdv.anct.gouv.fr"
+    )
+  end
+
+  def matches
+    {
+      "612f2ebab473e40555dee806": 2098,
+      "612f2ebfb473e40555dee9d4": 1861,
+      "612f2ec1b473e40555deeb00": 1933,
+      "612f2ec1b473e40555deeb04": 1904,
+      "612f2ec1b473e40555deeb06": 1906,
+      "612f2ec1b473e40555deeb08": 1932,
+      "612f2ec1b473e40555deeb1a": 1926,
+      "612f2ec2b473e40555deeb1c": 1927,
+      "612f2ec2b473e40555deeb20": 1942,
+      "612f2ec2b473e40555deeb26": 1936,
+    }
   end
 end

--- a/spec/requests/api/justice/lieu_spec.rb
+++ b/spec/requests/api/justice/lieu_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe "Api pour Justice.fr" do
+  it "renvoie une liste des lieux de justice" do
+    get "/api/justice/lieux"
+    parsed_response = JSON.parse(response.body)
+    expect(parsed_response.symbolize_keys).to eq({ lieux: [] })
+  end
+end

--- a/spec/requests/api/justice/lieu_spec.rb
+++ b/spec/requests/api/justice/lieu_spec.rb
@@ -1,7 +1,32 @@
 RSpec.describe "Api pour Justice.fr" do
+  let!(:lieu_with_po) { create(:lieu, id: 1861, organisation:) }
+  let(:organisation) { create(:organisation) }
+  let(:motif) { create(:motif, organisation:, bookable_by: :everyone) }
+  let!(:lieu_without_po) { create(:lieu, id: 2098) }
+
+  before do
+    create(:plage_ouverture, lieu: lieu_with_po, motifs: [motif])
+  end
+
   it "renvoie une liste des lieux de justice" do
     get "/api/justice/lieux"
-    parsed_response = JSON.parse(response.body)
-    expect(parsed_response.symbolize_keys).to eq({ lieux: [] })
+
+    lieu_without_online_booking = response.parsed_body["lieux"].first.symbolize_keys
+    expect(lieu_without_online_booking).to match(
+      {
+        ee_id: "612f2ebab473e40555dee806",
+        reservation_en_ligne: false,
+        url: anything,
+      }
+    )
+
+    lieu_with_online_booking = response.parsed_body["lieux"].last.symbolize_keys
+    expect(lieu_with_online_booking).to match(
+      {
+        ee_id: "612f2ebfb473e40555dee9d4",
+        reservation_en_ligne: true,
+        url: anything,
+      }
+    )
   end
 end


### PR DESCRIPTION
Cette PR propose des premières données pour l'intégration avec Justice.fr.

Pour le moment, on reste très minimaliste : j'ai fais la correspondance à la main sur quelques points justice en m'aidant du script qui est sur la branche justicefr-integration (voir le diff ici : https://github.com/betagouv/rdv-service-public/compare/production...justicefr-integration).
On décide de ne pas encore faire de maintenance long terme de ces données, vu qu'on est encore au tout début de comment on construit cette intégration, et on a besoin de montrer des premiers résultats à nos partenaires.

La prochaine étape sera de nettoyer et commiter le script, puis d'ajouter les correspondances obtenues avec la version plus complète du script.