### PR TITLE
Rails 7.2: active_record.postgresql_adapter_decode_dates

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -53,7 +53,7 @@ Rails.application.config.active_record.validate_migration_timestamps = true
 #
 # This query used to return a `String`.
 #++
-# Rails.application.config.active_record.postgresql_adapter_decode_dates = true
+Rails.application.config.active_record.postgresql_adapter_decode_dates = true
 
 ###
 # Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are


### PR DESCRIPTION
# Contexte

Il ne semble pas que nous faisions des requêtes manuelles avec des dates. Il semble donc tout à fait safe de décommenter cette ligne.