### PR TITLE
Rails 7.2: YJIT

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,11 @@ module Lapin
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    # À partir de Rails 7.2, YJIT est activé par défaut avec Ruby 3.3
+    # Compte tenu de notre environnement mémoire contraint sur Scalingo, on le désactive pour l'instant.
+    # Au besoin, nous pourrons le réactiver plus tard si nous avons + de mémoire ou en modifiant la mémoire allouée à YJIT.
+    Rails.application.config.yjit = false
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -54,9 +54,3 @@ Rails.application.config.active_record.validate_migration_timestamps = true
 # This query used to return a `String`.
 #++
 Rails.application.config.active_record.postgresql_adapter_decode_dates = true
-
-###
-# Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are
-# deploying to a memory constrained environment you may want to set this to `false`.
-#++
-# Rails.application.config.yjit = true


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5583.osc-secnum-fr1.scalingo.io/) 

# Contexte

Comme indiqué dans le commentaire du fichier proposé par Rails, l’activation de YJIT (sans configuration additionnelle) semble être pertinent que dans des environnements dans lesquels nous ne sommes pas contraints par la RAM.
Aujourd’hui, nous sommes assez juste en RAM sur les environnements de prod. Il paraît donc risqué d’activer YJIT dès maintenant sans étude additionnelle.
Je propose alors de le laisser désactiver pour le moment.