### PR TITLE
Correctif en cas d'erreur de mise à jour d'un rdv

### DIFF
--- a/app/views/admin/rdvs/update.turbo_stream.slim
+++ b/app/views/admin/rdvs/update.turbo_stream.slim
@@ -2,7 +2,7 @@
 
 - if rdv.errors.any?
   = turbo_stream.replace "rdv-error-message-#{rdv.id}" do
-    = render partial: "admin/rdvs/update_error", rdv: rdv
+    = render "admin/rdvs/update_error", rdv: rdv
 - else
     = turbo_stream.replace "rdv-#{rdv.id}" do
       - template = quick_update.to_bool ? "admin/rdvs/rdv_with_quick_update" : "admin/rdvs/rdv"


### PR DESCRIPTION
Correctif pour https://sentry.incubateur.net/organizations/betagouv/issues/195080/?project=74&referrer=webhooks_plugin


Le code n'était jamais appelé dans les specs, mais en essayant de le tester, je suis tombé sur un problème plus profond : il ne faut pas qu'un rdv invalide soit impossible à renseigner (surtout si c'est pour l'annuler). C'est une autres problème plus large.
Vu le contexte actuelle, je ne vais pas pouvoir résoudre ça tout de suite, mais on peut au moins éviter la 500, afficher un message d'erreur bizarre mais correct, et éviter le bruit dans Sentry.