### PR TITLE
Ajout d’un message invitant les usagers à ne pas répondre aux mails de RDV

### DIFF
--- a/app/views/mailers/common/_no_reply.html.slim
+++ b/app/views/mailers/common/_no_reply.html.slim
@@ -1,0 +1,3 @@
+div.aligncenter
+  p
+    | Ceci est un email automatique, merci de ne pas y répondre.

--- a/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
@@ -1,3 +1,4 @@
+= render "mailers/common/no_reply"
 div
   p= t("mailers.common.hello")
 

--- a/app/views/mailers/users/rdv_mailer/rdv_created.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_created.html.slim
@@ -1,3 +1,4 @@
+= render "mailers/common/no_reply"
 div
   p Bonjour,
   p

--- a/app/views/mailers/users/rdv_mailer/rdv_upcoming_reminder.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_upcoming_reminder.html.slim
@@ -1,3 +1,4 @@
+= render "mailers/common/no_reply"
 div
   p Bonjour,
   p

--- a/app/views/mailers/users/rdv_mailer/rdv_updated.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_updated.html.slim
@@ -1,3 +1,4 @@
+= render "mailers/common/no_reply"
 div
   p Bonjour,
   p


### PR DESCRIPTION
# Contexte

Suite au travail que nous avons fait sur le retour à Zammad, nous avons constaté que nous avions encore pas mal d’usagers qui répondent aux mails de confirmation/rappel/modification/annulation de RDV.
Nous avons toujours un système qui transfère le mail à l’agent qui est en charge du RDV. Néanmoins, dans certains cas, nous n’avons pas le mail de l’agent, car il s’agit d’un compte intervenant. Nous nous apercevons alors qu’il est difficile de traiter ces messages, et bien généralement, on demande à l’usager de contacter l’organisation.

# Solution

Étant donné qu’on donne déjà les informations de contact dans le mail et que nous proposons des actions via le CTA, on veut essayer de limiter un peu plus ces mails en indiquant à l’usager ne pas répondre.
On sait pertinemment qu’on recevra tout de même des mails, mais on espère que ça va diminuer un peu. 

Nous réfléchissons en parallèle à des actions supplémentaires pour les RDVs qui sont fait par des intervenants et pour lesquels nous ne pouvons pas transférer le message de l’usager.

<img width="610" height="251" alt="image" src="https://github.com/user-attachments/assets/5d20aff2-dea3-4bb5-9b3a-1678ffa62ff5" />
