### PR TITLE
test_boot: vérifier que le server a démarré grâce à une requête HTTP

### DIFF
--- a/bin/test_boot
+++ b/bin/test_boot
@@ -1,8 +1,22 @@
 #!/usr/bin/env ruby
 # from https://stackoverflow.com/a/69014550
 
+require 'net/http'
+require 'timeout'
+
 pid = Process.spawn("bundle exec rails s")
-sleep 5 # time in seconds you need to ensure the server boots without errors
+
+Timeout.timeout(30) do
+  loop do
+    begin
+      res = Net::HTTP.get_response(URI('http://localhost:3000'))
+      break if res.is_a?(Net::HTTPSuccess) || res.is_a?(Net::HTTPRedirection)
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+      # Le serveur n'est pas encore prêt
+    end
+    sleep 0.5
+  end
+end
 
 Process.kill("INT", pid) # send ^C, gracefully terminate the server
 

--- a/bin/test_boot
+++ b/bin/test_boot
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# from https://stackoverflow.com/a/69014550
+# from https://stackoverflow.com/a/69014550 (avec un petit changement pour éviter d’avoir un temps d’attente en dur).
 
 require 'net/http'
 require 'timeout'
@@ -10,6 +10,8 @@ Timeout.timeout(30) do
   loop do
     begin
       res = Net::HTTP.get_response(URI('http://localhost:3000'))
+      # On attend un code 200, 3xx ou 5xx (le serveur est prêt à répondre)
+      # En l’occurrence, on reçoit un 500, car nous n’avons pas de base de données dans ce cas.
       break if res.is_a?(Net::HTTPSuccess) || res.is_a?(Net::HTTPRedirection) || res.is_a?(Net::HTTPServerError)
     rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
       # Le serveur n'est pas encore prêt

--- a/bin/test_boot
+++ b/bin/test_boot
@@ -10,7 +10,7 @@ Timeout.timeout(30) do
   loop do
     begin
       res = Net::HTTP.get_response(URI('http://localhost:3000'))
-      break if res.is_a?(Net::HTTPSuccess) || res.is_a?(Net::HTTPRedirection)
+      break if res.is_a?(Net::HTTPSuccess) || res.is_a?(Net::HTTPRedirection) || res.is_a?(Net::HTTPServerError)
     rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
       # Le serveur n'est pas encore prêt
     end


### PR DESCRIPTION
# Contexte

Depuis quelque temps, la CI « Boot webserver without database » plante. Les logs donnent l’impression qu’on interrupt avant que le serveur n’ait pu boot. 

```
/home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/xpath_parser.rb:15:in 'Module#method_added': Interrupt
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/xpath_parser.rb:15:in 'block in <module:DClonable>'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/xpath_parser.rb:12:in 'Module#refine'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/xpath_parser.rb:12:in '<module:DClonable>'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/xpath_parser.rb:11:in '<module:REXML>'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/xpath_parser.rb:10:in '<main>'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/xpath.rb:3:in 'Kernel#require_relative'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/xpath.rb:3:in '<main>'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/element.rb:6:in 'Kernel#require_relative'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/element.rb:6:in '<main>'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/document.rb:3:in 'Kernel#require_relative'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/rexml-3.4.0/lib/rexml/document.rb:3:in '<main>'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/skylight-6.0.1/lib/skylight/probes.rb:166:in 'Kernel#require'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/letter_opener_web-3.0.0/lib/letter_opener_web.rb:5:in '<main>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel.replace_require'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/gems/3.4.0/gems/bundler-2.6.4/lib/bundler/runtime.rb:63:in 'block (2 levels) in Bundler::Runtime#require'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/gems/3.4.0/gems/bundler-2.6.4/lib/bundler/runtime.rb:58:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/gems/3.4.0/gems/bundler-2.6.4/lib/bundler/runtime.rb:58:in 'block in Bundler::Runtime#require'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/gems/3.4.0/gems/bundler-2.6.4/lib/bundler/runtime.rb:52:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/gems/3.4.0/gems/bundler-2.6.4/lib/bundler/runtime.rb:52:in 'Bundler::Runtime#require'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/gems/3.4.0/gems/bundler-2.6.4/lib/bundler.rb:215:in 'Bundler.require'
	from /home/runner/work/rdv-service-public/rdv-service-public/config/application.rb:17:in '<main>'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/commands/server/server_command.rb:139:in 'block in Rails::Command::ServerCommand#perform'
	from <internal:kernel>:91:in 'Kernel#tap'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/commands/server/server_command.rb:136:in 'Rails::Command::ServerCommand#perform'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/thor-1.4.0/lib/thor/command.rb:28:in 'Thor::Command#run'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/thor-1.4.0/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/command/base.rb:178:in 'Rails::Command::Base#invoke_command'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/thor-1.4.0/lib/thor.rb:538:in 'Thor.dispatch'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/command/base.rb:73:in 'Rails::Command::Base.perform'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/command.rb:71:in 'block in Rails::Command.invoke'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/command.rb:149:in 'Rails::Command.with_argv'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/command.rb:69:in 'Rails::Command.invoke'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/commands.rb:18:in '<main>'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
	from /opt/hostedtoolcache/Ruby/3.4.5/x64/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
	from /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
	from bin/rails:4:in '<main>'
bin/test_boot:11:in 'Kernel#exit': no implicit conversion from nil to integer (TypeError)

exit status.exitstatus
     ^^^^^^^^^^^^^^^^^
	from bin/test_boot:11:in '<main>'

```

# Solution

Afin d’attendre le juste temps, je propose d’attendre qu’on ait une réponse HTTP (en l’occurrence une 500 vu qu’on a pas de DB).
