### PR TITLE
Ajout de correspondances pour l'intégration à Justice.fr

### DIFF
--- a/app/controllers/api/justice/lieux_controller.rb
+++ b/app/controllers/api/justice/lieux_controller.rb
@@ -66,8 +66,6 @@ class Api::Justice::LieuxController < ActionController::Base # rubocop:disable R
       "612f2ec2b473e40555deeb1c": 1927,
       "612f2ec2b473e40555deeb20": 1942,
       "612f2ec2b473e40555deeb26": 1936,
-      "612f2ec1b473e40555deeb04": 1904,
-      "612f2ec1b473e40555deeb06": 1906,
       "612f2ec1b473e40555deeafe": 1910,
       "612f2ec2b473e40555deeb32": 1910,
       "612f2ec2b473e40555deeb2a": 1905,

--- a/app/controllers/api/justice/lieux_controller.rb
+++ b/app/controllers/api/justice/lieux_controller.rb
@@ -66,6 +66,16 @@ class Api::Justice::LieuxController < ActionController::Base # rubocop:disable R
       "612f2ec2b473e40555deeb1c": 1927,
       "612f2ec2b473e40555deeb20": 1942,
       "612f2ec2b473e40555deeb26": 1936,
+      "612f2ec1b473e40555deeb04": 1904,
+      "612f2ec1b473e40555deeb06": 1906,
+      "612f2ec1b473e40555deeafe": 1910,
+      "612f2ec2b473e40555deeb32": 1910,
+      "612f2ec2b473e40555deeb2a": 1905,
+      "612f2ec1b473e40555deeb12": 1905,
+      "612f2ec1b473e40555deeb18": 1935,
+      "612f2ec2b473e40555deeb30": 1935,
+      "612f2ed8b473e40555def3fc": 1431,
+      "680126c3eb6d1e45d3eb20cb": 1621,
     }
   end
 end


### PR DESCRIPTION
Suite de https://github.com/betagouv/rdv-service-public/pull/5581

On en a pas mal discuté avec Matis et Nesserine, et on est dans un impasse pour ajouter plus de lieux pour le moment :
- soit de notre côté on a plusieurs lieux qui pourraient correspondre, et c'est pas clair lequel choisir
- soit du côté de la base de données de Justice.fr les données ne sont pas à jour.

On est en train de discuter avec les différents partenaires pour avancer sur ces deux points.

Pour le moment, on reste donc très "low tech" sur cette intégration, et on essaye de résoudre les problèmes en amont avant de développer plus.

Les correspondances ajoutées ici viennent d'une version un peu plus évoluée du script utilisé dans la PR précédente. Je n'ai pas beaucoup avancé sur le nettoyage qui permettrait de le commiter.