### PR TITLE
Transfert des mails usagers RDV intervenant à l’orga

### DIFF
--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -25,11 +25,13 @@ class TransferEmailReplyJob < ApplicationJob
     email_address.match(UUID_EXTRACTOR)&.captures&.first
   end
 
-  def perform(sendinblue_hash)
+  def perform(sendinblue_hash) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     @sendinblue_hash = sendinblue_hash.with_indifferent_access
 
     if rdv&.agents&.pluck(:email)&.compact&.any?
       notify_agents
+    elsif rdv&.organisation&.email.present?
+      notify_organisation
     else
       forward_to_default_mailbox
     end
@@ -42,6 +44,16 @@ class TransferEmailReplyJob < ApplicationJob
       rdv: rdv,
       author: user || source_mail.header[:from],
       agents: rdv.agents,
+      reply_body: extracted_response,
+      source_mail: source_mail
+    ).deliver_now
+  end
+
+  def notify_organisation
+    Agents::ReplyTransferMailer.notify_organisation(
+      rdv: rdv,
+      author: user || source_mail.header[:from],
+      organisation: rdv.organisation,
       reply_body: extracted_response,
       source_mail: source_mail
     ).deliver_now

--- a/app/mailers/agents/reply_transfer_mailer.rb
+++ b/app/mailers/agents/reply_transfer_mailer.rb
@@ -17,6 +17,21 @@ class Agents::ReplyTransferMailer < ApplicationMailer
     mail(to: agents.map(&:email), subject: t(".title", date: @date))
   end
 
+  # @param [Rdv] rdv
+  # @param [User, String] author
+  # @param [Organisation] organisation
+  # @param [Mail::Message] source_mail
+  def notify_organisation(rdv:, author:, organisation:, reply_body:, source_mail:)
+    @rdv = rdv
+    @author = author
+    @reply_subject = source_mail.subject
+    @reply_body = reply_body
+    @attachment_names = source_mail.attachments.map(&:filename).join(", ")
+    @date = relative_date(@rdv.starts_at)
+
+    mail(to: organisation.email, subject: "Message d'usager⋅e au sujet d’un RDV du #{@date}")
+  end
+
   # @param [String] reply_body
   # @param [Mail::Message] source_mail
   def forward_to_default_mailbox(reply_body:, source_mail:)

--- a/app/views/mailers/agents/reply_transfer_mailer/notify_organisation.html.slim
+++ b/app/views/mailers/agents/reply_transfer_mailer/notify_organisation.html.slim
@@ -1,0 +1,17 @@
+div
+  p
+    | Bonjour,
+  p
+    | Dans le cadre du RDV du #{@date} avec #{@rdv.agents.map(&:short_name).sort.to_sentence}, l'usager⋅e #{@author} a envoyé la réponse suivante par e-mail :
+  blockquote
+    h4 = @reply_subject
+    div = simple_format(@reply_body)
+
+  p
+    = auto_link t("agents.reply_transfer_mailer.shared.attachments", attachment_names: @attachment_names) if @attachment_names.present?
+
+  p
+    | Merci de ne pas répondre à cet e-mail. Vous pouvez contacter l'usager⋅e à l'aide des informations inclues dans le RDV.
+
+  .btn-wrapper
+    = link_to "Voir le RDV", admin_organisation_rdv_url(@rdv.organisation_id, @rdv.id),  class: "btn btn-primary"

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -157,6 +157,17 @@ RSpec.describe TransferEmailReplyJob do
         expect(transferred_email.to).to eq([organisation.email])
         expect(transferred_email.html_part.body.to_s).to include(%(Dans le cadre du RDV du 20 mai avec J. INTERVENANTE, l'usager⋅e Bénédicte FICIAIRE a envoyé))
       end
+
+      context "et que l'organisation n'a pas d'adresse email" do
+        let!(:organisation) { create(:organisation, email: nil) }
+
+        it "transfère le mail à notre support" do
+          expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+          transferred_email = ActionMailer::Base.deliveries.last
+          expect(transferred_email.to).to eq(["support@rdv-service-public.fr"])
+          expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
+        end
+      end
     end
   end
 end

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -47,9 +47,10 @@ RSpec.describe TransferEmailReplyJob do
     end
 
     let!(:user) { create(:user, email: "bene_ficiaire@lapin.fr", first_name: "Bénédicte", last_name: "Ficiaire") }
-    let!(:agent) { create(:agent, email: "je_suis_un_agent@departement.fr") }
+    let!(:organisation) { create(:organisation, email: "contact@departement.fr") }
+    let!(:agent) { create(:agent, email: "je_suis_un_agent@departement.fr", organisations: [organisation]) }
     let(:rdv_uuid) { "8fae4d5f-4d63-4f60-b343-854d939881a3" }
-    let!(:rdv) { create(:rdv, users: [user], agents: [agent], uuid: rdv_uuid) }
+    let!(:rdv) { create(:rdv, users: [user], agents: [agent], uuid: rdv_uuid, organisation:) }
 
     let(:sendinblue_valid_payload) do
       # The usual payload has more info, but I removed non-essential fields for readability.
@@ -148,13 +149,13 @@ RSpec.describe TransferEmailReplyJob do
     end
 
     context "quand le RDV est avec un agent intervenant sans email" do
-      let!(:agent) { create(:agent, :intervenant) }
+      let!(:agent) { create(:agent, :intervenant, first_name: "Jeanne", last_name: "Intervenante") }
 
-      it "transfère le mail à notre support" do
+      it "transfère le mail à l’adresse générique de l’organisation" do
         expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
         transferred_email = ActionMailer::Base.deliveries.last
-        expect(transferred_email.to).to eq(["support@rdv-service-public.fr"])
-        expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
+        expect(transferred_email.to).to eq([organisation.email])
+        expect(transferred_email.html_part.body.to_s).to include(%(Dans le cadre du RDV du 20 mai avec J. INTERVENANTE, l'usager⋅e Bénédicte FICIAIRE a envoyé))
       end
     end
   end


### PR DESCRIPTION
# Contexte

Nous recevons encore quelques Zammad d’usagers qui répondent à des mails de notification de RDV. Ces mails ne sont actuellement pas transférés à l’agent qui gère le RDV, car celui-ci a un compte intervenant (sans email). Quand nous les recevons, nous indiquons généralement à l’usager de contacter directement l’organisation ou nous transférons le mail à l’adresse générique de l’organisation. 

# Solution

Quand l’organisation a un email de contact, on transfère alors le mail sur cette adresse.
