### PR TITLE
Espaces sans nom

### DIFF
--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -13,7 +13,7 @@ module ConfigurationHelper
         tag.ol class: "breadcrumb m-0 p-0" do
           concat(tag.li(class: "breadcrumb-item") do
             link_to admin_territory_path(current_territory) do
-              concat(t("admin.territories.nav.configuration_title", territory: current_territory))
+              concat(t("admin.territories.nav.configuration_title", territory: current_territory.name_for_agent))
             end
           end)
           previous_links.each do |prev_link|

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -46,7 +46,7 @@ class Territory < ApplicationRecord
 
   # Validations
   validates :departement_number, length: { maximum: 3 }, if: -> { departement_number.present? }
-  validates :name, presence: true, if: -> { persisted? }
+
   validate do
     if name_changed? && name_was.in?(SPECIAL_NAMES)
       errors.add(:name, "Le nom de cet espace lui donne des propriétés particulières et ne peut donc pas être changé")
@@ -130,7 +130,11 @@ class Territory < ApplicationRecord
   end
 
   def to_s
-    [name, departement_number.presence].compact.join(" - ")
+    if name
+      [name, departement_number.presence].compact.join(" - ")
+    else
+      "Espace sans nom"
+    end
   end
 
   def waiting_room_enabled?

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -129,11 +129,11 @@ class Territory < ApplicationRecord
     attributes.symbolize_keys.slice(*LEGACY_TOGGLES.keys).values.any?
   end
 
-  def to_s
-    if name
+  def name_in_stats
+    if name.present?
       [name, departement_number.presence].compact.join(" - ")
     else
-      "Espace sans nom"
+      organisations.first.name
     end
   end
 

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -137,6 +137,10 @@ class Territory < ApplicationRecord
     end
   end
 
+  def name_for_agent
+    name.presence || "votre espace"
+  end
+
   def waiting_room_enabled?
     OPTIONAL_RDV_WAITING_ROOM_FIELD_TOGGLES.keys.any? do |waiting_room_field|
       send(waiting_room_field)

--- a/app/models/territory_creation_request.rb
+++ b/app/models/territory_creation_request.rb
@@ -3,7 +3,7 @@ class TerritoryCreationRequest < ApplicationRecord
 
   belongs_to :agent
 
-  validates :organisation_name, :territory_name, presence: true
+  validates :organisation_name, presence: true
   validates :agent_id, uniqueness: true
   validate :can_only_have_one_response
 

--- a/app/views/admin/organisations/index.html.slim
+++ b/app/views/admin/organisations/index.html.slim
@@ -4,7 +4,7 @@
   .card
     .card-header
       .d-flex.justify-content-between.align-items-center
-        h5.m-2 #{territory.name_for_agent.capitalize}
+        h5.fr-m-2w #{territory.name_for_agent.capitalize}
         - if Agent::TerritoryPolicy.new(current_agent, territory).show?
           = link_to admin_territory_path(territory), class: "float-right fr-btn fr-btn--sm fr-btn--tertiary fr-icon-settings-5-fill fr-btn--icon-left" do
             = t(".territory_configuration")

--- a/app/views/admin/organisations/index.html.slim
+++ b/app/views/admin/organisations/index.html.slim
@@ -4,7 +4,7 @@
   .card
     .card-header
       .d-flex.justify-content-between.align-items-center
-        h5.m-2 #{territory.name || "Espace sans nom"}
+        h5.m-2 #{territory.name_for_agent.capitalize}
         - if Agent::TerritoryPolicy.new(current_agent, territory).show?
           = link_to admin_territory_path(territory), class: "float-right fr-btn fr-btn--sm fr-btn--tertiary fr-icon-settings-5-fill fr-btn--icon-left" do
             = t(".territory_configuration")
@@ -16,5 +16,5 @@
             - if current_agent.admin_in_organisation?(organisation)
               i.fa.fa-user-cog.text-muted[title="Vous administrez cette organisation"]
       - if policy(Organisation.new(territory: territory), policy_class: Agent::OrganisationPolicy).new?
-        .rdv-text-align-center.mt-4
-          = link_to "Ajouter une organisation", new_admin_organisation_path(territory_id: territory.id), class: "btn btn-primary"
+        .fr-mt-4w.fr-ml-2w
+          = link_to "Ajouter une organisation", new_admin_organisation_path(territory_id: territory.id), class: "fr-btn"

--- a/app/views/admin/organisations/index.html.slim
+++ b/app/views/admin/organisations/index.html.slim
@@ -4,7 +4,7 @@
   .card
     .card-header
       .d-flex.justify-content-between.align-items-center
-        h5.m-2 Espace : #{territory}
+        h5.m-2 #{territory.name || "Espace sans nom"}
         - if Agent::TerritoryPolicy.new(current_agent, territory).show?
           = link_to admin_territory_path(territory), class: "float-right fr-btn fr-btn--sm fr-btn--tertiary fr-icon-settings-5-fill fr-btn--icon-left" do
             = t(".territory_configuration")

--- a/app/views/admin/organisations/new.html.slim
+++ b/app/views/admin/organisations/new.html.slim
@@ -12,5 +12,5 @@
           collection: [@organisation.territory], \
           include_blank: false, \
           readonly: true, \
-          label_method: -> { _1.to_s }
-        = f.submit value: "Enregistrer", class: "btn btn-primary"
+          label_method: -> { _1.name_for_agent.capitalize }
+        = f.submit value: "Enregistrer", class: "fr-btn"

--- a/app/views/admin/territories/edit.html.slim
+++ b/app/views/admin/territories/edit.html.slim
@@ -1,4 +1,4 @@
-= territory_navigation(t(".title", name: current_territory))
+= territory_navigation(t(".title", name: current_territory.name_for_agent))
 
 .card
   .card-header

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -1,10 +1,10 @@
-- content_for :title, "Paramètres de votre espace"
+- content_for :title, "Paramètres de #{current_territory.name_for_agent}"
 
 = link_to(root_path, class: "pt-1 pb-4") do
   i.fa.fa-arrow-left
   |< Retour à l'accueil
 
-h1.m-2.rdv-text-align-center.border-bottom.pb-2 = "Paramètres de votre espace"
+h1.m-2.rdv-text-align-center.border-bottom.pb-2 =  t("admin.territories.show.title", territory: current_territory.name_for_agent)
 .row.mb-3
   - if Agent::TerritoryPolicy.new(pundit_user, current_territory).edit?
     .col.col-md-4.p-2.rounded.settings-box

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -1,10 +1,10 @@
-- content_for :title, "Paramètres de #{current_territory.name}"
+- content_for :title, "Paramètres de votre espace"
 
 = link_to(root_path, class: "pt-1 pb-4") do
   i.fa.fa-arrow-left
   |< Retour à l'accueil
 
-h1.m-2.rdv-text-align-center.border-bottom.pb-2 = t("admin.territories.show.title", territory: current_territory)
+h1.m-2.rdv-text-align-center.border-bottom.pb-2 = "Paramètres de votre espace"
 .row.mb-3
   - if Agent::TerritoryPolicy.new(pundit_user, current_territory).edit?
     .col.col-md-4.p-2.rounded.settings-box

--- a/app/views/agents/territories/new.html.slim
+++ b/app/views/agents/territories/new.html.slim
@@ -6,6 +6,4 @@
         = form_for @compte_form, url: agents_territories_path, builder: Dsfr::FormBuilder, as: :compte do |f|
           = f.fields_for :organisation, @compte_form.organisation do |ff|
             = ff.dsfr_text_field :name, label: "Nom de votre organisation", hint: "par exemple : CCAS de Montreuil", autocomplete: "organization", required: true
-          = f.fields_for :territory, @compte_form.territory do |ff|
-            = ff.dsfr_text_field :name, label: "Nom du territoire", hint: "par exemple : Commune de Montreuil ou Communauté de communes de Saint-Clément", required: true
           = f.submit "Enregistrer", class: "fr-btn float-right"

--- a/app/views/agents/territory_creation_requests/new.html.slim
+++ b/app/views/agents/territory_creation_requests/new.html.slim
@@ -4,7 +4,6 @@
       .card-body
         h1.fr-h2 Demande d'ouverture d'un nouvel espace
         = form_for @territory_creation_request, url: agents_territory_creation_requests_path, builder: Dsfr::FormBuilder do |f|
-          = f.dsfr_text_field :territory_name, hint: "par exemple : Commune de Montreuil, Préfecture de Seine-Saint-Denis", required: true
           = f.dsfr_text_field :organisation_name, hint: "par exemple : CCAS de Montreuil, Bureau de Bobigny", autocomplete: "organization", required: true
 
           = f.submit "Envoyer la demande", class: "fr-btn float-right"

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -23,7 +23,7 @@ header.header.bg-white
             - Agent::TerritoryPolicy::Scope.new(current_agent, Territory.all).resolve.distinct.order(:name).each do |territory|
               li = link_to admin_territory_path(territory), class: "dropdown-item-dsfr dropdown-item" do
                 span.fr-icon--sm.fr-mr-2v.fr-icon-settings-5-line[aria-hidden="true"]
-                | Paramètres de #{territory}
+                | Paramètres de #{territory.name_for_agent}
             .dropdown-divider.my-1[aria-hidden="true"]
             li = link_to destroy_agent_session_path, method: :delete, class: "dropdown-item-dsfr dropdown-item" do
               span.fr-icon--sm.fr-mr-2v.fr-icon-logout-box-r-line[aria-hidden="true"]

--- a/app/views/stats/territories.html.slim
+++ b/app/views/stats/territories.html.slim
@@ -10,7 +10,7 @@
     .fr-mb-2w= "#{@territories.count} structures utilisent #{current_domain.name}"
     ul
       - @territories.ordered_by_name.each do |territory|
-        li = link_to "Statistiques - #{territory}", stats_territory_path(territory:)
+        li = link_to territory.name_in_stats, stats_territory_path(territory:)
 
     .fr-callout.fr-my-8w
       p

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -15,7 +15,7 @@ section.main-content__body
     - if @territory_creation_request
       = f.hidden_field :territory_creation_request_id, value: @territory_creation_request.id
     = f.simple_fields_for :territory do |ff|
-      = ff.input :name, label: "Nom de l'espace", input_html: { value: @territory_creation_request&.territory_name }, required: false
+      = ff.input :name, label: "Nom de l'espace (facultatif)", input_html: { value: @territory_creation_request&.territory_name }, required: false
       = ff.input :category, as: :select, collection: Compte::CATEGORIES, label: "Catégorie de l'espace"
 
     = f.simple_fields_for :organisation do |ff|

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -15,7 +15,7 @@ section.main-content__body
     - if @territory_creation_request
       = f.hidden_field :territory_creation_request_id, value: @territory_creation_request.id
     = f.simple_fields_for :territory do |ff|
-      = ff.input :name, label: "Nom de l'espace", input_html: { value: @territory_creation_request&.territory_name }
+      = ff.input :name, label: "Nom de l'espace", input_html: { value: @territory_creation_request&.territory_name }, required: false
       = ff.input :category, as: :select, collection: Compte::CATEGORIES, label: "Catégorie de l'espace"
 
     = f.simple_fields_for :organisation do |ff|

--- a/app/views/super_admins/territory_creation_requests/edit.html.slim
+++ b/app/views/super_admins/territory_creation_requests/edit.html.slim
@@ -6,8 +6,9 @@ header.main-content__header
 
 section.main-content__body
   dl
-    dt.attribute-label.attribute-label--normal-case Espace
-    dd.attribute-data = @territory_creation_request.territory_name
+    - if @territory_creation_request.territory_name.present?
+      dt.attribute-label.attribute-label--normal-case Espace
+      dd.attribute-data = @territory_creation_request.territory_name
 
     dt.attribute-label.attribute-label--normal-case Organisation
     dd.attribute-data = @territory_creation_request.organisation_name
@@ -28,8 +29,9 @@ section.main-content__body
         - if annuaire_client.mairie?
           p ✅ Cette structure est une mairie
 
-    dt.attribute-label.attribute-label--normal-case Service
-    dd.attribute-data = @territory_creation_request.service_name
+    - if @territory_creation_request.service_name.present?
+      dt.attribute-label.attribute-label--normal-case Service
+      dd.attribute-data = @territory_creation_request.service_name
 
   section.main-content__body[style=""]
     - if @territory_creation_request.possible_duplicate_organisations_by_email_domain.none?

--- a/app/views/super_admins/territory_creation_requests/index.html.slim
+++ b/app/views/super_admins/territory_creation_requests/index.html.slim
@@ -20,7 +20,7 @@ section.main-content__body.main-content__body--flush
     - @territory_creation_requests.each do |request|
         h3
           = link_to(edit_super_admins_territory_creation_request_path(request.id))
-            = request.territory_name
+            = request.territory_name || request.organisation_name
         p
           = "demandé par #{request.agent.full_name}"
           br

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -12,7 +12,7 @@ fr:
       show:
         title: Paramètres de %{territory}
       edit:
-        title: Configuration %{name}
+        title: Configuration de %{name}
 
       sectorisation_tests:
         search:

--- a/spec/features/autodoc/creation_espace_spec.rb
+++ b/spec/features/autodoc/creation_espace_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
 
     doc.add_screenshot(page, wait_for: "Nom de")
 
-    fill_in("Nom de l’espace", with: "Commune de Montreuil")
     fill_in("Nom de votre première organisation", with: "CCAS de Montreuil")
 
     doc.add_screenshot(page,
@@ -58,9 +57,9 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
 
     doc.add_screenshot(page,
                        text: "Je consulte la liste des demandes d'ouverture d'espace",
-                       wait_for: "Commune de Montreuil")
+                       wait_for: "CCAS de Montreuil")
 
-    click_on "Commune de Montreuil"
+    click_on "CCAS de Montreuil"
 
     doc.add_screenshot(page,
                        text: "J'examine la demande. C'est à cette étape que je peux avoir des informations sur des doublons potentiels",

--- a/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe "Configuration de RDV Service Public par un administrateur de DS"
 
     click_on "Ouvrir un espace"
 
-    fill_in("Nom du territoire", with: "Préfecture de Police de Paris")
     fill_in("Nom de votre organisation", with: "Préfecture de Police de Paris")
 
     doc.add_screenshot(page,

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
           visit new_agents_territory_path
 
           fill_in("Nom de votre organisation", with: "CCAS de Montreuil")
-          fill_in("Nom du territoire", with: "Commune de Montreuil")
           click_on "Enregistrer"
 
           expect(page).to have_content "Nouveau rendez-vous"

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
         visit "/admin/organisations/configuration" # Les pages de paramètres des applications externes mènent à cette url
         click_on "Demander à ouvrir un espace"
 
-        fill_in("Nom de l’espace", with: "Commune de Montreuil")
         fill_in("Nom de votre première organisation", with: "CCAS de Montreuil")
         click_on "Envoyer la demande"
 
@@ -71,7 +70,7 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
         login_as(super_admin, scope: :super_admin)
 
         visit super_admins_territory_creation_requests_url(host: "http://www.rdv-mairie-test.localhost")
-        click_on "Commune de Montreuil"
+        click_on "CCAS de Montreuil"
 
         expect(page).to have_content("Demande d'ouverture d'espace")
 
@@ -83,7 +82,6 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
         expect(page).to have_content "Le nouvel espace a été créé"
 
         expect(Territory.last).to have_attributes(
-          name: "Commune de Montreuil",
           admin_agents: [agent]
         )
 
@@ -107,7 +105,7 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
         visit "/admin/organisations/configuration" # Les pages de paramètres des applications externes mènent à cette url
         expect(page).to have_content "Besoin d'aide pour bien démarrer ? Nous pouvons vous aider"
 
-        click_on "Paramètres de Commune de Montreuil"
+        click_on "Paramètres votre espace"
 
         expect(page).to have_content("Configuration générale") # Pour s'assurer qu'on attend que la nouvelle page charge
         expect(page).to have_content "Besoin d'aide pour bien démarrer ? Nous pouvons vous aider"

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
         click_on "Ouvrir un espace"
 
         fill_in("Nom de votre organisation", with: "CCAS de Montreuil")
-        fill_in("Nom du territoire", with: "Commune de Montreuil")
         click_on "Enregistrer"
 
         expect(page).to have_content "Configuration"
@@ -99,13 +98,13 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
 
         click_on("Demandes acceptées")
 
-        expect(page).to have_content "Commune de Montreuil"
+        expect(page).to have_content "CCAS de Montreuil"
 
         # On affiche ensuite un bandeau d'aide
         visit "/admin/organisations/configuration" # Les pages de paramètres des applications externes mènent à cette url
         expect(page).to have_content "Besoin d'aide pour bien démarrer ? Nous pouvons vous aider"
 
-        click_on "Paramètres votre espace"
+        click_on "Paramètres de votre espace"
 
         expect(page).to have_content("Configuration générale") # Pour s'assurer qu'on attend que la nouvelle page charge
         expect(page).to have_content "Besoin d'aide pour bien démarrer ? Nous pouvons vous aider"

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -44,15 +44,15 @@ RSpec.describe Territory, type: :model do
     end
   end
 
-  describe "#to_s" do
+  describe "#name_in_stats" do
     it "returns name and departement number if exist" do
       territory = build(:territory, departement_number: "93", name: "Seine Saint-Denis")
-      expect(territory.to_s).to eq("Seine Saint-Denis - 93")
+      expect(territory.name_in_stats).to eq("Seine Saint-Denis - 93")
     end
 
     it "returns name" do
       territory = build(:territory, departement_number: nil, name: "Seine Saint-Denis")
-      expect(territory.to_s).to eq("Seine Saint-Denis")
+      expect(territory.name_in_stats).to eq("Seine Saint-Denis")
     end
   end
 


### PR DESCRIPTION
# Contexte

Voir l'issue https://github.com/betagouv/rdv-service-public/issues/5592

# Solution

On remplace `Territory#to_s` par `Territory#name_in_stats` et `Territory#name_for_agent`, et on rend le champs facultatif.

## Captures d'écran

Avant | Après
:- | -:
<img width="291" height="223" alt="Screenshot 2025-08-29 at 14 25 44" src="https://github.com/user-attachments/assets/518627f4-1ac4-48a3-82d9-ee2014e0bbf2" />|<img width="322" height="227" alt="Screenshot 2025-08-29 at 14 25 17" src="https://github.com/user-attachments/assets/54f87159-bdb6-4787-b0bf-715e0b82c437" />
<img width="841" height="460" alt="Screenshot 2025-08-29 at 14 22 33" src="https://github.com/user-attachments/assets/8f5ff2e7-a08b-4aee-9c1b-aeb9fea32a34" />|<img width="847" height="339" alt="Screenshot 2025-08-29 at 14 22 57" src="https://github.com/user-attachments/assets/6dfc3e19-a865-40d0-b1e9-1906b7b52db7" />
<img width="1144" height="692" alt="Screenshot 2025-08-29 at 14 20 19" src="https://github.com/user-attachments/assets/60ab5bd1-1a6f-4f2c-9b5f-49ba68c7bcd0" />|<img width="1146" height="697" alt="Screenshot 2025-08-29 at 14 19 10" src="https://github.com/user-attachments/assets/a26c3bea-a2c0-49f6-aac6-8272e6ed181b" />
<img width="845" height="398" alt="Screenshot 2025-08-29 at 14 20 41" src="https://github.com/user-attachments/assets/e05aa0ad-2746-4c02-bdc2-95ec1702d4f3" />|<img width="795" height="396" alt="Screenshot 2025-08-29 at 14 21 14" src="https://github.com/user-attachments/assets/5df12111-c975-4e1f-b2f7-a39c306547b6" />
