### PR TITLE
Ne plus activer les services pour les espaces ouverts par intégration

### DIFF
--- a/app/controllers/agents/territories_controller.rb
+++ b/app/controllers/agents/territories_controller.rb
@@ -22,13 +22,12 @@ class Agents::TerritoriesController < AgentAuthController
   def compte_params
     params[:compte][:agent] = {
       id: current_agent.id,
-      service_ids: OauthApplication.default_service_ids_for(current_agent),
     }
 
     params.require(:compte).permit(
       territory: %i[name departement_number],
       organisation: %i[name],
-      agent: [:id, { service_ids: [] }]
+      agent: [:id]
     )
   end
 

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -3,6 +3,8 @@ class OauthApplication < Doorkeeper::Application
 
   def self.agent_is_verified_by_an_application?(agent)
     # Les applications qui ont un default_service_id permettent la création de territoire
+    # TODO: les default_services ne sont plus utilisés pour créer des services par défaut à l'agent
+    #       Il faudrait donc les remplacer par un booléen qui indique si l'application permet la création d'espace
     default_service_ids_for(agent).present?
   end
 

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
           name: "Suivi de dossier"
         )
         expect(agent.reload.organisations.last.name).to eq "CCAS de Montreuil"
+        expect(agent.services).to be_empty
       end
     end
 


### PR DESCRIPTION
# Contexte

Maintenant que les services sont facultatifs (voir https://github.com/betagouv/rdv-service-public/pull/5576), on les supprime aussi des comptes qui sont créés via les intégrations pour fournir une version plus simple de l'application aux agents concernés.

Cette PR est motivée par l'ouverture soudaine de l'intégration avec Démarches Simplifiées, donc on corrige un peu tout dans l'urgence.