### PR TITLE
Rediriger vers la prise de rdv après l'ouverture d'un espace

### DIFF
--- a/app/controllers/agents/territories_controller.rb
+++ b/app/controllers/agents/territories_controller.rb
@@ -11,7 +11,12 @@ class Agents::TerritoriesController < AgentAuthController
     @compte_form.agent = current_agent
 
     if @compte_form.save!
-      redirect_to admin_organisation_configuration_path(@compte_form.organisation)
+      if RdvPlan.where(planning_agent: current_agent).any?
+        latest_rdv_plan = RdvPlan.where(planning_agent: current_agent).order("created_at desc").first
+        redirect_to agents_rdv_plan_path(latest_rdv_plan)
+      else
+        redirect_to admin_organisation_configuration_path(@compte_form.organisation)
+      end
     else
       render :new
     end

--- a/app/controllers/agents/territories_controller.rb
+++ b/app/controllers/agents/territories_controller.rb
@@ -11,8 +11,9 @@ class Agents::TerritoriesController < AgentAuthController
     @compte_form.agent = current_agent
 
     if @compte_form.save!
-      if RdvPlan.where(planning_agent: current_agent).any?
-        latest_rdv_plan = RdvPlan.where(planning_agent: current_agent).order("created_at desc").first
+      latest_rdv_plan = RdvPlan.where(planning_agent: current_agent).order("created_at desc").first
+
+      if latest_rdv_plan
         redirect_to agents_rdv_plan_path(latest_rdv_plan)
       else
         redirect_to admin_organisation_configuration_path(@compte_form.organisation)

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
         expect(agent.reload.organisations.last.name).to eq "CCAS de Montreuil"
         expect(agent.services).to be_empty
       end
+
+      context "et qu'il a un rdv plan qui a été créé par intégration" do
+        before do
+          create(:rdv_plan, planning_agent: agent)
+        end
+
+        it "permet d'ouvrir l'organisation et redirige vers le rdv plan" do
+          visit new_agents_territory_path
+
+          fill_in("Nom de votre organisation", with: "CCAS de Montreuil")
+          fill_in("Nom du territoire", with: "Commune de Montreuil")
+          click_on "Enregistrer"
+
+          expect(page).to have_content "Nouveau rendez-vous"
+        end
+      end
     end
 
     context "mais que son compte n'est pas vérifié par une application partenaire" do

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
 
       context "et qu'il a un rdv plan qui a été créé par intégration" do
         before do
-          create(:rdv_plan, planning_agent: agent)
+          create(:rdv_plan, planning_agent: agent, rdv_agent: agent)
         end
 
         it "permet d'ouvrir l'organisation et redirige vers le rdv plan" do


### PR DESCRIPTION
Un autre petit correctif pour les intégrations dans le même contexte que https://github.com/betagouv/rdv-service-public/pull/5596.

Quand un agent essaye de prendre un rdv via une intégration alors qu'il n'a pas encore d'orga, ou le redirige vers l'ouverture de compte, mais on ne le renvoie pas vers la prise de rdv après.
On ajoute donc ici la redirection manquante.