### PR TITLE
Fix LAPINS-31Z

### DIFF
--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -23,6 +23,7 @@ class Agents::RdvPlansController < AgentAuthController
 
   def edit_starts_at
     @rdv_plan.starts_at = nil
+    @rdv_plan.update!(rdv_agent: current_agent) unless @rdv_plan.rdv_agent
 
     other_agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).active.ordered_by_last_name.where.not(id: current_agent.id)
 
@@ -134,7 +135,7 @@ class Agents::RdvPlansController < AgentAuthController
   end
 
   def event_sources
-    agent = @rdv_plan.rdv_agent || current_agent
+    agent = @rdv_plan.rdv_agent
     organisation = agent.organisations.first
 
     event_sources = [

--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -134,7 +134,7 @@ class Agents::RdvPlansController < AgentAuthController
   end
 
   def event_sources
-    agent = @rdv_plan.rdv_agent
+    agent = @rdv_plan.rdv_agent || current_agent
     organisation = agent.organisations.first
 
     event_sources = [


### PR DESCRIPTION
# Contexte

Dans cette PR : #5564
On a set le `rdv_agent` à `current_agent` par défaut. Or, nous n’avons pas de contrainte de non-nullité sur `rdv_agent` donc il est encore possible d’avoir des valeurs nulles dans certains cas.

Corrige LAPINS-31Z

# Solution

Pour éviter que ça casse pour les agents, si nous avons une valeur nulle, nous utilisons le current agent et nous l’assignons au `rdv_agent`.
