### PR TITLE
Correction des créneaux envoyés à l’ANTS

### DIFF
--- a/app/controllers/api/ants/editor_controller.rb
+++ b/app/controllers/api/ants/editor_controller.rb
@@ -92,7 +92,7 @@ class Api::Ants::EditorController < Api::Ants::BaseController
 
     def time_slots_for_lieu(lieu)
       Motif
-        .where(organisation_id: lieu.organisation_id, motif_category_id:)
+        .where(organisation_id: lieu.organisation_id, motif_category_id:, bookable_by: :everyone)
         .map { |motif| time_slots_for_lieu_and_motif(lieu:, motif:) }
         .flatten
         .uniq { _1[:datetime] }

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe "User can search rdv on rdv mairie" do
   let!(:organisation) { create(:organisation, :with_contact, ants_connectable: true, name: "Mairie de Wavignies", territory:) }
   let(:service) { create(:service) }
   let!(:cni_motif) do
-    create(:motif, name: "Carte d'identité", organisation: organisation, restriction_for_rdv: nil, service: service, motif_category: cni_motif_category, default_duration_in_min: 25)
+    create(:motif, name: "Carte d'identité", organisation:, restriction_for_rdv: nil, service:, motif_category: cni_motif_category, default_duration_in_min: 25, bookable_by:)
   end
   let!(:passport_motif) do
-    create(:motif, name: "Passeport", organisation: organisation, restriction_for_rdv: nil, service: service, motif_category: passport_motif_category, default_duration_in_min: 25)
+    create(:motif, name: "Passeport", organisation:, restriction_for_rdv: nil, service:, motif_category: passport_motif_category, default_duration_in_min: 25)
   end
 
+  let(:bookable_by) { :everyone }
   let!(:cni_motif_category) { create(:motif_category, name: Api::Ants::EditorController::CNI_MOTIF_CATEGORY_NAME) }
   let!(:passport_motif_category) { create(:motif_category, name: Api::Ants::EditorController::PASSPORT_MOTIF_CATEGORY_NAME) }
   let!(:lieu) { create(:lieu, organisation: organisation, name: "Mairie de Sannois", address: "15 Place du Général Leclerc, Sannois, 95110") }
@@ -139,6 +140,26 @@ RSpec.describe "User can search rdv on rdv mairie" do
     it "displays the organisation name for a public link" do
       visit public_link_to_org_url(organisation_id: organisation.id)
       expect(page).to have_content "Prenez rendez-vous avec Mairie de Wavignies"
+    end
+  end
+
+  context "quand la mairie a désactivé la réservation en ligne sur un motif ANTS" do
+    let(:bookable_by) { :agents }
+
+    it "le point d’API ne retourne pas de créneau" do
+      visit api_ants_getManagedMeetingPoints_url
+      lieux_ids = json_response.pluck("id")
+      expect(lieux_ids).to eq([lieu.id.to_s])
+
+      visit api_ants_availableTimeSlots_url(
+        meeting_point_ids: lieux_ids.first,
+        start_date: Date.yesterday,
+        end_date: Date.tomorrow,
+        reason: "CNI",
+        documents_number: 2
+      )
+
+      expect(json_response).to eq({ lieu.id.to_s => [] })
     end
   end
 


### PR DESCRIPTION
# Contexte

En travaillant sur [ce ticket](https://zammad10.ethibox.fr/#ticket/zoom/27584), je me suis aperçu de la chose suivante : si une organisation met une catégorie de motif ANTS mais indique que le RDV n’est pas réservable en ligne, l’ANTS propose le créneau, mais l’usager se prend une 403 en fin de parcours.

# Solution

Pour la mairie concernée, j’ai retiré la catégorie de motif qui posait un problème (elle avait bien les 3 motifs CNI, Passeport et CNI + Passeport configuré à côté).
Je propose à travers cette PR, de ne plus remonter à l’ANTS les créneaux concernés pour éviter d’avoir d’autres usagers bloqués.

