### PR TITLE
Rediriger vers la liste des agents après l'invitation d'un agent

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -38,7 +38,7 @@ class Admin::AgentsController < AgentAuthController
     if @agent.valid?
       flash[:success] = create_agent.confirmation_message
       flash[:alert] = create_agent.warning_message
-      redirect_to_index_path_for(@agent)
+      redirect_to admin_organisation_agents_path(current_organisation)
     else
       render_new
     end
@@ -66,7 +66,7 @@ class Admin::AgentsController < AgentAuthController
     if update_agent.call
       flash[:success] = update_agent.confirmation_message
 
-      redirect_to_index_path_for(@agent)
+      redirect_to admin_organisation_agents_path(current_organisation)
     else
       render_edit
     end
@@ -82,7 +82,7 @@ class Admin::AgentsController < AgentAuthController
       agent_removal.remove!
       flash[:notice] = agent_removal.confirmation_message
 
-      redirect_to_index_path_for(@agent)
+      redirect_to admin_organisation_agents_path(current_organisation)
     else
       redirect_to edit_admin_organisation_agent_path(current_organisation, @agent), flash: { error: agent_removal.errors.full_messages.join }
     end
@@ -105,14 +105,6 @@ class Admin::AgentsController < AgentAuthController
     @roles = access_levels_collection
 
     render :edit
-  end
-
-  def redirect_to_index_path_for(agent)
-    if agent.invitation_sent_at? && !agent.invitation_accepted?
-      redirect_to admin_organisation_invitations_path(current_organisation)
-    else
-      redirect_to admin_organisation_agents_path(current_organisation)
-    end
   end
 
   def index_params

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -12,9 +12,9 @@
     - if needs_agent_search?
       .fr-my-2w.d-flex.justify-content-end
         - search = params[:term].blank? && "d-none"
-        div= link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "btn btn-link #{search}"
+        div= link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "fr-btn fr-btn--tertiary-no-outline #{search}"
         = f.input :term, placeholder: "Prénom, Nom, Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:term] }, required: false
-        = f.button :submit, t("helpers.search")
+        = f.submit t("helpers.search"), class: "fr-btn"
     table.table
       thead
         tr
@@ -36,7 +36,7 @@
 
     - if current_agent_can_create_agent_in?(current_organisation)
       .m-3.d-flex.justify-content-center.align-items-center
-        = link_to t("agents.create_cta"), new_admin_organisation_agent_path(current_organisation), class: "btn btn-primary"
+        = link_to t("agents.create_cta"), new_admin_organisation_agent_path(current_organisation), class: "fr-btn"
         - if needs_agent_search?
           - if @invited_agents_count > 0
             = link_to "Voir les #{@invited_agents_count} invitations en attente", admin_organisation_invitations_path(current_organisation), class: "btn btn-link"

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -5,7 +5,7 @@
 
 - if current_agent_can_create_agent_in?(current_organisation)
   - content_for :breadcrumb do
-    = link_to t("agents.create_cta"), new_admin_organisation_agent_path(current_organisation), class:"btn btn-outline-primary"
+    = link_to t("agents.create_cta"), new_admin_organisation_agent_path(current_organisation), class:"fr-btn fr-btn--secondary"
 
 = simple_form_for "", url: admin_organisation_agents_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
   .container-fluid.bg-white.rounded
@@ -37,7 +37,8 @@
     - if current_agent_can_create_agent_in?(current_organisation)
       .m-3.d-flex.justify-content-center.align-items-center
         = link_to t("agents.create_cta"), new_admin_organisation_agent_path(current_organisation), class: "btn btn-primary"
-        - if @invited_agents_count > 0
-          = link_to "Voir les #{@invited_agents_count} invitations en attente", admin_organisation_invitations_path(current_organisation), class: "btn btn-link"
-        - else
-          .m-2 Aucune invitation en attente
+        - if needs_agent_search?
+          - if @invited_agents_count > 0
+            = link_to "Voir les #{@invited_agents_count} invitations en attente", admin_organisation_invitations_path(current_organisation), class: "btn btn-link"
+          - else
+            .m-2 Aucune invitation en attente

--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -58,7 +58,7 @@
                 = icon("fr-icon-user-fill",class: "fr-mr-1w")
                 | Agents
             p.fr-tile__desc
-              = @agents_scope.limit(3).map(&:full_name).join(", ")
+              = @agents_scope.limit(3).map(&:full_name_or_email).join(", ")
               - if @agents_scope.count > 3
                 - autres_count = @agents_scope.count - 3
                 = " et #{autres_count} #{'autre'.pluralize(autres_count)}"

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -35,14 +35,10 @@ RSpec.describe Admin::AgentsController, type: :controller do
   describe "DELETE #destroy" do
     subject { delete :destroy, params: { organisation_id: organisation.id, id: agent1.id } }
 
-    it "destroys the requested agent" do
+    it "destroys the requested agent and redirects to the agents list" do
       subject
       expect(agent1.reload.organisations).not_to include(organisation)
-    end
-
-    it "redirects to the invitations list" do
-      subject
-      expect(response).to redirect_to(admin_organisation_invitations_path(organisation))
+      expect(response).to redirect_to(admin_organisation_agents_path(organisation))
     end
   end
 
@@ -193,10 +189,10 @@ RSpec.describe Admin::AgentsController, type: :controller do
         }
       end
 
-      it "creates a new agent, sends an email and redirect to invitations list" do
+      it "creates a new agent, sends an email and redirect to agents list" do
         expect { subject }.to change(Agent, :count).by(1)
 
-        expect(response).to redirect_to(admin_organisation_invitations_path(organisation.id))
+        expect(response).to redirect_to(admin_organisation_agents_path(organisation.id))
 
         perform_enqueued_jobs
         expect(Devise.mailer.deliveries.count).to eq(1)

--- a/spec/features/agents/agent_can_crud_intervenants_spec.rb
+++ b/spec/features/agents/agent_can_crud_intervenants_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Agent can CRUD intervenants" do
       absence_notification_level: "all"
     )
 
-    expect_page_title("Invitations en cours pour Organisation n°1")
+    expect_page_title("Agents de Organisation n°1")
     expect(page).to have_content("ancien_intervenant1@invitation.com")
     expect(page).to have_content("FICTIF Bob")
 

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
       click_button("Enregistrer")
       expect(Agent.count).to eq(2)
 
-      expect(page).to have_content("Invitations en cours")
+      expect(page).to have_content("Agents de ")
       expect(organisation2.reload.agents.count).to eq 2
     end
 
@@ -92,7 +92,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
       check(pmi.name)
       click_button "Enregistrer"
 
-      expect_page_title("Invitations en cours pour Organisation n°1")
+      expect_page_title("Agents de Organisation n°1")
       expect(page).to have_content("jean@paul.com")
 
       click_on "Se déconnecter"

--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
       $stdout.reopen("log/test_sinatra.log", "r+") # Pour ne pas logger sur stdout
       FakeOauthClient.run!
     end
+    sleep 0.5 # Pour attendre que le serveur démarre et éviter une flaky spec
 
     example.run
 


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1280" height="720" alt="avant" src="https://github.com/user-attachments/assets/0e670f7e-8ffd-4b90-a72f-5a0029e1843d" />|<img width="1280" height="720" alt="après" src="https://github.com/user-attachments/assets/da5163f5-9453-4455-b2f3-0baee2b6861d" />

En documentant l'invitation d'agents avec Mehdi, on s'est rendu compte que c'est hyper confusant qu'on redirige vers la liste des invitations d'agents après avoir ajouté un agent, plutôt que d'afficher l'agent invité parmis les agents qui font partie de l'organisation.

On change donc ce comportement pour rediriger vers la liste des agents, et bien voir que l'agent invité fait partie de agents de l'organisation.


On avait envisagé de même supprimer complètement la liste des invitations, mais je me souviens qu'elle est utile dans les grosses organisations du médico-social pour voir qui est dans l'organisation ou non, donc pour le moment je le cache juste dans le cas (fréquent) des petites organisations.
On pourra revoir ça de plus près quand on aura le temps de s'assurer que ce changement ne casse pas l'existant.



