### PR TITLE
Fix typo lors du toggle_feature

### DIFF
--- a/app/controllers/super_admins/agents_controller.rb
+++ b/app/controllers/super_admins/agents_controller.rb
@@ -64,9 +64,9 @@ module SuperAdmins
 
       flash[:notice] =
         if agent.feature_enabled?(feature)
-          "#{feature} désactivé pour #{agent.email}"
-        else
           "#{feature} activé pour #{agent.email}"
+        else
+          "#{feature} désactivé pour #{agent.email}"
         end
 
       redirect_to super_admins_agent_path(agent)


### PR DESCRIPTION
# Contexte

Juste un petit fix d’un problème de typo dont nous nous sommes rendu compte lors de la démo des features flags.
