### PR TITLE
Bugfix : menu planning déplié quand on navigue sur les RDVs collectifs

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -51,7 +51,6 @@ module AgentsHelper
       "menu-agendas" => "planning",
       "menu-plages-ouvertures" => "planning",
       "menu-absences" => "planning",
-      "menu-rdvs-collectifs-list" => "planning",
       "menu-settings" => "settings",
       "menu-organisation-stats" => "stats",
       "menu-stats" => "stats",


### PR DESCRIPTION
Il y a eu un oubli dans #5460 qui fait que lorsqu'on clique sur "RDV collectifs" dans le menu, alors la section "Planning" est dépliée, ce qui n'est plus souhaité.

# Avant

<img width="285" height="696" alt="image" src="https://github.com/user-attachments/assets/66962548-63dc-40bf-ba47-a146c2bfc27f" />

# Après

<img width="285" height="696" alt="image" src="https://github.com/user-attachments/assets/6e76d824-515c-45dc-b439-799f8543c00e" />
