### PR TITLE
Correctif pour les doublons d'usagers par numéro de téléphone

### DIFF
--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -14,7 +14,7 @@ ul.list-unstyled.mb-5
     - if user.phone_number.present? && DuplicateUsersFinderService.find_duplicate_based_on_phone_number(user, current_organisation).present?
       = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mt-1v" } do
         span> D'autres usagers utilisent ce numéro de téléphone.
-        = link_to "voir la liste", admin_organisation_users_path(current_organisation, "search": user.phone_number), class: "fr-link"
+        = link_to "voir la liste", admin_organisation_users_path(current_organisation, "search": user.humanized_phone_number), class: "fr-link"
 
   li.mb-2= object_attribute_tag(user, :notify_by_sms, notify_by_sms_description(user))
   - if user.pending_reconfirmation?

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -24,7 +24,7 @@
             = f.label :agent_id, "Agent référent", {class: "form-control-label select optional"}
             = f.select :agent_id, [], {}, { class: "form-control select optional select2-input", data: { "select2-config": { ajax: { url: admin_organisation_agents_path(current_organisation), dataType: "json", delay: 250 } } } }
 
-      input.btn.btn-primary.d-print-none type="submit" value="Rechercher"
+      input.fr-btn.d-print-none type="submit" value="Rechercher"
 
       - if @search_needed
         p.fr-mt-4w.text-muted.fr-mb-0.fr-text--sm


### PR DESCRIPTION
Bug remonté par un conum : depuis les détails d'un usager, s'il y a d'autres usagers qui ont le même numéro de téléphone, mais qu'il y a des points dans le numéro de téléphone, la liste affichée en lien est vide

Par exemple : 
<img width="546" height="129" alt="Screenshot 2025-09-02 at 17 41 36" src="https://github.com/user-attachments/assets/b7441976-903e-421c-a03a-6a75454da1a5" />

Actuellement ça mène à une liste vide :
<img width="1174" height="341" alt="Screenshot 2025-09-02 at 17 43 07" src="https://github.com/user-attachments/assets/c0c3f068-bf46-4ff1-8e7a-6da0fd59cf0d" />

Et avec ce correctif on a bien la bonne liste : 
<img width="1186" height="531" alt="Screenshot 2025-09-02 at 17 44 00" src="https://github.com/user-attachments/assets/6b10049b-eba1-48cb-82bf-bafce0f6f849" />

Vu qu'on est sur une très petite feature je vais un peu vite et je n'ajoute pas de spec, mais c'est peut-être pas une super idée.