### PR TITLE
Fix flaky connexion DS autodoc

### DIFF
--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -21,17 +21,18 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
       `touch log/test_sinatra.log`
       $stdout.reopen("log/test_sinatra.log", "r+") # Pour ne pas logger sur stdout
       FakeOauthClient.run!
-      Timeout.timeout(30) do
-        loop do
-          begin
-            res = Net::HTTP.get_response(URI("http://localhost:4567"))
-            # On attend que l’app soit prête avant de lancer les tests
-            break if res.is_a?(Net::HTTPSuccess)
-          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
-            # Le serveur n'est pas encore prêt
-          end
-          sleep 0.5
+    end
+
+    Timeout.timeout(30) do
+      loop do
+        begin
+          res = Net::HTTP.get_response(URI("http://localhost:4567"))
+          # On attend que l’app soit prête avant de lancer les tests
+          break if res.is_a?(Net::HTTPSuccess)
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          # Le serveur n'est pas encore prêt
         end
+        sleep 0.5
       end
     end
     sleep 0.5 # Pour attendre que le serveur démarre et éviter une flaky spec

--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
       `touch log/test_sinatra.log`
       $stdout.reopen("log/test_sinatra.log", "r+") # Pour ne pas logger sur stdout
       FakeOauthClient.run!
+      Timeout.timeout(30) do
+        loop do
+          begin
+            res = Net::HTTP.get_response(URI("http://localhost:4567"))
+            # On attend que l’app soit prête avant de lancer les tests
+            break if res.is_a?(Net::HTTPSuccess)
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            # Le serveur n'est pas encore prêt
+          end
+          sleep 0.5
+        end
+      end
     end
     sleep 0.5 # Pour attendre que le serveur démarre et éviter une flaky spec
 

--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -23,19 +23,7 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
       FakeOauthClient.run!
     end
 
-    Timeout.timeout(30) do
-      loop do
-        begin
-          res = Net::HTTP.get_response(URI("http://localhost:4567"))
-          # On attend que l’app soit prête avant de lancer les tests
-          break if res.is_a?(Net::HTTPSuccess)
-        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
-          # Le serveur n'est pas encore prêt
-        end
-        sleep 0.5
-      end
-    end
-    sleep 0.5 # Pour attendre que le serveur démarre et éviter une flaky spec
+    sleep 0.5 # on attend que le serveur soit démarré pour éviter les flaky
 
     example.run
 


### PR DESCRIPTION
# Contexte

Depuis l’arrivée de cette nouvelle autodoc, nous avons très régulièrement le job d’autodoc qui casse dans la CI, car le serveur Sinatra n’est pas encore prêt (Timeout sur le call `http://localhost:4567/`). Je propose donc d’attendre que le serveur Sinatra soit prêt, avant de démarrer la spec.
