### PR TITLE
Changement de la bannière de prise de rdv en ligne pour RDV Service Public

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -69,7 +69,7 @@ class Domain
       name: "RDV Service Public",
       presentation_for_agents_template_name: nil, # C'est la homepage qui joue ce rôle pour ce domaine
       address_selection_template_name: nil,
-      search_banner_template_name: "search/banners/rdv_mairie",
+      search_banner_template_name: "search/banners/rdv_service_public",
       online_reservation_with_public_link: true,
       sms_sender_name: "RDV S.P.",
       france_connect_enabled: true,

--- a/app/views/search/banners/_rdv_mairie.html.slim
+++ b/app/views/search/banners/_rdv_mairie.html.slim
@@ -1,7 +1,6 @@
-span Prenez rendez-vous avec
-br.fr-hidden.fr-unhidden-md
-span<
-  - if @context&.public_link_organisation
-    = @context.public_link_organisation.name
-  - else
-    = "votre mairie"
+span Prenez rendez-vous
+- if @context&.public_link_organisation
+  = " avec "
+  br.fr-hidden.fr-unhidden-md
+  span<
+      =  @context.public_link_organisation.name

--- a/app/views/search/banners/_rdv_mairie.html.slim
+++ b/app/views/search/banners/_rdv_mairie.html.slim
@@ -1,6 +1,0 @@
-span Prenez rendez-vous
-- if @context&.public_link_organisation
-  = " avec "
-  br.fr-hidden.fr-unhidden-md
-  span<
-      =  @context.public_link_organisation.name

--- a/app/views/search/banners/_rdv_service_public.html.slim
+++ b/app/views/search/banners/_rdv_service_public.html.slim
@@ -1,0 +1,14 @@
+/# locals: (context:)
+span Prenez rendez-vous
+- if context&.public_link_organisation
+  = " avec "
+  br.fr-hidden.fr-unhidden-md
+  span<
+      =  context.public_link_organisation.name
+- else
+  - territory =  Territory.where(departement_number: context.departement).sole
+  - if territory&.name.present?
+    = " avec "
+    br.fr-hidden.fr-unhidden-md
+    span<
+      =  territory.name

--- a/app/views/search/banners/_rdv_service_public.html.slim
+++ b/app/views/search/banners/_rdv_service_public.html.slim
@@ -4,12 +4,12 @@ span Prenez rendez-vous
   = " avec "
   br.fr-hidden.fr-unhidden-md
   span<
-      =  context.public_link_organisation.name
+    = context.public_link_organisation.name
 - else
   - territories = Territory.where(departement_number: context.departement)
-  - territory =  territories.count == 1 ? territories.first : nil
+  - territory = territories.count == 1 ? territories.first : nil
   - if territory&.name.present?
     = " avec "
     br.fr-hidden.fr-unhidden-md
     span<
-      =  territory.name
+      = territory.name

--- a/app/views/search/banners/_rdv_service_public.html.slim
+++ b/app/views/search/banners/_rdv_service_public.html.slim
@@ -6,7 +6,8 @@ span Prenez rendez-vous
   span<
       =  context.public_link_organisation.name
 - else
-  - territory =  Territory.where(departement_number: context.departement).sole
+  - territories = Territory.where(departement_number: context.departement)
+  - territory =  territories.count == 1 ? territories.first : nil
   - if territory&.name.present?
     = " avec "
     br.fr-hidden.fr-unhidden-md


### PR DESCRIPTION
Avant | Après
:- | -:
_mettre un screenshot ici_ | _et ici_
<img width="1128" height="549" alt="Screenshot 2025-09-03 at 11 57 52" src="https://github.com/user-attachments/assets/2556e035-f35a-41bc-a524-d860bf2180e1" />|<img width="760" height="557" alt="Screenshot 2025-09-03 at 11 58 19" src="https://github.com/user-attachments/assets/9f17704f-0317-4a0e-8ddd-f7142899c906" /><img width="728" height="497" alt="Screenshot 2025-09-03 at 11 58 45" src="https://github.com/user-attachments/assets/b0fd33bd-07ce-416d-9a04-9678bf81d163" />

On gère les deux cas où il y a un nom ou non pour l'espace


# Contexte

Le CDAD du 21 a un lien de prise de rendez-vous à l'échelle de toutes leur organisations : https://rdv.anct.gouv.fr/prendre_rdv?departement=C21
(on a mis un C dans le numéro de département pour éviter de mélanger leur dispos avec d'autres espaces qui sont sur le même département mais qui n'ont rien à voir).

Le problème, c'est qu'il y a écrit "prenez rendez-vous avec votre mairie", alors qu'ils n'ont rien à voir avec des mairies. C'est un reliquat de l'ouverture aux mairies en 2023 avant qu'on soit officiellement RDV Service Public.

# Solution

On ajoute donc un bout de logique pour afficher soit le nom de l'espace, soit juste "Prenez rendez-vous"


