### PR TITLE
Rendre le bouton de lien vers RDV Aide Numérique plus visible pour les usagers importés

### DIFF
--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -18,7 +18,6 @@ ruby:
     - references.each do |reference|
       = link_to("Voir sur #{reference.oauth_application.name}", reference.external_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-mr-2w")
 
-
   = link_to "Trouver un RDV pour l’usager", admin_organisation_creneaux_search_path(current_organisation, user_ids: [@user.id]), class: "fr-btn fr-btn--secondary", title: "Trouver un RDV pour l’usager #{@user.full_name}"
 
 .row

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -13,6 +13,12 @@ ruby:
   = render "common/fil_ariane", titles_and_paths:, current_page_title: @user.full_name
 
 - content_for :breadcrumb do
+  - references = Agent::ExternalReferencePolicy::Scope.new(current_agent, @user.external_references.where(territory: current_territory)).resolve
+  - if references.present?
+    - references.each do |reference|
+      = link_to("Voir sur #{reference.oauth_application.name}", reference.external_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-mr-2w")
+
+
   = link_to "Trouver un RDV pour l’usager", admin_organisation_creneaux_search_path(current_organisation, user_ids: [@user.id]), class: "fr-btn fr-btn--secondary", title: "Trouver un RDV pour l’usager #{@user.full_name}"
 
 .row
@@ -50,11 +56,6 @@ ruby:
             li= object_attribute_tag(@user, :birth_date, birth_date_and_age(@user))
             - if current_territory.enable_notes_field?
               li= object_attribute_tag(@user, :annotation_content, formatted_user_annotation(@user, current_territory))
-
-        - references = Agent::ExternalReferencePolicy::Scope.new(current_agent, @user.external_references.where(territory: current_territory)).resolve
-        - if references.present?
-          - references.each do |reference|
-            = link_to("Voir sur #{reference.oauth_application.name}", reference.external_url, target: :_blank, class: "fr-mb-2w")
 
         ul.fr-btns-group.fr-btns-group--right.fr-btns-group--inline.fr-btns-group--icon-left.fr-mb-0
           li


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1178" height="718" alt="Screenshot 2025-09-03 at 12 30 40" src="https://github.com/user-attachments/assets/0fe0e251-b01f-4e8e-9b75-d5e5ac0dff02" />|<img width="1177" height="694" alt="Screenshot 2025-09-03 at 12 30 25" src="https://github.com/user-attachments/assets/5130818e-ac59-4fe2-aa81-5bc52b46a7ad" />

On a des retours d'agents qui demandent si c'est possible d'avoir l'historique des rendez-vous d'un usager suite à une migration, ce qui indique qu'ils n'ont pas vu ce lien qui permet d'y accéder.

C'est  plus logique de mettre le lien beaucoup plus en avant, et plus proche des composants qui indiquent l'historique des rendez-vous