### PR TITLE
Ne pas afficher les préférences de notification si elles n'ont pas de sens sur les détails des usagers

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -83,9 +83,7 @@ module UsersHelper
   end
 
   def notify_by_email_description(user)
-    if user.preferred_email.blank?
-      "🔴 pas d'email renseigné"
-    elsif user.responsible_notify_by_email?
+    if user.responsible_notify_by_email?
       "🟢 Activées"
     else
       "🔴 Désactivées"
@@ -101,9 +99,7 @@ module UsersHelper
   end
 
   def notify_by_sms_description(user)
-    if user.responsible_phone_number.blank?
-      "🔴 pas de numéro de téléphone renseigné"
-    elsif !user.responsible_phone_number_mobile?
+    if !user.responsible_phone_number_mobile?
       "🔴 le numéro de téléphone renseigné n'est pas un mobile"
     elsif user.responsible_notify_by_sms?
       "🟢 Activées"

--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -17,7 +17,9 @@ ul.list-unstyled.mb-5
         span> D'autres usagers utilisent ce numéro de téléphone.
         = link_to "voir la liste", admin_organisation_users_path(current_organisation, "search": user.humanized_phone_number), class: "fr-link"
 
+    - if user.phone_number.present?
       li.mb-2= object_attribute_tag(user, :notify_by_sms, notify_by_sms_description(user))
+
   - if user.pending_reconfirmation?
     .text-muted.mb-2
       | En attente de confirmation pour #{user.unconfirmed_email}

--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -8,7 +8,8 @@ ul.list-unstyled.mb-5
     li.mb-2= object_attribute_tag(user, :birth_date, birth_date_and_age(user))
   li.mb-2= object_attribute_tag(user, :address)
   li.mb-2= object_attribute_tag(user, :preferred_email, clickable_user_email(user))
-  li.mb-2= object_attribute_tag(user, :notify_by_email, notify_by_email_description(user))
+  - if user.preferred_email.present?
+    li.mb-2= object_attribute_tag(user, :notify_by_email, notify_by_email_description(user))
   li.mb-2
     = object_attribute_tag(user, :phone_number, clickable_user_phone_number(user))
     - if user.phone_number.present? && DuplicateUsersFinderService.find_duplicate_based_on_phone_number(user, current_organisation).present?
@@ -16,7 +17,7 @@ ul.list-unstyled.mb-5
         span> D'autres usagers utilisent ce numéro de téléphone.
         = link_to "voir la liste", admin_organisation_users_path(current_organisation, "search": user.humanized_phone_number), class: "fr-link"
 
-  li.mb-2= object_attribute_tag(user, :notify_by_sms, notify_by_sms_description(user))
+      li.mb-2= object_attribute_tag(user, :notify_by_sms, notify_by_sms_description(user))
   - if user.pending_reconfirmation?
     .text-muted.mb-2
       | En attente de confirmation pour #{user.unconfirmed_email}


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="598" height="710" alt="Screenshot 2025-09-03 at 12 38 47" src="https://github.com/user-attachments/assets/a7c2fd1e-10fd-4e86-8794-f01e1bcaac36" />|<img width="587" height="606" alt="Screenshot 2025-09-03 at 12 38 18" src="https://github.com/user-attachments/assets/3fb5bf79-6e88-417f-ba99-7c27655e200d" />

Un petit complément pour https://github.com/betagouv/rdv-service-public/pull/5611 : pour les usagers qui n'ont pas d'emails ou de numéro de téléphone, ça n'a pas de sens d'afficher s'ils acceptent ou non de recevoir des notifications (surtout avec un fonctionnement ou on affiche "Accepte les notifications par email : 🔴 pas d'email renseigné").