### PR TITLE
Faciliter la fermeture des lieux

### DIFF
--- a/app/controllers/admin/lieux_controller.rb
+++ b/app/controllers/admin/lieux_controller.rb
@@ -53,6 +53,26 @@ class Admin::LieuxController < AgentAuthController
     end
   end
 
+  def close
+    set_and_authorize_lieu
+    if @lieu.update(availability: :disabled)
+      flash[:success] = "Le lieu a été fermé."
+      redirect_to admin_organisation_lieux_path(@lieu.organisation)
+    else
+      render :edit
+    end
+  end
+
+  def reopen
+    set_and_authorize_lieu
+    if @lieu.update(availability: :enabled)
+      flash[:success] = "Le lieu a été réouvert."
+      redirect_to admin_organisation_lieux_path(@lieu.organisation)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def set_and_authorize_lieu

--- a/app/policies/agent/lieu_policy.rb
+++ b/app/policies/agent/lieu_policy.rb
@@ -8,6 +8,8 @@ class Agent::LieuPolicy < ApplicationPolicy
   alias new? update?
   alias create? update?
   alias edit? update?
+  alias close? update?
+  alias reopen? update?
   alias destroy? update?
   alias versions? update?
 

--- a/app/views/admin/lieux/_lieu.html.slim
+++ b/app/views/admin/lieux/_lieu.html.slim
@@ -1,21 +1,18 @@
 - nb_rdv = Agent::RdvPolicy::Scope.apply(AgentOrganisationContext.new(current_agent, current_organisation), Rdv).for_today.merge(lieu.rdvs).count
 tr id="lieu_#{lieu.id}"
   td
-    = lieu.name
-    = unavailability_tag(lieu)
+    - if @lieux_policy.edit?
+      = link_to edit_admin_organisation_lieu_path(current_organisation, lieu) do
+        = lieu.name
+        = unavailability_tag(lieu)
+    - else
+      = lieu.name
+      = unavailability_tag(lieu)
   td= lieu.address
   td= lieu.phone_number
   td= link_to nb_rdv > 0 ? nb_rdv : "aucun", admin_organisation_rdvs_path(current_organisation, lieu_id: lieu.id, start: Time.zone.now.beginning_of_day, end: Time.zone.now.end_of_day )
   td
-    - if @lieux_policy.edit? || @lieux_policy.destroy?
-      .d-flex
-        - if @lieux_policy.edit?
-          div.mr-3= link_to edit_admin_organisation_lieu_path(current_organisation, lieu),
-                  title: t("helpers.edit") do
-            i.fa.fa-edit
-        - if @lieux_policy.destroy?
-          div= link_to admin_organisation_lieu_path(current_organisation, lieu),
-                  title: t("helpers.delete"),
-                  method: :delete,
-                  data: { confirm: "Confirmez-vous la suppression de ce lieu ?"} do
-            i.fa.fa-trash-alt
+    - if @lieux_policy.edit?
+      div.mr-3= link_to edit_admin_organisation_lieu_path(current_organisation, lieu),
+              title: t("helpers.edit") do
+        i.fa.fa-edit

--- a/app/views/admin/lieux/_lieu_fields.html.slim
+++ b/app/views/admin/lieux/_lieu_fields.html.slim
@@ -17,32 +17,3 @@
 = f.input :address, input_html: { data: { "address-autocomplete": "on" } }
 = f.hidden_field :latitude
 = f.hidden_field :longitude
-
-/ Edit only
-- if is_edit_form
-  = f.input :enabled
-
-/ New and Edit
-- if is_new_form || is_edit_form
-  - lieu_is_referenced = @lieu.plage_ouvertures.any? || @lieu.rdvs.any?
-  .row
-    - if is_edit_form
-      .col.text-left
-        - if lieu_is_referenced
-          = button_tag t("helpers.delete"), type: "button", disabled: true, class: "btn btn-outline-danger"
-        - else
-          = link_to t("helpers.delete"), admin_organisation_lieu_path(@lieu.organisation, @lieu), method: :delete, class: "btn btn-outline-danger", data: { confirm: t(".confirm_delete") }
-    .col.text-right
-      = link_to t("helpers.cancel"), admin_organisation_lieux_path(@lieu.organisation), class: "btn btn-link"
-      = f.button :submit
-  .row.mt-3
-    .col
-      - if lieu_is_referenced
-        .alert.alert-info
-          h5.alert-heading =t(".referenced_lieu")
-          - if @lieu.plage_ouvertures.any?
-            p= t(".referenced_in_plage_ouvertures")
-          - if @lieu.rdvs.any?
-            p
-              = link_to t(".referenced_in_rdvs_1"), admin_organisation_rdvs_path(current_organisation, lieu_id: @lieu.id)
-              =< t(".referenced_in_rdvs_2")

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -37,7 +37,7 @@
       .card
         .card-body
           - lieu_is_referenced = @lieu.plage_ouvertures.any? || @lieu.rdvs.any?
-          .row.mt-3
+          .row
             .col
               - if lieu_is_referenced
                 .alert.alert-info
@@ -51,6 +51,7 @@
           - if lieu_is_referenced
             = button_tag t("helpers.delete"), type: "button", disabled: true, class: "btn btn-outline-danger"
           - else
+            p Vous pouvez supprimer ce lieu
             = link_to t("helpers.delete"), admin_organisation_lieu_path(@lieu.organisation, @lieu), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce lieu ?" }
 
 

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -54,8 +54,6 @@
             p Vous pouvez supprimer ce lieu
             = link_to t("helpers.delete"), admin_organisation_lieu_path(@lieu.organisation, @lieu), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce lieu ?" }
 
-
-
 .row.justify-content-center
   .col-md-12.col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: @lieu_policy, resource: @lieu

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -21,18 +21,22 @@
         - if @lieu.enabled?
           h2.fr-h6 Ce lieu est ouvert aux nouveaux rendez-vous
           p Vous pouvez fermer ce lieu pour empêcher que de nouveaux rendez-vous ou des nouvelles plages d'ouvertures y soient associées.
-          p Il sera ensuite possible de rouvrir ce lieu dès que vous le souhaitez.
-          = link_to "Fermer ce lieu", archive_admin_organisation_motif_path(current_organisation, @lieu), method: :post, data: { confirm: t("admin.motifs.actions.archive_confirm") }, class: "fr-btn fr-btn--secondary"
-
+          p Il sera ensuite possible de réouvrir ce lieu dès que vous le souhaitez.
+          = link_to "Fermer ce lieu", close_admin_organisation_lieu_path(current_organisation, @lieu), method: :post, class: "fr-btn fr-btn--secondary"
 
         - else
+          h2.fr-h6 Ce lieu est fermé aux nouveaux rendez-vous
+
+          p Il n'est pas possible d'ajouter des rendez-vous ou des plages d'ouverture pour ce lieu.
+          p Si vous le souhaitez, vous pouvez le réouvrir
+          = link_to "Réouvrir ce lieu", reopen_admin_organisation_lieu_path(current_organisation, @lieu), method: :post, class: "fr-btn fr-btn--secondary"
+
+- if @lieu.disabled?
+  .row.justify-content-center
+    .col-md-12.col-lg-8
+      .card
+        .card-body
           - lieu_is_referenced = @lieu.plage_ouvertures.any? || @lieu.rdvs.any?
-          .row
-            .col.text-left
-              - if lieu_is_referenced
-                = button_tag t("helpers.delete"), type: "button", disabled: true, class: "btn btn-outline-danger"
-              - else
-                = link_to t("helpers.delete"), admin_organisation_lieu_path(@lieu.organisation, @lieu), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce lieu ?" }
           .row.mt-3
             .col
               - if lieu_is_referenced
@@ -44,6 +48,12 @@
                     p
                       = link_to "Des RDVs sont associés à ce lieu.", admin_organisation_rdvs_path(current_organisation, lieu_id: @lieu.id)
                       =< "Supprimez-les avant de pouvoir supprimer ce lieu."
+          - if lieu_is_referenced
+            = button_tag t("helpers.delete"), type: "button", disabled: true, class: "btn btn-outline-danger"
+          - else
+            = link_to t("helpers.delete"), admin_organisation_lieu_path(@lieu.organisation, @lieu), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce lieu ?" }
+
+
 
 .row.justify-content-center
   .col-md-12.col-lg-8

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -10,6 +10,40 @@
       .card-body
         = simple_form_for [:admin, @lieu.organisation, @lieu] do |f|
           = render "lieu_fields", f: f
+          .col.text-right.fr-p-0
+            = link_to t("helpers.cancel"), admin_organisation_lieux_path(@lieu.organisation), class: "fr-btn fr-btn--tertiary-no-outline fr-mr-1w"
+            = f.submit "Enregistrer", class: "fr-btn"
+
+.row.justify-content-center
+  .col-md-12.col-lg-8
+    .card
+      .card-body
+        - if @lieu.enabled?
+          h2.fr-h6 Ce lieu est ouvert aux nouveaux rendez-vous
+          p Vous pouvez fermer ce lieu pour empêcher que de nouveaux rendez-vous ou des nouvelles plages d'ouvertures y soient associées.
+          p Il sera ensuite possible de rouvrir ce lieu dès que vous le souhaitez.
+          = link_to "Fermer ce lieu", archive_admin_organisation_motif_path(current_organisation, @lieu), method: :post, data: { confirm: t("admin.motifs.actions.archive_confirm") }, class: "fr-btn fr-btn--secondary"
+
+
+        - else
+          - lieu_is_referenced = @lieu.plage_ouvertures.any? || @lieu.rdvs.any?
+          .row
+            .col.text-left
+              - if lieu_is_referenced
+                = button_tag t("helpers.delete"), type: "button", disabled: true, class: "btn btn-outline-danger"
+              - else
+                = link_to t("helpers.delete"), admin_organisation_lieu_path(@lieu.organisation, @lieu), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce lieu ?" }
+          .row.mt-3
+            .col
+              - if lieu_is_referenced
+                .alert.alert-info
+                  h5.alert-heading Ce lieu ne peut pas être supprimé.
+                  - if @lieu.plage_ouvertures.any?
+                    p Des plages d’ouvertures sont programmées à ce lieu. Déplacez-les pour pouvoir le supprimer.
+                  - if @lieu.rdvs.any?
+                    p
+                      = link_to "Des RDVs sont associés à ce lieu.", admin_organisation_rdvs_path(current_organisation, lieu_id: @lieu.id)
+                      =< "Supprimez-les avant de pouvoir supprimer ce lieu."
 
 .row.justify-content-center
   .col-md-12.col-lg-8

--- a/app/views/admin/lieux/new.html.slim
+++ b/app/views/admin/lieux/new.html.slim
@@ -10,4 +10,7 @@
       .card-body
         = simple_form_for [:admin, @lieu.organisation, @lieu] do |f|
           = render "lieu_fields", f: f
-          = f.submit "Enregistrer", class: "fr-btn"
+
+          .col.text-right.fr-p-0
+            = link_to t("helpers.cancel"), admin_organisation_lieux_path(@lieu.organisation), class: "fr-btn fr-btn--tertiary-no-outline fr-mr-1w"
+            = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/lieux/new.html.slim
+++ b/app/views/admin/lieux/new.html.slim
@@ -10,3 +10,4 @@
       .card-body
         = simple_form_for [:admin, @lieu.organisation, @lieu] do |f|
           = render "lieu_fields", f: f
+          = f.submit "Enregistrer", class: "fr-btn"

--- a/config/locales/views/admin_lieux.fr.yml
+++ b/config/locales/views/admin_lieux.fr.yml
@@ -1,9 +1,0 @@
-fr:
-  admin:
-    lieux:
-      lieu_fields:
-        confirm_delete: "Confirmez-vous la suppression de ce lieu ?"
-        referenced_lieu: "Ce lieu ne peut pas être supprimé."
-        referenced_in_plage_ouvertures: "Des plages d’ouvertures sont programmées à ce lieu. Déplacez-les pour pouvoir le supprimer."
-        referenced_in_rdvs_1: "Des RDVs sont associés à ce lieu."
-        referenced_in_rdvs_2: "Supprimez-les avant de pouvoir supprimer ce lieu."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,7 +228,13 @@ Rails.application.routes.draw do
         get "agent_searches", to: redirect(path: "/admin/organisations/%{organisation_id}/creneaux_search")
         get "slots", to: redirect(path: "/admin/organisations/%{organisation_id}/creneaux_search/selection_creneaux")
 
-        resources :lieux, except: :show
+        resources :lieux, except: :show do
+          member do
+            post :close
+            post :reopen
+          end
+        end
+
         resources :motifs do
           member do
             post :archive

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe "Admin can configure the organisation" do
     expect(page).to have_content("Vous n'avez pas encore ajouté de lieu de consultation.")
 
     click_link "Ajouter un lieu", match: :first
+
+    expect_page_title("Nouveau lieu")
+    fill_in "Nom", with: "Un autre nouveau lieu"
+    fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000"
+    first("input#lieu_latitude", visible: false).set(48.583844)
+    first("input#lieu_longitude", visible: false).set(7.735253)
+    click_button "Enregistrer"
+    expect_page_title("Lieux")
+
+    le_nouveau_lieu = Lieu.find_by(name: "Un autre nouveau lieu")
+    within("#lieu_#{le_nouveau_lieu.id}") do
+      click_link "Modifier"
+    end
   end
 
   it "Update organisation contact information" do

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -30,25 +30,29 @@ RSpec.describe "Admin can configure the organisation" do
       click_link "Modifier"
     end
 
+    click_link("Fermer ce lieu")
+    expect_page_title("Lieux")
+
+    expect(nouveau_lieu.reload).to have_attributes(availability: "disabled")
+
+    expect(page).to have_content("Le lieu a été fermé.")
+
+    click_on("Le nouveau lieu")
+    expect(page).to have_content("Ce lieu est fermé")
+
+    click_link("Réouvrir ce lieu")
+    expect(page).to have_content("Le lieu a été réouvert.")
+    expect(nouveau_lieu.reload).to have_attributes(availability: "enabled")
+
+    nouveau_lieu.update!(availability: :disabled)
+
+    click_on("Le nouveau lieu")
     click_link("Supprimer")
 
     expect_page_title("Lieux")
     expect(page).to have_content("Vous n'avez pas encore ajouté de lieu de consultation.")
 
     click_link "Ajouter un lieu", match: :first
-
-    expect_page_title("Nouveau lieu")
-    fill_in "Nom", with: "Un autre nouveau lieu"
-    fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000"
-    first("input#lieu_latitude", visible: false).set(48.583844)
-    first("input#lieu_longitude", visible: false).set(7.735253)
-    click_button "Enregistrer"
-    expect_page_title("Lieux")
-
-    le_nouveau_lieu = Lieu.find_by(name: "Un autre nouveau lieu")
-    within("#lieu_#{le_nouveau_lieu.id}") do
-      click_link "Modifier"
-    end
   end
 
   it "Update organisation contact information" do


### PR DESCRIPTION
# Contexte

Un agent nous a contacté parce qu'il avait un bug lors de la suppression d'un lieu. En débuggant, je me suis dit que ça serait beaucoup plus pratique d'avoir une fonctionnalité similaire à "archiver un motif" mais pour les lieux. Grâce à François, j'ai ensuite appris que la fonctionnalité existe déjà, mais elle est tellement caché que c'est impossible de la voir.

Il y a deux problèmes principaux  :
- sur l'index des lieux on met un picto pour supprimer le lieu, mais rien pour le fermer
- sur le formulaire de lieu, la fermeture se fait en décochant une checkbox (super difficile à voir et à comprendre).

# Solution

On reprend le fonctionnement de l'archivage des motifs, et on explique les choses plus clairement dans le formulaire.


## Captures d'écran

Avant | Après
:- | -:
<img width="1175" height="516" alt="Screenshot 2025-09-03 at 15 18 12" src="https://github.com/user-attachments/assets/6849236d-93bc-4bf7-b207-226cbb61bded" />|<img width="1180" height="493" alt="Screenshot 2025-09-03 at 15 18 28" src="https://github.com/user-attachments/assets/16676f6a-31b2-4a10-a6ab-743183736f3a" />
<img width="988" height="783" alt="Screenshot 2025-09-03 at 15 19 22" src="https://github.com/user-attachments/assets/32c004ea-2eaa-4356-a9b8-6bdad9191039" />|<img width="968" height="776" alt="Screenshot 2025-09-03 at 15 19 07" src="https://github.com/user-attachments/assets/9ff8c2c5-4f4f-4e76-ad00-1d1dcbe884d8" />



