### PR TITLE
Ajout prescripteurs dans le superadmin - Fix LAPINS-32G

### DIFF
--- a/app/controllers/super_admins/prescripteurs_controller.rb
+++ b/app/controllers/super_admins/prescripteurs_controller.rb
@@ -1,0 +1,4 @@
+module SuperAdmins
+  class PrescripteursController < SuperAdminsController
+  end
+end

--- a/app/dashboards/prescripteur_dashboard.rb
+++ b/app/dashboards/prescripteur_dashboard.rb
@@ -1,0 +1,29 @@
+require "administrate/base_dashboard"
+
+class PrescripteurDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    first_name: Field::String,
+    last_name: Field::String,
+    phone_number: Field::String,
+    phone_number_formatted: Field::String,
+    email: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+    rdv: Field::HasOne,
+    user: Field::HasOne,
+  }.freeze
+
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    first_name
+    last_name
+    phone_number
+    phone_number_formatted
+    email
+    created_at
+    updated_at
+    rdv
+    user
+  ].freeze
+end

--- a/app/policies/super_admin/prescripteur_policy.rb
+++ b/app/policies/super_admin/prescripteur_policy.rb
@@ -1,0 +1,3 @@
+class SuperAdmin::PrescripteurPolicy < DefaultSuperAdminPolicy
+  alias show? team_member?
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
     resources :users
     resources :comptes, only: %i[new create]
     resources :rdvs, only: %i[show]
+    resources :prescripteurs, only: %i[show]
     root to: "agents#index"
 
     authenticate :super_admin do

--- a/spec/policies/super_admin/prescripteur_policy_spec.rb
+++ b/spec/policies/super_admin/prescripteur_policy_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe SuperAdmin::PrescripteurPolicy, type: :policy do
+  subject { described_class }
+
+  context "Permitted actions for super_admin" do
+    let!(:super_admin) { create(:super_admin) }
+    let!(:pundit_context) { super_admin }
+    let!(:prescripteur) { create(:prescripteur) }
+
+    it_behaves_like "permit actions", :prescripteur, :show?
+    it_behaves_like "not permit actions", :prescripteur, :new?, :create?, :edit?, :update?, :destroy?
+  end
+
+  context "permitted actions for support" do
+    let!(:super_admin) { create(:super_admin, :support) }
+    let!(:pundit_context) { super_admin }
+    let!(:prescripteur) { create(:prescripteur) }
+
+    it_behaves_like "permit actions", :prescripteur, :show?
+    it_behaves_like "not permit actions", :prescripteur, :new?, :create?, :edit?, :update?, :destroy?
+  end
+end


### PR DESCRIPTION
# Contexte

Suite à : https://sentry.incubateur.net/organizations/betagouv/issues/198197/ 

On s’est rendu compte qu’on ne pouvait pas afficher un RDV dans le superadmin lorsque celui-ci avait été pris par un prescripteur. Cela vient du fait que la notion de prescripteur n’existe pour le moment pas dans Administrate.

# Solution

J’avoue ce qu’il faut pour que le RDV s’affiche correctement et que nous puissions voir les infos du prescripteur.
