### PR TITLE
Eviter les erreurs sur les files d'attentes si on ne clique pas sur les boutons dans le bon ordre

### DIFF
--- a/app/controllers/admin/user_in_waiting_rooms_controller.rb
+++ b/app/controllers/admin/user_in_waiting_rooms_controller.rb
@@ -5,16 +5,14 @@ class Admin::UserInWaitingRoomsController < AgentAuthController
     rdv = Rdv.find(params[:rdv_id])
     authorize(rdv, policy_class: Agent::RdvPolicy)
 
-    if rdv.status == "unknown"
-      rdv.set_user_in_waiting_room!
+    rdv.set_user_in_waiting_room!
 
-      if current_organisation.territory.enable_waiting_room_mail_field
-        rdv.agents.select(&:email?).map do |agent|
-          Agents::WaitingRoomMailer.with(agent: agent, rdv: rdv).user_in_waiting_room.deliver_later
-        end
+    if current_organisation.territory.enable_waiting_room_mail_field
+      rdv.agents.select(&:email?).map do |agent|
+        Agents::WaitingRoomMailer.with(agent: agent, rdv: rdv).user_in_waiting_room.deliver_later
       end
-
-      render locals: { rdv: }
     end
+
+    render locals: { rdv: }
   end
 end


### PR DESCRIPTION
Correctif pour https://sentry.incubateur.net/organizations/betagouv/issues/198103/?project=74&referrer=webhooks_plugin

Dans le cas où le rdv est marqué comme honoré avant que l'usager soit marqué comme étant en salle d'attente, on a une race condition qui fait que le rdv n'est pas marqué comme étant en salle d'attente, et on a cette erreur dans sentry.

On peut tout simplement enlever la condition sur l'état, et ça évite ce bug.

(voir ici pour l'historique : https://github.com/betagouv/rdv-service-public/pull/2911)