### PR TITLE
Fix flaky autodoc

### DIFF
--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
       `touch log/test_sinatra.log`
       $stdout.reopen("log/test_sinatra.log", "r+") # Pour ne pas logger sur stdout
       FakeOauthClient.run!
+      Timeout.timeout(30) do
+        loop do
+          begin
+            res = Net::HTTP.get_response(URI("http://localhost:4567"))
+            # On attend que l’app soit prête avant de lancer les tests
+            break if res.is_a?(Net::HTTPSuccess)
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            # Le serveur n'est pas encore prêt
+          end
+          sleep 0.5
+        end
+      end
     end
     sleep 0.5 # Pour attendre que le serveur démarre et éviter une flaky spec
 

--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -21,20 +21,20 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
       `touch log/test_sinatra.log`
       $stdout.reopen("log/test_sinatra.log", "r+") # Pour ne pas logger sur stdout
       FakeOauthClient.run!
-      Timeout.timeout(30) do
-        loop do
-          begin
-            res = Net::HTTP.get_response(URI("http://localhost:4567"))
-            # On attend que l’app soit prête avant de lancer les tests
-            break if res.is_a?(Net::HTTPSuccess)
-          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
-            # Le serveur n'est pas encore prêt
-          end
-          sleep 0.5
+    end
+
+    Timeout.timeout(30) do
+      loop do
+        begin
+          res = Net::HTTP.get_response(URI("http://localhost:4567"))
+          # On attend que l’app soit prête avant de lancer les tests
+          break if res.is_a?(Net::HTTPSuccess)
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          # Le serveur n'est pas encore prêt
         end
+        sleep 0.5
       end
     end
-    sleep 0.5 # Pour attendre que le serveur démarre et éviter une flaky spec
 
     example.run
 


### PR DESCRIPTION
# Contexte

On essaye de corriger la flakiness de l’autodoc qui fait appel à Sinatra en attendant que le serveur soit lancé.