### PR TITLE
Ne pas utiliser l'app sinatra dans l'autodoc

### DIFF
--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -2,6 +2,10 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
   let!(:agent) do
     create(:agent, :francis_factice, password: "RdvServicePublicTest1!")
   end
+  let(:oauth_application) do
+    create(:oauth_application, name: "Démarches Simplifiées",
+                               logo_base64: file_fixture("logo_demarches_simplifiees_base_64.txt").read)
+  end
 
   around do |example|
     previous_host = Capybara.app_host
@@ -14,54 +18,15 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
   # dans un contexte où notre application est le fournisseur d'oauth : on démarre une petite application
   # Sinatra qui joue le rôle d'une application externe (comme Démarches Simplifiées) qui propose un
   # oauth vers notre appli.
-  around do |example|
-    pid = Process.fork do
-      OmniAuth.config.test_mode = false
-
-      `touch log/test_sinatra.log`
-      $stdout.reopen("log/test_sinatra.log", "r+") # Pour ne pas logger sur stdout
-      FakeOauthClient.run!
-    end
-
-    Timeout.timeout(30) do
-      loop do
-        begin
-          res = Net::HTTP.get_response(URI("http://localhost:4567"))
-          # On attend que l’app soit prête avant de lancer les tests
-          break if res.is_a?(Net::HTTPSuccess)
-        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
-          # Le serveur n'est pas encore prêt
-        end
-        sleep 0.5
-      end
-    end
-
-    example.run
-
-    Process.kill("KILL", pid)
-    Process.wait(pid) # pour éviter d'avoir un process zombie
-  end
-
   stub_env_for_proconnect
-  before do
-    application = Doorkeeper::Application.new(
-      name: "Démarches Simplifiées",
-      uid: "fake_app_id",
-      redirect_uri: "http://localhost:4567/omniauth/rdvservicepublic/callback",
-      post_logout_redirect_uri: "http://localhost:4567/",
-      logo_base64: file_fixture("logo_demarches_simplifiees_base_64.txt").read
-    )
-
-    application.secret_strategy.store_secret(application, :secret, "fake_app_secret")
-    application.save!
-  end
 
   specify do
     doc = Autodoc.start_scenario("Connexion de Démarches Simplifiées à RDV Service Public par un admin", self)
 
-    visit "http://localhost:4567/"
-    click_button "Se connecter avec RDV Service Public"
-
+    visit oauth_authorization_path(
+      client_id: oauth_application.uid,
+      redirect_uri: oauth_application.redirect_uri.split("\n").first, response_type: :code, scope: :write, state: "fakestate"
+    )
     doc.start_section("Connexion initiale")
 
     doc.add_text <<~TEXT


### PR DESCRIPTION
En faisant le bon appel, on peut mimer le parcours oauth pour la documentation sans avoir à démarrer une appli sinatra. Ça évite beaucoup de flakiness.