### PR TITLE
Ajoute du debug dans le wizard prescripteur

### DIFF
--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -1,6 +1,7 @@
 class PrescripteurRdvWizardController < ApplicationController
   include SearchContextHelper
 
+  before_action :log_session_to_sentry
   before_action :check_rdv_wizard_attributes, except: %i[start confirmation]
   before_action :set_rdv_wizard, only: %i[new_prescripteur new_beneficiaire create_rdv]
   before_action :redirect_if_creneau_unavailable, only: %i[new_prescripteur new_beneficiaire create_rdv]
@@ -69,6 +70,10 @@ class PrescripteurRdvWizardController < ApplicationController
   end
 
   private
+
+  def log_session_to_sentry
+    Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: "Session", data: session.to_h.slice("rdv_wizard_attributes", "autocomplete_prescripteur_attributes")))
+  end
 
   def check_rdv_wizard_attributes
     if session[:rdv_wizard_attributes].blank?


### PR DESCRIPTION
Pour aider à débugger [LAPINS-314](https://sentry.incubateur.net/organizations/betagouv/issues/194391), on ajoute le contenu de `session[:rdv_wizard_attributes]` en breadcrumbs Sentry.

Au passage j'inclus `session[:autocomplete_prescripteur_attributes]` car ça peut être utile de savoir qui contacter pour avoir plus d'infos sur un crash.

Note : Le `session._to_h.splice` a été testé en local et renvoie bien le hash qui nous intéresse.