### PR TITLE
Améliorations visuelles mineures sur le formulaire de lieux

### DIFF
--- a/app/views/admin/lieux/_lieu_fields.html.slim
+++ b/app/views/admin/lieux/_lieu_fields.html.slim
@@ -12,8 +12,10 @@
 
 / All forms
 = f.input :name, required: true
-- unless is_nested_form
-  = f.input :phone_number, hint: I18n.t("simple_form.hints.lieu.phone_number", app_name: current_domain.name)
+
 = f.input :address, input_html: { data: { "address-autocomplete": "on" } }
 = f.hidden_field :latitude
 = f.hidden_field :longitude
+
+- unless is_nested_form
+  = f.input :phone_number, hint: I18n.t("simple_form.hints.lieu.phone_number", app_name: current_domain.name)

--- a/config/locales/models/lieu.fr.yml
+++ b/config/locales/models/lieu.fr.yml
@@ -26,9 +26,9 @@ fr:
   simple_form:
     hints:
       lieu:
-        address: L’adresse apparaîtra dans les notifications mails et SMS aux usagers.
+        address: L’adresse apparaît dans les notifications par email et SMS aux usagers.
         enabled: |
           Si le lieu est ouvert, de nouveaux rendez-vous et plages d’ouvertures peuvent y être posés.
           Fermez un lieu pour ne plus le voir dans les menus.
-        name: Le nom apparaîtra dans les notifications par email et SMS aux usagers.
-        phone_number: Ce numéro sera affiché coté usager pour leurs permettre de vous contacter. Faites en sorte que les personnes qui répondront au téléphone puissent avoir accès à %{app_name}.
+        name: Le nom apparaît dans les notifications par email et SMS aux usagers.
+        phone_number: Ce numéro permet aux usagers de vous contacter. Faites en sorte que les personnes qui répondent au téléphone puissent avoir accès à %{app_name}.


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1030" height="556" alt="Screenshot 2025-09-08 at 14 16 14" src="https://github.com/user-attachments/assets/77a1508b-828f-4d71-be7b-daf20d56b24a" />|<img width="989" height="559" alt="Screenshot 2025-09-08 at 14 15 59" src="https://github.com/user-attachments/assets/ba5c6bde-3c98-45eb-9803-307e8a8198e6" />

En faisant la documentation pour l'intégration à DS, j'ai vu que les champs n'étaient pas dans le bon ordre : l'adresse est plus importante que le numéro de téléphone (qui est facultatif).

J'en ai profité pour harmoniser les hints, et mettre les infos au présent, conforméments aux recos du dsfr et de notre tone & voice.


