### PR TITLE
Suppression d'un flag inutilisé dans les réponses d'api en cas d'erreur

### DIFF
--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -41,14 +41,14 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
   def parameter_missing(exception)
     render(
       status: :unprocessable_entity,
-      json: { success: false, errors: [exception.to_s] }
+      json: { errors: [exception.to_s] }
     )
   end
 
   def record_not_found(exception)
     render(
       status: :not_found,
-      json: { success: false, errors: [exception.to_s] }
+      json: { errors: [exception.to_s] }
     )
   end
 
@@ -56,7 +56,6 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
     render(
       status: :unprocessable_entity,
       json: {
-        success: false,
         errors: exception.record.errors.details,
         error_messages: exception.record.errors.map { "#{_1.attribute} #{_1.message}" },
       }

--- a/app/controllers/api/v1/user_profiles_controller.rb
+++ b/app/controllers/api/v1/user_profiles_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::UserProfilesController < Api::V1::AgentAuthBaseController
     user_profile.save!
     render_record user_profile
   rescue ArgumentError => e
-    render_error :unprocessable_entity, { success: false, errors: {}, error_messages: [e] }
+    render_error :unprocessable_entity, { errors: {}, error_messages: [e] }
   end
 
   def destroy
@@ -20,7 +20,7 @@ class Api::V1::UserProfilesController < Api::V1::AgentAuthBaseController
       head :no_content
     else
       render_error :unprocessable_entity, {
-        success: false, errors: {},
+        errors: {},
         error_messages: [I18n.t("users.can_not_delete_because_has_future_rdvs")],
       }
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -26,7 +26,6 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
   def update
     if email_change_not_allowed?
       render_error :unprocessable_entity, {
-        success: false,
         errors: {},
         error_messages: [I18n.t("users.can_not_update_email_of_confirmed_user")],
       }

--- a/spec/requests/api/v1/swagger_doc/users_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/users_request_spec.rb
@@ -118,35 +118,25 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
 
         run_test!
 
-        it { expect(user.reload.organisations).to contain_exactly(organisation) }
-
-        it { expect(user.reload.first_name).to eq(first_name) }
-
-        it { expect(user.reload.last_name).to eq(last_name) }
-
-        it { expect(user.reload.birth_name).to eq(birth_name) }
-
-        it { expect(user.reload.birth_date).to eq(Date.new(1976, 10, 1)) }
-
-        it { expect(user.reload.email).to eq(email) }
-
-        it { expect(user.reload.phone_number).to eq(phone_number) }
-
-        it { expect(user.reload.address).to eq(address) }
-
-        it { expect(user.reload.caisse_affiliation).to eq(caisse_affiliation) }
-
-        it { expect(user.reload.affiliation_number).to eq(affiliation_number) }
-
-        it { expect(user.reload.family_situation).to eq(family_situation) }
-
-        it { expect(user.reload.number_of_children).to eq(number_of_children) }
-
-        it { expect(user.reload.notify_by_sms).to eq(notify_by_sms) }
-
-        it { expect(user.reload.notify_by_email).to eq(notify_by_email) }
-
-        it { expect(user.reload.responsible).to eq(user_responsible) }
+        specify do
+          expect(user.reload).to have_attributes(
+            organisations: [organisation],
+            first_name: first_name,
+            last_name: last_name,
+            birth_name: birth_name,
+            birth_date: Date.new(1976, 10, 1),
+            email: email,
+            phone_number: phone_number,
+            address: address,
+            caisse_affiliation: caisse_affiliation,
+            affiliation_number: affiliation_number,
+            family_situation: family_situation,
+            number_of_children: number_of_children,
+            notify_by_sms: notify_by_sms,
+            notify_by_email: notify_by_email,
+            responsible: user_responsible
+          )
+        end
       end
 
       response 200, "updates a user with a minimal set of params", document: false do

--- a/spec/requests/api/v1/swagger_doc/users_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/users_request_spec.rb
@@ -191,7 +191,6 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
 
         it {
           expect(parsed_response_body).to include(
-            success: false,
             errors: {},
             error_messages: ["Vous ne pouvez pas modifier l'email d'un usager ayant validé son compte."]
           )
@@ -208,7 +207,6 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
 
         it {
           expect(parsed_response_body).to include(
-            success: false,
             errors: {},
             error_messages: ["Vous ne pouvez pas modifier l'email d'un usager ayant validé son compte."]
           )

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -529,7 +529,6 @@ RSpec.configure do |config|
           error_unprocessable_entity: {
             type: "object",
             properties: {
-              success: { type: "boolean" },
               errors: {
                 type: "object",
               },
@@ -538,7 +537,7 @@ RSpec.configure do |config|
                 items: { type: "string" },
               },
             },
-            required: %w[success errors error_messages],
+            required: %w[errors error_messages],
           },
         },
       },

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -994,9 +994,6 @@
       "error_unprocessable_entity": {
         "type": "object",
         "properties": {
-          "success": {
-            "type": "boolean"
-          },
           "errors": {
             "type": "object"
           },
@@ -1008,7 +1005,6 @@
           }
         },
         "required": [
-          "success",
           "errors",
           "error_messages"
         ]
@@ -1340,7 +1336,6 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "success": false,
                       "errors": {
                         "end_time": [
                           {
@@ -3545,7 +3540,6 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "success": false,
                       "errors": [
                         "Couldn't find ReferentAssignation with [WHERE \"referent_assignations\".\"agent_id\" = $1 AND \"referent_assignations\".\"user_id\" = $2]"
                       ]
@@ -3840,7 +3834,6 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "success": false,
                       "errors": {
                         "user": [
                           {
@@ -3986,7 +3979,6 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "success": false,
                       "errors": [
                         "Couldn't find UserProfile with [WHERE \"user_profiles\".\"organisation_id\" = $1 AND \"user_profiles\".\"user_id\" = $2]"
                       ]
@@ -4430,7 +4422,6 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "success": false,
                       "errors": {
                         "last_name": [
                           {
@@ -5024,7 +5015,6 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "success": false,
                       "errors": {
                         "last_name": [
                           {
@@ -5637,7 +5627,6 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "success": false,
                       "errors": {
                         "target_url": [
                           {
@@ -5835,7 +5824,6 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "success": false,
                       "errors": {
                         "target_url": [
                           {


### PR DESCRIPTION
# Contexte

Dans le contexte de la migration des conums vers RDV Service Public, on ouvre des endpoints d'api pour des créations d'objets. Ça nous oblige à faire donc de la gestion d'erreur dans les réponses d'api.

Dans, les rares cas dans l'api où on fait de la gestion d'erreur, on passe un booléen `success: false` dans le corps de la réponse (ce booléen n'est pas présent en cas de succès 🙃 ).
En regardant l'historique git, j'ai l'impression que ça avait été introduit pour un client d'api du 92, qui n'est plus utilisé.

J'ai vérifié les ApiCall via metabase, et le seul client d'api qui utilise ces endpoint est RDV Insertion. Or, il ne semble pas que le code de RDV Insertion utilise ce flag : dans leur codebase on a `app/services/rdv_solidarites_api/base.rb:17` qui fait un `rdv_solidarites_response.success?`, mais c'est un appel de méthode sur une response Faraday, qui se base sur le status code de la réponse, et pas sur le body.

# Solution

On peut donc supprimer ce flag sans risque, mais je préfère quand même avoir une approbation de quelqu'un de l'équipe RDVI pour être sûr de ne rien casser.


Ça fait plaisir d'avoir les ApiCall en base pour faire ce genre de changement ! 😃 
