### PR TITLE
Ajout de logging pour investiguer LAPINS-2JW

### DIFF
--- a/app/controllers/concerns/can_have_rdv_wizard_context.rb
+++ b/app/controllers/concerns/can_have_rdv_wizard_context.rb
@@ -12,6 +12,7 @@ module CanHaveRdvWizardContext
     return if parsed_uri.path != "/users/rdv_wizard_step/new"
 
     parsed_params = Rack::Utils.parse_nested_query(parsed_uri.query).to_h.symbolize_keys
+    Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: "parsed_params", data: { parsed_params:, ip: request.remote_ip }))
     rdv_wizard = UserRdvWizard::Step1.new(nil, parsed_params)
     # L'usager doit être connecté afin de voir les créneaux pour un motif de Follow Up
     return if rdv_wizard.motif&.follow_up?


### PR DESCRIPTION
Nous aimerions savoir si les appels réguliers causant [LAPINS-2JW](https://sentry.incubateur.net/organizations/betagouv/issues/177919) proviennent toujours de la même IP ou pas. Nous suspectons qu'il s'agit d'un crawler, que ce soit une intégration (carto CNFS, Resin') ou un autre bot.