### PR TITLE
Copie des agents lors de la migration des conums

### DIFF
--- a/app/controllers/admin/instance_exports_controller.rb
+++ b/app/controllers/admin/instance_exports_controller.rb
@@ -37,7 +37,7 @@ class Admin::InstanceExportsController < AgentAuthController
       @instance_export.update!(params.permit(:destination_organisation_id))
     end
 
-    @instance_export.copy_users!(current_domain)
+    @instance_export.copy_to_new_instance!(current_domain)
     redirect_to admin_organisation_instance_export_path(current_organisation, @instance_export.id)
   end
 

--- a/app/controllers/api/v1/agents_controller.rb
+++ b/app/controllers/api/v1/agents_controller.rb
@@ -5,6 +5,27 @@ class Api::V1::AgentsController < Api::V1::AgentAuthBaseController
     render_collection(agents.order(:created_at))
   end
 
+  def create
+    organisations = Organisation.where(id: params[:organisation_ids])
+
+    authorize(Agent.new(organisations:), policy_class: Agent::AgentPolicy)
+
+    create_agent = AdminCreatesAgent.new(
+      agent_params: params.permit(:email),
+      current_agent: current_agent,
+      organisations:,
+      access_level: params.require(:access_level)
+    )
+
+    @agent = create_agent.call
+
+    if @agent.valid?
+      render_record @agent
+    else
+      render status: :unprocessable_entity, json: { error_messages: @agent.errors.full_messages }
+    end
+  end
+
   def me
     render_record current_agent
   end

--- a/app/lib/rdv_service_public_api_client.rb
+++ b/app/lib/rdv_service_public_api_client.rb
@@ -1,0 +1,34 @@
+class RdvServicePublicApiClient
+  def initialize(api_token)
+    @api_token = api_token
+  end
+
+  def post(path, params)
+    response = Faraday.post(
+      "#{ENV['RDV_SERVICE_PUBLIC_OAUTH_BASE_URL']}/api/v1/#{path}",
+      params.to_json,
+      request_headers
+    )
+
+    JSON.parse(response.body)
+  end
+
+  def get(path, params = {})
+    response = Faraday.get(
+      "#{ENV['RDV_SERVICE_PUBLIC_OAUTH_BASE_URL']}/api/v1/#{path}",
+      params,
+      request_headers
+    )
+
+    JSON.parse(response.body)
+  end
+
+  private
+
+  def request_headers
+    {
+      "Authorization" => "Bearer #{@api_token}",
+      "Content-Type" => "application/json",
+    }
+  end
+end

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -13,7 +13,7 @@ class InstanceExport < ApplicationRecord
     new_org_attributes = source_organisation.attributes.slice(*%w[name website phone_number email])
     new_org_attributes.merge!({ external_reference: { external_id: source_organisation.id } })
 
-    destination_org = api_client.post("organisations", new_org_attributes)
+    destination_org = api_client.post("organisations", new_org_attributes)["organisation"]
 
     update!(destination_organisation_id: destination_org["id"])
   end
@@ -26,28 +26,49 @@ class InstanceExport < ApplicationRecord
     @destination_organisation ||= Organisation.new(new_instance_organisations.first).tap(&:readonly!)
   end
 
-  def copy_users!(current_domain)
+  def copy_to_new_instance!(current_domain)
     batch = GoodJob::Batch.new(instance_export_id: id)
 
-    batch.add do
-      source_organisation.users.pluck(:id).each do |user_id|
-        CopyUserJob.perform_later(id, user_id, current_domain.id)
+    transaction do
+      batch.add do
+        source_organisation.users.pluck(:id).each do |user_id|
+          CopyUserJob.perform_later(id, user_id, current_domain.id)
+        end
+        source_organisation.agents.where.not(id: agent.id).pluck(:id).each do |agent_id|
+          CopyAgentJob.perform_later(id, agent_id)
+        end
       end
+      update(good_job_batch_id: batch.id)
     end
-    update(good_job_batch_id: batch.id)
+  end
+
+  class CopyAgentJob < ApplicationJob
+    queue_as :latency_5m
+
+    def perform(instance_export_id, agent_id)
+      InstanceExport.find(instance_export_id).copy_agent!(agent_id)
+    end
+  end
+
+  def copy_agent!(agent_id)
+    agent = Agent.find(agent_id)
+    api_client.post("agents", {
+                      email: agent.email,
+                      organisation_ids: [destination_organisation_id],
+                      access_level: agent.role_in_organisation(source_organisation).access_level,
+                    })
   end
 
   class CopyUserJob < ApplicationJob
     queue_as :latency_5m
 
     def perform(instance_export_id, user_id, domain_id)
-      export = InstanceExport.find(instance_export_id)
-      user = User.find(user_id)
-      export.copy_user!(user, Domain.find(domain_id))
+      InstanceExport.find(instance_export_id).copy_user!(user_id, Domain.find(domain_id))
     end
   end
 
-  def copy_user!(user, domain)
+  def copy_user!(user_id, domain)
+    user = User.find(user_id)
     request_body = user.attributes.symbolize_keys.slice(*UserBlueprint.reflections[:default].fields.keys - %i[id responsible_id])
     request_body[:organisation_ids] = [destination_organisation_id]
 

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -6,28 +6,14 @@ class InstanceExport < ApplicationRecord
   encrypts :refresh_token
 
   def new_instance_organisations
-    return @new_instance_organisations if defined?(@new_instance_organisations)
-
-    response = Faraday.get(
-      "#{ENV['RDV_SERVICE_PUBLIC_OAUTH_BASE_URL']}/api/v1/organisations",
-      {},
-      request_headers
-    )
-
-    @new_instance_organisations = JSON.parse(response.body)["organisations"]
+    @new_instance_organisations ||= api_client.get("organisations")["organisations"]
   end
 
   def create_organisation_on_new_instance!
     new_org_attributes = source_organisation.attributes.slice(*%w[name website phone_number email])
     new_org_attributes.merge!({ external_reference: { external_id: source_organisation.id } })
 
-    response = Faraday.post(
-      "#{ENV['RDV_SERVICE_PUBLIC_OAUTH_BASE_URL']}/api/v1/organisations",
-      new_org_attributes.to_json,
-      request_headers
-    )
-
-    destination_org = JSON.parse(response.body)
+    destination_org = api_client.post("organisations", new_org_attributes)
 
     update!(destination_organisation_id: destination_org["id"])
   end
@@ -70,19 +56,12 @@ class InstanceExport < ApplicationRecord
       external_url: Rails.application.routes.url_helpers.admin_organisation_user_url(source_organisation.id, user.id, host: domain.host_name),
     }
 
-    Faraday.post(
-      "#{ENV['RDV_SERVICE_PUBLIC_OAUTH_BASE_URL']}/api/v1/users",
-      request_body.to_json,
-      request_headers
-    )
+    api_client.post("users", request_body)
   end
 
   private
 
-  def request_headers
-    {
-      "Authorization" => "Bearer #{api_token}",
-      "Content-Type" => "application/json",
-    }
+  def api_client
+    @api_client ||= RdvServicePublicApiClient.new(api_token)
   end
 end

--- a/app/views/admin/instance_exports/edit.html.slim
+++ b/app/views/admin/instance_exports/edit.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "Copier vos usagers vers RDV Service Public"
+- content_for :title, "Copier vos données vers RDV Service Public"
 
 = form_with url: admin_organisation_instance_export_path(current_organisation, @instance_export), method: :put, builder: Dsfr::FormBuilder do |form|
   .d-flex.rdv-justify-content-center
@@ -8,6 +8,8 @@
       .card-body
         h6= @instance_export.source_organisation.name
         p #{@instance_export.source_organisation.users.count} usagers
+        - if @instance_export.source_organisation.agents.count > 1
+          p #{@instance_export.source_organisation.agents.count} agents
 
     .fr-mx-4w[style="align-self: center"]= icon("fr-icon-arrow-right-fill")
 
@@ -16,7 +18,7 @@
         b RDV Service Public
       .card-body
         - if @instance_export.new_instance_organisations.empty?
-          h6= @instance_export.destination_organisation.name
+          h6= @instance_export.source_organisation.name
         - elsif @instance_export.new_instance_organisations.count == 1
           h6= @instance_export.source_organisation.name
           = form.hidden_field :destination_organisation_id, value: @instance_export.new_instance_organisations.first["id"]
@@ -25,8 +27,8 @@
 
   .rdv-text-align-center
     p
-      | Vous allez copier les #{@instance_export.source_organisation.users.count} usagers
+      | Vous allez copier ces données
       |  de #{@instance_export.source_organisation.name} sur #{current_domain.name}
       |  vers RDV Service Public
 
-    = form.submit  "Copier les usagers", class: "fr-btn"
+    = form.submit  "Copier les données", class: "fr-btn"

--- a/app/views/admin/instance_exports/index.html.slim
+++ b/app/views/admin/instance_exports/index.html.slim
@@ -6,14 +6,14 @@
     p #{link_to "RDV Service Public", "https://rdv.anct.gouv.fr", target: :_blank} est une version améliorée de RDV Aide Numérique. Cette nouvelle version vous permettra de :
     ul
       li
-        b Inviter vos collègues
-        |  qui travaillent dans d'autre domaines que la médiation numérique à rejoindre votre organisation sur RDV Service Public.
-      li
-        b ="Prendre des rendez-vous depuis la Coop de la Médiation Numérique"
-        |  sans avoir à copier les information des bénéficiaires.
-      li
         b Pré-remplir vos comptes-rendus d'activité sur la Coop de la Médiation Numérique
         |  en fonction de vos rendez-vous.
+      li
+        b Prendre des rendez-vous depuis la Coop de la Médiation Numérique
+        |  sans avoir à copier les information des bénéficiaires.
+      li
+        b Inviter vos collègues
+        |  qui travaillent dans d'autre domaines que la médiation numérique à rejoindre votre organisation sur RDV Service Public.
 
 .card
   .card-body

--- a/app/views/admin/instance_exports/index.html.slim
+++ b/app/views/admin/instance_exports/index.html.slim
@@ -26,9 +26,11 @@
 
     p Vous n'avez pas besoin d'avoir un compte sur RDV Service Public pour faire cette connexion. Il sera créé automatiquement si vous n'en avez pas.
 
-    h3.fr-h4 Copie de vos usagers
+    h3.fr-h4 Copie de vos données
     p Vos usagers seront copiés automatiquement sur RDV Service Public. Leur historique de rendez-vous ne sera pas copié, mais vous pourrez retrouver un lien vers RDV Aide Numérique sur chaque fiche usager.
     p Si vous avez de nouveaux usagers qui sont ajoutés sur #{current_domain.name} après votre première migration, vous pouvez répéter cette étape sans créer de doublons.
+
+    p Les agents de votre organisation actuelle seront aussi invités à se créer un compte sur RDV Service Public
 
     p.fr-mt-2w
       = icon("fr-icon-checkbox-circle-fill", class: "fr-mr-1w")

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -3,7 +3,7 @@ namespace :api do
     # Need agent authentication to
     mount_devise_token_auth_for "AgentWithTokenAuth", at: "auth"
     resources :absences, except: %i[new edit]
-    resources :agents, only: %i[index]
+    resources :agents, only: %i[index create]
     get "agents/me", to: "agents#me"
     resources :users, only: %i[create index show update] do
       post :rdv_invitation_token, to: "users#rdv_invitation_token", on: :member

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     create(:agent, first_name: "Camille", last_name: "Clavier", admin_role_in_organisations: [organisation_rdv_aide_num])
   end
 
+  let!(:collegue) do
+    create(:agent, first_name: "Francis", last_name: "Factice", basic_role_in_organisations: [organisation_rdv_aide_num])
+  end
+
   let!(:users) do
     create_list(:user, 3, organisations: [organisation_rdv_aide_num])
   end
@@ -86,10 +90,10 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     visit "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/instance_exports/#{instance_export.id}/edit"
 
     doc.add_screenshot(page,
-                       text: "Je suis redirigé vers RDV Aide Numérique, je clique sur Copier les usagers",
+                       text: "Je suis redirigé vers RDV Aide Numérique, je clique sur Copier les données",
                        wait_for: "Vous allez copier ")
 
-    click_on "Copier les usagers"
+    click_on "Copier les données"
 
     doc.add_screenshot(page,
                        text: "La migration est réussie. Mes usagers sont maintenant disponibles sur RDV Service Public",
@@ -104,5 +108,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
       website: "www.montreuil.fr/france-service",
       email: "contact@exemple.montreuil.fr"
     )
+
+    expect(created_organisation.agents.count).to eq 2
   end
 end

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -110,5 +110,12 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     )
 
     expect(created_organisation.agents.count).to eq 2
+
+    login_as(agent_rdv_sp, scope: :agent)
+    visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"
+
+    doc.add_screenshot(page,
+                       text: "En se connectant sur RDV Service Public, on constate que les agents ont bien été créés.",
+                       wait_for: collegue.email)
   end
 end

--- a/spec/requests/api/v1/agents_spec.rb
+++ b/spec/requests/api/v1/agents_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Agents API" do
 
       created_agent = Agent.find_by(email: "francis@factice.fr")
 
-      expect(created_agent.roles.first).to have_attributes(
+      expect(created_agent.roles.sole).to have_attributes(
         access_level: "basic",
         organisation_id: organisation.id
       )

--- a/spec/requests/api/v1/agents_spec.rb
+++ b/spec/requests/api/v1/agents_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe "Agents API" do
+  let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
+  let(:headers) do
+    { "Content-Type": "application/json", Authorization: "Bearer #{oauth_token.plaintext_token}" }
+  end
+  let(:application) { create(:oauth_application) }
+  let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let(:organisation) { create(:organisation) }
+
+  describe "#create" do
+    let(:params) do
+      {
+        email: "francis@factice.fr",
+        organisation_ids: [organisation.id],
+        access_level: "basic",
+      }
+    end
+
+    it "invites the agent into the organisation" do
+      post "/api/v1/agents", headers:, params:, as: :json
+
+      expect(parsed_response_body["agent"]["email"]).to eq "francis@factice.fr"
+
+      created_agent = Agent.find_by(email: "francis@factice.fr")
+
+      expect(created_agent.roles.first).to have_attributes(
+        access_level: "basic",
+        organisation_id: organisation.id
+      )
+    end
+
+    context "when the agent can't be created" do
+      let(:params) do
+        {
+          email: "invalid",
+          organisation_ids: [organisation.id],
+          access_level: "basic",
+        }
+      end
+
+      it "returns a error messages" do
+        post "/api/v1/agents", headers:, params:, as: :json
+
+        expect(response.status).to eq 422
+        expect(parsed_response_body["error_messages"].first).to eq "Email n'est pas valide"
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/agents_spec.rb
+++ b/spec/requests/api/v1/agents_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe "Agents API" do
     end
 
     it "invites the agent into the organisation" do
-      post "/api/v1/agents", headers:, params:, as: :json
+      expect do
+        post "/api/v1/agents", headers:, params:, as: :json
+      end.to change(Agent, :count).by(1)
 
       expect(parsed_response_body["agent"]["email"]).to eq "francis@factice.fr"
 


### PR DESCRIPTION
Suite de https://github.com/betagouv/rdv-service-public/pull/5626

Pour limiter nos risques de doublons d'ouverture de nouvelles organisations sur RDV SP, on ajoute les agents aux données copiées pendant la migration.

Pour une fois l'historique de commit est plutôt bien découpé.