### PR TITLE
Ajout des liens de visio dans les pièces jointes ICS

### DIFF
--- a/app/models/concerns/ics_payloads/rdv.rb
+++ b/app/models/concerns/ics_payloads/rdv.rb
@@ -7,9 +7,16 @@ module IcsPayloads
         ends_at: ends_at,
         ical_uid: uuid,
         summary: "RDV #{motif&.name}",
-        address: motif.phone? ? nil : address,
         domain: domain,
       }
+
+      payload[:address] = if motif.phone?
+                            nil
+                          elsif motif.visio?
+                            visio_url
+                          else
+                            address
+                          end
 
       payload[:description] = ics_description(recipient)
 
@@ -29,6 +36,7 @@ module IcsPayloads
     def ics_description(recipient)
       description = ""
       description += "RDV Téléphonique " if motif.phone?
+      description += "RDV par visioconférence " if motif.visio?
       description += case recipient
                      when User
                        "Infos et annulation: #{Rails.application.routes.url_helpers.rdvs_short_url(host: domain.host_name)}"

--- a/app/models/concerns/ics_payloads/rdv.rb
+++ b/app/models/concerns/ics_payloads/rdv.rb
@@ -7,16 +7,9 @@ module IcsPayloads
         ends_at: ends_at,
         ical_uid: uuid,
         summary: "RDV #{motif&.name}",
+        location: ics_location,
         domain: domain,
       }
-
-      payload[:address] = if motif.phone?
-                            nil
-                          elsif motif.visio?
-                            visio_url
-                          else
-                            address
-                          end
 
       payload[:description] = ics_description(recipient)
 
@@ -32,6 +25,16 @@ module IcsPayloads
     end
 
     private
+
+    def ics_location
+      if motif.phone?
+        nil
+      elsif motif.visio?
+        visio_url
+      else
+        address
+      end
+    end
 
     def ics_description(recipient) # rubocop:disable Metrics/CyclomaticComplexity
       description = ""

--- a/app/models/concerns/ics_payloads/rdv.rb
+++ b/app/models/concerns/ics_payloads/rdv.rb
@@ -33,7 +33,7 @@ module IcsPayloads
 
     private
 
-    def ics_description(recipient)
+    def ics_description(recipient) # rubocop:disable Metrics/CyclomaticComplexity
       description = ""
       description += "RDV Téléphonique " if motif.phone?
       description += "RDV par visioconférence " if motif.visio?

--- a/app/services/ical_formatters/ics.rb
+++ b/app/services/ical_formatters/ics.rb
@@ -51,7 +51,7 @@ module IcalFormatters
         payload[:attendees].each { |attendee| event.append_attendee("mailto:#{attendee}") }
       end
       event.summary = payload[:summary]
-      event.location = payload[:address]
+      event.location = payload[:location]
       event.rrule = payload[:rrule]
       event.sequence = 0 # not sure if this is necessary, but not worth investigating right now
       event.description = payload[:description]

--- a/spec/models/concerns/ics_payloads/rdv_spec.rb
+++ b/spec/models/concerns/ics_payloads/rdv_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe IcsPayloads::Rdv, type: :service do
   describe "#payload" do
-    %i[name ical_uid summary ends_at description address].each do |key|
+    %i[name ical_uid summary ends_at description location].each do |key|
       it "return an hash with key #{key}" do
         user = build(:user)
         rdv = build(:rdv, users: [user])
@@ -68,26 +68,26 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
       end
     end
 
-    describe ":address" do
+    describe ":location" do
       let(:user) { build(:user) }
 
       context "with a phone motif" do
         let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :by_phone)) }
 
-        it { expect(rdv.payload[:address]).to be_nil }
+        it { expect(rdv.payload[:location]).to be_nil }
       end
 
       context "without a phone motif" do
         let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :public_office), lieu: build(:lieu, address: "17 rue de l'adresse, Paris, 75016")) }
 
-        it { expect(rdv.payload[:address]).to eq("17 rue de l'adresse, Paris, 75016") }
+        it { expect(rdv.payload[:location]).to eq("17 rue de l'adresse, Paris, 75016") }
       end
 
       context "with a visio motif" do
         let(:rdv) { build(:rdv, users: [user], motif: build(:motif, location_type: :visio), uuid: 123) }
 
         it "shows the link to the visio" do
-          expect(rdv.payload[:address]).to eq "https://webconf.numerique.gouv.fr/RdvServicePublic"
+          expect(rdv.payload[:location]).to eq "https://webconf.numerique.gouv.fr/RdvServicePublic"
         end
       end
     end

--- a/spec/models/concerns/ics_payloads/rdv_spec.rb
+++ b/spec/models/concerns/ics_payloads/rdv_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
         expect(rdv.payload[:description]).to eq("Infos et annulation: http://www.rdv-solidarites-test.localhost/r")
       end
 
+      context "with a visio motif" do
+        let(:rdv) { build(:rdv, users: [user], motif: build(:motif, location_type: :visio), uuid: 123) }
+
+        it "indicates the location type" do
+          expect(rdv.payload[:description]).to start_with "RDV par visioconférence"
+        end
+      end
+
       context "when sending to an agent" do
         it "provides a link to the RDV in the agent interface" do
           description = "Voir sur RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{rdv.organisation_id}/rdvs/#{rdv.id}"
@@ -73,6 +81,14 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
         let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :public_office), lieu: build(:lieu, address: "17 rue de l'adresse, Paris, 75016")) }
 
         it { expect(rdv.payload[:address]).to eq("17 rue de l'adresse, Paris, 75016") }
+      end
+
+      context "with a visio motif" do
+        let(:rdv) { build(:rdv, users: [user], motif: build(:motif, location_type: :visio), uuid: 123) }
+
+        it "shows the link to the visio" do
+          expect(rdv.payload[:address]).to eq "https://webconf.numerique.gouv.fr/RdvServicePublic"
+        end
       end
     end
 

--- a/spec/services/ical_formatters/ics_spec.rb
+++ b/spec/services/ical_formatters/ics_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe IcalFormatters::Ics do
         ends_at: Time.zone.parse("20190704 15h45"),
         sequence: 0,
         description: "Infos et annulation:",
-        address: "10 rue de la Ferronerie 44100 Nantes",
+        location: "10 rue de la Ferronerie 44100 Nantes",
         ical_uid: "rdv_15@RDV Solidarités",
         rrule: "FREQ=WEEKLY;",
         domain: domain,


### PR DESCRIPTION
# Contexte

Kévin a remarqué une petite amélioration qu'on peut faire sur les RDV par visio : le lien de la visio est dans le corps de l'email de confirmation, mais pas dans la pièce jointe ics qui s'ajoute dans le calendrier externe (par exemple celui de la suite).
Ça fait que si on essaye de retrouver le lien depuis son calendrier et pas depuis ses mails, il faut d'abord se connecter à RDV SP, ce qui n'est pas très pratique.

# Solution

On ajoute tout simplement le lien dans la pièce jointe ics dans la section adresse, comme le font beaucoup d'autres outils.
Ce lien est déjà présent dans le mail, donc ça ne pose pas de question rgdp
