### PR TITLE
Clarifier le wording des préférences de notif de RDV

### DIFF
--- a/config/locales/models/agent.fr.yml
+++ b/config/locales/models/agent.fr.yml
@@ -17,16 +17,16 @@ fr:
         allow_to_manage_access_rights: Autorisé à gérer les droits d'accès et les services des agents
         allow_to_invite_agents: Autorisé à inviter et affecter des agents sur des organisations
       agent/rdv_notifications_levels:
-        all: À chaque modification
-        others: Uniquement les modifications faites par un usager (ou par un autre agent)
-        soon: Uniquement les modifications (faites par un usager ou un autre agent) moins de 24 heures à l’avance
-        none: Jamais
+        all: Je veux être notifié(e) systématiquement
+        others: Seulement quand la modification est initiée par quelqu'un d'autre que moi
+        soon: Seulement quand la modification est initiée par quelqu'un d'autre que moi, dans les 24h avant le rendez-vous
+        none: Non, je n'ai pas besoin d'être notifié(e)
       agent/plage_ouverture_notification_levels:
-        all: À chaque modification
-        none: Jamais
+        all: Je veux être notifié(e) systématiquement
+        none: Non, je n'ai pas besoin d'être notifié(e)
       agent/absence_notification_levels:
-        all: À chaque modification
-        none: Jamais
+        all: Je veux être notifié(e) systématiquement
+        none: Non, je n'ai pas besoin d'être notifié(e)
       agent/display_cancelled_rdvs:
         true: "Afficher les RDV annulés"
         false: "Ne pas afficher les RDV annulés"

--- a/config/locales/views/agents.fr.yml
+++ b/config/locales/views/agents.fr.yml
@@ -12,9 +12,9 @@ fr:
     preferences:
       show:
         title: Préférences de notifications
-        rdv_notifications_header: "Recevoir un email de notification pour mes rendez-vous :"
-        plage_ouverture_notifications_header: "Recevoir un email de notification pour mes plages d'ouverture :"
-        absence_notifications_header: "Recevoir un email de notification pour mes indisponibilités :"
+        rdv_notifications_header: "Être notifié(e) de la création, modification et annulation d’un rendez-vous auquel je participe :"
+        plage_ouverture_notifications_header: "Être notifié(e) de la création, modification et annulation d’une de mes plages d'ouverture :"
+        absence_notifications_header: "Être notifié(e) de la création, modification et annulation d’une de mes indisponibilités :"
         technical_email_explanation: Les emails de notification sont envoyés avec un fichier .ics qui vous permet de synchroniser votre calendrier (Outlook, zimbra, etc.) avec RDV Solidarités.
       update:
         done: Préférences de notifications mises à jour.


### PR DESCRIPTION
Le wording actuel utilise le terme "modifications" qui est ambigu voire trompeur. Nous voulons clarifier que les notifs sont bien envoyée pour une création / modif / suppression.

# Avant

<img width="3030" height="1804" alt="image" src="https://github.com/user-attachments/assets/b59c9a96-22e4-4c22-8d27-15453ae505b6" />


# Après

<img width="3030" height="2012" alt="image" src="https://github.com/user-attachments/assets/3c19e948-c20d-4152-8e6c-7c7cd6861408" />
