### PR TITLE
Retire des index inutilisés sur les receipts

### DIFF
--- a/db/migrate/20250912045657_remove_unused_indexes_on_receipts.rb
+++ b/db/migrate/20250912045657_remove_unused_indexes_on_receipts.rb
@@ -1,0 +1,26 @@
+# Pour savoir quels indexes sont utilisés, j'ai lancé cette commande :
+#
+# SELECT relname , indexrelname , idx_scan , idx_tup_read , idx_tup_fetch
+# FROM pg_stat_user_indexes
+# WHERE schemaname = 'public' and relname = 'receipts';
+#
+# => [
+#  {"relname" => "receipts", "indexrelname" => "receipts_pkey", "idx_scan" => 1681725, "idx_tup_read" => 1760766, "idx_tup_fetch" => 1681725},
+#  {"relname" => "receipts", "indexrelname" => "index_receipts_on_channel", "idx_scan" => 1, "idx_tup_read" => 0, "idx_tup_fetch" => 0},
+#  {"relname" => "receipts", "indexrelname" => "index_receipts_on_created_at", "idx_scan" => 1899, "idx_tup_read" => 9307453699, "idx_tup_fetch" => 8047106287},
+#  {"relname" => "receipts", "indexrelname" => "index_receipts_on_event", "idx_scan" => 0, "idx_tup_read" => 0, "idx_tup_fetch" => 0},
+#  {"relname" => "receipts", "indexrelname" => "index_receipts_on_organisation_id", "idx_scan" => 25260, "idx_tup_read" => 161382114, "idx_tup_fetch" => 20266037},
+#  {"relname" => "receipts", "indexrelname" => "index_receipts_on_rdv_id", "idx_scan" => 18977044, "idx_tup_read" => 44858454, "idx_tup_fetch" => 44775097},
+#  {"relname" => "receipts", "indexrelname" => "index_receipts_on_result", "idx_scan" => 0, "idx_tup_read" => 0, "idx_tup_fetch" => 0},
+#  {"relname" => "receipts", "indexrelname" => "index_receipts_on_user_id", "idx_scan" => 306106, "idx_tup_read" => 55972, "idx_tup_fetch" => 43327}
+# ]
+#
+# On y voit que les indexes sur channel, event et result son inutilisés.
+
+class RemoveUnusedIndexesOnReceipts < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :receipts, :channel
+    remove_index :receipts, :event
+    remove_index :receipts, :result
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_11_132916) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_12_045657) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -689,12 +689,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_11_132916) do
     t.string "sms_phone_number"
     t.string "email_address"
     t.bigint "organisation_id", null: false
-    t.index ["channel"], name: "index_receipts_on_channel"
     t.index ["created_at"], name: "index_receipts_on_created_at"
-    t.index ["event"], name: "index_receipts_on_event"
     t.index ["organisation_id"], name: "index_receipts_on_organisation_id"
     t.index ["rdv_id"], name: "index_receipts_on_rdv_id"
-    t.index ["result"], name: "index_receipts_on_result"
     t.index ["user_id"], name: "index_receipts_on_user_id"
   end
 


### PR DESCRIPTION
Ce matin j'ai réfléchi à mettre en place les webhooks SMS Factor pour afficher aux agents les infos de livraison des SMS.

En regardant le schéma de la table receipts, j'ai constaté qu'on avait 3 index inutiles car sur des colonnes à faible entropie. Cette PR les supprime.