### PR TITLE
Ajout des lieux à la migration des conums

### DIFF
--- a/app/controllers/admin/lieux_controller.rb
+++ b/app/controllers/admin/lieux_controller.rb
@@ -18,7 +18,6 @@ class Admin::LieuxController < AgentAuthController
   def create
     @lieu = Lieu.new(organisation_id: current_organisation.id)
     @lieu.assign_attributes(lieu_params)
-    @lieu.availability = :enabled # Always enable new Lieux
 
     authorize(@lieu, policy_class: Agent::LieuPolicy)
     if @lieu.save

--- a/app/controllers/api/v1/lieux_controller.rb
+++ b/app/controllers/api/v1/lieux_controller.rb
@@ -4,20 +4,18 @@ class Api::V1::LieuxController < Api::V1::AgentAuthBaseController
 
     authorize(lieu, policy_class: Agent::LieuPolicy)
 
-    external_reference_params = params[:external_reference]
-
-    if external_reference_params.present?
-      @external_reference = ExternalReference.new(
-        params.require(:external_reference).permit(:external_id, :external_url).merge(
-          item: lieu,
-          oauth_application: doorkeeper_token&.application,
-          territory_id: lieu.organisation.territory_id
-        )
-      )
-    end
-
     lieu.transaction do
-      lieu.save && @external_reference&.save!
+      lieu.save
+
+      if params[:external_reference].present?
+        ExternalReference.create!(
+          params.require(:external_reference).permit(:external_id, :external_url).merge(
+            item: lieu,
+            oauth_application: doorkeeper_token&.application,
+            territory_id: lieu.organisation.territory_id
+          )
+        )
+      end
     end
 
     if lieu.persisted?

--- a/app/controllers/api/v1/lieux_controller.rb
+++ b/app/controllers/api/v1/lieux_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::LieuxController < Api::V1::AgentAuthBaseController
+  def create
+    lieu = Lieu.new(params.permit(:organisation_id, :name, :address, :latitude, :longitude, :phone_number))
+
+    authorize(lieu, policy_class: Agent::LieuPolicy)
+
+    if lieu.save
+      render json: LieuBlueprint.render(lieu)
+    else
+      render status: :unprocessable_entity, json: { error_messages: lieu.errors.full_messages }
+    end
+  end
+
+  private
+
+  def pundit_user
+    current_agent
+  end
+end

--- a/app/controllers/api/v1/lieux_controller.rb
+++ b/app/controllers/api/v1/lieux_controller.rb
@@ -4,7 +4,23 @@ class Api::V1::LieuxController < Api::V1::AgentAuthBaseController
 
     authorize(lieu, policy_class: Agent::LieuPolicy)
 
-    if lieu.save
+    external_reference_params = params[:external_reference]
+
+    if external_reference_params.present?
+      @external_reference = ExternalReference.new(
+        params.require(:external_reference).permit(:external_id, :external_url).merge(
+          item: lieu,
+          oauth_application: doorkeeper_token&.application,
+          territory_id: lieu.organisation.territory_id
+        )
+      )
+    end
+
+    lieu.transaction do
+      lieu.save && @external_reference&.save!
+    end
+
+    if lieu.persisted?
       render json: LieuBlueprint.render(lieu)
     else
       render status: :unprocessable_entity, json: { error_messages: lieu.errors.full_messages }

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -37,9 +37,30 @@ class InstanceExport < ApplicationRecord
         source_organisation.agents.where.not(id: agent.id).pluck(:id).each do |agent_id|
           CopyAgentJob.perform_later(id, agent_id)
         end
+        source_organisation.lieux.enabled.each do |lieu|
+          CopyLieuJob.perform_later(id, lieu.id)
+        end
       end
       update(good_job_batch_id: batch.id)
     end
+  end
+
+  class CopyLieuJob < ApplicationJob
+    queue_as :latency_5m
+
+    def perform(instance_export_id, lieu_id)
+      InstanceExport.find(instance_export_id).copy_lieu!(lieu_id)
+    end
+  end
+
+  def copy_lieu!(lieu_id)
+    lieu = Lieu.find(lieu_id)
+    attributes = lieu.attributes.slice(*%w[name address latitude longitude phone_number])
+
+    attributes[:external_reference] = { external_id: lieu.id }
+    attributes[:organisation_id] = destination_organisation_id
+
+    api_client.post("lieux", attributes)
   end
 
   class CopyAgentJob < ApplicationJob

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -20,12 +20,12 @@ class Lieu < ApplicationRecord
   has_many :plage_ouvertures_not_expired, -> { not_expired },
            class_name: "PlageOuverture", dependent: :restrict_with_error, inverse_of: :lieu
   has_many :plage_ouvertures # rubocop:disable Rails/HasManyOrHasOneDependent
-
-  has_many :webhook_endpoints, through: :organisation
+  has_many :external_references, as: :item, dependent: :destroy
 
   # Through relations
   has_many :motifs, through: :plage_ouvertures
   has_many :agents, through: :plage_ouvertures
+  has_many :webhook_endpoints, through: :organisation
 
   # Validations
   validates :name, :address, :availability, presence: true

--- a/app/views/admin/instance_exports/edit.html.slim
+++ b/app/views/admin/instance_exports/edit.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "Copier vos données vers RDV Service Public"
+- content_for :title, "Migration vers RDV Service Public"
 
 = form_with url: admin_organisation_instance_export_path(current_organisation, @instance_export), method: :put, builder: Dsfr::FormBuilder do |form|
   .d-flex.rdv-justify-content-center
@@ -10,6 +10,7 @@
         p #{@instance_export.source_organisation.users.count} usagers
         - if @instance_export.source_organisation.agents.count > 1
           p #{@instance_export.source_organisation.agents.count} agents
+        p #{@instance_export.lieux.count} lieux
 
     .fr-mx-4w[style="align-self: center"]= icon("fr-icon-arrow-right-fill")
 

--- a/app/views/admin/instance_exports/edit.html.slim
+++ b/app/views/admin/instance_exports/edit.html.slim
@@ -10,7 +10,7 @@
         p #{@instance_export.source_organisation.users.count} usagers
         - if @instance_export.source_organisation.agents.count > 1
           p #{@instance_export.source_organisation.agents.count} agents
-        p #{@instance_export.lieux.count} lieux
+        p #{@instance_export.source_organisation.lieux.count} lieux
 
     .fr-mx-4w[style="align-self: center"]= icon("fr-icon-arrow-right-fill")
 

--- a/app/views/admin/instance_exports/new.html.slim
+++ b/app/views/admin/instance_exports/new.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "Copier vos usagers vers RDV Service Public"
+- content_for :title, "Migration vers RDV Service Public"
 
 .card
   .card-body

--- a/app/views/admin/instance_exports/show.html.slim
+++ b/app/views/admin/instance_exports/show.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "Copier vos usagers vers RDV Service Public"
+- content_for :title, "Migration vers RDV Service Public"
 
 .card
   .card-body

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -4,6 +4,7 @@ namespace :api do
     mount_devise_token_auth_for "AgentWithTokenAuth", at: "auth"
     resources :absences, except: %i[new edit]
     resources :agents, only: %i[index create]
+    resources :lieux, only: %i[create]
     get "agents/me", to: "agents#me"
     resources :users, only: %i[create index show update] do
       post :rdv_invitation_token, to: "users#rdv_invitation_token", on: :member

--- a/db/migrate/20250912081158_add_default_lieux_availability.rb
+++ b/db/migrate/20250912081158_add_default_lieux_availability.rb
@@ -1,0 +1,5 @@
+class AddDefaultLieuxAvailability < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default :lieux, :availability, from: nil, to: :enabled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_12_045657) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_12_081158) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -425,7 +425,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_12_045657) do
     t.float "longitude"
     t.string "phone_number"
     t.string "phone_number_formatted"
-    t.enum "availability", null: false, comment: "Permet de savoir si le lieu est un lieu normal (enabled), un lieu ponctuel qui sera utilisé pour un seul rdv (single_use), ou un lieu supprimé par soft-delete (disabled). Dans la plupart des cas on s'intéresse uniquement aux lieux enabled\n", enum_type: "lieu_availability"
+    t.enum "availability", default: "enabled", null: false, comment: "Permet de savoir si le lieu est un lieu normal (enabled), un lieu ponctuel qui sera utilisé pour un seul rdv (single_use), ou un lieu supprimé par soft-delete (disabled). Dans la plupart des cas on s'intéresse uniquement aux lieux enabled\n", enum_type: "lieu_availability"
     t.string "address", null: false
     t.index ["availability"], name: "index_lieux_on_availability"
     t.index ["name"], name: "index_lieux_on_name"

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -60,9 +60,13 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     login_as(agent_rdv_aide_num, scope: :agent)
     visit "http://www.rdv-aide-numerique-test.localhost/agents/instance_exports"
 
+    Capybara.page.current_window.resize_to(1280, 1200)
+
     doc.add_screenshot(page,
                        text: "J'ouvre la page à https://www.rdv-aide-numerique.fr/agents/instance_exports, puis je clique sur le bouton pour commencer",
                        wait_for: "Migration vers RDV Service Public")
+
+    Capybara.page.current_window.resize_to(1280, 720)
 
     click_on "Commencer"
 

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   let!(:collegue) do
     create(:agent, first_name: "Francis", last_name: "Factice", basic_role_in_organisations: [organisation_rdv_aide_num])
   end
+  let!(:lieu) { create(:lieu, organisation: organisation_rdv_aide_num) }
 
   let!(:users) do
     create_list(:user, 3, organisations: [organisation_rdv_aide_num])
@@ -110,6 +111,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     )
 
     expect(created_organisation.agents.count).to eq 2
+    expect(created_organisation.lieux.last).to have_attributes(name: lieu.name)
+    expect(created_organisation.lieux.last.external_references.last).to have_attributes(external_id: lieu.id.to_s)
 
     login_as(agent_rdv_sp, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"

--- a/spec/requests/api/v1/lieux_spec.rb
+++ b/spec/requests/api/v1/lieux_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe "Lieux API" do
+  let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
+  let(:headers) do
+    { "Content-Type": "application/json", Authorization: "Bearer #{oauth_token.plaintext_token}" }
+  end
+  let(:application) { create(:oauth_application, default_service: create(:service)) }
+
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+  describe "#create" do
+    context "when a lieux already exists for the given external reference" do
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          latitude: 44.5569244,
+          longitude: 4.7521632,
+          name: "Maison France Service de Montreuil",
+          address: "77 avenue de Ségur, 75015 Paris",
+          phone_number: "01 22 33 44 55",
+          external_reference: { external_id: "123ABC" },
+        }
+      end
+      let!(:existing_lieu) do
+        create(:lieu, organisation_id: organisation.id)
+      end
+      let!(:external_refenrece) do
+        create(:external_reference, oauth_application: application, item: existing_lieu, territory_id: organisation.territory_id, external_id: "123ABC")
+      end
+
+      it "doesn't create the lieu and returns an error message" do
+        expect { post "/api/v1/organisations", headers:, params:, as: :json }.not_to change(Lieu, :count)
+
+        expect(response.status).to eq 422
+        expect(response.error_message).to eq "asdf"
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/lieux_spec.rb
+++ b/spec/requests/api/v1/lieux_spec.rb
@@ -9,6 +9,26 @@ RSpec.describe "Lieux API" do
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
 
   describe "#create" do
+    context "without an external reference" do
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          latitude: 44.5569244,
+          longitude: 4.7521632,
+          name: "Maison France Service de Montreuil",
+          address: "77 avenue de Ségur, 75015 Paris",
+          phone_number: "01 22 33 44 55",
+        }
+      end
+
+      it "creates the lieu" do
+        expect { post "/api/v1/lieux", headers:, params:, as: :json }.to change(Lieu, :count)
+
+        expect(response.status).to eq 200
+        expect(parsed_response_body["name"]).to eq "Maison France Service de Montreuil"
+      end
+    end
+
     context "when a lieux already exists for the given external reference" do
       let(:params) do
         {
@@ -29,10 +49,10 @@ RSpec.describe "Lieux API" do
       end
 
       it "doesn't create the lieu and returns an error message" do
-        expect { post "/api/v1/organisations", headers:, params:, as: :json }.not_to change(Lieu, :count)
+        expect { post "/api/v1/lieux", headers:, params:, as: :json }.not_to change(Lieu, :count)
 
         expect(response.status).to eq 422
-        expect(response.error_message).to eq "asdf"
+        expect(parsed_response_body["error_messages"]).to eq ["external_id est déjà utilisé"]
       end
     end
   end

--- a/spec/requests/api/v1/lieux_spec.rb
+++ b/spec/requests/api/v1/lieux_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Lieux API" do
       let!(:existing_lieu) do
         create(:lieu, organisation_id: organisation.id)
       end
-      let!(:external_refenrece) do
+      let!(:external_reference) do
         create(:external_reference, oauth_application: application, item: existing_lieu, territory_id: organisation.territory_id, external_id: "123ABC")
       end
 

--- a/spec/requests/api/v1/swagger_doc/lieux_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/lieux_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "API des lieux", swagger_doc: "v1/api.json" do
 
   path "/api/v1/lieux" do
     post "Créer un profil utilisateur" do
-      with_authentication
+      with_oauth_token_authentication
 
       tags "Lieux"
       produces "application/json"
@@ -28,10 +28,8 @@ RSpec.describe "API des lieux", swagger_doc: "v1/api.json" do
 
       let!(:organisation) { create(:organisation) }
       let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-      let(:auth_headers) { api_auth_headers_for_agent(agent) }
-      let(:"access-token") { auth_headers["access-token"].to_s }
-      let(:uid) { auth_headers["uid"].to_s }
-      let(:client) { auth_headers["client"].to_s }
+      let(:oauth_token) { create(:access_token, resource_owner_id: agent.id) }
+      let(:authorization) { "Bearer #{oauth_token.plaintext_token}" }
 
       response 200, "Crée et renvoie un lieu" do
         let(:organisation_id) { organisation.id }

--- a/spec/requests/api/v1/swagger_doc/lieux_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/lieux_request_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe "API des lieux", swagger_doc: "v1/api.json" do
       parameter name: "latitude", in: :query, type: :float
       parameter name: "longitude", in: :query, type: :float
       parameter name: "phone_number", in: :query, type: :string, description: "Numéro de téléphone", example: "33600008012", required: false
+      parameter name: "external_reference", in: :query, schema: {
+        type: :object,
+        properties: { external_reference: {
+          type: :object,
+          properties: { external_id: { type: :string } },
+        } },
+      }, description: "L'id du lieu dans votre système pour éviter la création de doublons", required: false
 
       let!(:organisation) { create(:organisation) }
       let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
@@ -33,6 +40,11 @@ RSpec.describe "API des lieux", swagger_doc: "v1/api.json" do
         let(:name) { "Maison France Service de Montreuil" }
         let(:address) { "77 avenue de Ségur, 75015 Paris" }
         let(:phone_number) { "01 22 33 44 55" }
+        let(:external_reference) do
+          {
+            external_reference: { external_id: "123ABC" },
+          }
+        end
 
         schema "$ref" => "#/components/schemas/lieu"
 
@@ -41,6 +53,10 @@ RSpec.describe "API des lieux", swagger_doc: "v1/api.json" do
         specify do
           expect(Lieu.last).to have_attributes(
             address:, name:, latitude:, longitude:, organisation_id:, phone_number:
+          )
+
+          expect(Lieu.last.external_references.last).to have_attributes(
+            external_id: "123ABC", territory_id: organisation.territory_id
           )
         end
       end

--- a/spec/requests/api/v1/swagger_doc/lieux_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/lieux_request_spec.rb
@@ -1,0 +1,49 @@
+require "swagger_helper"
+
+RSpec.describe "API des lieux", swagger_doc: "v1/api.json" do
+  with_examples
+
+  path "/api/v1/lieux" do
+    post "Créer un profil utilisateur" do
+      with_authentication
+
+      tags "Lieux"
+      produces "application/json"
+      operationId "createLieu"
+      description "Crée un lieu"
+
+      parameter name: "organisation_id", in: :query, type: :integer, description: "ID de l'organisation", example: 12
+      parameter name: "name", in: :query, type: :string, description: "Le nom de l'organisation", example: "Maison France Service de Montreuil"
+      parameter name: "address", in: :query, type: :string, description: "L'adresse au format 123 Rue Exemple, 12345 Ville", example: "77 avenue de Ségur, 75015 Paris"
+      parameter name: "latitude", in: :query, type: :float
+      parameter name: "longitude", in: :query, type: :float
+      parameter name: "phone_number", in: :query, type: :string, description: "Numéro de téléphone", example: "33600008012", required: false
+
+      let!(:organisation) { create(:organisation) }
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let(:auth_headers) { api_auth_headers_for_agent(agent) }
+      let(:"access-token") { auth_headers["access-token"].to_s }
+      let(:uid) { auth_headers["uid"].to_s }
+      let(:client) { auth_headers["client"].to_s }
+
+      response 200, "Crée et renvoie un lieu" do
+        let(:organisation_id) { organisation.id }
+        let(:latitude) { 44.5569244 }
+        let(:longitude) { 4.7521632 }
+        let(:name) { "Maison France Service de Montreuil" }
+        let(:address) { "77 avenue de Ségur, 75015 Paris" }
+        let(:phone_number) { "01 22 33 44 55" }
+
+        schema "$ref" => "#/components/schemas/lieu"
+
+        run_test!
+
+        specify do
+          expect(Lieu.last).to have_attributes(
+            address:, name:, latitude:, longitude:, organisation_id:, phone_number:
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/support/api_spec_macros.rb
+++ b/spec/support/api_spec_macros.rb
@@ -23,6 +23,14 @@ module ApiSpecMacros
     parameter name: "uid", in: :header, type: :string, description: "Identifiant d'accès (authentification)", example: "martine@demo.rdv-solidarites.fr"
   end
 
+  def with_oauth_token_authentication
+    security [{ "content-type": [], autorization: [] }]
+
+    parameter name: "content-type", in: :header, type: :string
+    parameter name: "authorization", in: :header, type: :string, description: "Token d'accès (authentification)", example: "Bearer 123456"
+    let(:"content-type") { "application/json" }
+  end
+
   def with_visioplainte_authentication
     with_examples
     produces "application/json"


### PR DESCRIPTION
suite de https://github.com/betagouv/rdv-service-public/pull/5629

Rien de très surprenant : on ajoute un endpoint d'api pour créer des lieux, avec la possibilité d'ajouter une external reference pour rendre la création idempotente (et peut-être plus tard faciliter les updates).

Contrairement à la PR précédente, j'ai commencé à ajouter la doc swagger, puisque ça pourra être utile pour d'autres clients d'api.

Je pense qu'avec les améliorations récentes faites à l'ouverture de comptes (plus de services ni de nom pour les territoires), ça devient raisonnable de proposer plus d'options de configuration de compte par api, ce qui pourrait très largement simplifier l'UX de l'ouverture de compte par intégration.