### PR TITLE
Ajout des motifs à la migration des conums

### DIFF
--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -49,23 +49,7 @@ class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
   private
 
   def motif_attribute_names
-    %i[
-      organisation_id name color
-      default_duration_in_min
-      min_public_booking_delay
-      max_public_booking_delay
-      restriction_for_rdv
-      instruction_for_rdv
-      for_secretariat
-      follow_up
-      visibility_type
-      custom_cancel_warning_message
-      collectif
-      location_type
-      rdvs_editable_by_user
-      rdvs_cancellable_by_user
-      bookable_by
-    ]
+    InstanceExport::MOTIF_ATTRIBUTE_NAMES + [:organisation_id]
   end
 
   def pundit_user

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -20,7 +20,53 @@ class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
     render_collection(motifs.order(:id))
   end
 
+  def create
+    motif = Motif.new(params.permit(*motif_attribute_names))
+
+    authorize(motif, policy_class: Agent::MotifPolicy)
+
+    motif.transaction do
+      motif.save
+
+      if params[:external_reference].present?
+        ExternalReference.create!(
+          params.require(:external_reference).permit(:external_id, :external_url).merge(
+            item: motif,
+            oauth_application: doorkeeper_token&.application,
+            territory_id: motif.organisation.territory_id
+          )
+        )
+      end
+    end
+
+    if motif.persisted?
+      render json: MotifBlueprint.render(motif)
+    else
+      render status: :unprocessable_entity, json: { error_messages: motif.errors.full_messages }
+    end
+  end
+
   private
+
+  def motif_attribute_names
+    %i[
+      organisation_id name color
+      default_duration_in_min
+      min_public_booking_delay
+      max_public_booking_delay
+      restriction_for_rdv
+      instruction_for_rdv
+      for_secretariat
+      follow_up
+      visibility_type
+      custom_cancel_warning_message
+      collectif
+      location_type
+      rdvs_editable_by_user
+      rdvs_cancellable_by_user
+      bookable_by
+    ]
+  end
 
   def pundit_user
     current_agent

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -34,15 +34,55 @@ class InstanceExport < ApplicationRecord
         source_organisation.users.pluck(:id).each do |user_id|
           CopyUserJob.perform_later(id, user_id, current_domain.id)
         end
+
         source_organisation.agents.where.not(id: agent.id).pluck(:id).each do |agent_id|
           CopyAgentJob.perform_later(id, agent_id)
         end
+
         source_organisation.lieux.enabled.each do |lieu|
           CopyLieuJob.perform_later(id, lieu.id)
+        end
+
+        source_organisation.motifs.active.each do |motif|
+          CopyMotifJob.perform_later(id, motif.id)
         end
       end
       update(good_job_batch_id: batch.id)
     end
+  end
+
+  class CopyMotifJob < ApplicationJob
+    queue_as :latency_5m
+
+    def perform(instance_export_id, motif_id)
+      InstanceExport.find(instance_export_id).copy_motif!(motif_id)
+    end
+  end
+
+  def copy_motif!(motif_id)
+    motif = Motif.find(motif_id)
+    attributes = motif.attributes.slice(*%w[
+                                          name color
+                                          default_duration_in_min
+                                          min_public_booking_delay
+                                          max_public_booking_delay
+                                          restriction_for_rdv
+                                          instruction_for_rdv
+                                          for_secretariat
+                                          follow_up
+                                          visibility_type
+                                          custom_cancel_warning_message
+                                          collectif
+                                          location_type
+                                          rdvs_editable_by_user
+                                          rdvs_cancellable_by_user
+                                          bookable_by
+                                        ])
+
+    attributes[:external_reference] = { external_id: motif.id }
+    attributes[:organisation_id] = destination_organisation_id
+
+    api_client.post("motifs", attributes)
   end
 
   class CopyLieuJob < ApplicationJob

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -59,25 +59,28 @@ class InstanceExport < ApplicationRecord
     end
   end
 
+  MOTIF_ATTRIBUTE_NAMES = %i[
+    name
+    color
+    default_duration_in_min
+    min_public_booking_delay
+    max_public_booking_delay
+    restriction_for_rdv
+    instruction_for_rdv
+    for_secretariat
+    follow_up
+    visibility_type
+    custom_cancel_warning_message
+    collectif
+    location_type
+    rdvs_editable_by_user
+    rdvs_cancellable_by_user
+    bookable_by
+  ].freeze
+
   def copy_motif!(motif_id)
     motif = Motif.find(motif_id)
-    attributes = motif.attributes.slice(*%w[
-                                          name color
-                                          default_duration_in_min
-                                          min_public_booking_delay
-                                          max_public_booking_delay
-                                          restriction_for_rdv
-                                          instruction_for_rdv
-                                          for_secretariat
-                                          follow_up
-                                          visibility_type
-                                          custom_cancel_warning_message
-                                          collectif
-                                          location_type
-                                          rdvs_editable_by_user
-                                          rdvs_cancellable_by_user
-                                          bookable_by
-                                        ])
+    attributes = motif.attributes.slice(*MOTIF_ATTRIBUTE_NAMES)
 
     attributes[:external_reference] = { external_id: motif.id }
     attributes[:organisation_id] = destination_organisation_id

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -80,7 +80,7 @@ class InstanceExport < ApplicationRecord
 
   def copy_motif!(motif_id)
     motif = Motif.find(motif_id)
-    attributes = motif.attributes.slice(*MOTIF_ATTRIBUTE_NAMES)
+    attributes = motif.attributes.symbolize_keys.slice(*MOTIF_ATTRIBUTE_NAMES)
 
     attributes[:external_reference] = { external_id: motif.id }
     attributes[:organisation_id] = destination_organisation_id

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -40,6 +40,7 @@ class Motif < ApplicationRecord
   belongs_to :motif_category, optional: true
   has_many :rdvs, dependent: :restrict_with_exception
   has_many :motifs_plage_ouvertures, dependent: :delete_all
+  has_many :external_references, as: :item, dependent: :destroy
 
   # Through relations
   has_many :webhook_endpoints, through: :organisation

--- a/app/views/admin/instance_exports/edit.html.slim
+++ b/app/views/admin/instance_exports/edit.html.slim
@@ -11,8 +11,8 @@
         p #{source_org.users.count} usagers
         - if source_org.agents.count > 1
           p #{source_org.agents.count} agents
-        p #{source_org.lieux.count} lieux
-        p #{source_org.motifs.count} motifs
+        p #{source_org.lieux.count}  #{"lieu".pluralize(source_org.lieux.count)}
+        p #{source_org.motifs.count} #{"motif".pluralize(source_org.motifs.count)}
 
     .fr-mx-4w[style="align-self: center"]= icon("fr-icon-arrow-right-fill")
 

--- a/app/views/admin/instance_exports/edit.html.slim
+++ b/app/views/admin/instance_exports/edit.html.slim
@@ -6,11 +6,13 @@
       .card-header
         b= current_domain.name
       .card-body
-        h6= @instance_export.source_organisation.name
-        p #{@instance_export.source_organisation.users.count} usagers
-        - if @instance_export.source_organisation.agents.count > 1
-          p #{@instance_export.source_organisation.agents.count} agents
-        p #{@instance_export.source_organisation.lieux.count} lieux
+        - source_org = @instance_export.source_organisation
+        h6= source_org.name
+        p #{source_org.users.count} usagers
+        - if source_org.agents.count > 1
+          p #{source_org.agents.count} agents
+        p #{source_org.lieux.count} lieux
+        p #{source_org.motifs.count} motifs
 
     .fr-mx-4w[style="align-self: center"]= icon("fr-icon-arrow-right-fill")
 

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -17,6 +17,7 @@ namespace :api do
       resources :motifs, only: %i[index]
       resources :rdvs, only: %i[index]
     end
+    resources :motifs, only: %i[create]
     resources :rdvs, only: %i[index]
     resources :participations, only: %i[update]
     resources :rdv_plans, only: %i[create show]

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     create(:agent, first_name: "Francis", last_name: "Factice", basic_role_in_organisations: [organisation_rdv_aide_num])
   end
   let!(:lieu) { create(:lieu, organisation: organisation_rdv_aide_num) }
+  let!(:motif) { create(:motif, organisation: organisation_rdv_aide_num) }
 
   let!(:users) do
     create_list(:user, 3, organisations: [organisation_rdv_aide_num])
@@ -117,6 +118,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     expect(created_organisation.agents.count).to eq 2
     expect(created_organisation.lieux.last).to have_attributes(name: lieu.name)
     expect(created_organisation.lieux.last.external_references.last).to have_attributes(external_id: lieu.id.to_s)
+
+    expect(created_organisation.motifs.last).to have_attributes(name: motif.name)
 
     login_as(agent_rdv_sp, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"

--- a/spec/requests/api/v1/motifs_spec.rb
+++ b/spec/requests/api/v1/motifs_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe "Lieux API" do
+  let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
+  let(:headers) do
+    { "Content-Type": "application/json", Authorization: "Bearer #{oauth_token.plaintext_token}" }
+  end
+  let(:application) { create(:oauth_application, default_service: create(:service)) }
+
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+  describe "#create" do
+    context "without an external reference" do
+      let(:params) do
+        {
+          name: "Suivi de dossier",
+          organisation_id: organisation.id,
+          color: "#000000",
+          default_duration_in_min: 30,
+          min_public_booking_delay: 1800,
+          max_public_booking_delay: 7889238,
+          collectif: false,
+          bookable_by: "everyone",
+        }
+      end
+
+      it "creates the motif" do
+        expect { post "/api/v1/motifs", headers:, params:, as: :json }.to change(Motif, :count)
+
+        expect(response.status).to eq 200
+        expect(parsed_response_body["name"]).to eq "Suivi de dossier"
+      end
+    end
+
+    context "when a motif already exists for the given external reference" do
+      let(:params) do
+        {
+          name: "Suivi de dossier",
+          organisation_id: organisation.id,
+          color: "#000000",
+          default_duration_in_min: 30,
+          min_public_booking_delay: 1800,
+          max_public_booking_delay: 7889238,
+          collectif: false,
+          bookable_by: "everyone",
+          external_reference: { external_id: "123ABC" },
+        }
+      end
+
+      let!(:existing_motif) do
+        create(:motif, organisation_id: organisation.id)
+      end
+      let!(:external_refenrece) do
+        create(:external_reference, oauth_application: application, item: existing_motif, territory_id: organisation.territory_id, external_id: "123ABC")
+      end
+
+      it "doesn't create the motif and returns an error message" do
+        expect { post "/api/v1/motifs", headers:, params:, as: :json }.not_to change(Motif, :count)
+
+        expect(response.status).to eq 422
+        expect(parsed_response_body["error_messages"]).to eq ["external_id est déjà utilisé"]
+      end
+    end
+  end
+end

--- a/spec/support/autodoc/scenario.html.slim
+++ b/spec/support/autodoc/scenario.html.slim
@@ -13,7 +13,7 @@
       - section.steps.each do |step|
         div[style="padding: 8px; display: flex; flex-direction: column; align-items: center"]
           - if step[:img_src]
-            img[src='#{step[:img_src]}' width=800 style='border: solid 2px grey']
+            img[src='#{step[:img_src]}' width=800 style='box-shadow: rgba(0, 0, 0, 0.20) 0px 7px 20px; border-radius: 4px']
             - if step[:text]
               p.fr-mt-2w.fr-mb-5w = step[:text]
           - else


### PR DESCRIPTION
suite de https://github.com/betagouv/rdv-service-public/pull/5636/

C'est très similaire à l'ajout des lieux.
Cette fois on ne documente pas l'api parce que les règles métiers autour de la création de motif sont beaucoup plus complexes, donc on ne pas probablement pas proposer à des partenaires de faire de la création de motif pour le moment.