### PR TITLE
Ajout des rdvs à venir en tant qu'absence dans la migration des conums

### DIFF
--- a/app/controllers/api/v1/absences_controller.rb
+++ b/app/controllers/api/v1/absences_controller.rb
@@ -9,6 +9,17 @@ class Api::V1::AbsencesController < Api::V1::AgentAuthBaseController
     absence = Absence.new(create_params)
     authorize(absence, policy_class: Agent::AbsencePolicy) if absence.valid?
     absence.save!
+
+    if params[:external_reference].present?
+      ExternalReference.create!(
+        params.require(:external_reference).permit(:external_id, :external_url).merge(
+          item: absence,
+          oauth_application: doorkeeper_token&.application,
+          territory_id: absence.agent.territories.first.id
+        )
+      )
+    end
+
     render_record absence
   rescue ActiveRecord::RecordNotFound
     render_error :not_found, not_found: :agent

--- a/app/controllers/api/v1/absences_controller.rb
+++ b/app/controllers/api/v1/absences_controller.rb
@@ -14,8 +14,7 @@ class Api::V1::AbsencesController < Api::V1::AgentAuthBaseController
       ExternalReference.create!(
         params.require(:external_reference).permit(:external_id, :external_url).merge(
           item: absence,
-          oauth_application: doorkeeper_token&.application,
-          territory_id: absence.agent.territories.first.id
+          oauth_application: doorkeeper_token&.application
         )
       )
     end

--- a/app/controllers/api/v1/absences_controller.rb
+++ b/app/controllers/api/v1/absences_controller.rb
@@ -68,6 +68,8 @@ class Api::V1::AbsencesController < Api::V1::AgentAuthBaseController
       params.delete(:agent_email)
     end
 
+    params[:agent_id] ||= current_agent.id
+
     params.permit(:agent_id, :title, :first_day, :start_time, :end_day, :end_time)
   end
 

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -11,6 +11,7 @@ class Absence < ApplicationRecord
 
   # Relations
   belongs_to :agent
+  has_many :external_references, as: :item, dependent: :destroy
 
   # Through relations
   def webhook_endpoints

--- a/app/models/external_reference.rb
+++ b/app/models/external_reference.rb
@@ -1,7 +1,7 @@
 class ExternalReference < ApplicationRecord
   belongs_to :item, polymorphic: true
   belongs_to :oauth_application, class_name: "Doorkeeper::Application"
-  belongs_to :territory
+  belongs_to :territory, optional: true
 
   # Permet de rendre les créations d'objets idempotentes
   validates :external_id, uniqueness: { scope: %i[item_type oauth_application_id territory] }

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -74,7 +74,7 @@ class InstanceExport < ApplicationRecord
           start_time: rdv.starts_at.strftime("%H:%M"),
           end_time: rdv.ends_at.strftime("%H:%M"),
           external_reference: {
-            external_id: rdv_id,
+            external_id: "rdv:#{rdv_id}", # on créera aussi des external_reference pour des absences, donc on préfixe par "rdv"
             external_url: Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
           },
         }

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -64,10 +64,10 @@ class InstanceExport < ApplicationRecord
 
     def perform(instance_export_id, rdv_id, domain_id)
       domain = Domain.find(domain_id)
+      instance_export = InstanceExport.find(instance_export_id)
       rdv = Rdv.find(rdv_id)
       rdv.agents.each do |agent|
         params = {
-          agent_email: agent.email,
           title: "RDV pris sur #{domain.name}",
           first_day: rdv.starts_at.strftime("%Y-%m-%d"),
           end_day: rdv.starts_at.strftime("%Y-%m-%d"),
@@ -79,7 +79,10 @@ class InstanceExport < ApplicationRecord
           },
         }
 
-        api_client = InstanceExport.find(instance_export_id).api_client
+        if agent != instance_export.agent
+          params[:agent_email] = agent.email
+        end
+        api_client = instance_export.api_client
         api_client.post("absences", params)
       end
     end

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -39,15 +39,41 @@ class InstanceExport < ApplicationRecord
           CopyAgentJob.perform_later(id, agent_id)
         end
 
-        source_organisation.lieux.enabled.each do |lieu|
-          CopyLieuJob.perform_later(id, lieu.id)
+        source_organisation.lieux.enabled.pluck(:id).each do |lieu_id|
+          CopyLieuJob.perform_later(id, lieu_id)
         end
 
-        source_organisation.motifs.active.each do |motif|
-          CopyMotifJob.perform_later(id, motif.id)
+        source_organisation.motifs.active.pluck(:id).each do |motif_id|
+          CopyMotifJob.perform_later(id, motif_id)
+        end
+
+        source_organisation.rdvs.future.not_cancelled.pluck(:id).each do |rdv_id|
+          CopyRdvAsAbsenceJob.perform_later(id, rdv_id)
         end
       end
       update(good_job_batch_id: batch.id)
+    end
+  end
+
+  class CopyRdvAsAbsenceJob < ApplicationJob
+    queue_as :latency_5m
+
+    def perform(instance_export_id, rdv_id)
+      api_client = InstanceExport.find(instance_export_id).api_client
+
+      rdv = Rdv.find(rdv_id)
+      rdv.agents.each do |agent|
+        params = {
+          agent_email: agent.email,
+          title: "RDV pris sur RDV Aide Numérique",
+          first_day: rdv.starts_at.strftime("%Y-%m-%d"),
+          end_day: rdv.starts_at.strftime("%Y-%m-%d"),
+          start_time: rdv.starts_at.strftime("%H:%M"),
+          end_time: rdv.ends_at.strftime("%H:%M"),
+        }
+
+        api_client.post("absences", params)
+      end
     end
   end
 
@@ -143,8 +169,6 @@ class InstanceExport < ApplicationRecord
 
     api_client.post("users", request_body)
   end
-
-  private
 
   def api_client
     @api_client ||= RdvServicePublicApiClient.new(api_token)

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -68,7 +68,7 @@ class InstanceExport < ApplicationRecord
       rdv.agents.each do |agent|
         params = {
           agent_email: agent.email,
-          title: "RDV pris sur RDV Aide Numérique",
+          title: "RDV pris sur #{domain.name}",
           first_day: rdv.starts_at.strftime("%Y-%m-%d"),
           end_day: rdv.starts_at.strftime("%Y-%m-%d"),
           start_time: rdv.starts_at.strftime("%H:%M"),
@@ -76,7 +76,6 @@ class InstanceExport < ApplicationRecord
           external_reference: {
             external_id: rdv_id,
             external_url: Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
-
           },
         }
 
@@ -145,7 +144,7 @@ class InstanceExport < ApplicationRecord
       instance_export.api_client.post("agents", {
                                         email: agent.email,
                                         organisation_ids: [instance_export.destination_organisation_id],
-                                        access_level: agent.role_in_organisation(source_organisation).access_level,
+                                        access_level: agent.role_in_organisation(instance_export.source_organisation).access_level,
                                       })
     end
   end
@@ -154,19 +153,19 @@ class InstanceExport < ApplicationRecord
     queue_as :latency_5m
 
     def perform(instance_export_id, user_id, domain_id)
-      api_client = InstanceExport.find(instance_export_id).api_client
+      instance_export = InstanceExport.find(instance_export_id)
       domain = Domain.find(domain_id)
       user = User.find(user_id)
 
       request_body = user.attributes.symbolize_keys.slice(*UserBlueprint.reflections[:default].fields.keys - %i[id responsible_id])
-      request_body[:organisation_ids] = [destination_organisation_id]
+      request_body[:organisation_ids] = [instance_export.destination_organisation_id]
 
       request_body[:external_reference] = {
         external_id: user.id,
-        external_url: Rails.application.routes.url_helpers.admin_organisation_user_url(source_organisation.id, user.id, host: domain.host_name),
+        external_url: Rails.application.routes.url_helpers.admin_organisation_user_url(instance_export.source_organisation.id, user.id, host: domain.host_name),
       }
 
-      api_client.post("users", request_body)
+      instance_export.api_client.post("users", request_body)
     end
   end
 end

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -4,6 +4,7 @@ class InstanceExport < ApplicationRecord
 
   encrypts :api_token
   encrypts :refresh_token
+
   def new_instance_organisations
     @new_instance_organisations ||= api_client.get("organisations")["organisations"]
   end
@@ -51,7 +52,7 @@ class InstanceExport < ApplicationRecord
         end
 
         source_organisation.rdvs.future.not_cancelled.pluck(:id).each do |rdv_id|
-          CopyRdvAsAbsenceJob.perform_later(id, rdv_id)
+          CopyRdvAsAbsenceJob.perform_later(id, rdv_id, current_domain.id)
         end
       end
       update(good_job_batch_id: batch.id)
@@ -61,7 +62,8 @@ class InstanceExport < ApplicationRecord
   class CopyRdvAsAbsenceJob < ApplicationJob
     queue_as :latency_5m
 
-    def perform(instance_export_id, rdv_id)
+    def perform(instance_export_id, rdv_id, domain_id)
+      domain = Domain.find(domain_id)
       rdv = Rdv.find(rdv_id)
       rdv.agents.each do |agent|
         params = {
@@ -71,6 +73,11 @@ class InstanceExport < ApplicationRecord
           end_day: rdv.starts_at.strftime("%Y-%m-%d"),
           start_time: rdv.starts_at.strftime("%H:%M"),
           end_time: rdv.ends_at.strftime("%H:%M"),
+          external_reference: {
+            external_id: rdv_id,
+            external_url: Rails.application.routes.url_helpers.admin_organisations_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
+
+          },
         }
 
         api_client = InstanceExport.find(instance_export_id).api_client

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -75,7 +75,7 @@ class InstanceExport < ApplicationRecord
           end_time: rdv.ends_at.strftime("%H:%M"),
           external_reference: {
             external_id: rdv_id,
-            external_url: Rails.application.routes.url_helpers.admin_organisations_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
+            external_url: Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
 
           },
         }
@@ -109,15 +109,14 @@ class InstanceExport < ApplicationRecord
     queue_as :latency_5m
 
     def perform(instance_export_id, motif_id)
-      InstanceExport.find(instance_export_id).copy_motif!(motif_id)
+      instance_export = InstanceExport.find(instance_export_id)
       motif = Motif.find(motif_id)
       attributes = motif.attributes.symbolize_keys.slice(*MOTIF_ATTRIBUTE_NAMES)
 
       attributes[:external_reference] = { external_id: motif.id }
-      attributes[:organisation_id] = destination_organisation_id
+      attributes[:organisation_id] = instance_export.destination_organisation_id
 
-      api_client = InstanceExport.find(instance_export_id).api_client
-      api_client.post("motifs", attributes)
+      instance_export.api_client.post("motifs", attributes)
     end
   end
 
@@ -125,14 +124,14 @@ class InstanceExport < ApplicationRecord
     queue_as :latency_5m
 
     def perform(instance_export_id, lieu_id)
+      instance_export = InstanceExport.find(instance_export_id)
       lieu = Lieu.find(lieu_id)
       attributes = lieu.attributes.slice(*%w[name address latitude longitude phone_number])
 
       attributes[:external_reference] = { external_id: lieu.id }
-      attributes[:organisation_id] = destination_organisation_id
+      attributes[:organisation_id] = instance_export.destination_organisation_id
 
-      api_client = InstanceExport.find(instance_export_id).api_client
-      api_client.post("lieux", attributes)
+      instance_export.api_client.post("lieux", attributes)
     end
   end
 
@@ -140,13 +139,14 @@ class InstanceExport < ApplicationRecord
     queue_as :latency_5m
 
     def perform(instance_export_id, agent_id)
+      instance_export = InstanceExport.find(instance_export_id)
       agent = Agent.find(agent_id)
-      api_client = InstanceExport.find(instance_export_id).api_client
-      api_client.post("agents", {
-                        email: agent.email,
-                        organisation_ids: [destination_organisation_id],
-                        access_level: agent.role_in_organisation(source_organisation).access_level,
-                      })
+
+      instance_export.api_client.post("agents", {
+                                        email: agent.email,
+                                        organisation_ids: [instance_export.destination_organisation_id],
+                                        access_level: agent.role_in_organisation(source_organisation).access_level,
+                                      })
     end
   end
 

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -4,7 +4,6 @@ class InstanceExport < ApplicationRecord
 
   encrypts :api_token
   encrypts :refresh_token
-
   def new_instance_organisations
     @new_instance_organisations ||= api_client.get("organisations")["organisations"]
   end
@@ -24,6 +23,10 @@ class InstanceExport < ApplicationRecord
 
   def destination_organisation
     @destination_organisation ||= Organisation.new(new_instance_organisations.first).tap(&:readonly!)
+  end
+
+  def api_client
+    @api_client ||= RdvServicePublicApiClient.new(api_token)
   end
 
   def copy_to_new_instance!(current_domain)
@@ -59,8 +62,6 @@ class InstanceExport < ApplicationRecord
     queue_as :latency_5m
 
     def perform(instance_export_id, rdv_id)
-      api_client = InstanceExport.find(instance_export_id).api_client
-
       rdv = Rdv.find(rdv_id)
       rdv.agents.each do |agent|
         params = {
@@ -72,16 +73,9 @@ class InstanceExport < ApplicationRecord
           end_time: rdv.ends_at.strftime("%H:%M"),
         }
 
+        api_client = InstanceExport.find(instance_export_id).api_client
         api_client.post("absences", params)
       end
-    end
-  end
-
-  class CopyMotifJob < ApplicationJob
-    queue_as :latency_5m
-
-    def perform(instance_export_id, motif_id)
-      InstanceExport.find(instance_export_id).copy_motif!(motif_id)
     end
   end
 
@@ -104,73 +98,68 @@ class InstanceExport < ApplicationRecord
     bookable_by
   ].freeze
 
-  def copy_motif!(motif_id)
-    motif = Motif.find(motif_id)
-    attributes = motif.attributes.symbolize_keys.slice(*MOTIF_ATTRIBUTE_NAMES)
+  class CopyMotifJob < ApplicationJob
+    queue_as :latency_5m
 
-    attributes[:external_reference] = { external_id: motif.id }
-    attributes[:organisation_id] = destination_organisation_id
+    def perform(instance_export_id, motif_id)
+      InstanceExport.find(instance_export_id).copy_motif!(motif_id)
+      motif = Motif.find(motif_id)
+      attributes = motif.attributes.symbolize_keys.slice(*MOTIF_ATTRIBUTE_NAMES)
 
-    api_client.post("motifs", attributes)
+      attributes[:external_reference] = { external_id: motif.id }
+      attributes[:organisation_id] = destination_organisation_id
+
+      api_client = InstanceExport.find(instance_export_id).api_client
+      api_client.post("motifs", attributes)
+    end
   end
 
   class CopyLieuJob < ApplicationJob
     queue_as :latency_5m
 
     def perform(instance_export_id, lieu_id)
-      InstanceExport.find(instance_export_id).copy_lieu!(lieu_id)
+      lieu = Lieu.find(lieu_id)
+      attributes = lieu.attributes.slice(*%w[name address latitude longitude phone_number])
+
+      attributes[:external_reference] = { external_id: lieu.id }
+      attributes[:organisation_id] = destination_organisation_id
+
+      api_client = InstanceExport.find(instance_export_id).api_client
+      api_client.post("lieux", attributes)
     end
-  end
-
-  def copy_lieu!(lieu_id)
-    lieu = Lieu.find(lieu_id)
-    attributes = lieu.attributes.slice(*%w[name address latitude longitude phone_number])
-
-    attributes[:external_reference] = { external_id: lieu.id }
-    attributes[:organisation_id] = destination_organisation_id
-
-    api_client.post("lieux", attributes)
   end
 
   class CopyAgentJob < ApplicationJob
     queue_as :latency_5m
 
     def perform(instance_export_id, agent_id)
-      InstanceExport.find(instance_export_id).copy_agent!(agent_id)
+      agent = Agent.find(agent_id)
+      api_client = InstanceExport.find(instance_export_id).api_client
+      api_client.post("agents", {
+                        email: agent.email,
+                        organisation_ids: [destination_organisation_id],
+                        access_level: agent.role_in_organisation(source_organisation).access_level,
+                      })
     end
-  end
-
-  def copy_agent!(agent_id)
-    agent = Agent.find(agent_id)
-    api_client.post("agents", {
-                      email: agent.email,
-                      organisation_ids: [destination_organisation_id],
-                      access_level: agent.role_in_organisation(source_organisation).access_level,
-                    })
   end
 
   class CopyUserJob < ApplicationJob
     queue_as :latency_5m
 
     def perform(instance_export_id, user_id, domain_id)
-      InstanceExport.find(instance_export_id).copy_user!(user_id, Domain.find(domain_id))
+      api_client = InstanceExport.find(instance_export_id).api_client
+      domain = Domain.find(domain_id)
+      user = User.find(user_id)
+
+      request_body = user.attributes.symbolize_keys.slice(*UserBlueprint.reflections[:default].fields.keys - %i[id responsible_id])
+      request_body[:organisation_ids] = [destination_organisation_id]
+
+      request_body[:external_reference] = {
+        external_id: user.id,
+        external_url: Rails.application.routes.url_helpers.admin_organisation_user_url(source_organisation.id, user.id, host: domain.host_name),
+      }
+
+      api_client.post("users", request_body)
     end
-  end
-
-  def copy_user!(user_id, domain)
-    user = User.find(user_id)
-    request_body = user.attributes.symbolize_keys.slice(*UserBlueprint.reflections[:default].fields.keys - %i[id responsible_id])
-    request_body[:organisation_ids] = [destination_organisation_id]
-
-    request_body[:external_reference] = {
-      external_id: user.id,
-      external_url: Rails.application.routes.url_helpers.admin_organisation_user_url(source_organisation.id, user.id, host: domain.host_name),
-    }
-
-    api_client.post("users", request_body)
-  end
-
-  def api_client
-    @api_client ||= RdvServicePublicApiClient.new(api_token)
   end
 end

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -20,6 +20,7 @@ class Lieu < ApplicationRecord
   has_many :plage_ouvertures_not_expired, -> { not_expired },
            class_name: "PlageOuverture", dependent: :restrict_with_error, inverse_of: :lieu
   has_many :plage_ouvertures # rubocop:disable Rails/HasManyOrHasOneDependent
+  has_many :external_references, as: :item, dependent: :destroy
 
   # Through relations
   has_many :motifs, through: :plage_ouvertures

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -20,7 +20,6 @@ class Lieu < ApplicationRecord
   has_many :plage_ouvertures_not_expired, -> { not_expired },
            class_name: "PlageOuverture", dependent: :restrict_with_error, inverse_of: :lieu
   has_many :plage_ouvertures # rubocop:disable Rails/HasManyOrHasOneDependent
-  has_many :external_references, as: :item, dependent: :destroy
 
   # Through relations
   has_many :motifs, through: :plage_ouvertures

--- a/app/policies/agent/external_reference_policy.rb
+++ b/app/policies/agent/external_reference_policy.rb
@@ -5,7 +5,7 @@ class Agent::ExternalReferencePolicy < ApplicationPolicy
     alias current_agent pundit_user
 
     def resolve
-      scope.where(territory_id: @pundit_user.organisations.select(:territory_id) + [nil])
+      scope.where(territory_id: @pundit_user.organisations.pluck(:territory_id) + [nil])
         .joins(:oauth_application).merge(
           OauthApplication.joins(:access_tokens).merge(current_agent.access_tokens)
         ).uniq

--- a/app/policies/agent/external_reference_policy.rb
+++ b/app/policies/agent/external_reference_policy.rb
@@ -5,7 +5,7 @@ class Agent::ExternalReferencePolicy < ApplicationPolicy
     alias current_agent pundit_user
 
     def resolve
-      scope.where(territory_id: @pundit_user.organisations.select(:territory_id))
+      scope.where(territory_id: @pundit_user.organisations.select(:territory_id) + [nil])
         .joins(:oauth_application).merge(
           OauthApplication.joins(:access_tokens).merge(current_agent.access_tokens)
         ).uniq

--- a/app/views/admin/planning/absences/edit.html.slim
+++ b/app/views/admin/planning/absences/edit.html.slim
@@ -16,6 +16,12 @@
             titles_and_paths: [["Accueil", root_path], ["Indisponibilités de #{@absence.agent.full_name_and_service}", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
             current_page_title: yield(:title)
 
+- content_for :breadcrumb do
+  - references = Agent::ExternalReferencePolicy::Scope.new(current_agent, @absence.external_references.where(territory: current_territory)).resolve
+  - if references.present?
+    - references.each do |reference|
+      = link_to("Voir sur #{reference.oauth_application.name}", reference.external_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-mr-2w")
+
 .row.justify-content-center
   .col-md-6
     .card

--- a/app/views/admin/planning/absences/edit.html.slim
+++ b/app/views/admin/planning/absences/edit.html.slim
@@ -17,7 +17,7 @@
             current_page_title: yield(:title)
 
 - content_for :breadcrumb do
-  - references = Agent::ExternalReferencePolicy::Scope.new(current_agent, @absence.external_references.where(territory: current_territory)).resolve
+  - references = Agent::ExternalReferencePolicy::Scope.new(current_agent, @absence.external_references).resolve
   - if references.present?
     - references.each do |reference|
       = link_to("Voir sur #{reference.oauth_application.name}", reference.external_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-mr-2w")

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -14,9 +14,8 @@ ruby:
 
 - content_for :breadcrumb do
   - references = Agent::ExternalReferencePolicy::Scope.new(current_agent, @user.external_references.where(territory: current_territory)).resolve
-  - if references.present?
-    - references.each do |reference|
-      = link_to("Voir sur #{reference.oauth_application.name}", reference.external_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-mr-2w")
+  - references.each do |reference|
+    = link_to("Voir sur #{reference.oauth_application.name}", reference.external_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-mr-2w")
 
   = link_to "Trouver un RDV pour l’usager", admin_organisation_creneaux_search_path(current_organisation, user_ids: [@user.id]), class: "fr-btn fr-btn--secondary", title: "Trouver un RDV pour l’usager #{@user.full_name}"
 

--- a/db/migrate/20250912170321_allow_external_reference_without_territory.rb
+++ b/db/migrate/20250912170321_allow_external_reference_without_territory.rb
@@ -1,0 +1,5 @@
+class AllowExternalReferenceWithoutTerritory < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :external_references, :territory_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_12_081158) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_12_170321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -296,7 +296,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_12_081158) do
     t.string "item_type", null: false
     t.bigint "item_id", null: false
     t.bigint "oauth_application_id", null: false
-    t.bigint "territory_id", null: false
+    t.bigint "territory_id"
     t.text "external_id", null: false
     t.text "external_url"
     t.datetime "created_at", null: false

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     create_list(:user, 3, organisations: [organisation_rdv_aide_num])
   end
 
+  let!(:future_rdv) do
+    create(:rdv, agents: [collegue], users: [users.last], starts_at: 2.weeks.from_now, motif:, lieu:, organisation: organisation_rdv_aide_num)
+  end
+
   let!(:agent_rdv_sp) do
     create(:agent, first_name: "Camille", last_name: "Clavier", password: "c0rrecThorse!", admin_role_in_organisations: [])
   end
@@ -119,7 +123,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     expect(created_organisation.lieux.last).to have_attributes(name: lieu.name)
     expect(created_organisation.lieux.last.external_references.last).to have_attributes(external_id: lieu.id.to_s)
 
-    expect(created_organisation.motifs.last).to have_attributes(name: motif.name)
+    # On crée des absences qui permettent de retrouver les rendez-vous sur l'ancienne instance
+    expect(collegue.absences.last.starts_at).to be_within(1.minute).of(future_rdv.starts_at)
 
     login_as(agent_rdv_sp, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   end
 
   let!(:future_rdv) do
-    create(:rdv, agents: [collegue], users: [users.last], starts_at: 2.weeks.from_now, motif:, lieu:, organisation: organisation_rdv_aide_num)
+    create(:rdv, agents: [agent_rdv_aide_num], users: [users.last], starts_at: 2.weeks.from_now, motif:, lieu:, organisation: organisation_rdv_aide_num)
   end
 
   let!(:agent_rdv_sp) do
@@ -124,8 +124,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     expect(created_organisation.lieux.last.external_references.last).to have_attributes(external_id: lieu.id.to_s)
 
     # On crée des absences qui permettent de retrouver les rendez-vous sur l'ancienne instance
-    expect(collegue.absences.last.starts_at).to be_within(1.minute).of(future_rdv.starts_at)
-    expect(collegue.absences.last.external_references.last.external_url).to eq "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{future_rdv.id}"
+    expect(agent_rdv_sp.absences.last.starts_at).to be_within(1.minute).of(future_rdv.starts_at)
+    expect(agent_rdv_sp.absences.last.external_references.last.external_url).to eq "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{future_rdv.id}"
 
     login_as(agent_rdv_sp, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
 
     # On crée des absences qui permettent de retrouver les rendez-vous sur l'ancienne instance
     expect(collegue.absences.last.starts_at).to be_within(1.minute).of(future_rdv.starts_at)
+    expect(collegue.absences.last.external_references.last.external_url).to eq "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{future_rdv.id}"
 
     login_as(agent_rdv_sp, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"


### PR DESCRIPTION
suite de https://github.com/betagouv/rdv-service-public/pull/5638

Pour faciliter la migration et éviter que deux rendez-vous soient pris à la même heure sur les deux instances, on crée une absence dans RDV Service Public pour chaque rdv futur dans RDV Aide Numérique.

On permet même d'afficher un lien vers le rendez-vous dans l'ancienne instance depuis la page d'édition de l'absence (sur laquelle on arrive si on clique dessus depuis le calendrier).
C'est pas l'interface la plus élégante au monde d'avoir ce lien depuis le formulaire, mais ça fait le job pour ce edge case.

Prochaines PR : 
- copie des absences
- copie des plages d'ouvertures
- amélioration de l'ux du wizard de migration (revoir les textes)
- ajout d'un système de feature flag pour afficher une tuile dans la config.