### PR TITLE
Préparation à la suppression de external_references.territory_id

### DIFF
--- a/app/controllers/api/v1/lieux_controller.rb
+++ b/app/controllers/api/v1/lieux_controller.rb
@@ -17,8 +17,7 @@ class Api::V1::LieuxController < Api::V1::AgentAuthBaseController
         ExternalReference.create!(
           params.require(:external_reference).permit(:external_id, :external_url).merge(
             item: lieu,
-            oauth_application: doorkeeper_token&.application,
-            territory_id: lieu.organisation.territory_id
+            oauth_application: doorkeeper_token&.application
           )
         )
       end

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -32,8 +32,7 @@ class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
         ExternalReference.create!(
           params.require(:external_reference).permit(:external_id, :external_url).merge(
             item: motif,
-            oauth_application: doorkeeper_token&.application,
-            territory_id: motif.organisation.territory_id
+            oauth_application: doorkeeper_token&.application
           )
         )
       end

--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -39,8 +39,7 @@ class Api::V1::OrganisationsController < Api::V1::AgentAuthBaseController
         ExternalReference.create!(
           params.require(:external_reference).permit(:external_id, :external_url).merge(
             item: @organisation,
-            oauth_application: doorkeeper_token&.application,
-            territory_id: @organisation.territory_id
+            oauth_application: doorkeeper_token&.application
           )
         )
       end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -73,12 +73,9 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
     if params[:external_reference].present?
       attributes_from_params = params.require(:external_reference).permit(:external_id, :external_url)
 
-      territory_id = Organisation.find_by(id: params[:organisation_ids])&.territory_id
+      Organisation.find_by(id: params[:organisation_ids])&.territory_id
       permitted_params.merge!(
-        external_references_attributes: [attributes_from_params.merge(
-          oauth_application: doorkeeper_token&.application,
-          territory_id: territory_id
-        )]
+        external_references_attributes: [attributes_from_params.merge(oauth_application: doorkeeper_token&.application)]
       )
     end
 

--- a/app/models/external_reference.rb
+++ b/app/models/external_reference.rb
@@ -1,11 +1,12 @@
 class ExternalReference < ApplicationRecord
+  self.ignored_columns += [:territory_id]
+
   belongs_to :item, polymorphic: true
   belongs_to :oauth_application, class_name: "Doorkeeper::Application"
-  belongs_to :territory, optional: true
 
   # Permet de rendre les créations d'objets idempotentes
-  validates :external_id, uniqueness: { scope: %i[item_type oauth_application_id territory] }
+  validates :external_id, uniqueness: { scope: %i[item_type oauth_application_id] }
 
   # Evite que le même item ai deux ids différents dans le même système
-  validates :item_id, uniqueness: { scope: %i[item_type oauth_application_id territory] }
+  validates :item_id, uniqueness: { scope: %i[item_type oauth_application_id] }
 end

--- a/db/migrate/20250915174644_remove_external_reference_territory_id_from_index.rb
+++ b/db/migrate/20250915174644_remove_external_reference_territory_id_from_index.rb
@@ -1,0 +1,11 @@
+class RemoveExternalReferenceTerritoryIdFromIndex < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index "external_references", %w[external_id item_type oauth_application_id], unique: true, algorithm: :concurrently
+    add_index "external_references", %w[item_id item_type oauth_application_id], unique: true, algorithm: :concurrently
+
+    remove_index "external_references", column: %w[external_id item_type oauth_application_id territory_id]
+    remove_index "external_references", column: %w[item_id item_type oauth_application_id territory_id]
+  end
+end

--- a/db/migrate/20250915174644_remove_external_reference_territory_id_from_index.rb
+++ b/db/migrate/20250915174644_remove_external_reference_territory_id_from_index.rb
@@ -2,6 +2,28 @@ class RemoveExternalReferenceTerritoryIdFromIndex < ActiveRecord::Migration[7.2]
   disable_ddl_transaction!
 
   def change
+    duplicates_on_first_index = ExternalReference.joins <<~SQL.squish
+      INNER JOIN external_references AS ext_refs2 ON
+        external_references.id != ext_refs2.id
+        AND external_references.external_id = ext_refs2.external_id
+        AND external_references.item_type = ext_refs2.item_type
+        AND external_references.oauth_application_id = ext_refs2.oauth_application_id
+    SQL
+
+    duplicate_ids = duplicates_on_first_index.limit(10).pluck(:id)
+    raise "Duplicate external reference #{duplicate_ids}" if duplicate_ids.any?
+
+    duplicates_on_second_index = ExternalReference.joins <<~SQL.squish
+      INNER JOIN external_references AS ext_refs2 ON
+        external_references.id != ext_refs2.id
+        AND external_references.external_id = ext_refs2.external_id
+        AND external_references.item_type = ext_refs2.item_type
+        AND external_references.oauth_application_id = ext_refs2.oauth_application_id
+    SQL
+
+    duplicate_ids = duplicates_on_second_index.limit(10).pluck(:id)
+    raise "Duplicate external reference #{duplicate_ids}" if duplicate_ids.any?
+
     add_index "external_references", %w[external_id item_type oauth_application_id], unique: true, algorithm: :concurrently
     add_index "external_references", %w[item_id item_type oauth_application_id], unique: true, algorithm: :concurrently
 
@@ -9,3 +31,4 @@ class RemoveExternalReferenceTerritoryIdFromIndex < ActiveRecord::Migration[7.2]
     remove_index "external_references", column: %w[item_id item_type oauth_application_id territory_id]
   end
 end
+ActiveRecord::Base.logger = Logger.new(STDOUT)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -233,8 +233,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_30_134819) do
     t.text "external_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["external_id", "item_type", "oauth_application_id", "territory_id"], name: "idx_on_external_id_item_type_oauth_application_id_t_09b6418013", unique: true
-    t.index ["item_id", "item_type", "oauth_application_id", "territory_id"], name: "idx_on_item_id_item_type_oauth_application_id_terri_6db34b5548", unique: true
+    t.index ["external_id", "item_type", "oauth_application_id"], name: "idx_on_external_id_item_type_oauth_application_id_a18ac19e34", unique: true
+    t.index ["item_id", "item_type", "oauth_application_id"], name: "idx_on_item_id_item_type_oauth_application_id_fa816313d2", unique: true
   end
 
   create_table "file_attentes", force: :cascade do |t|

--- a/spec/factories/external_reference.rb
+++ b/spec/factories/external_reference.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     external_id {  generate(:external_id) }
     external_url { "monsuivisocial.anct.gouv.fr/users/#{generate(:external_id_in_url)}" }
     oauth_application
-    territory
     item { create(:user) }
   end
 end

--- a/spec/features/agents/users/agent_can_display_user_spec.rb
+++ b/spec/features/agents/users/agent_can_display_user_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Agent can display user" do
     let!(:user) { create(:user, organisations: [organisation]) }
     let(:application) { create(:oauth_application, name: "Démarches Simplifiées") }
     let!(:external_reference) do
-      create(:external_reference, oauth_application: application, territory: organisation.territory, item: user)
+      create(:external_reference, oauth_application: application, item: user)
     end
 
     it "shows a link to the external reference" do

--- a/spec/requests/api/v1/lieux_spec.rb
+++ b/spec/requests/api/v1/lieux_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "Lieux API" do
         create(:lieu, organisation_id: organisation.id)
       end
       let!(:external_reference) do
-        create(:external_reference, oauth_application: application, item: existing_lieu, territory_id: organisation.territory_id, external_id: "123ABC")
+        create(:external_reference, oauth_application: application, item: existing_lieu, external_id: "123ABC")
       end
 
       it "doesn't create the lieu and returns an error message" do

--- a/spec/requests/api/v1/motifs_spec.rb
+++ b/spec/requests/api/v1/motifs_spec.rb
@@ -49,8 +49,9 @@ RSpec.describe "Motifs API" do
       let!(:existing_motif) do
         create(:motif, organisation_id: organisation.id)
       end
+
       let!(:external_reference) do
-        create(:external_reference, oauth_application: application, item: existing_motif, territory_id: organisation.territory_id, external_id: "123ABC")
+        create(:external_reference, oauth_application: application, item: existing_motif, external_id: "123ABC")
       end
 
       it "doesn't create the motif and returns an error message" do

--- a/spec/requests/api/v1/organisations_spec.rb
+++ b/spec/requests/api/v1/organisations_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe "RDV API" do
 
       expect(created_organisation.external_references.first).to have_attributes(
         oauth_application_id: application.id,
-        territory: created_organisation.territory,
         external_id: "123"
       )
     end

--- a/spec/requests/api/v1/plage_ouvertures_spec.rb
+++ b/spec/requests/api/v1/plage_ouvertures_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe "Plage ouvertures API" do
   let!(:motif) { create(:motif, organisation:) }
   let!(:lieu) { create(:lieu, organisation:) }
   let!(:motif_external_reference) do
-    create(:external_reference, item: motif, external_id: 123, oauth_application: application, territory_id: nil)
+    create(:external_reference, item: motif, external_id: 123, oauth_application: application)
   end
-  let!(:lieu_external_reference) { create(:external_reference, item: lieu, external_id: 456, oauth_application: application, territory_id: nil) }
+  let!(:lieu_external_reference) { create(:external_reference, item: lieu, external_id: 456, oauth_application: application) }
 
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
 

--- a/spec/requests/api/v1/swagger_doc/lieux_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/lieux_request_spec.rb
@@ -70,9 +70,7 @@ RSpec.describe "API des lieux", swagger_doc: "v1/api.json" do
             address:, name:, latitude:, longitude:, organisation_id:, phone_number:
           )
 
-          expect(Lieu.last.external_references.last).to have_attributes(
-            external_id: "123ABC", territory_id: organisation.territory_id
-          )
+          expect(Lieu.last.external_references.last).to have_attributes(external_id: "123ABC")
         end
       end
     end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe "/api/v1/users" do
         expect(references.last).to have_attributes(
           external_id: "123456",
           external_url: "monsuivisocial.anct.gouv.fr/users/123456",
-          territory_id: my_organisation.territory.id,
           oauth_application_id: oauth_token.application_id
         )
       end
@@ -104,7 +103,6 @@ RSpec.describe "/api/v1/users" do
             item: create(:user),
             external_id: "123456",
             external_url: "monsuivisocial.anct.gouv.fr/users/123456",
-            territory_id: my_organisation.territory.id,
             oauth_application_id: oauth_token.application_id
           )
         end


### PR DESCRIPTION
Comme vu avec françois, on s'est rendu compte que cette colonne n'était pas vraiment utile. Le scope par application externe est suffisant pour les contraintes d'unicité qu'on souhaite. Pas besoin de compliquer les choses plus que ça.