### PR TITLE
Utilisation des notification emails dans la migration des conums

### DIFF
--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -161,6 +161,7 @@ class InstanceExport < ApplicationRecord
       user = User.find(user_id)
 
       request_body = user.attributes.symbolize_keys.slice(*UserBlueprint.reflections[:default].fields.keys - %i[id responsible_id])
+      request_body[:notification_email] ||= request_body.delete(:email) # Les users n'auront pas de mot de passe devise sur la nouvelle instance, donc il faut uniquement utiliser le notification_email
       request_body[:organisation_ids] = [instance_export.destination_organisation_id]
 
       request_body[:external_reference] = {

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -119,6 +119,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
       email: "contact@exemple.montreuil.fr"
     )
 
+    expect(created_organisation.users.last.notification_email).to be_present
+
     expect(created_organisation.agents.count).to eq 2
     expect(created_organisation.lieux.last).to have_attributes(name: lieu.name)
     expect(created_organisation.lieux.last.external_references.last).to have_attributes(external_id: lieu.id.to_s)


### PR DESCRIPTION
Autre amélioration vue avec François : vu que les usagers n'auront pas encore de login devise sur la nouvelle instance, et pour éviter les problèmes d'unicité de l'email, on utilise le champs notification_email pour migrer les usagers.