### PR TITLE
Activation du champs contexte pour les créations de territoires des conums

### DIFF
--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -18,6 +18,11 @@ class Api::V1::OrganisationsController < Api::V1::AgentAuthBaseController
     ActiveRecord::Base.transaction do
       @organisation = Organisation.new(organisation_params)
       @organisation.territory = Territory.create!
+
+      if doorkeeper_token&.application&.name == "RDV Aide Numérique"
+        # Pour garder le même fonctionnement que sur le territoire historique des cnfs, on active ce champs dans la config
+        @organisation.territory.update!(enable_context_field: true)
+      end
       @organisation.save!
 
       AgentRole.create!(agent: current_agent, access_level: :admin, organisation: @organisation)

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -117,6 +117,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     created_organisation = Organisation.last
     expect(created_organisation.external_references.last.external_id).to eq organisation_rdv_aide_num.id.to_s
 
+    expect(created_organisation.territory.enable_context_field).to be true
+
     expect(created_organisation).to have_attributes(
       name: "France Service de Montreuil",
       phone_number: "01 22 33 44 55",


### PR DESCRIPTION
Un des retour de beta test qu'on a eu avec la migration des conums, c'est qu'ils demandaient comment retrouver le champs contexte auquel ils sont habitués sur RDV Aide Numérique.
On leur permet donc de garder ce fonctionnement on configurant le territoire qui est créé lors de la migration