### PR TITLE
Rendre les liens vers les détails des rdvs collectifs plus explicites

### DIFF
--- a/app/views/admin/rdvs_collectifs/_rdv.html.slim
+++ b/app/views/admin/rdvs_collectifs/_rdv.html.slim
@@ -1,9 +1,7 @@
 .card
   .card-header.d-flex.justify-content-between.align-items-center
-    div
-      = link_to admin_organisation_rdv_path(rdv.organisation, rdv) do
-        h5= rdv_title_for_agent(rdv)
-      |&nbsp;
+    .d-flex.flex-column
+      = link_to rdv_title_for_agent(rdv), admin_organisation_rdv_path(rdv.organisation, rdv)
       = I18n.l(rdv.starts_at, format: "%A %-d %B à %H:%M").capitalize
     - if current_agent.admin_in_organisation?(current_organisation)
       div


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="448" height="716" alt="Screenshot 2025-09-17 at 08 21 18" src="https://github.com/user-attachments/assets/c760e314-920a-4f6f-bddb-98363e4fdf50" />|<img width="468" height="713" alt="Screenshot 2025-09-17 at 08 18 47" src="https://github.com/user-attachments/assets/8c33c243-12d2-4e7e-b491-007007f353cf" />


Hier en discutant du produit avec Mehdi, on s'est rendu compte qu'il ne savait pas que les liens vers les détails des rendez-vous étaient cliquables et c'est normal, vu qu'ils n'ont plus une apparence de lien.
Je pense que ça a été cassé pendant le passage au dsfr côté agent.

Il y aurait beaucoup d'autres choses à faire sur cette page (et ce correctif minimaliste n'est pas top en terme d'accessibilité), mais on se limite à ce petit correctif évident pour pas ouvrir un nouveau chantier tout de suite.