### PR TITLE
Afficher la date de demande d'ouverture de compte

### DIFF
--- a/app/views/super_admins/territory_creation_requests/edit.html.slim
+++ b/app/views/super_admins/territory_creation_requests/edit.html.slim
@@ -19,6 +19,9 @@ section.main-content__body
       = " "
       = mail_to(@territory_creation_request.agent.email)
 
+    dt.attribute-label.attribute-label--normal-case Le
+    dd.attribute-data = "#{l(@territory_creation_request.created_at, format: :human)} (il y a #{time_ago_in_words(@territory_creation_request.created_at)})"
+
     - siret = @territory_creation_request.agent.proconnect_siret
     - if siret
       dt.attribute-label SIRET

--- a/app/views/super_admins/territory_creation_requests/edit.html.slim
+++ b/app/views/super_admins/territory_creation_requests/edit.html.slim
@@ -19,7 +19,7 @@ section.main-content__body
       = " "
       = mail_to(@territory_creation_request.agent.email)
 
-    dt.attribute-label.attribute-label--normal-case Le
+    dt.attribute-label.attribute-label--normal-case Envoyé le
     dd.attribute-data = "#{l(@territory_creation_request.created_at, format: :human)} (il y a #{time_ago_in_words(@territory_creation_request.created_at)})"
 
     - siret = @territory_creation_request.agent.proconnect_siret

--- a/app/views/super_admins/territory_creation_requests/index.html.slim
+++ b/app/views/super_admins/territory_creation_requests/index.html.slim
@@ -22,8 +22,6 @@ section.main-content__body.main-content__body--flush
         = link_to(edit_super_admins_territory_creation_request_path(request.id))
           = request.territory_name || request.organisation_name
       p
-        = "demandé par #{request.agent.full_name}"
+        = "demandé par #{request.agent.full_name} (#{request.agent.email})"
         br
         = "le #{l(request.created_at, format: :human)} (il y a #{time_ago_in_words(request.created_at)})"
-        br
-        = request.agent.email

--- a/app/views/super_admins/territory_creation_requests/index.html.slim
+++ b/app/views/super_admins/territory_creation_requests/index.html.slim
@@ -18,10 +18,10 @@ section.main-content__body.main-content__body--flush
     - if @territory_creation_requests.empty?
       p Il n'y a aucune demande avec ce statut
     - @territory_creation_requests.each do |request|
-        h3
-          = link_to(edit_super_admins_territory_creation_request_path(request.id))
-            = request.territory_name || request.organisation_name
-        p
-          = "demandé par #{request.agent.full_name}"
-          br
-          = request.agent.email
+      h3
+        = link_to(edit_super_admins_territory_creation_request_path(request.id))
+          = request.territory_name || request.organisation_name
+      p
+        = "demandé par #{request.agent.full_name}"
+        br
+        = request.agent.email

--- a/app/views/super_admins/territory_creation_requests/index.html.slim
+++ b/app/views/super_admins/territory_creation_requests/index.html.slim
@@ -24,4 +24,6 @@ section.main-content__body.main-content__body--flush
       p
         = "demandé par #{request.agent.full_name}"
         br
+        = "le #{l(request.created_at, format: :human)} (il y a #{time_ago_in_words(request.created_at)})"
+        br
         = request.agent.email


### PR DESCRIPTION
J'ai utilisé la feature de confirmation d'ouverture de compte (dans le cadre du bug bounty) et j'ai cherché la date de création de la demande mais je ne l'ai pas trouvé, donc je l'ajoute ici.

# Screenshots (merci l'autodoc :star_struck:  )

Avant | Après
:- | -:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/addfb16a-c656-4100-9cbf-483ac5ce2779" /> | <img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/5a28510a-9e5f-4084-83cd-512da96a5953" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/2db61328-7558-4a57-9be9-a56b81725c3d" /> |<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/5cc30d96-b4db-4d0a-b8c4-9e50e8344c4b" />

