### PR TITLE
Ajout des plages d'ouvertures à la migration pour les conums

### DIFF
--- a/app/controllers/api/v1/plage_ouvertures_controller.rb
+++ b/app/controllers/api/v1/plage_ouvertures_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
       plage_ouverture.lieu_id = external_reference_scope.find_by(item_type: "Lieu", external_id: params[:lieu_external_id])&.item_id
 
       if plage_ouverture.lieu_id.nil?
-        render status: :not_found, json: { error_messages: ["Aucun lieu trouvé pour le lieux_external_id #{params[:lieu_external_id]}"] }
+        render status: :not_found, json: { error_messages: ["Aucun lieu trouvé pour le lieu_external_id #{params[:lieu_external_id]}"] }
         return
       end
     end

--- a/app/controllers/api/v1/plage_ouvertures_controller.rb
+++ b/app/controllers/api/v1/plage_ouvertures_controller.rb
@@ -1,0 +1,65 @@
+class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
+  def create
+    plage_ouverture = PlageOuverture.new(create_params)
+
+    # On ne documente pas encore la possibilité d'utiliser le param recurrence, puisqu'on s'en sert uniquement
+    # pour la migration des Conseillers Numériques, et que l'api actuelle permettrait de créer des absences qu'on
+    # ne saurait pas gérer sur l'interface web avec le formulaire actuel.
+    if params[:recurrence].present?
+      plage_ouverture.recurrence = Montrose::Recurrence.load(params[:recurrence])
+    end
+
+    if params[:lieu_external_id].present?
+      plage_ouverture.lieu_id = external_reference_scope.find_by(item_type: "Lieu", external_id: params[:lieu_external_id])&.item_id
+    end
+
+    if params[:motif_external_ids].present?
+      plage_ouverture.motif_ids = external_reference_scope.where(item_type: "Motif", external_id: params[:motif_external_ids]).pluck(:item_id)
+    end
+
+    authorize(plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
+    plage_ouverture.transaction do
+      plage_ouverture.save!
+
+      if params[:external_reference].present?
+        ExternalReference.create!(
+          params.require(:external_reference).permit(:external_id, :external_url).merge(
+            item: plage_ouverture,
+            oauth_application: doorkeeper_token&.application
+          )
+        )
+      end
+    end
+
+    if plage_ouverture.persisted?
+      render json: PlageOuvertureBlueprint.render(lieu)
+    else
+      render status: :unprocessable_entity, json: { error_messages: plage_ouverture.errors.full_messages }
+    end
+  rescue ActiveRecord::RecordNotFound
+    render_error :not_found, not_found: :agent
+  end
+
+  private
+
+  def create_params
+    # Allow creating an plage_ouverture for an agent identified by their email.
+    if params[:agent_id].blank? && params[:agent_email].present?
+      agent = Agent.find_by!(email: params[:agent_email])
+      render_error :not_found, not_found: :agent unless agent
+      params[:agent_id] = agent.id
+      params.delete(:agent_email)
+    end
+
+    params[:agent_id] ||= current_agent.id
+
+    params.permit(:agent_id, :title, :first_day, :start_time, :end_day, :end_time, :lieu_id)
+  end
+
+  def external_reference_scope
+    @external_reference_scope ||= Agent::ExternalReferencePolicy::Scope.new(
+      current_agent,
+      ExternalReference.where(oauth_application_id: doorkeeper_token.application_id)
+    ).resolve
+  end
+end

--- a/app/controllers/api/v1/plage_ouvertures_controller.rb
+++ b/app/controllers/api/v1/plage_ouvertures_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
-  def create
+  def create # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     plage_ouverture = PlageOuverture.new(create_params)
 
     # On ne documente pas encore la possibilité d'utiliser le param recurrence, puisqu'on s'en sert uniquement
@@ -32,7 +32,7 @@ class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
     end
 
     if plage_ouverture.persisted?
-      render json: PlageOuvertureBlueprint.render(lieu)
+      render json: PlageOuvertureBlueprint.render(plage_ouverture)
     else
       render status: :unprocessable_entity, json: { error_messages: plage_ouverture.errors.full_messages }
     end
@@ -53,7 +53,7 @@ class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
 
     params[:agent_id] ||= current_agent.id
 
-    params.permit(:agent_id, :title, :first_day, :start_time, :end_day, :end_time, :lieu_id)
+    params.permit(:agent_id, :title, :first_day, :start_time, :end_day, :end_time, :organisation_id)
   end
 
   def external_reference_scope

--- a/app/controllers/api/v1/plage_ouvertures_controller.rb
+++ b/app/controllers/api/v1/plage_ouvertures_controller.rb
@@ -11,6 +11,11 @@ class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
 
     if params[:lieu_external_id].present?
       plage_ouverture.lieu_id = external_reference_scope.find_by(item_type: "Lieu", external_id: params[:lieu_external_id])&.item_id
+
+      if plage_ouverture.lieu_id.nil?
+        render status: :not_found, json: { error_messages: ["Aucun lieu trouvé pour le lieux_external_id #{params[:lieu_external_id]}"] }
+        return
+      end
     end
 
     if params[:motif_external_ids].present?

--- a/app/controllers/api/v1/plage_ouvertures_controller.rb
+++ b/app/controllers/api/v1/plage_ouvertures_controller.rb
@@ -20,6 +20,12 @@ class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
 
     if params[:motif_external_ids].present?
       plage_ouverture.motif_ids = external_reference_scope.where(item_type: "Motif", external_id: params[:motif_external_ids]).pluck(:item_id)
+
+      if plage_ouverture.motif_ids.count != params[:motif_external_ids].count
+        render status: :not_found, json: { error_messages: ["Certains motifs n'ont pas été trouvés pour les motif_external_ids #{params[:motif_external_ids].join(', ')}"] }
+        return
+      end
+
     end
 
     authorize(plage_ouverture, policy_class: Agent::PlageOuverturePolicy)

--- a/app/controllers/api/v1/plage_ouvertures_controller.rb
+++ b/app/controllers/api/v1/plage_ouvertures_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
     end
 
     if params[:lieu_external_id].present?
-      plage_ouverture.lieu_id = external_reference_scope.find_by(item_type: "Lieu", external_id: params[:lieu_external_id])&.item_id
+      plage_ouverture.lieu_id = ExternalReference.find_by(item_type: "Lieu", external_id: params[:lieu_external_id])&.item_id
 
       if plage_ouverture.lieu_id.nil?
         render status: :not_found, json: { error_messages: ["Aucun lieu trouvé pour le lieu_external_id #{params[:lieu_external_id]}"] }
@@ -19,7 +19,7 @@ class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
     end
 
     if params[:motif_external_ids].present?
-      plage_ouverture.motif_ids = external_reference_scope.where(item_type: "Motif", external_id: params[:motif_external_ids]).pluck(:item_id)
+      plage_ouverture.motif_ids = ExternalReference.where(item_type: "Motif", external_id: params[:motif_external_ids]).pluck(:item_id)
 
       if plage_ouverture.motif_ids.count != params[:motif_external_ids].count
         render status: :not_found, json: { error_messages: ["Certains motifs n'ont pas été trouvés pour les motif_external_ids #{params[:motif_external_ids].join(', ')}"] }
@@ -65,12 +65,5 @@ class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
     params[:agent_id] ||= current_agent.id
 
     params.permit(:agent_id, :title, :first_day, :start_time, :end_day, :end_time, :organisation_id)
-  end
-
-  def external_reference_scope
-    @external_reference_scope ||= Agent::ExternalReferencePolicy::Scope.new(
-      current_agent,
-      ExternalReference.where(oauth_application_id: doorkeeper_token.application_id)
-    ).resolve
   end
 end

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -1,4 +1,7 @@
 class CopyPlanningToNewInstanceJob < ApplicationJob
+  # Les objets qu'on copie dans ce job (rdvs, plage ouverture, absence) ont besoin que les objets
+  # de configuration (agents, motifs, lieux) soient déjà créés dans la nouvelle organisation.
+  # On les copie donc dans ce deuxième batch, après que le premier ai copié tous les objets de config.
   def perform(batch, _context)
     instance_export = InstanceExport.find(batch.properties[:instance_export_id])
     current_domain_id = batch.properties[:current_domain_id]

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -6,19 +6,25 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
     source_organisation = instance_export.source_organisation
 
     instance_export.transaction do
-      source_organisation.rdvs.future.not_cancelled.pluck(:id).each do |rdv_id|
-        CopyRdvAsAbsenceJob.perform_later(instance_export.id, rdv_id, current_domain_id)
+      batch = GoodJob::Batch.new(instance_export_id: instance_export.id)
+
+      batch.enqueue do
+        source_organisation.rdvs.future.not_cancelled.pluck(:id).each do |rdv_id|
+          CopyRdvAsAbsenceJob.perform_later(instance_export.id, rdv_id, current_domain_id)
+        end
+
+        organisation_absences = Absence.where(agent_id: source_organisation.agents.select(:agent_id)).not_expired
+
+        organisation_absences.pluck(:id).each do |absence_id|
+          CopyAbsenceJob.perform_later(instance_export.id, absence_id, current_domain_id)
+        end
+
+        source_organisation.plage_ouvertures.not_expired.pluck(:id).each do |plage_ouverture_id|
+          CopyPlageOuvertureJob.perform_later(instance_export.id, plage_ouverture_id)
+        end
       end
 
-      organisation_absences = Absence.where(agent_id: source_organisation.agents.select(:agent_id)).not_expired
-
-      organisation_absences.pluck(:id).each do |absence_id|
-        CopyAbsenceJob.perform_later(instance_export.id, absence_id, current_domain_id)
-      end
-
-      source_organisation.plage_ouvertures.not_expired.pluck(:id).each do |plage_ouverture_id|
-        CopyPlageOuvertureJob.perform_later(instance_export.id, plage_ouverture_id)
-      end
+      instance_export.update(good_job_batch_id: batch.id)
     end
   end
 

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -1,0 +1,117 @@
+class CopyPlanningToNewInstanceJob < ApplicationJob
+  def perform(batch, _context)
+    instance_export = InstanceExport.find(batch.properties[:instance_export_id])
+    current_domain_id = batch.properties[:current_domain_id]
+
+    source_organisation = instance_export.source_organisation
+
+    instance_export.transaction do
+      source_organisation.rdvs.future.not_cancelled.pluck(:id).each do |rdv_id|
+        CopyRdvAsAbsenceJob.perform_later(instance_export.id, rdv_id, current_domain_id)
+      end
+
+      organisation_absences = Absence.where(agent_id: source_organisation.agents.select(:agent_id)).not_expired
+
+      organisation_absences.pluck(:id).each do |absence_id|
+        CopyAbsenceJob.perform_later(instance_export.id, absence_id, current_domain_id)
+      end
+
+      source_organisation.plage_ouvertures.not_expired.pluck(:id).each do |plage_ouverture_id|
+        CopyPlageOuvertureJob.perform_later(instance_export.id, plage_ouverture_id)
+      end
+    end
+  end
+
+  class CopyRdvAsAbsenceJob < ApplicationJob
+    queue_as :latency_5m
+
+    def perform(instance_export_id, rdv_id, domain_id)
+      domain = Domain.find(domain_id)
+      instance_export = InstanceExport.find(instance_export_id)
+      rdv = Rdv.find(rdv_id)
+      rdv.agents.each do |agent|
+        params = {
+          title: "RDV pris sur #{domain.name}",
+          first_day: rdv.starts_at.strftime("%Y-%m-%d"),
+          end_day: rdv.starts_at.strftime("%Y-%m-%d"),
+          start_time: rdv.starts_at.strftime("%H:%M"),
+          end_time: rdv.ends_at.strftime("%H:%M"),
+          external_reference: {
+            external_id: "rdv:#{rdv_id}", # on créera aussi des external_reference pour des absences, donc on préfixe par "rdv"
+            external_url: Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
+          },
+        }
+
+        if agent != instance_export.agent
+          params[:agent_email] = agent.email
+        end
+        api_client = instance_export.api_client
+        api_client.post("absences", params)
+      end
+    end
+  end
+
+  class CopyAbsenceJob < ApplicationJob
+    queue_as :latency_5m
+
+    def perform(instance_export_id, absence_id, domain_id)
+      domain = Domain.find(domain_id)
+      absence = Absence.find(absence_id)
+      instance_export = InstanceExport.find(instance_export_id)
+
+      params = {
+        title: absence.title,
+        recurrence: Montrose::Recurrence.dump(absence.recurrence),
+        first_day: absence.first_day.strftime("%Y-%m-%d"),
+        end_day: absence.end_day.strftime("%Y-%m-%d"),
+        start_time: absence.start_time.strftime("%H:%M"),
+        end_time: absence.end_time.strftime("%H:%M"),
+
+        external_reference: {
+          external_id: "absence:#{absence_id}", # on préfixe par absence pour éviter la collision avec les rendez-vous
+          external_url: Rails.application.routes.url_helpers.edit_admin_organisation_planning_absence_url(
+            instance_export.source_organisation.id, absence.id, host: domain.host_name
+          ),
+        },
+      }
+
+      if absence.agent != instance_export.agent
+        params[:agent_email] = agent.email
+      end
+
+      api_client = instance_export.api_client
+      api_client.post("absences", params)
+    end
+  end
+
+  class CopyPlageOuvertureJob < ApplicationJob
+    queue_as :latency_5m
+
+    def perform(instance_export_id, plage_ouverture_id)
+      plage_ouverture = PlageOuverture.find(plage_ouverture_id)
+      instance_export = InstanceExport.find(instance_export_id)
+
+      params = {
+        title: plage_ouverture.title,
+        recurrence: Montrose::Recurrence.dump(plage_ouverture.recurrence),
+        first_day: plage_ouverture.first_day.strftime("%Y-%m-%d"),
+        start_time: plage_ouverture.start_time.strftime("%H:%M"),
+        end_time: plage_ouverture.end_time.strftime("%H:%M"),
+        lieu_external_id: plage_ouverture.lieu_id,
+        secondary_start_time: plage_ouverture.secondary_start_time&.strftime("%H:%M"),
+        secondary_end_time: plage_ouverture.secondary_end_time&.strftime("%H:%M"),
+        motif_external_ids: plage_ouverture.motif_ids,
+        organisation_id: instance_export.destination_organisation_id,
+
+        external_reference: { external_id: plage_ouverture_id },
+      }
+
+      if plage_ouverture.agent != instance_export.agent
+        params[:agent_email] = agent.email
+      end
+
+      api_client = instance_export.api_client
+      api_client.post("plage_ouvertures", params)
+    end
+  end
+end

--- a/app/lib/rdv_service_public_api_client.rb
+++ b/app/lib/rdv_service_public_api_client.rb
@@ -4,21 +4,28 @@ class RdvServicePublicApiClient
   end
 
   def post(path, params)
-    response = Faraday.post(
+    response = Typhoeus.post(
       "#{ENV['RDV_SERVICE_PUBLIC_OAUTH_BASE_URL']}/api/v1/#{path}",
-      params.to_json,
-      request_headers
+      body: params.to_json,
+      headers: request_headers
     )
+    if response.failure?
+      Sentry.capture_message("Erreur lors de l'appel à l'api de RDV Service Public")
+    end
 
     JSON.parse(response.body)
   end
 
   def get(path, params = {})
-    response = Faraday.get(
+    response = Typhoeus.get(
       "#{ENV['RDV_SERVICE_PUBLIC_OAUTH_BASE_URL']}/api/v1/#{path}",
-      params,
-      request_headers
+      params:,
+      headers: request_headers
     )
+
+    if response.failure?
+      Sentry.capture_message("Erreur lors de l'appel à l'api de RDV Service Public")
+    end
 
     JSON.parse(response.body)
   end

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -56,7 +56,6 @@ class InstanceExport < ApplicationRecord
           CopyMotifJob.perform_later(id, motif_id)
         end
       end
-      update(good_job_batch_id: batch.id)
     end
   end
 

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -34,6 +34,7 @@ class InstanceExport < ApplicationRecord
   def copy_to_new_instance!(current_domain)
     batch = GoodJob::Batch.new(instance_export_id: id)
 
+    # batch.on_success = "MyBatchCallbackJob" TODO: séparer en deux batches les créations
     transaction do
       batch.add do
         source_organisation.users.pluck(:id).each do |user_id|

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -2,6 +2,7 @@ class InstanceExport < ApplicationRecord
   belongs_to :agent
   belongs_to :good_job_batch, class_name: "GoodJob::BatchRecord", optional: true
   belongs_to :source_organisation, optional: true, class_name: "Organisation"
+  belongs_to :copy_planning_batch, class_name: "GoodJob::BatchRecord", optional: true
 
   encrypts :api_token
   encrypts :refresh_token
@@ -34,9 +35,11 @@ class InstanceExport < ApplicationRecord
   def copy_to_new_instance!(current_domain)
     batch = GoodJob::Batch.new(instance_export_id: id)
 
-    # batch.on_success = "MyBatchCallbackJob" TODO: séparer en deux batches les créations
+    batch.properties = { instance_export_id: id, current_domain_id: current_domain.id }
+    batch.on_success = "CopyPlanningToNewInstanceJob"
+
     transaction do
-      batch.add do
+      batch.enqueue do
         source_organisation.users.pluck(:id).each do |user_id|
           CopyUserJob.perform_later(id, user_id, current_domain.id)
         end
@@ -52,115 +55,8 @@ class InstanceExport < ApplicationRecord
         source_organisation.motifs.active.pluck(:id).each do |motif_id|
           CopyMotifJob.perform_later(id, motif_id)
         end
-
-        source_organisation.rdvs.future.not_cancelled.pluck(:id).each do |rdv_id|
-          CopyRdvAsAbsenceJob.perform_later(id, rdv_id, current_domain.id)
-        end
-
-        organisation_absences = Absence.where(agent_id: source_organisation.agents.select(:agent_id)).not_expired
-
-        organisation_absences.pluck(:id).each do |absence_id|
-          CopyAbsenceJob.perform_later(id, absence_id, current_domain.id)
-        end
-
-        source_organisation.plage_ouvertures.not_expired.pluck(:id).each do |plage_ouverture_id|
-          CopyPlageOuvertureJob.perform_later(id, plage_ouverture_id)
-        end
       end
       update(good_job_batch_id: batch.id)
-    end
-  end
-
-  class CopyRdvAsAbsenceJob < ApplicationJob
-    queue_as :latency_5m
-
-    def perform(instance_export_id, rdv_id, domain_id)
-      domain = Domain.find(domain_id)
-      instance_export = InstanceExport.find(instance_export_id)
-      rdv = Rdv.find(rdv_id)
-      rdv.agents.each do |agent|
-        params = {
-          title: "RDV pris sur #{domain.name}",
-          first_day: rdv.starts_at.strftime("%Y-%m-%d"),
-          end_day: rdv.starts_at.strftime("%Y-%m-%d"),
-          start_time: rdv.starts_at.strftime("%H:%M"),
-          end_time: rdv.ends_at.strftime("%H:%M"),
-          external_reference: {
-            external_id: "rdv:#{rdv_id}", # on créera aussi des external_reference pour des absences, donc on préfixe par "rdv"
-            external_url: Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
-          },
-        }
-
-        if agent != instance_export.agent
-          params[:agent_email] = agent.email
-        end
-        api_client = instance_export.api_client
-        api_client.post("absences", params)
-      end
-    end
-  end
-
-  class CopyAbsenceJob < ApplicationJob
-    queue_as :latency_5m
-
-    def perform(instance_export_id, absence_id, domain_id)
-      domain = Domain.find(domain_id)
-      absence = Absence.find(absence_id)
-      instance_export = InstanceExport.find(instance_export_id)
-
-      params = {
-        title: absence.title,
-        recurrence: Montrose::Recurrence.dump(absence.recurrence),
-        first_day: absence.first_day.strftime("%Y-%m-%d"),
-        end_day: absence.end_day.strftime("%Y-%m-%d"),
-        start_time: absence.start_time.strftime("%H:%M"),
-        end_time: absence.end_time.strftime("%H:%M"),
-
-        external_reference: {
-          external_id: "absence:#{absence_id}", # on préfixe par absence pour éviter la collision avec les rendez-vous
-          external_url: Rails.application.routes.url_helpers.edit_admin_organisation_planning_absence_url(
-            instance_export.source_organisation.id, absence.id, host: domain.host_name
-          ),
-        },
-      }
-
-      if absence.agent != instance_export.agent
-        params[:agent_email] = agent.email
-      end
-
-      api_client = instance_export.api_client
-      api_client.post("absences", params)
-    end
-  end
-
-  class CopyPlageOuvertureJob < ApplicationJob
-    queue_as :latency_5m
-
-    def perform(instance_export_id, plage_ouverture_id)
-      plage_ouverture = PlageOuverture.find(plage_ouverture_id)
-      instance_export = InstanceExport.find(instance_export_id)
-
-      params = {
-        title: plage_ouverture.title,
-        recurrence: Montrose::Recurrence.dump(plage_ouverture.recurrence),
-        first_day: plage_ouverture.first_day.strftime("%Y-%m-%d"),
-        start_time: plage_ouverture.start_time.strftime("%H:%M"),
-        end_time: plage_ouverture.end_time.strftime("%H:%M"),
-        lieu_external_id: plage_ouverture.lieu_id,
-        secondary_start_time: plage_ouverture.secondary_start_time&.strftime("%H:%M"),
-        secondary_end_time: plage_ouverture.secondary_end_time&.strftime("%H:%M"),
-        motif_external_ids: plage_ouverture.motif_ids,
-        organisation_id: instance_export.destination_organisation_id,
-
-        external_reference: { external_id: plage_ouverture_id },
-      }
-
-      if plage_ouverture.agent != instance_export.agent
-        params[:agent_email] = agent.email
-      end
-
-      api_client = instance_export.api_client
-      api_client.post("plage_ouvertures", params)
     end
   end
 

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -61,6 +61,10 @@ class InstanceExport < ApplicationRecord
         organisation_absences.pluck(:id).each do |absence_id|
           CopyAbsenceJob.perform_later(id, absence_id, current_domain.id)
         end
+
+        source_organisation.plage_ouvertures.not_expired.pluck(:id).each do |plage_ouverture_id|
+          CopyPlageOuvertureJob.perform_later(id, plage_ouverture_id)
+        end
       end
       update(good_job_batch_id: batch.id)
     end
@@ -125,6 +129,37 @@ class InstanceExport < ApplicationRecord
 
       api_client = instance_export.api_client
       api_client.post("absences", params)
+    end
+  end
+
+  class CopyPlageOuvertureJob < ApplicationJob
+    queue_as :latency_5m
+
+    def perform(instance_export_id, plage_ouverture_id)
+      plage_ouverture = PlageOuverture.find(plage_ouverture_id)
+      instance_export = InstanceExport.find(instance_export_id)
+
+      params = {
+        title: plage_ouverture.title,
+        recurrence: Montrose::Recurrence.dump(plage_ouverture.recurrence),
+        first_day: plage_ouverture.first_day.strftime("%Y-%m-%d"),
+        start_time: plage_ouverture.start_time.strftime("%H:%M"),
+        end_time: plage_ouverture.end_time.strftime("%H:%M"),
+        lieu_external_id: plage_ouverture.lieu_id,
+        secondary_start_time: plage_ouverture.secondary_start_time&.strftime("%H:%M"),
+        secondary_end_time: plage_ouverture.secondary_end_time&.strftime("%H:%M"),
+        motif_external_ids: plage_ouverture.motif_ids,
+        organisation_id: instance_export.destination_organisation_id,
+
+        external_reference: { external_id: plage_ouverture_id },
+      }
+
+      if plage_ouverture.agent != instance_export.agent
+        params[:agent_email] = agent.email
+      end
+
+      api_client = instance_export.api_client
+      api_client.post("plage_ouvertures", params)
     end
   end
 

--- a/app/views/admin/instance_exports/show.html.slim
+++ b/app/views/admin/instance_exports/show.html.slim
@@ -3,10 +3,9 @@
 .card
   .card-body
     .rdv-text-align-center
-      - if @instance_export.good_job_batch
-        - if @instance_export.good_job_batch.jobs.where(finished_at: nil).none?
-          p Migration terminée !
+      - if @instance_export.good_job_batch && @instance_export.good_job_batch.jobs.where(finished_at: nil).none?
+        p Migration terminée !
 
-          = link_to  "Ouvrir RDV Service Public", ENV["RDV_SERVICE_PUBLIC_OAUTH_BASE_URL"], class: "fr-btn fr-btn--secondary"
-        - else
-          p Migration en cours. Rechargez cette page dans quelques instants.
+        = link_to  "Ouvrir RDV Service Public", ENV["RDV_SERVICE_PUBLIC_OAUTH_BASE_URL"], class: "fr-btn fr-btn--secondary"
+      - else
+        p Migration en cours. Rechargez cette page dans quelques instants.

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -3,6 +3,7 @@ namespace :api do
     # Need agent authentication to
     mount_devise_token_auth_for "AgentWithTokenAuth", at: "auth"
     resources :absences, except: %i[new edit]
+    resources :plage_ouvertures, only: %i[create]
     resources :agents, only: %i[index create]
     resources :lieux, only: %i[create]
     get "agents/me", to: "agents#me"

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -25,6 +25,10 @@ FactoryBot.define do
       recurrence { Montrose.every(:week, on: [:monday], starts: first_day, interval: 1) }
     end
 
+    trait :weekly_on_monday_until_next_month do
+      recurrence { Montrose.every(:week, on: [:monday], starts: first_day, interval: 1, until: 1.month.from_now) }
+    end
+
     trait :once_a_week do
       recurrence { Montrose.every(:week, starts: first_day, interval: 1, until: 2.months.from_now) }
     end

--- a/spec/features/agents/instance_export_spec.rb
+++ b/spec/features/agents/instance_export_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", js: true do
+  around { |example| perform_enqueued_jobs { example.run } }
+
   context "quand l'agent a deux organisations sur RDV SP" do
     let(:organisation_rdv_aide_num) { create(:organisation, name: "France Service de Montreuil") }
     let!(:agent_rdv_aide_num) do

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   let!(:absence) { create(:absence, :no_recurrence, agent: agent_rdv_aide_num) }
   let!(:recurrent_absence) { create(:absence, :weekly_on_monday, agent: agent_rdv_aide_num) }
   let!(:recurrent_absence_with_end_date) { create(:absence, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num) }
+  let!(:plage_ouverture) { create(:plage_ouverture, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num) }
 
   let!(:agent_rdv_sp) do
     create(:agent, first_name: "Camille", last_name: "Clavier", password: "c0rrecThorse!", admin_role_in_organisations: [])
@@ -147,7 +148,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     expect(Montrose::Recurrence.dump(new_absence_with_end_date.recurrence)).to eq Montrose::Recurrence.dump(recurrent_absence_with_end_date.recurrence)
     expect(new_absence_with_end_date.recurrence_ends_at).to eq recurrent_absence_with_end_date.recurrence_ends_at
 
-    agent_rdv_sp.absences.regulieres.where.not(recurrence_ends_at: nil).first
+    new_plage_ouverture = agent_rdv_sp.plage_ouvertures.last
+    expect(Montrose::Recurrence.dump(new_plage_ouverture.recurrence)).to eq Montrose::Recurrence.dump(plage_ouverture.recurrence)
 
     login_as(agent_rdv_sp, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   let!(:absence) { create(:absence, :no_recurrence, agent: agent_rdv_aide_num) }
   let!(:recurrent_absence) { create(:absence, :weekly_on_monday, agent: agent_rdv_aide_num) }
   let!(:recurrent_absence_with_end_date) { create(:absence, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num) }
-  let!(:plage_ouverture) { create(:plage_ouverture, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num, organisation: organisation_rdv_aide_num) }
+  let!(:plage_ouverture) do
+    create(:plage_ouverture, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num, organisation: organisation_rdv_aide_num, lieu: lieu)
+  end
 
   let!(:agent_rdv_sp) do
     create(:agent, first_name: "Camille", last_name: "Clavier", password: "c0rrecThorse!", admin_role_in_organisations: [])

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   let!(:absence) { create(:absence, :no_recurrence, agent: agent_rdv_aide_num) }
   let!(:recurrent_absence) { create(:absence, :weekly_on_monday, agent: agent_rdv_aide_num) }
   let!(:recurrent_absence_with_end_date) { create(:absence, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num) }
-  let!(:plage_ouverture) { create(:plage_ouverture, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num) }
+  let!(:plage_ouverture) { create(:plage_ouverture, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num, organisation: organisation_rdv_aide_num) }
 
   let!(:agent_rdv_sp) do
     create(:agent, first_name: "Camille", last_name: "Clavier", password: "c0rrecThorse!", admin_role_in_organisations: [])

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   let!(:recurrent_absence) { create(:absence, :weekly_on_monday, agent: agent_rdv_aide_num) }
   let!(:recurrent_absence_with_end_date) { create(:absence, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num) }
   let!(:plage_ouverture) do
-    create(:plage_ouverture, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num, organisation: organisation_rdv_aide_num, lieu: lieu)
+    create(:plage_ouverture, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num, organisation: organisation_rdv_aide_num, lieu: lieu, motifs: [motif])
   end
 
   let!(:agent_rdv_sp) do
@@ -132,8 +132,13 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     expect(created_organisation.users.last.notification_email).to be_present
 
     expect(created_organisation.agents.count).to eq 2
-    expect(created_organisation.lieux.last).to have_attributes(name: lieu.name)
-    expect(created_organisation.lieux.last.external_references.last).to have_attributes(external_id: lieu.id.to_s)
+
+    created_lieu = created_organisation.lieux.sole
+    expect(created_lieu).to have_attributes(name: lieu.name)
+    expect(created_lieu.external_references.last).to have_attributes(external_id: lieu.id.to_s)
+
+    created_motif = created_organisation.motifs.sole
+    expect(created_motif).to have_attributes(name: motif.name)
 
     # On crée des absences qui permettent de retrouver les rendez-vous sur l'ancienne instance
     expect(collegue.absences.last.starts_at).to be_within(1.minute).of(future_rdv.starts_at)
@@ -152,6 +157,12 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
 
     new_plage_ouverture = agent_rdv_sp.plage_ouvertures.last
     expect(Montrose::Recurrence.dump(new_plage_ouverture.recurrence)).to eq Montrose::Recurrence.dump(plage_ouverture.recurrence)
+
+    # Les external_ids permettent de configurer les associations correctement
+    expect(new_plage_ouverture).to have_attributes(
+      lieu_id: created_lieu.id,
+      motif_ids: [created_motif.id]
+    )
 
     login_as(agent_rdv_sp, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"

--- a/spec/lib/rdv_service_public_api_client_spec.rb
+++ b/spec/lib/rdv_service_public_api_client_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe RdvServicePublicApiClient do
+  stub_env_with RDV_SERVICE_PUBLIC_OAUTH_BASE_URL: "http://rdv.localhost"
+
+  context "pour une requête qui échoue" do
+    before do
+      stub_request(:post, "http://rdv.localhost/api/v1/plage_ouvertures")
+        .to_return(
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+          body: { error_message: ["Aucun lieu trouvé pour le lieux_external_id 123456"] }.to_json
+        )
+    end
+
+    it "envoie un message dans Sentry avec des breadcrumbs qui indiquent les valeurs de l'appel HTTP" do
+      client = described_class.new("123456")
+      client.post("plage_ouvertures", { lieu_external_ids: "asdf" })
+
+      expect(sentry_events.last.message).to eq("Erreur lors de l'appel à l'api de RDV Service Public")
+      expect(sentry_events.last.breadcrumbs.first.data[:body]).to include("lieu_external_id")
+    end
+  end
+end

--- a/spec/lib/rdv_service_public_api_client_spec.rb
+++ b/spec/lib/rdv_service_public_api_client_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RdvServicePublicApiClient do
         .to_return(
           status: 404,
           headers: { "Content-Type": "application/json" },
-          body: { error_message: ["Aucun lieu trouvé pour le lieux_external_id 123456"] }.to_json
+          body: { error_message: ["Aucun lieu trouvé pour le lieu_external_id 123456"] }.to_json
         )
     end
 

--- a/spec/requests/api/v1/motifs_spec.rb
+++ b/spec/requests/api/v1/motifs_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Lieux API" do
+RSpec.describe "Motifs API" do
   let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
   let(:headers) do
     { "Content-Type": "application/json", Authorization: "Bearer #{oauth_token.plaintext_token}" }
@@ -49,7 +49,7 @@ RSpec.describe "Lieux API" do
       let!(:existing_motif) do
         create(:motif, organisation_id: organisation.id)
       end
-      let!(:external_refenrece) do
+      let!(:external_reference) do
         create(:external_reference, oauth_application: application, item: existing_motif, territory_id: organisation.territory_id, external_id: "123ABC")
       end
 

--- a/spec/requests/api/v1/plage_ouvertures_spec.rb
+++ b/spec/requests/api/v1/plage_ouvertures_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe "Plage ouvertures API" do
+  let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
+  let(:headers) do
+    { "Content-Type": "application/json", Authorization: "Bearer #{oauth_token.plaintext_token}" }
+  end
+  let(:application) { create(:oauth_application, default_service: create(:service)) }
+
+  let!(:organisation) { create(:organisation) }
+  let!(:motif) { create(:motif, organisation:) }
+  let!(:lieu) { create(:lieu, organisation:) }
+  let!(:motif_external_reference) do
+    create(:external_reference, item: motif, external_id: 123, oauth_application: application, territory_id: nil)
+  end
+  let!(:lieu_external_reference) { create(:external_reference, item: lieu, external_id: 456, oauth_application: application, territory_id: nil) }
+
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+  describe "#create" do
+    let(:params) do
+      {
+        title: "Dispo",
+        recurrence: nil,
+        first_day: Time.zone.today.strftime("%Y-%m-%d"),
+        start_time: "08:00",
+        end_time: "12:00",
+        lieu_external_id: lieu_external_reference.external_id,
+        motif_external_ids: [motif_external_reference.external_id],
+        organisation_id: organisation.id,
+
+        external_reference: { external_id: "789" },
+      }
+    end
+
+    it "creates the plage_ouverture" do
+      expect { post "/api/v1/plage_ouvertures", headers:, params:, as: :json }.to change(PlageOuverture, :count)
+
+      expect(response.status).to eq 200
+      expect(parsed_response_body["title"]).to eq "Dispo"
+
+      expect(PlageOuverture.last).to have_attributes(
+        title: "Dispo",
+        lieu_id: lieu.id,
+        motif_ids: [motif.id]
+      )
+    end
+
+    context "quand on ne trouve pas le lieu par l'external id" do
+      before do
+        params[:lieu_external_id] = "123456"
+      end
+
+      it "returns a 404 status" do
+        expect { post "/api/v1/plage_ouvertures", headers:, params:, as: :json }.not_to change(PlageOuverture, :count)
+
+        expect(response.status).to eq 404
+
+        expect(parsed_response_body["error_messages"].first).to eq "Aucun lieu trouvé pour le lieux_external_id 123456"
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/plage_ouvertures_spec.rb
+++ b/spec/requests/api/v1/plage_ouvertures_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Plage ouvertures API" do
 
         expect(response.status).to eq 404
 
-        expect(parsed_response_body["error_messages"].first).to eq "Aucun lieu trouvé pour le lieux_external_id 123456"
+        expect(parsed_response_body["error_messages"].first).to eq "Aucun lieu trouvé pour le lieu_external_id 123456"
       end
     end
 

--- a/spec/requests/api/v1/plage_ouvertures_spec.rb
+++ b/spec/requests/api/v1/plage_ouvertures_spec.rb
@@ -57,5 +57,19 @@ RSpec.describe "Plage ouvertures API" do
         expect(parsed_response_body["error_messages"].first).to eq "Aucun lieu trouvé pour le lieux_external_id 123456"
       end
     end
+
+    context "quand on ne trouve pas le motif par external id" do
+      before do
+        params[:motif_external_ids] = %w[123456 345678]
+      end
+
+      it "returns a 404 status" do
+        expect { post "/api/v1/plage_ouvertures", headers:, params:, as: :json }.not_to change(PlageOuverture, :count)
+
+        expect(response.status).to eq 404
+
+        expect(parsed_response_body["error_messages"].first).to eq "Certains motifs n'ont pas été trouvés pour les motif_external_ids 123456, 345678"
+      end
+    end
   end
 end


### PR DESCRIPTION
Suite (et bientôt fin ?) de https://github.com/betagouv/rdv-service-public/pull/5643

On ajoute la migration des plages d'ouverture, et c'est les dernières données qu'il nous reste à migrer.
La prochaine étape c'est de refaire une passe sur l'interface et permettre la "bascule" pour rediriger vers la nouvelle orga.
