### PR TITLE
Bugfix: Crash lors de l'update d'un espace dans le SuperAdmin

### DIFF
--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -60,6 +60,7 @@ class Territory < ApplicationRecord
 
   # Hooks
   before_create :fill_name_for_departements
+  before_save { self.departement_number ||= "" }
 
   # Scopes
   scope :with_upcoming_rdvs, lambda {


### PR DESCRIPTION
[LAPINS-35C](https://sentry.incubateur.net/organizations/betagouv/issues/201470/)

# Le problème 

On a toujours un crash quand on valide des modification d'un espace (territory) qui a le champ "Département" vide.

# Explication technique

La colonne a la définition suivante : 

```ruby
t.string "departement_number", default: "", null: false
```

Le formulaire contient le champ `departement_number`, et donc quand on update on passe explicitement le param `departement_number: nil`, ce qui se traduit par une requête Postgres `UPDATE` qui demande explicitement de mettre la colonne à `NULL`, ce qui est interdit par la contrainte `NOT NULL`.

# Solutions

1. passer `""` plutôt que `nil` lors de cet update ou via un callback de modèle
2. retirer le `NOT NULL` de la colonne, mais ça lance un débat technique sur `default: "", null: false` et ça change légèrement notre API v1

Je suis ouvert aux deux solutions mais j'ai choisi ici la première parce qu'elle est très simple et répare le bug (et débloque donc Mehdi).