### PR TITLE
Fix CI: `secret_key_base` for test environment must be a type of String

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
-      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 9)
+      - name: Prevent https://github.com/rails/rails/issues/53661
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
-      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 2)
+      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 3)
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
-      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 1)
+      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 2)
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
-      - name: Prevent https://github.com/rails/rails/issues/53661
+      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 1)
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
-      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 8)
+      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 9)
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
-      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 5)
+      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 6)
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
-      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 3)
+      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 4)
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
-      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 7)
+      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 8)
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
+      - name: Prevent https://github.com/rails/rails/issues/53661
+        run: touch tmp/local_secret.txt && head -c 96 /dev/urandom | base64 | head -c 128 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -249,7 +251,7 @@ jobs:
       - uses: ./.github/actions/setup-playwright
       - name: Precompile assets
         run: yarn run build
-      - name: Setup parallel tests and run feature specs
+      - name: Setup DB and run autodoc feature specs
         run: RAILS_ENV=test bundle exec rake db:drop db:create db:schema:load; bundle exec rspec spec/features/autodoc
         env:
           HOST: http://example.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
-      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 6)
+      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 7)
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           timezoneLinux: "Europe/Paris"
       - name: Prevent https://github.com/rails/rails/issues/53661
-        run: touch tmp/local_secret.txt && head -c 96 /dev/urandom | base64 | head -c 128 > tmp/local_secret.txt
+        run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: WitherZuo/set-timezone@v1.0.0
         with:
           timezoneLinux: "Europe/Paris"
-      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 4)
+      - name: Prevent https://github.com/rails/rails/issues/53661 (test de lancement CI 5)
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Nous avons très fréquemment cette erreur sur nos jobs de tests parallèles en CI : 

```
Run RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema parallel:spec['spec/(?!features)']
rake aborted!
ArgumentError: `secret_key_base` for test environment must be a type of String` (ArgumentError)

          raise ArgumentError, "`secret_key_base` for #{Rails.env} environment must be a type of String`"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/application/configuration.rb:517:in 'Rails::Application::Configuration#secret_key_base='
/home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/application/configuration.rb:503:in 'Rails::Application::Configuration#secret_key_base'
/home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.4.0/gems/railties-7.2.2.2/lib/rails/application.rb:470:in 'Rails::Application#secret_key_base'
```

Exemple : https://github.com/betagouv/rdv-service-public/actions/runs/17854893843/job/50771572669?pr=5654

Le bug semble avoir été exploré en longueur dans cette issue et les issues qui y sont mentionnées (un beau labyrinthe) : 
https://github.com/rails/rails/issues/53661

Je n'ai pas eu le temps de lire et comprendre tous les enjeux autour des changements de comportement de chaque version de Rails. 

En revanche j'ai lu le code de notre version (Rails 7.2) pour comprendre la cause du bug, qui est **causé par une race condition** à ce que je sais et je vois : 

```ruby
        def generate_local_secret
          key_file = root.join("tmp/local_secret.txt")

          unless File.exist?(key_file)
            random_key = SecureRandom.hex(64)
            FileUtils.mkdir_p(key_file.dirname)
            File.binwrite(key_file, random_key)
          end

          File.binread(key_file)
        end
```
https://github.com/rails/rails/blob/v7.2.2.2/railties/lib/rails/application/configuration.rb#L629

Je me dis donc que la race condition est causée par l'appel système de création du fichier `tmp/local_secret.txt`, qui est fait en même temps par tous les processes qui lancent les tests en parallèle. **Donc si on crée ce fichier préalablement, il devrait simplement être lu (on ne passe pas dans le unless), et donc on n'a pas de race condition.**

Je teste en relançant la CI plein de fois sur cette PR, je vous dirai si ça a l'air concluant. Edit : c'est concluant ! :tada: Sur les 12 lancers de CI, aucun n'a souffert de ce crash !

<img width="1230" height="1658" alt="image" src="https://github.com/user-attachments/assets/4565ce73-581f-4972-8007-8bf6971c194c" />
