### PR TITLE
YWH-PGM14753-4 (agent access_level)

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -1,7 +1,7 @@
 class Admin::AgentsController < AgentAuthController
   respond_to :html, :json
 
-  before_action :ensure_agent_is_admin
+  before_action :ensure_agent_is_admin, except: :index
 
   def index
     @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).active

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -55,6 +55,8 @@ class Admin::AgentsController < AgentAuthController
     @agent = Agent.find(params[:id])
     authorize(@agent, policy_class: Agent::AgentPolicy)
 
+    raise Pundit::NotAuthorizedError, "Current agent is not admin" unless current_agent.admin_in_organisation?(current_organisation)
+
     update_agent = AdminUpdatesAgent.new(
       agent: @agent,
       organisation: current_organisation,

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -1,6 +1,8 @@
 class Admin::AgentsController < AgentAuthController
   respond_to :html, :json
 
+  before_action :ensure_agent_is_admin
+
   def index
     @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).active
 
@@ -55,8 +57,6 @@ class Admin::AgentsController < AgentAuthController
     @agent = Agent.find(params[:id])
     authorize(@agent, policy_class: Agent::AgentPolicy)
 
-    raise Pundit::NotAuthorizedError, "Current agent is not admin" unless current_agent.admin_in_organisation?(current_organisation)
-
     update_agent = AdminUpdatesAgent.new(
       agent: @agent,
       organisation: current_organisation,
@@ -91,6 +91,10 @@ class Admin::AgentsController < AgentAuthController
   end
 
   private
+
+  def ensure_agent_is_admin
+    raise Pundit::NotAuthorizedError unless current_agent.admin_in_organisation?(current_organisation)
+  end
 
   def render_new
     @services = current_territory.services

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -343,6 +343,9 @@ RSpec.describe Admin::AgentsController, type: :controller do
         expect do
           patch :update, params:
         end.not_to change { agent.reload.access_level_in(organisation) }
+
+        expect(response).to redirect_to("/")
+        expect(flash[:error]).to eq "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
       end
     end
   end

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -329,4 +329,21 @@ RSpec.describe Admin::AgentsController, type: :controller do
       end
     end
   end
+
+  describe "PATCH #update" do
+    describe "preventing the current basic agent to self-elevate to admin" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+      it "works" do
+        params = {
+          organisation_id: organisation,
+          id: agent.id,
+          agent: { agent_role: { access_level: "admin" } },
+        }
+        expect do
+          patch :update, params:
+        end.not_to change { agent.reload.access_level_in(organisation) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Très satisfaisant d'écrire le test et de l'avoir au rouge avec le message :

> expected `agent.reload.access_level_in(organisation)` not to have changed, but did change from "basic" to "admin"