### PR TITLE
Suppression de nested attributes inutilisés

### DIFF
--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -37,8 +37,7 @@ class Users::UsersController < UserAuthController
       :number_of_children,
       :notify_by_email,
       :notify_by_sms,
-      :address_details,
-      user_profiles_attributes: %i[logement id organisation_id]
+      :address_details
     )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,7 @@ class User < ApplicationRecord
   has_many :webhook_endpoints, through: :organisations
   has_many :rdvs, through: :participations
 
-  accepts_nested_attributes_for :user_profiles, :external_references
+  accepts_nested_attributes_for :external_references
 
   include User::ResponsabilityConcern # relies on belongs_to :responsible
 


### PR DESCRIPTION
En faisant des vérifs pour des correctifs de sécurité, j'ai vu ces nested attributes inutilisés (ils datent d'avant nos refactos des user profiles). Je pense que ça vaut le coup de les supprimer.