### PR TITLE
Revert "Utilisation de ProConnect pour la connexion SuperAdmin (#5662)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,8 @@ gem "devise", git: "https://github.com/victormours/devise", ref: "0c502c8ab7f11e
 gem "devise_invitable"
 # Deliver Devise's emails in the background using ActiveJob.
 gem "devise-async"
+# Official OmniAuth strategy for GitHub.
+gem "omniauth-github"
 # omniauth provider for Microsoft Graph
 gem "omniauth-microsoft_graph"
 # omniauth provider for inter-instance migrations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,9 @@ GEM
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
+    omniauth-github (2.0.1)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
     omniauth-microsoft_graph (2.0.0)
       jwt (~> 2.0)
       omniauth (~> 2.0)
@@ -790,6 +793,7 @@ DEPENDENCIES
   mail
   montrose
   notion-ruby-client (~> 1.2)
+  omniauth-github
   omniauth-microsoft_graph
   omniauth-rails_csrf_protection
   omniauth-rdv-service-public!

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -8,54 +8,31 @@ class AgentConnectController < ApplicationController
       client_id: current_domain.agent_connect_client_id,
       client_secret: current_domain.agent_connect_client_secret
     )
+    session[:agent_connect_state] = auth_client.state
+    session[:nonce] = auth_client.nonce
+    if params[:for_user]
+      session[:proconnect_for_user] = true
+    end
 
-    connection_for = if params[:for_user]
-                       "user"
-                     elsif params[:for_super_admin]
-                       "super_admin"
-                     else
-                       "agent"
-                     end
-
-    session[:pro_connect] = {
-      state: auth_client.state,
-      nonce: auth_client.nonce,
-      connection_for:,
-    }
-
-    force_2fa = connection_for == "super_admin"
-
-    redirect_to auth_client.redirect_url(agent_connect_callback_url, force_2fa:), allow_other_host: true
+    redirect_to auth_client.redirect_url(agent_connect_callback_url), allow_other_host: true
   end
 
   def callback
-    pro_connect_session = session.delete(:pro_connect).symbolize_keys
-
     callback_client = AgentConnectOpenIdClient::Callback.new(
-      session_state: pro_connect_session[:state],
+      session_state: session.delete(:agent_connect_state),
       params_state: params[:state],
       callback_url: agent_connect_callback_url,
-      nonce: pro_connect_session[:nonce],
+      nonce: session.delete(:nonce),
       client_id: current_domain.agent_connect_client_id,
       client_secret: current_domain.agent_connect_client_secret
     )
 
     if callback_client.fetch_user_info_from_code!(params[:code])
 
-      case pro_connect_session[:connection_for]
-      when "user"
+      if session.delete(:proconnect_for_user)
         connect_user(callback_client)
-      when "super_admin"
-        if callback_client.went_through_2fa?
-          connect_super_admin(callback_client)
-        else
-          flash[:error] = "Vous devez activer la double authentification sur votre compte ProConnect pour vous connecter en tant que super administrateur."
-          redirect_to connexion_super_admins_path
-        end
-      when "agent"
-        connect_agent(callback_client)
       else
-        raise "Unknown connection_for #{pro_connect_session[:connection_for]}"
+        connect_agent(callback_client)
       end
     else
       flash[:error] = generic_error_message
@@ -71,25 +48,6 @@ class AgentConnectController < ApplicationController
   # jamais revenir vers ses paths après un login.
   def storable_location?
     false
-  end
-
-  def connect_super_admin(callback_client)
-    # Création d'un super admin en dev si aucun n'existe
-    if Rails.env.development? && SuperAdmin.none?
-      SuperAdmin.create!(email: callback_client.user_email, first_name: callback_client.user_first_name, last_name: callback_client.user_last_name, role: :legacy_admin)
-    end
-
-    super_admin = SuperAdmin.find_by(email: callback_client.user_email)
-
-    if super_admin
-      bypass_sign_in super_admin, scope: :super_admin
-
-      session[:agent_connect_id_token] = callback_client.id_token_for_logout
-      redirect_to super_admins_agents_path
-    else
-      flash[:error] = "Compte ProConnect non autorisé"
-      redirect_to connexion_super_admins_path
-    end
   end
 
   def connect_user(callback_client)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,6 +1,26 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   before_action :log_params_to_sentry
 
+  def github
+    email = request.env["omniauth.auth"]["info"]["email"]
+
+    # Automatically create the first SuperAdmin in development
+    if Rails.env.development? && SuperAdmin.none?
+      first_name, last_name = request.env["omniauth.auth"]["info"]["name"].split
+      SuperAdmin.create!(email: email, first_name: first_name, last_name: last_name, role: :legacy_admin)
+    end
+
+    super_admin = SuperAdmin.find_by(email: email)
+    if super_admin.present?
+      bypass_sign_in super_admin, scope: :super_admin
+      redirect_to super_admins_agents_path
+    else
+      flash[:alert] = "Compte GitHub non autorisé"
+      Rails.logger.error("OmniAuth failed for #{email}")
+      redirect_to root_path
+    end
+  end
+
   def microsoft_graph
     if current_agent.update(microsoft_graph_token: microsoft_graph_token, refresh_microsoft_graph_token: refresh_microsoft_graph_token)
       Outlook::MassCreateEventJob.perform_later(current_agent)

--- a/app/controllers/super_admins/sessions_controller.rb
+++ b/app/controllers/super_admins/sessions_controller.rb
@@ -1,17 +1,10 @@
 module SuperAdmins
   class SessionsController < ApplicationController
     def destroy
-      agent_connect_id_token = session.delete(:agent_connect_id_token)
       skip_authorization
       sign_out_all_scopes if super_admin_signed_in?
 
-      if agent_connect_id_token.present?
-        agent_connect_client = AgentConnectOpenIdClient::Logout.new(agent_connect_id_token)
-
-        redirect_to agent_connect_client.agent_connect_logout_url(root_url), allow_other_host: true
-      else
-        redirect_to root_path
-      end
+      redirect_to root_path
     end
   end
 end

--- a/app/services/agent_connect_open_id_client/auth.rb
+++ b/app/services/agent_connect_open_id_client/auth.rb
@@ -1,10 +1,6 @@
-# voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique
+# voir # https://github.com/numerique-gouv/agentconnect-documentation/blob/main/doc_fs/implementation_technique.md
 module AgentConnectOpenIdClient
   class Auth
-    SCOPES = "openid email given_name usual_name siret".freeze
-    EIDAS1 = ["eidas1"].freeze
-    EIDAS_FOR_2FA = %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa].freeze
-
     def initialize(client_id:, client_secret:, login_hint: nil, force_login: false)
       @login_hint = login_hint
       @force_login = force_login
@@ -16,33 +12,22 @@ module AgentConnectOpenIdClient
 
     attr_reader :state, :nonce
 
-    def redirect_url(callback_url, force_2fa: false)
+    def redirect_url(callback_url)
+      scopes = "openid email given_name usual_name siret"
+
       query_params = {
         response_type: "code",
         client_id: @client_id,
         redirect_uri: callback_url,
-        scope: SCOPES,
+        scope: scopes,
         state: state,
         nonce: nonce,
+        acr_values: "eidas1",
         login_hint: @login_hint,
         prompt: @force_login ? "login" : nil,
-        claims: claims(force_2fa:).to_json,
       }.compact_blank
 
       "#{ENV['AGENT_CONNECT_BASE_URL']}/authorize?#{query_params.to_query}"
-    end
-
-    private
-
-    def claims(force_2fa:)
-      {
-        id_token: {
-          acr: {
-            essential: true,
-            values: force_2fa ? EIDAS_FOR_2FA : EIDAS1,
-          },
-        },
-      }
     end
   end
 end

--- a/app/services/agent_connect_open_id_client/callback.rb
+++ b/app/services/agent_connect_open_id_client/callback.rb
@@ -1,4 +1,4 @@
-# voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique
+# voir https://github.com/france-connect/Documentation-AgentConnect/blob/main/doc_fs/technique_fca/endpoints.md
 module AgentConnectOpenIdClient
   class Callback
     class OpenIdFlowError < StandardError; end
@@ -45,11 +45,6 @@ module AgentConnectOpenIdClient
 
     def openid_sub
       @user_info["sub"]
-    end
-
-    # voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/double_authentification
-    def went_through_2fa?
-      @acr.in?(AgentConnectOpenIdClient::Auth::EIDAS_FOR_2FA)
     end
 
     private
@@ -99,13 +94,11 @@ module AgentConnectOpenIdClient
 
     def validate_nonce!(encoded_id_token)
       decoded_id_token = OpenIDConnect::ResponseObject::IdToken.decode(encoded_id_token, agent_connect_config.jwks)
-
       decoded_id_token.verify!(
         issuer: agent_connect_config.issuer,
         client_id: @client_id,
         nonce: @nonce
       )
-      @acr = decoded_id_token.acr
     end
 
     def fetch_user_info(token)

--- a/app/views/common/_proconnect_button_dsfr.html.slim
+++ b/app/views/common/_proconnect_button_dsfr.html.slim
@@ -1,12 +1,10 @@
-/# locals: (login_hint: nil, for_user: false, for_super_admin: false)
+/# locals: (login_hint: nil, for_user: false)
 form.fr-connect-group[action="#{agent_connect_auth_path}" method="get"]
 
   - if login_hint
     input[type="hidden" value="#{login_hint}" name="login_hint"]
   - if for_user
     input[type="hidden" value="1" name="for_user"]
-  - elsif for_super_admin
-    input[type="hidden" value="1" name="for_super_admin"]
   button.fr-connect.fr-proconnect
     span.fr-connect__login
       | S’identifier avec

--- a/app/views/welcome/super_admin.html.slim
+++ b/app/views/welcome/super_admin.html.slim
@@ -1,6 +1,6 @@
 .fr-mb-3w
   .rdv-text-align-center
-    = render "common/proconnect_button_dsfr", for_super_admin: true
+    = link_to "Accéder à superadmin", "/omniauth/github", class: "fr-btn", method: :post
 
   - if Rails.env.development?
     .fr-col-lg-3.fr-col-offset-lg-5.fr-mt-3w

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,8 @@
 require "omniauth-rdv-service-public"
 
 Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :github, ENV.fetch("GITHUB_APP_ID", nil), ENV.fetch("GITHUB_APP_SECRET", nil), scope: "user:email"
+
   provider :microsoft_graph, ENV.fetch("AZURE_APPLICATION_CLIENT_ID", nil), ENV.fetch("AZURE_APPLICATION_CLIENT_SECRET", nil),
            scope: %w[offline_access openid email profile User.Read Calendars.ReadWrite]
 

--- a/docs/architecture-technique.md
+++ b/docs/architecture-technique.md
@@ -114,6 +114,7 @@ plusieurs tables dans la base de données de RDV Insertion.
 |------------|------------------|---------------|------|---------------------|--------------------------------|
 | Navigateur | FranceConnect    | HTTPS (OAuth) | 443  | Paris, France       | smtp-relay.sendinblue.com      |
 | Navigateur | ProConnect       | HTTPS (OAuth) | 443  | France              | auth.agentconnect.gouv.fr      |
+| Navigateur | GitHub           | HTTPS (OAuth) | 443  | USA                 | github.com                     |
 
 ### Inventaire des dépendances
 
@@ -237,11 +238,13 @@ C4Container
 
     System_Ext(france_connect, "FranceConnect", "")
     System_Ext(oauth_microsoft, "Oauth Microsoft", "")
+    System_Ext(oauth_github, "Oauth GitHub", "")
 
     Rel(user, web_app, "HTTPS redirect")
 
     Rel(user, france_connect, "HTTPS redirect")
     Rel(user, oauth_microsoft, "HTTPS redirect")
+    Rel(user, oauth_github, "HTTPS redirect")
 ```
 
 #### Échanges entre l'app et Metabase
@@ -420,12 +423,12 @@ Il existe deux niveaux d'accès pour les super-admins : "complet" et "support". 
 niveau "complet", ainsi que l'équipe produit de RDV Service Public. L'équipe produit de RDV Insertion est quant à elle
 limitée à un niveau "support".
 
-Pour se connecter aux interfaces de super-admin, il faut utiliser ProConnect. L'adresse e-mail du compte ProConnect
-doit être présente dans une table `super_admins`, où les entrées sont créées et supprimées à la main lors
+Pour se connecter aux interfaces de super-admin, il faut utiliser l'OAuth de GitHub. L'adresse e-mail alors fournie
+par GitHub doit être présente dans une table `super_admins`, où les entrées sont créées et supprimées à la main lors
 de l'arrivée et du départ de membres de l'équipe.
 
-Pour assurer la sécurité des comptes super-admins, l’authentification à deux facteurs (2FA) est obligatoire.
-Si celle-ci n’est pas activée, le super-admin ne peut pas se connecter.
+Tous les membres de l'équipe faisant partie de [l'organisation `betagouv` sur Github](https://github.com/betagouv),
+ils utilisent forcément une authentification à 2 facteurs (car cette politique est imposée au niveau de l'organisation GitHub).
 
 ### Traçabilité des erreurs et des actions utilisateurs
 

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -11,20 +11,13 @@ RSpec.describe AgentConnectController do
 
       expect(redirect_url_query_params.symbolize_keys).to match(
         login_hint: "francis.factice@exemple.gouv.fr",
+        acr_values: "eidas1",
         client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
         redirect_uri: "http://test.host/agent_connect/callback",
         response_type: "code",
         scope: "openid email given_name usual_name siret",
         state: be_a(String),
-        nonce: be_a(String),
-        claims: {
-          id_token: {
-            acr: {
-              essential: true,
-              values: ["eidas1"],
-            },
-          },
-        }.to_json
+        nonce: be_a(String)
       )
     end
 
@@ -39,51 +32,16 @@ RSpec.describe AgentConnectController do
 
         expect(redirect_url_query_params.symbolize_keys).to match(
           login_hint: "francis.factice@exemple.gouv.fr",
+          acr_values: "eidas1",
           client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
           redirect_uri: "http://test.host/agent_connect/callback",
           response_type: "code",
           scope: "openid email given_name usual_name siret",
           state: be_a(String),
-          nonce: be_a(String),
-          claims: {
-            id_token: {
-              acr: {
-                essential: true,
-                values: ["eidas1"],
-              },
-            },
-          }.to_json
+          nonce: be_a(String)
         )
-        expect(session["pro_connect"][:connection_for]).to eq("user")
+        expect(session["proconnect_for_user"]).to be_present
       end
-    end
-  end
-
-  describe "with the for_super_admin param" do
-    it "adds the force_2fa param to the request" do
-      get :auth, params: { for_super_admin: true }
-      expect(response).to redirect_to(start_with("https://fca.integ01.dev-agentconnect.fr/api/v2/authorize?"))
-
-      redirect_url = response.headers["Location"]
-      redirect_url_query_params = Rack::Utils.parse_query(URI.parse(redirect_url).query)
-
-      expect(redirect_url_query_params.symbolize_keys).to match(
-        client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
-        redirect_uri: "http://test.host/agent_connect/callback",
-        response_type: "code",
-        scope: "openid email given_name usual_name siret",
-        state: be_a(String),
-        nonce: be_a(String),
-        claims: {
-          id_token: {
-            acr: {
-              essential: true,
-              values: ["eidas2", "eidas3", "https://proconnect.gouv.fr/assurance/consistency-checked-2fa", "https://proconnect.gouv.fr/assurance/self-asserted-2fa"],
-            },
-          },
-        }.to_json
-      )
-      expect(session["pro_connect"][:connection_for]).to eq("super_admin")
     end
   end
 
@@ -109,10 +67,7 @@ RSpec.describe AgentConnectController do
     end
 
     before do
-      session[:pro_connect] = {
-        state: state,
-        connection_for: "agent",
-      }
+      session[:agent_connect_state] = state
       AgentConnectStubs.stub_callback_requests(code, user_info)
 
       session[:agent_return_to] = "/agents/edit" # Pour simuler le retour vers la page demandée avant la connexion
@@ -135,10 +90,7 @@ RSpec.describe AgentConnectController do
 
     context "when logging in a user" do
       before do
-        session[:pro_connect] = {
-          state:,
-          connection_for: "user",
-        }
+        session["proconnect_for_user"] = true
         session[:user_return_to] = "/users/informations" # Pour simuler le retour vers la page demandée avant la connexion
       end
 
@@ -171,72 +123,6 @@ RSpec.describe AgentConnectController do
           expect(session["agent_connect_id_token"]).to be_present
 
           expect(response).to redirect_to("/users/informations")
-        end
-      end
-    end
-
-    context "when logging in a super admin" do
-      before do
-        session[:pro_connect] = {
-          state:,
-          connection_for: "super_admin",
-        }
-        session[:super_admin_return_to] = "/super_admins/agents" # Pour simuler le retour vers la page demandée avant la connexion
-      end
-
-      context "with a non 2FA account" do
-        it "redirects to the super admin sign in page if the super admin does not activate 2FA" do
-          get :callback, params: { state: state, code: code }
-
-          expect(session["agent_connect_id_token"]).to be_nil
-          expect(response).to redirect_to("/connexion_super_admins")
-          expect(flash[:error]).to eq("Vous devez activer la double authentification sur votre compte ProConnect pour vous connecter en tant que super administrateur.")
-        end
-      end
-
-      context "with a 2FA account" do
-        before do
-          AgentConnectStubs.stub_callback_requests(code, user_info, with_2fa: true)
-        end
-
-        context "when the super admin does not exist" do
-          it "redirects to the super admin sign in page" do
-            get :callback, params: { state: state, code: code }
-
-            expect(session["agent_connect_id_token"]).to be_nil
-            expect(response).to redirect_to("/connexion_super_admins")
-            expect(flash[:error]).to eq("Compte ProConnect non autorisé")
-          end
-        end
-
-        context "when the super admin already exists" do
-          let!(:super_admin) { create(:super_admin, email: "francis.factice@exemple.gouv.fr") }
-
-          it "redirects to the super admin agents page" do
-            get :callback, params: { state: state, code: code }
-
-            expect(session["agent_connect_id_token"]).to be_present
-            expect(response).to redirect_to("/super_admins/agents")
-          end
-        end
-
-        context "in development, when no super admin exists" do
-          before do
-            allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
-          end
-
-          it "creates the super admin and redirects to the super admin agents page" do
-            expect(SuperAdmin.count).to eq(0)
-
-            get :callback, params: { state: state, code: code }
-
-            expect(SuperAdmin.count).to eq(1)
-            expect(SuperAdmin.last).to have_attributes(
-              email: "francis.factice@exemple.gouv.fr"
-            )
-            expect(session["agent_connect_id_token"]).to be_present
-            expect(response).to redirect_to("/super_admins/agents")
-          end
         end
       end
     end

--- a/spec/support/agent_connect_stubs.rb
+++ b/spec/support/agent_connect_stubs.rb
@@ -7,14 +7,10 @@ module AgentConnectStubs
     load Rails.root.join("config/initializers/agent_connect.rb").to_s
   end
 
-  def self.stub_callback_requests(code, user_info, with_2fa: false)
+  def self.stub_callback_requests(code, user_info)
     stub_and_run_discover_request
 
-    if with_2fa
-      stub_token_request(code, acr: "https://proconnect.gouv.fr/assurance/self-asserted-2fa")
-    else
-      stub_token_request(code)
-    end
+    stub_token_request(code)
 
     userinfo_encoded_response_body = "fake_userinfo_encoded_response_body"
 
@@ -34,7 +30,7 @@ module AgentConnectStubs
     ).and_return([user_info])
   end
 
-  def self.stub_token_request(code, acr: "eidas1")
+  def self.stub_token_request(code)
     WebMock.stub_request(:post, "https://fca.integ01.dev-agentconnect.fr/api/v2/token").with(
       body: {
         "client_id" => "ec41582-1d60-4f11-a63b-d8abaece16aa",
@@ -52,7 +48,7 @@ module AgentConnectStubs
     }.to_json, headers: {})
 
     allow(OpenIDConnect::ResponseObject::IdToken).to receive(:decode).and_return(
-      instance_double(OpenIDConnect::ResponseObject::IdToken, verify!: true, acr:)
+      instance_double(OpenIDConnect::ResponseObject::IdToken, verify!: true)
     )
   end
 


### PR DESCRIPTION
This reverts commit d3209de376871d4b166954999f530d99005ff7bb.

Revert #5662

# Contexte

La connexion en tant que super admin via la 2fa agent connect a l’air de fonctionner

En revanche, n a plusieurs erreurs pour des agents qui se connectent à leurs comptes agents : 

~~-  [LAPINS-323](https://sentry.incubateur.net/organizations/betagouv/issues/196336/?project=74&referrer=webhooks_plugin&statsPeriod=24h) `ActionView::Template::Error : undefined method 'full_name' for nil (ActionView::Template::Error)`~~ : celui ci ne concerne que des super admin et c’est un cas très mineur

- [LAPINS-353]() : `AgentConnectOpenIdClient::Callback::ApiRequestError code:400, body:{"error":"invalid_request","error_description":"missing required parameter 'code' (undefined`

- [LAPINS-370](https://sentry.incubateur.net/organizations/betagouv/issues/203478/?project=74&referrer=webhooks_plugin) : [NoMethodError: undefined method 'symbolize_keys' for nil (NoMethodError)](https://sentry.incubateur.net/organizations/betagouv/issues/203478/?referrer=webhooks_plugin)

On a vu en regardant les volumes de connexions que les agents arrivaient majoritairement à se connecter, mais ces erreurs sont suffisament nombreuses et inquiétantes pour qu’on souhaite revert.

Sur le compte agent de Mehdi on semble reproduire de manière fiable une partie de ces erreurs


# Solution

On revert