### PR TITLE
Utilisation de ProConnect pour la connexion SuperAdmin 2nd try

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,8 +67,6 @@ gem "devise", git: "https://github.com/victormours/devise", ref: "0c502c8ab7f11e
 gem "devise_invitable"
 # Deliver Devise's emails in the background using ActiveJob.
 gem "devise-async"
-# Official OmniAuth strategy for GitHub.
-gem "omniauth-github"
 # omniauth provider for Microsoft Graph
 gem "omniauth-microsoft_graph"
 # omniauth provider for inter-instance migrations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,9 +417,6 @@ GEM
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
-    omniauth-github (2.0.1)
-      omniauth (~> 2.0)
-      omniauth-oauth2 (~> 1.8)
     omniauth-microsoft_graph (2.0.0)
       jwt (~> 2.0)
       omniauth (~> 2.0)
@@ -804,7 +801,6 @@ DEPENDENCIES
   mail
   montrose
   notion-ruby-client (~> 1.2)
-  omniauth-github
   omniauth-microsoft_graph
   omniauth-rails_csrf_protection
   omniauth-rdv-service-public!

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -8,31 +8,54 @@ class AgentConnectController < ApplicationController
       client_id: current_domain.agent_connect_client_id,
       client_secret: current_domain.agent_connect_client_secret
     )
-    session[:agent_connect_state] = auth_client.state
-    session[:nonce] = auth_client.nonce
-    if params[:for_user]
-      session[:proconnect_for_user] = true
-    end
 
-    redirect_to auth_client.redirect_url(agent_connect_callback_url), allow_other_host: true
+    connection_for = if params[:for_user]
+                       "user"
+                     elsif params[:for_super_admin]
+                       "super_admin"
+                     else
+                       "agent"
+                     end
+
+    session[:pro_connect] = {
+      state: auth_client.state,
+      nonce: auth_client.nonce,
+      connection_for:,
+    }
+
+    force_2fa = connection_for == "super_admin"
+
+    redirect_to auth_client.redirect_url(agent_connect_callback_url, force_2fa:), allow_other_host: true
   end
 
   def callback
+    pro_connect_session = session.delete(:pro_connect).symbolize_keys
+
     callback_client = AgentConnectOpenIdClient::Callback.new(
-      session_state: session.delete(:agent_connect_state),
+      session_state: pro_connect_session[:state],
       params_state: params[:state],
       callback_url: agent_connect_callback_url,
-      nonce: session.delete(:nonce),
+      nonce: pro_connect_session[:nonce],
       client_id: current_domain.agent_connect_client_id,
       client_secret: current_domain.agent_connect_client_secret
     )
 
     if callback_client.fetch_user_info_from_code!(params[:code])
 
-      if session.delete(:proconnect_for_user)
+      case pro_connect_session[:connection_for]
+      when "user"
         connect_user(callback_client)
-      else
+      when "super_admin"
+        if callback_client.went_through_2fa?
+          connect_super_admin(callback_client)
+        else
+          flash[:error] = "Vous devez activer la double authentification sur votre compte ProConnect pour vous connecter en tant que super administrateur."
+          redirect_to connexion_super_admins_path
+        end
+      when "agent"
         connect_agent(callback_client)
+      else
+        raise "Unknown connection_for #{pro_connect_session[:connection_for]}"
       end
     else
       flash[:error] = generic_error_message
@@ -48,6 +71,25 @@ class AgentConnectController < ApplicationController
   # jamais revenir vers ses paths après un login.
   def storable_location?
     false
+  end
+
+  def connect_super_admin(callback_client)
+    # Création d'un super admin en dev si aucun n'existe
+    if Rails.env.development? && SuperAdmin.none?
+      SuperAdmin.create!(email: callback_client.user_email, first_name: callback_client.user_first_name, last_name: callback_client.user_last_name, role: :legacy_admin)
+    end
+
+    super_admin = SuperAdmin.find_by(email: callback_client.user_email)
+
+    if super_admin
+      bypass_sign_in super_admin, scope: :super_admin
+
+      session[:agent_connect_id_token] = callback_client.id_token_for_logout
+      redirect_to super_admins_agents_path
+    else
+      flash[:error] = "Compte ProConnect non autorisé"
+      redirect_to connexion_super_admins_path
+    end
   end
 
   def connect_user(callback_client)

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -29,7 +29,15 @@ class AgentConnectController < ApplicationController
   end
 
   def callback
-    pro_connect_session = session.delete(:pro_connect).symbolize_keys
+    pro_connect_session = session.delete(:pro_connect)
+
+    unless pro_connect_session
+      flash[:error] = generic_error_message
+      redirect_to root_path
+      return
+    end
+
+    pro_connect_session.symbolize_keys!
 
     callback_client = AgentConnectOpenIdClient::Callback.new(
       session_state: pro_connect_session[:state],

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,26 +1,6 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   before_action :log_params_to_sentry
 
-  def github
-    email = request.env["omniauth.auth"]["info"]["email"]
-
-    # Automatically create the first SuperAdmin in development
-    if Rails.env.development? && SuperAdmin.none?
-      first_name, last_name = request.env["omniauth.auth"]["info"]["name"].split
-      SuperAdmin.create!(email: email, first_name: first_name, last_name: last_name, role: :legacy_admin)
-    end
-
-    super_admin = SuperAdmin.find_by(email: email)
-    if super_admin.present?
-      bypass_sign_in super_admin, scope: :super_admin
-      redirect_to super_admins_agents_path
-    else
-      flash[:alert] = "Compte GitHub non autorisé"
-      Rails.logger.error("OmniAuth failed for #{email}")
-      redirect_to root_path
-    end
-  end
-
   def microsoft_graph
     if current_agent.update(microsoft_graph_token: microsoft_graph_token, refresh_microsoft_graph_token: refresh_microsoft_graph_token)
       Outlook::MassCreateEventJob.perform_later(current_agent)

--- a/app/controllers/super_admins/sessions_controller.rb
+++ b/app/controllers/super_admins/sessions_controller.rb
@@ -1,10 +1,17 @@
 module SuperAdmins
   class SessionsController < ApplicationController
     def destroy
+      agent_connect_id_token = session.delete(:agent_connect_id_token)
       skip_authorization
       sign_out_all_scopes if super_admin_signed_in?
 
-      redirect_to root_path
+      if agent_connect_id_token.present?
+        agent_connect_client = AgentConnectOpenIdClient::Logout.new(agent_connect_id_token)
+
+        redirect_to agent_connect_client.agent_connect_logout_url(root_url), allow_other_host: true
+      else
+        redirect_to root_path
+      end
     end
   end
 end

--- a/app/services/agent_connect_open_id_client/auth.rb
+++ b/app/services/agent_connect_open_id_client/auth.rb
@@ -1,6 +1,10 @@
-# voir # https://github.com/numerique-gouv/agentconnect-documentation/blob/main/doc_fs/implementation_technique.md
+# voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique
 module AgentConnectOpenIdClient
   class Auth
+    SCOPES = "openid email given_name usual_name siret".freeze
+    EIDAS1 = ["eidas1"].freeze
+    EIDAS_FOR_2FA = %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa].freeze
+
     def initialize(client_id:, client_secret:, login_hint: nil, force_login: false)
       @login_hint = login_hint
       @force_login = force_login
@@ -12,22 +16,33 @@ module AgentConnectOpenIdClient
 
     attr_reader :state, :nonce
 
-    def redirect_url(callback_url)
-      scopes = "openid email given_name usual_name siret"
-
+    def redirect_url(callback_url, force_2fa: false)
       query_params = {
         response_type: "code",
         client_id: @client_id,
         redirect_uri: callback_url,
-        scope: scopes,
+        scope: SCOPES,
         state: state,
         nonce: nonce,
-        acr_values: "eidas1",
         login_hint: @login_hint,
         prompt: @force_login ? "login" : nil,
+        claims: claims(force_2fa:).to_json,
       }.compact_blank
 
       "#{ENV['AGENT_CONNECT_BASE_URL']}/authorize?#{query_params.to_query}"
+    end
+
+    private
+
+    def claims(force_2fa:)
+      {
+        id_token: {
+          acr: {
+            essential: true,
+            values: force_2fa ? EIDAS_FOR_2FA : EIDAS1,
+          },
+        },
+      }
     end
   end
 end

--- a/app/services/agent_connect_open_id_client/auth.rb
+++ b/app/services/agent_connect_open_id_client/auth.rb
@@ -2,8 +2,7 @@
 module AgentConnectOpenIdClient
   class Auth
     SCOPES = "openid email given_name usual_name siret".freeze
-    EIDAS1 = ["eidas1"].freeze
-    EIDAS_FOR_2FA = %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa].freeze
+    ACR_FOR_2FA = %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa].freeze
 
     def initialize(client_id:, client_secret:, login_hint: nil, force_login: false)
       @login_hint = login_hint
@@ -38,8 +37,8 @@ module AgentConnectOpenIdClient
       {
         id_token: {
           acr: {
-            essential: true,
-            values: force_2fa ? EIDAS_FOR_2FA : EIDAS1,
+            essential: force_2fa,
+            values: ACR_FOR_2FA,
           },
         },
       }

--- a/app/services/agent_connect_open_id_client/callback.rb
+++ b/app/services/agent_connect_open_id_client/callback.rb
@@ -49,7 +49,7 @@ module AgentConnectOpenIdClient
 
     # voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/double_authentification
     def went_through_2fa?
-      @acr.in?(AgentConnectOpenIdClient::Auth::EIDAS_FOR_2FA)
+      @acr.in?(AgentConnectOpenIdClient::Auth::ACR_FOR_2FA)
     end
 
     private

--- a/app/services/agent_connect_open_id_client/callback.rb
+++ b/app/services/agent_connect_open_id_client/callback.rb
@@ -1,4 +1,4 @@
-# voir https://github.com/france-connect/Documentation-AgentConnect/blob/main/doc_fs/technique_fca/endpoints.md
+# voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique
 module AgentConnectOpenIdClient
   class Callback
     class OpenIdFlowError < StandardError; end
@@ -45,6 +45,11 @@ module AgentConnectOpenIdClient
 
     def openid_sub
       @user_info["sub"]
+    end
+
+    # voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/double_authentification
+    def went_through_2fa?
+      @acr.in?(AgentConnectOpenIdClient::Auth::EIDAS_FOR_2FA)
     end
 
     private
@@ -94,11 +99,13 @@ module AgentConnectOpenIdClient
 
     def validate_nonce!(encoded_id_token)
       decoded_id_token = OpenIDConnect::ResponseObject::IdToken.decode(encoded_id_token, agent_connect_config.jwks)
+
       decoded_id_token.verify!(
         issuer: agent_connect_config.issuer,
         client_id: @client_id,
         nonce: @nonce
       )
+      @acr = decoded_id_token.acr
     end
 
     def fetch_user_info(token)

--- a/app/views/common/_proconnect_button_dsfr.html.slim
+++ b/app/views/common/_proconnect_button_dsfr.html.slim
@@ -1,10 +1,12 @@
-/# locals: (login_hint: nil, for_user: false)
+/# locals: (login_hint: nil, for_user: false, for_super_admin: false)
 form.fr-connect-group[action="#{agent_connect_auth_path}" method="get"]
 
   - if login_hint
     input[type="hidden" value="#{login_hint}" name="login_hint"]
   - if for_user
     input[type="hidden" value="1" name="for_user"]
+  - elsif for_super_admin
+    input[type="hidden" value="1" name="for_super_admin"]
   button.fr-connect.fr-proconnect
     span.fr-connect__login
       | S’identifier avec

--- a/app/views/welcome/super_admin.html.slim
+++ b/app/views/welcome/super_admin.html.slim
@@ -1,6 +1,6 @@
 .fr-mb-3w
   .rdv-text-align-center
-    = link_to "Accéder à superadmin", "/omniauth/github", class: "fr-btn", method: :post
+    = render "common/proconnect_button_dsfr", for_super_admin: true
 
   - if Rails.env.development?
     .fr-col-lg-3.fr-col-offset-lg-5.fr-mt-3w

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,8 +1,6 @@
 require "omniauth-rdv-service-public"
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :github, ENV.fetch("GITHUB_APP_ID", nil), ENV.fetch("GITHUB_APP_SECRET", nil), scope: "user:email"
-
   provider :microsoft_graph, ENV.fetch("AZURE_APPLICATION_CLIENT_ID", nil), ENV.fetch("AZURE_APPLICATION_CLIENT_SECRET", nil),
            scope: %w[offline_access openid email profile User.Read Calendars.ReadWrite]
 

--- a/docs/architecture-technique.md
+++ b/docs/architecture-technique.md
@@ -108,7 +108,6 @@ plusieurs tables dans la base de données de RDV Insertion.
 |------------|------------------|---------------|------|---------------------|--------------------------------|
 | Navigateur | FranceConnect    | HTTPS (OAuth) | 443  | Paris, France       | smtp-relay.sendinblue.com      |
 | Navigateur | ProConnect       | HTTPS (OAuth) | 443  | France              | auth.agentconnect.gouv.fr      |
-| Navigateur | GitHub           | HTTPS (OAuth) | 443  | USA                 | github.com                     |
 
 ### Inventaire des dépendances
 
@@ -232,13 +231,11 @@ C4Container
 
     System_Ext(france_connect, "FranceConnect", "")
     System_Ext(oauth_microsoft, "Oauth Microsoft", "")
-    System_Ext(oauth_github, "Oauth GitHub", "")
 
     Rel(user, web_app, "HTTPS redirect")
 
     Rel(user, france_connect, "HTTPS redirect")
     Rel(user, oauth_microsoft, "HTTPS redirect")
-    Rel(user, oauth_github, "HTTPS redirect")
 ```
 
 #### Échanges entre l'app et Metabase
@@ -418,12 +415,12 @@ Il existe deux niveaux d'accès pour les super-admins : "complet" et "support". 
 niveau "complet", ainsi que l'équipe produit de RDV Service Public. L'équipe produit de RDV Insertion est quant à elle
 limitée à un niveau "support".
 
-Pour se connecter aux interfaces de super-admin, il faut utiliser l'OAuth de GitHub. L'adresse e-mail alors fournie
-par GitHub doit être présente dans une table `super_admins`, où les entrées sont créées et supprimées à la main lors
+Pour se connecter aux interfaces de super-admin, il faut utiliser ProConnect. L'adresse e-mail du compte ProConnect
+doit être présente dans une table `super_admins`, où les entrées sont créées et supprimées à la main lors
 de l'arrivée et du départ de membres de l'équipe.
 
-Tous les membres de l'équipe faisant partie de [l'organisation `betagouv` sur Github](https://github.com/betagouv),
-ils utilisent forcément une authentification à 2 facteurs (car cette politique est imposée au niveau de l'organisation GitHub).
+Pour assurer la sécurité des comptes super-admins, l’authentification à deux facteurs (2FA) est obligatoire.
+Si celle-ci n’est pas activée, le super-admin ne peut pas se connecter.
 
 ### Traçabilité des erreurs et des actions utilisateurs
 

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -11,13 +11,20 @@ RSpec.describe AgentConnectController do
 
       expect(redirect_url_query_params.symbolize_keys).to match(
         login_hint: "francis.factice@exemple.gouv.fr",
-        acr_values: "eidas1",
         client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
         redirect_uri: "http://test.host/agent_connect/callback",
         response_type: "code",
         scope: "openid email given_name usual_name siret",
         state: be_a(String),
-        nonce: be_a(String)
+        nonce: be_a(String),
+        claims: {
+          id_token: {
+            acr: {
+              essential: true,
+              values: ["eidas1"],
+            },
+          },
+        }.to_json
       )
     end
 
@@ -32,16 +39,51 @@ RSpec.describe AgentConnectController do
 
         expect(redirect_url_query_params.symbolize_keys).to match(
           login_hint: "francis.factice@exemple.gouv.fr",
-          acr_values: "eidas1",
           client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
           redirect_uri: "http://test.host/agent_connect/callback",
           response_type: "code",
           scope: "openid email given_name usual_name siret",
           state: be_a(String),
-          nonce: be_a(String)
+          nonce: be_a(String),
+          claims: {
+            id_token: {
+              acr: {
+                essential: true,
+                values: ["eidas1"],
+              },
+            },
+          }.to_json
         )
-        expect(session["proconnect_for_user"]).to be_present
+        expect(session["pro_connect"][:connection_for]).to eq("user")
       end
+    end
+  end
+
+  describe "with the for_super_admin param" do
+    it "adds the force_2fa param to the request" do
+      get :auth, params: { for_super_admin: true }
+      expect(response).to redirect_to(start_with("https://fca.integ01.dev-agentconnect.fr/api/v2/authorize?"))
+
+      redirect_url = response.headers["Location"]
+      redirect_url_query_params = Rack::Utils.parse_query(URI.parse(redirect_url).query)
+
+      expect(redirect_url_query_params.symbolize_keys).to match(
+        client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
+        redirect_uri: "http://test.host/agent_connect/callback",
+        response_type: "code",
+        scope: "openid email given_name usual_name siret",
+        state: be_a(String),
+        nonce: be_a(String),
+        claims: {
+          id_token: {
+            acr: {
+              essential: true,
+              values: ["eidas2", "eidas3", "https://proconnect.gouv.fr/assurance/consistency-checked-2fa", "https://proconnect.gouv.fr/assurance/self-asserted-2fa"],
+            },
+          },
+        }.to_json
+      )
+      expect(session["pro_connect"][:connection_for]).to eq("super_admin")
     end
   end
 
@@ -67,7 +109,10 @@ RSpec.describe AgentConnectController do
     end
 
     before do
-      session[:agent_connect_state] = state
+      session[:pro_connect] = {
+        state: state,
+        connection_for: "agent",
+      }
       AgentConnectStubs.stub_callback_requests(code, user_info)
 
       session[:agent_return_to] = "/agents/edit" # Pour simuler le retour vers la page demandée avant la connexion
@@ -90,7 +135,10 @@ RSpec.describe AgentConnectController do
 
     context "when logging in a user" do
       before do
-        session["proconnect_for_user"] = true
+        session[:pro_connect] = {
+          state:,
+          connection_for: "user",
+        }
         session[:user_return_to] = "/users/informations" # Pour simuler le retour vers la page demandée avant la connexion
       end
 
@@ -123,6 +171,72 @@ RSpec.describe AgentConnectController do
           expect(session["agent_connect_id_token"]).to be_present
 
           expect(response).to redirect_to("/users/informations")
+        end
+      end
+    end
+
+    context "when logging in a super admin" do
+      before do
+        session[:pro_connect] = {
+          state:,
+          connection_for: "super_admin",
+        }
+        session[:super_admin_return_to] = "/super_admins/agents" # Pour simuler le retour vers la page demandée avant la connexion
+      end
+
+      context "with a non 2FA account" do
+        it "redirects to the super admin sign in page if the super admin does not activate 2FA" do
+          get :callback, params: { state: state, code: code }
+
+          expect(session["agent_connect_id_token"]).to be_nil
+          expect(response).to redirect_to("/connexion_super_admins")
+          expect(flash[:error]).to eq("Vous devez activer la double authentification sur votre compte ProConnect pour vous connecter en tant que super administrateur.")
+        end
+      end
+
+      context "with a 2FA account" do
+        before do
+          AgentConnectStubs.stub_callback_requests(code, user_info, with_2fa: true)
+        end
+
+        context "when the super admin does not exist" do
+          it "redirects to the super admin sign in page" do
+            get :callback, params: { state: state, code: code }
+
+            expect(session["agent_connect_id_token"]).to be_nil
+            expect(response).to redirect_to("/connexion_super_admins")
+            expect(flash[:error]).to eq("Compte ProConnect non autorisé")
+          end
+        end
+
+        context "when the super admin already exists" do
+          let!(:super_admin) { create(:super_admin, email: "francis.factice@exemple.gouv.fr") }
+
+          it "redirects to the super admin agents page" do
+            get :callback, params: { state: state, code: code }
+
+            expect(session["agent_connect_id_token"]).to be_present
+            expect(response).to redirect_to("/super_admins/agents")
+          end
+        end
+
+        context "in development, when no super admin exists" do
+          before do
+            allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+          end
+
+          it "creates the super admin and redirects to the super admin agents page" do
+            expect(SuperAdmin.count).to eq(0)
+
+            get :callback, params: { state: state, code: code }
+
+            expect(SuperAdmin.count).to eq(1)
+            expect(SuperAdmin.last).to have_attributes(
+              email: "francis.factice@exemple.gouv.fr"
+            )
+            expect(session["agent_connect_id_token"]).to be_present
+            expect(response).to redirect_to("/super_admins/agents")
+          end
         end
       end
     end

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe AgentConnectController do
         claims: {
           id_token: {
             acr: {
-              essential: true,
-              values: ["eidas1"],
+              essential: false,
+              values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
             },
           },
         }.to_json
@@ -48,8 +48,8 @@ RSpec.describe AgentConnectController do
           claims: {
             id_token: {
               acr: {
-                essential: true,
-                values: ["eidas1"],
+                essential: false,
+                values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
               },
             },
           }.to_json
@@ -78,7 +78,7 @@ RSpec.describe AgentConnectController do
           id_token: {
             acr: {
               essential: true,
-              values: ["eidas2", "eidas3", "https://proconnect.gouv.fr/assurance/consistency-checked-2fa", "https://proconnect.gouv.fr/assurance/self-asserted-2fa"],
+              values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
             },
           },
         }.to_json

--- a/spec/support/agent_connect_stubs.rb
+++ b/spec/support/agent_connect_stubs.rb
@@ -7,10 +7,14 @@ module AgentConnectStubs
     load Rails.root.join("config/initializers/agent_connect.rb").to_s
   end
 
-  def self.stub_callback_requests(code, user_info)
+  def self.stub_callback_requests(code, user_info, with_2fa: false)
     stub_and_run_discover_request
 
-    stub_token_request(code)
+    if with_2fa
+      stub_token_request(code, acr: "https://proconnect.gouv.fr/assurance/self-asserted-2fa")
+    else
+      stub_token_request(code)
+    end
 
     userinfo_encoded_response_body = "fake_userinfo_encoded_response_body"
 
@@ -30,7 +34,7 @@ module AgentConnectStubs
     ).and_return([user_info])
   end
 
-  def self.stub_token_request(code)
+  def self.stub_token_request(code, acr: "eidas1")
     WebMock.stub_request(:post, "https://fca.integ01.dev-agentconnect.fr/api/v2/token").with(
       body: {
         "client_id" => "ec41582-1d60-4f11-a63b-d8abaece16aa",
@@ -48,7 +52,7 @@ module AgentConnectStubs
     }.to_json, headers: {})
 
     allow(OpenIDConnect::ResponseObject::IdToken).to receive(:decode).and_return(
-      instance_double(OpenIDConnect::ResponseObject::IdToken, verify!: true)
+      instance_double(OpenIDConnect::ResponseObject::IdToken, verify!: true, acr:)
     )
   end
 


### PR DESCRIPTION
# Contexte

Nous avons déjà fait une première tentative pour passer les comptes SuperAdmin sur ProConnect : #5662 
Néanmoins, nous avons rencontré un problème avec les agents qui utilisent Passage 2 pour l’authentification, car ils ont de base un niveau d’authentification fort, avec carte agent + code PIN.
La première PR proposé (que nous avons rollback) demandait dans le claim, un ACR `eidas1`, parce que je m’étais calqué sur l’ancienne `acr_values`. Le problème étant que ces agents qui ont une carte + code PIN, ne rentrent pas dans cette case.

# Solution

Dans cette seconde PR, je propose donc de passer la valeur de l’`acr` en `essential=false`, ce qui correspond à l’ancien mode de fonctionnement (voir [ce commit](https://github.com/betagouv/rdv-service-public/pull/5667/commits/9fd41989f6ef86a5328c64729b3908d42ad11153)). Les agents qui ont Passage 2 devraient alors pouvoir se connecter sans souci. Ceci est confirmé par l’équipe de ProConnect via Tchap.

Lors de la mise en prod, il faudra tout de même surveiller les Sentry pour être sur que nous n’avons pas réintroduit un problème.

