### PR TITLE
Correction de la création d'absence avec une external reference

### DIFF
--- a/app/controllers/api/v1/absences_controller.rb
+++ b/app/controllers/api/v1/absences_controller.rb
@@ -16,15 +16,18 @@ class Api::V1::AbsencesController < Api::V1::AgentAuthBaseController
     end
 
     authorize(absence, policy_class: Agent::AbsencePolicy) if absence.valid?
-    absence.save!
 
-    if params[:external_reference].present?
-      ExternalReference.create!(
-        params.require(:external_reference).permit(:external_id, :external_url).merge(
-          item: absence,
-          oauth_application: doorkeeper_token&.application
+    absence.transaction do
+      absence.save!
+
+      if params[:external_reference].present?
+        ExternalReference.create!(
+          params.require(:external_reference).permit(:external_id, :external_url).merge(
+            item: absence,
+            oauth_application: doorkeeper_token&.application
+          )
         )
-      )
+      end
     end
 
     render_record absence

--- a/spec/requests/api/v1/absences_spec.rb
+++ b/spec/requests/api/v1/absences_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Plage ouvertures API" do
       let(:previous_absence) { create(:absence) }
 
       before do
-        create(:external_reference, item: previous_absence, external_id: 123, oauth_application: application)
+        create(:external_reference, item: previous_absence, external_id: 123, oauth_application: application, territory_id: nil)
       end
 
       it "doesn't create the absence" do

--- a/spec/requests/api/v1/absences_spec.rb
+++ b/spec/requests/api/v1/absences_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe "Plage ouvertures API" do
+  let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
+  let(:headers) do
+    { "Content-Type": "application/json", Authorization: "Bearer #{oauth_token.plaintext_token}" }
+  end
+  let(:application) { create(:oauth_application) }
+
+  let!(:agent) { create(:agent, basic_role_in_organisations: [create(:organisation)]) }
+
+  describe "#create" do
+    let(:params) do
+      {
+        title: "Congé",
+        first_day: Time.zone.today.strftime("%Y-%m-%d"),
+        end_day: Time.zone.today.strftime("%Y-%m-%d"),
+        start_time: "08:00",
+        end_time: "12:00",
+        agent_id: agent.id,
+
+        external_reference: { external_id: "123" },
+      }
+    end
+
+    context "when there already is an absence with this external reference" do
+      let(:previous_absence) { create(:absence) }
+
+      before do
+        create(:external_reference, item: previous_absence, external_id: 123, oauth_application: application)
+      end
+
+      it "doesn't create the absence" do
+        expect { post "/api/v1/absences", headers:, params:, as: :json }.not_to change(Absence, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
On a eu un retour d'un conum qui a migré deux organisations et pour lequel les absences ont été crées en double.

🤦 Il manquait un bloc de transaction.

J'ai vérifié les autres controllers, et on n'a pas ce problème pour eux.