### PR TITLE
Correctif pour la création de plages d'ouverture et d'absences pour des collègues lors de la migration des conums

### DIFF
--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -88,7 +88,7 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
       }
 
       if absence.agent != instance_export.agent
-        params[:agent_email] = instance_export.agent.email
+        params[:agent_email] = absence.agent.email
       end
 
       api_client = instance_export.api_client
@@ -119,7 +119,7 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
       }
 
       if plage_ouverture.agent != instance_export.agent
-        params[:agent_email] = instance_export.agent.email
+        params[:agent_email] = plage_ouverture.agent.email
       end
 
       api_client = instance_export.api_client

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -34,9 +34,6 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   end
 
   let!(:absence_du_collegue) { create(:absence, :no_recurrence, agent: collegue) }
-  let!(:plage_ouverture_du_collegue) do
-    create(:plage_ouverture, agent: collegue, organisation: organisation_rdv_aide_num, lieu: lieu, motifs: [motif])
-  end
 
   let!(:agent_rdv_sp) do
     create(:agent, first_name: "Camille", last_name: "Clavier", password: "c0rrecThorse!", admin_role_in_organisations: [])
@@ -169,9 +166,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
       motif_ids: [created_motif.id]
     )
 
-    # Les absences et plages d'ouverture du collègue sont copiées
+    # Les absences du collègue sont copiées
     expect(collegue.reload.absences.count).to eq 3
-    expect(collegue.reload.plage_ouvertures.count).to eq 2
 
     login_as(agent_rdv_sp, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     create(:plage_ouverture, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num, organisation: organisation_rdv_aide_num, lieu: lieu, motifs: [motif])
   end
 
+  let!(:absence_du_collegue) { create(:absence, :no_recurrence, agent: collegue) }
+  let!(:plage_ouverture_du_collegue) do
+    create(:plage_ouverture, agent: collegue, organisation: organisation_rdv_aide_num, lieu: lieu, motifs: [motif])
+  end
+
   let!(:agent_rdv_sp) do
     create(:agent, first_name: "Camille", last_name: "Clavier", password: "c0rrecThorse!", admin_role_in_organisations: [])
   end
@@ -163,6 +168,10 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
       lieu_id: created_lieu.id,
       motif_ids: [created_motif.id]
     )
+
+    # Les absences et plages d'ouverture du collègue sont copiées
+    expect(collegue.reload.absences.count).to eq 2
+    expect(collegue.reload.plage_ouvertures.count).to eq 2
 
     login_as(agent_rdv_sp, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -146,8 +146,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     expect(created_motif).to have_attributes(name: motif.name)
 
     # On crée des absences qui permettent de retrouver les rendez-vous sur l'ancienne instance
-    expect(collegue.absences.last.starts_at).to be_within(1.minute).of(future_rdv.starts_at)
-    expect(collegue.absences.last.external_references.last.external_url).to eq "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{future_rdv.id}"
+    expect(collegue.absences.where(title: "RDV pris sur RDV Aide Numérique").last.starts_at).to be_within(1.minute).of(future_rdv.starts_at)
+    expect(collegue.absences.where(title: "RDV pris sur RDV Aide Numérique").last.external_references.last.external_url).to eq "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{future_rdv.id}"
 
     # On crée aussi des copies des absences futures
     expect(agent_rdv_sp.absences.exceptionnelles.first.starts_at).to eq absence.starts_at
@@ -170,7 +170,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     )
 
     # Les absences et plages d'ouverture du collègue sont copiées
-    expect(collegue.reload.absences.count).to eq 2
+    expect(collegue.reload.absences.count).to eq 3
     expect(collegue.reload.plage_ouvertures.count).to eq 2
 
     login_as(agent_rdv_sp, scope: :agent)

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -167,7 +167,9 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     )
 
     # Les absences du collègue sont copiées
-    expect(collegue.reload.absences.count).to eq 3
+    copied_absence = collegue.reload.absences.joins(:external_references)
+      .where(external_references: { external_id: "absence:#{absence_du_collegue.id}" })
+    expect(copied_absence).to be_present
 
     login_as(agent_rdv_sp, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"


### PR DESCRIPTION
Autre bug (comme https://github.com/betagouv/rdv-service-public/pull/5668), on met le mauvais agent lors de la création d'absence ou de plage d'ouverture pour un collègue.

C'est un peu galère de tester la création de plage d'ouverture pour un collègue, vu que la règle de validation ne permet pas de la créer dans le cas des specs où on est en fait sur la même base de données.