### PR TITLE
Améliorations de l'affichage des absences

### DIFF
--- a/app/controllers/admin/planning/absences_controller.rb
+++ b/app/controllers/admin/planning/absences_controller.rb
@@ -10,8 +10,13 @@ class Admin::Planning::AbsencesController < AgentAuthController
     absences = policy_scope(Absence, policy_scope_class: Agent::AbsencePolicy::Scope)
       .where(agent: @agent)
       .includes(:agent)
-      .by_starts_at
       .page(page_number)
+
+    absences = if params[:current_tab] == "expired"
+                 absences.by_starts_at(:desc)
+               else
+                 absences.by_starts_at(:asc)
+               end
 
     @absences = params[:current_tab] == "expired" ? absences.expired : absences.not_expired
     @display_tabs = absences.expired.any? || params[:current_tab] == "expired"

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -31,7 +31,7 @@ class Absence < ApplicationRecord
   before_validation :set_end_day
 
   # Scopes
-  scope :by_starts_at, -> { order(first_day: :desc, start_time: :desc) }
+  scope :by_starts_at, ->(direction = :desc) { order(first_day: direction, start_time: direction) }
   scope :in_range, lambda { |range|
     return all if range.nil?
 

--- a/app/views/admin/planning/absences/_absence.html.slim
+++ b/app/views/admin/planning/absences/_absence.html.slim
@@ -9,7 +9,7 @@ tr
       - if absence.first_day != absence.end_day
         | Du #{l(absence.starts_at, format: :human)} au #{l(absence.first_occurrence_ends_at, format: :human)}
       - else
-        | Le #{l(absence.first_day, format: :human)} de #{l(absence.starts_at, format: "%H:%M")} à #{l(absence.ends_at, format: "%H:%M")}
+        | Le #{l(absence.first_day, format: :human)} #{display_time_range(absence)}
 
   td
     .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline.rdv-gap-05rem

--- a/app/views/admin/planning/absences/_absence.html.slim
+++ b/app/views/admin/planning/absences/_absence.html.slim
@@ -3,13 +3,14 @@ tr
     = link_to absence.title,  edit_admin_organisation_planning_absence_path(current_organisation, absence)
     = absence_tag(absence)
   td
-    | Du #{l(absence.starts_at, format: :human)} au #{l(absence.first_occurrence_ends_at, format: :human)}
-
     - if absence.recurrence.present?
-      br
-      | Se répète&nbsp;:
-      br
       = sanitize(display_recurrence(absence).join("<br/>"))
+    - else
+      - if absence.first_day != absence.end_day
+        | Du #{l(absence.starts_at, format: :human)} au #{l(absence.first_occurrence_ends_at, format: :human)}
+      - else
+        | Le #{l(absence.first_day, format: :human)} de #{l(absence.starts_at, format: "%H:%M")} à #{l(absence.ends_at, format: "%H:%M")}
+
   td
     .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline.rdv-gap-05rem
       = link_to "",  edit_admin_organisation_planning_absence_path(current_organisation, absence),

--- a/app/views/admin/planning/absences/_form.html.slim
+++ b/app/views/admin/planning/absences/_form.html.slim
@@ -12,4 +12,4 @@
       .col.text-left
         = link_to "Supprimer", admin_organisation_planning_absence_path(current_organisation, absence), method: :delete, class: "btn btn-outline-danger", data: { confirm: t(".confirm_delete_absence")}
     .col.text-right
-      = f.button :submit
+      = f.submit class: "fr-btn"


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1071" height="728" alt="Screenshot 2025-09-26 at 11 44 42" src="https://github.com/user-attachments/assets/79ea4065-a9a1-43ea-830a-01f41c88cb53" />|<img width="1031" height="638" alt="Screenshot 2025-09-26 at 11 45 00" src="https://github.com/user-attachments/assets/41769d63-cae4-46e1-bc5e-be4a34069f2f" />


# Contexte

En corrigeant des absences mal assignées lors d'une migration de conums, j'ai passé pas mal de temps à regarder l'index des absences et à beaucoup galérer pour comprendre ce que je lisais.

Il y a deux points qui rendaient ça compliqué :
- pour les absences à venir, on les affiche de la plus lointaine à la plus proche. C'est à dire qu'on affichera les absences de 2026 en premier, puis celle de 2025. Quand on a plusieurs pages d'absences, ça veut dire que sur la première page, on n'affiche aucune des absences proche de nous. C'est très déroutant de voir d'abord le futur lointain, et petit à petit se rapprocher de la semaine courante. Par contre pour les absences passées, ça marche bien d'avoir les plus récentes en premières, et ensuite les plus anciennes.
- L'affichage des dates est très laborieux, et parfois faux quand on a des absences répétées. Par exemple : 
<img width="563" height="132" alt="Screenshot 2025-09-26 at 11 43 19" src="https://github.com/user-attachments/assets/554650a1-a9ba-40cc-b4a0-1c487e47ee11" />
<img width="537" height="44" alt="Screenshot 2025-09-26 at 11 43 40" src="https://github.com/user-attachments/assets/c7a0d869-45e9-4c90-af01-881f773e184d" />



# Solution

- on trie du plus proche au plus lointain pour les absences à venir
- on reprend l'affichage des dates et heures qu'on utilise déjà pour les plages d'ouverture

