### PR TITLE
Suppression des vieilles absences

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -132,6 +132,13 @@ class CronJob < ApplicationJob
     end
   end
 
+  class DestroyOldAbsencesJob < CronJob
+    def perform
+      Absence.where(recurrence: nil).where("end_day < ?", 2.years.ago).find_each(&:destroy)
+      Absence.where.not(recurrence: nil).where("recurrence_ends_at < ?", 2.years.ago).find_each(&:destroy)
+    end
+  end
+
   class AnonymizeOldReceipts < CronJob
     def perform
       Anonymizer.anonymize_records!("receipts", scope: Receipt.arel_table[:created_at].lt(6.months.ago))

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -52,6 +52,10 @@ Rails.application.configure do
       cron: "every day at 22:30 Europe/Paris",
       class: "CronJob::DestroyOldPlageOuvertureJob",
     },
+    destroy_old_absences_job: {
+      cron: "every day at 22:35 Europe/Paris",
+      class: "CronJob::DestroyOldAbsencesJob",
+    },
     destroy_old_oauth_objects: {
       cron: "every day at 22:45 Europe/Paris",
       class: "CronJob::DestroyOldOauthObjects",

--- a/docs/architecture-technique.md
+++ b/docs/architecture-technique.md
@@ -1,18 +1,12 @@
 # Dossier technique
 
-> Ce dossier a pour but de présenter l’architecture technique du SI. Il n’est par conséquent ni un dossier d’installation, ni un dossier d’exploitation ou un dossier de spécifications fonctionnelles.
+> Ce dossier présente l’architecture technique du SI. Il n’est pas un dossier d’installation, ni un dossier d’exploitation ou un dossier de spécifications fonctionnelles.
 
 **Nom du projet :** RDV Service Public
 
 **Dépôt de code :** https://github.com/betagouv/rdv-service-public
 
 **Hébergeur :** Scalingo, Paris (région Scalingo "osc-secnum-fr1", région Outscale "cloudgouv-eu-west-1")
-
-**Décision d’homologation :** !!<date>!!
-
-**France Relance :** ❌
-
-**Inclusion numérique :** ✅
 
 ## Suivi du document
 
@@ -562,6 +556,7 @@ Pour les membres de l'équipe technique, on prend ces mesures supplémentaires :
 Voici les suppressions automatiques mises en place :
 - Suppression des RDVs de plus de 2 ans
 - Suppression des plages d'ouverture de plus de 1 an
+- Suppression des indisponibilités de plus de 2 ans
 - Suppression des logs PaperTrail (auditing) de plus de 1 an contenant des données personnelles autres que l'identité de la personne dont on journalise l'action.
 - Anonymisation des logs PaperTrail(auditing) de plus de 1 an ne contenant pas données personnelles autre que l'identité de la personne dont on journalise l'action
 - Suppression des logs PaperTrail (auditing) de plus de 5 ans

--- a/spec/features/agents/sectorisation/sectorisation_setup_spec.rb
+++ b/spec/features/agents/sectorisation/sectorisation_setup_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Agent can setup sectorisation", type: :feature do
     fill_in :sector_name, with: "Secteur Nord"
     fill_in :sector_human_id, with: "nord"
     click_on "Enregistrer"
+    expect(page).to have_content("Communes ou rues associées")
     click_on "Ajouter une commune ou une rue"
     fill_in_readonly_input("#zone_city_name", "Valence")
     fill_in_readonly_input("#zone_city_code", "26362")

--- a/spec/jobs/cron_job/destroy_old_absences_job_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_absences_job_spec.rb
@@ -56,4 +56,15 @@ RSpec.describe CronJob::DestroyOldAbsencesJob do
       expect(Absence.all).not_to include(absence)
     end
   end
+
+  it "sends webhooks events" do
+    organisation = create(:organisation)
+    agent = create(:agent, basic_role_in_organisations: [organisation])
+    create(:absence, first_day: now - 2.years - 3.days, recurrence: nil, agent:)
+    create(:webhook_endpoint, organisation:, subscriptions: ["absence"])
+
+    described_class.new.perform
+
+    expect(enqueued_jobs.last["job_class"]).to eq("WebhookJob")
+  end
 end

--- a/spec/jobs/cron_job/destroy_old_absences_job_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_absences_job_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe CronJob::DestroyOldAbsencesJob do
+  let(:now) { Time.zone.parse("20220405 10:00") }
+
+  before { travel_to(now) }
+
+  it "Destroy exceptional absences closed since 2 years" do
+    absence_exceptionelle_closed_since_2_years = create(:absence, first_day: now - 2.years - 3.days, recurrence: nil)
+
+    described_class.new.perform
+
+    expect(Absence.all).not_to include(absence_exceptionelle_closed_since_2_years)
+  end
+
+  it "keep exceptional absence closed since 10 days" do
+    absence_exceptionelle_closed_since_10_days = create(:absence, first_day: now - 10.days, recurrence: nil)
+
+    described_class.new.perform
+
+    expect(Absence.all).to include(absence_exceptionelle_closed_since_10_days)
+  end
+
+  it "destroy recurrence absence closed since 2 years" do
+    absence_recurrence_closed_since_2_years = create(:absence, first_day: now - 3.years, recurrence: Montrose.every(:week, starts: now - 3.years, until: now - 2.years - 3.days))
+
+    described_class.new.perform
+
+    expect(Absence.all).not_to include(absence_recurrence_closed_since_2_years)
+  end
+
+  it "keep recurrence absence closed since 10 days" do
+    absence_recurrence_closed_since_10_days = create(:absence, first_day: now - 3.years, recurrence: Montrose.every(:week, starts: now - 3.years, until: now - 10.days))
+
+    described_class.new.perform
+
+    expect(Absence.all).to include(absence_recurrence_closed_since_10_days)
+  end
+
+  it "keep recurrence absence still open" do
+    absence_recurrence_not_closed = create(:absence, first_day: now - 3.years, recurrence: Montrose.every(:week, starts: now - 3.years, until: nil))
+
+    described_class.new.perform
+
+    expect(Absence.all).to include(absence_recurrence_not_closed)
+  end
+
+  context "multi-day absence" do
+    it "keeps it when finished since 18 month" do
+      absence = create(:absence, first_day: now - 2.years - 3.days, end_day: now - 18.months, recurrence: nil)
+      described_class.new.perform
+      expect(Absence.all).to include(absence)
+    end
+
+    it "destroys it when finished since more than 2 years" do
+      absence = create(:absence, first_day: now - 2.years - 3.days, end_day: now - 2.years - 1.day, recurrence: nil)
+      described_class.new.perform
+      expect(Absence.all).not_to include(absence)
+    end
+  end
+end


### PR DESCRIPTION
Dans le cadre de la migration des conums depuis RDV Aide Numérique vers RDV Service Public, on va probablement vouloir mettre des titres de rendez-vous dans des absences qu'on crée dans RDV SP pour matérialiser des rdvs à venir pris sur RDV AN.

Le problème, c'est qu'actuellement, même si on anonymise les intitulés d'absences dans l'etl, on ne supprime jamais les absences.

Ça semble donc raisonnable de faire pour les absences la même chose que ce qu'on fait pour les plages d'ouverture, à savoir supprimer les anciennes. Peut-être même que ça améliorera légèrement nos performances sur la recherche de créneaux et que ça diminuera légèrement la taille de nos index ?

Pour jouer la sécurité, pour le moment on supprime juste les absences de plus de 2 ans. Peut-être que ça peut être utile pour des agents de voir quel était leur planning de l'année dernière.
