### PR TITLE
Préparatifs planning multi-agents : modulariser select2-inputs.js

### DIFF
--- a/app/javascript/application_agent.js
+++ b/app/javascript/application_agent.js
@@ -28,7 +28,7 @@ import { RecurrenceForm } from './components/recurrence-form.js'
 import { MergeUsersForm } from './components/merge-users-form.js'
 import { SectorAttributionForm } from './components/sector-attribution-form.js'
 import { ZoneForm } from './components/zone-form.js'
-import { Select2Inputs } from './components/select2-inputs'
+import { initializeSelect2 } from './components/select2-inputs'
 import { PlanningAgentSelect } from './components/planning-agent-select'
 import { ParticipationSelect } from './components/rdv-user-select'
 import { Tooltips } from './components/tooltips'
@@ -57,7 +57,7 @@ $.fn.select2.defaults.set("theme", "bootstrap4")
 $.fn.select2.defaults.set("language", "fr")
 
 new Modal()
-new Select2Inputs()
+initializeSelect2()
 new ServiceFilterForMotifsSelects()
 
 global.$ = require('jquery')

--- a/app/javascript/application_agent_config.js
+++ b/app/javascript/application_agent_config.js
@@ -12,7 +12,7 @@ import { Modal } from './components/modal';
 import './components/browser-detection';
 import 'select2/dist/js/select2.min.js';
 import 'select2/dist/js/i18n/fr.js';
-import { Select2Inputs } from './components/select2-inputs';
+import { initializeSelect2 } from './components/select2-inputs';
 import 'bootstrap';
 import { Clipboard } from './components/clipboard.js'
 
@@ -20,7 +20,7 @@ import './stylesheets/application_agent_config';
 import './stylesheets/print';
 
 new Modal();
-new Select2Inputs();
+initializeSelect2();
 
 $(document).on('turbolinks:load', function () {
   DsfrNewPassword();

--- a/app/javascript/components/agent-user-form.js
+++ b/app/javascript/components/agent-user-form.js
@@ -1,4 +1,4 @@
-import { Select2Inputs } from "./select2-inputs"
+import { initializeSelect2 } from "./select2-inputs"
 import 'custom-event-polyfill'
 
 class AgentUserForm {
@@ -46,7 +46,7 @@ class AgentUserForm {
       )
         inputElt.previousSibling.disabled = newDisabledValue
     })
-    new Select2Inputs()
+    initializeSelect2()
   }
 
   divShouldBeVisible = (divElt) => {

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -65,7 +65,7 @@ class CalendarRdvSolidarites {
     const options = {
       plugins: [dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin],
       eventSources: JSON.parse(this.data.eventSourcesJson),
-      eventSourceFailure: this.handleAjaxError,
+      eventSourceFailure: handleAjaxError,
       initialDate: this.getDefaultDate(),
       initialView: this.getDefaultView(),
       hiddenDays: hiddenDays,
@@ -148,29 +148,29 @@ class CalendarRdvSolidarites {
     const now = new Date()
     return now >= activeStart && now <= activeEnd;
   }
-
-  handleAjaxError = (response) => {
-    if (this.ajaxErrorHandledAt) {
-      const secondsSinceLast = (Date.now() - this.ajaxErrorHandledAt) / 1000;
-      if (secondsSinceLast < 60) return
-    }
-    this.ajaxErrorHandledAt = Date.now()
-
-    switch (response.xhr.status) {
-      case 401:
-        window.location = this.calendarEl.attributes["data-sign-in-path"].value;
-        break;
-      case 500:
-        alert(`Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
-        break;
-      case 0:
-        alert(`Le chargement du calendrier a échoué, probablement car votre connexion internet a été coupée.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
-        break;
-      default:
-        alert(`Le chargement du calendrier a échoué avec une erreur ${response.xhr.status}\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`)
-    }
-  }
 }
+
+export const handleAjaxError = (response) => {
+  if (window.ajaxErrorHandledAt) {
+    const secondsSinceLast = (Date.now() - window.ajaxErrorHandledAt) / 1000;
+    if (secondsSinceLast < 60) return
+  }
+  window.ajaxErrorHandledAt = Date.now()
+
+  switch (response.xhr.status) {
+    case 401:
+      window.location = this.calendarEl.attributes["data-sign-in-path"].value;
+      break;
+    case 500:
+      alert(`Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
+      break;
+    case 0:
+      alert(`Le chargement du calendrier a échoué, probablement car votre connexion internet a été coupée.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
+      break;
+    default:
+      alert(`Le chargement du calendrier a échoué avec une erreur ${response.xhr.status}\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`)
+  }
+};
 
 document.addEventListener('turbolinks:load', function () {
   new CalendarRdvSolidarites()

--- a/app/javascript/components/select2-inputs.js
+++ b/app/javascript/components/select2-inputs.js
@@ -1,93 +1,92 @@
-class Select2Inputs {
-  constructor() {
-    this.selector = '.select2-input'
-    this.initInputs()
-    $(document).on('turbolinks:load', this.initInputs)
-    $(document).on('shown.bs.modal', '.modal', this.initInputs)
-    $(document).on("turbolinks:before-cache", this.destroyInputs)
-    $(document).on('select2:open', this.focusSearchInput)
-  }
+const SELECTOR = ".select2-input";
 
-  focusSearchInput = (e) => {
-    const selectId = e.target.id
-    $(".select2-search__field[aria-controls='select2-" + selectId + "-results']").each(function (key,value,) {
-      value.focus()
-    })
+const initInput = (elt) => {
+  const config = getInputConfig(elt)
+  $(elt).select2(config)
+  if (elt.dataset.autoSelectSoleOption) {
+    autoSelectSoleOption(elt, config)
   }
-
-  initInputs = () => {
-    document.querySelectorAll(this.selector).forEach(this.initInput)
-  }
-
-  initInput = (elt) => {
-    const config = this.getInputConfig(elt)
-    $(elt).select2(config)
-    if (elt.dataset.autoSelectSoleOption) {
-      this.autoSelectSoleOption(elt, config)
+  // select2 change le comportement de l’événement change.
+  // Pour pouvoir intercepter l’événement change, grâce à un data-action stimulus, il faut le re-déclencher manuellement.
+  // On ne fait ceci que si il y a un data-action "change->" sur l'élément pour éviter des conflits (notamment avec le formulaire de fusion usagers).
+  // cf https://psmy.medium.com/rails-6-stimulus-and-select2-de4a4d2b59e4
+  $(elt).on("change", function () {
+    const action = this.getAttribute("data-action") || "";
+    if (action.includes("change->")) {
+      let event = new Event("change");
+      this.dispatchEvent(event);
     }
-    // select2 change le comportement de l’événement change.
-    // Pour pouvoir intercepter l’événement change, grâce à un data-action stimulus, il faut le re-déclencher manuellement.
-    // On ne fait ceci que si il y a un data-action "change->" sur l'élément pour éviter des conflits (notamment avec le formulaire de fusion usagers).
-    // cf https://psmy.medium.com/rails-6-stimulus-and-select2-de4a4d2b59e4
-    $(elt).on("change", function () {
-      const action = this.getAttribute("data-action") || "";
-      if (action.includes("change->")) {
-        let event = new Event('change');
-        this.dispatchEvent(event);
-      }
-    });
+  });
+};
+
+const getInputConfig = (elt) => {
+  let config = {}
+  if (elt.dataset.select2Config !== undefined)
+    config = JSON.parse(elt.dataset.select2Config)
+
+  if (config.disableSearch)
+    config.minimumResultsForSearch = Infinity // cf https://select2.org/searching
+
+  // Make sure select2 works correctly inside a modal
+  // https://select2.org/troubleshooting/common-problems#select2-does-not-function-properly-when-i-use-it-inside-a-bootst
+  let modal = $(elt).closest(".modal")[0]
+  if (modal !== undefined)
+    config.dropdownParent = modal
+
+  // Lorsque le select est configuré en AJAX **et** qu'aucune <option> n'est pré-injectée dans le HTML,
+  // l'utilisateur⋅ice voit seulement un champ de recherche et une mention "Aucun résultat trouvé".
+  // Afin d'indiquer clairement qu'il est attendu de commencer à saisir quelque-chose, ce code fait en
+  // sorte que la mention soit plutot "Commencez à taper pour rechercher".
+  const isAjax = elt.dataset.select2Config?.includes("ajax");
+  const hasAnyOption = Array.from(elt.options).some(opt => opt.value); // we rule out options without value, they are usually placeholders
+  if (isAjax && !hasAnyOption) {
+    config.minimumInputLength = 1
+    config.language = { inputTooShort: () => "Commencez à taper pour rechercher" } // Overrides select2/i18n/fr.js
   }
 
-  getInputConfig = elt => {
-    let config = {}
-    if (elt.dataset.select2Config !== undefined)
-      config = JSON.parse(elt.dataset.select2Config)
+  return config
+};
 
-    if (config.disableSearch)
-      config.minimumResultsForSearch = Infinity // cf https://select2.org/searching
+const autoSelectSoleOption = (elt, options) => {
+  // This code checks if a select element (represented by the `elt` variable) has only one option.
+  // return all options if it is ajax
+  const isAjax = elt.dataset.select2Config?.includes("ajax");
+  if (isAjax) return;
 
-    // Make sure select2 works correctly inside a modal
-    // https://select2.org/troubleshooting/common-problems#select2-does-not-function-properly-when-i-use-it-inside-a-bootst
-    let modal = $(elt).closest(".modal")[0]
-    if (modal !== undefined)
-      config.dropdownParent = modal
-
-    // Lorsque le select est configuré en AJAX **et** qu'aucune <option> n'est pré-injectée dans le HTML,
-    // l'utilisateur⋅ice voit seulement un champ de recherche et une mention "Aucun résultat trouvé".
-    // Afin d'indiquer clairement qu'il est attendu de commencer à saisir quelque-chose, ce code fait en
-    // sorte que la mention soit plutot "Commencez à taper pour rechercher".
-    const isAjax = elt.dataset.select2Config?.includes("ajax");
-    const hasAnyOption = Array.from(elt.options).some(opt => opt.value); // we rule out options without value, they are usually placeholders
-    if (isAjax && !hasAnyOption) {
-      config.minimumInputLength = 1
-      config.language = { inputTooShort: () => "Commencez à taper pour rechercher" } // Overrides select2/i18n/fr.js
-    }
-
-    return config
+  // Get all options and remove blank values if exists (placeholders)
+  const optionsList = $(elt).find("option").filter(function() {
+    return $(this).val() !== "";
+  });
+  if (optionsList.length === 1) {
+    // if one option is already selected, return
+    if ($(elt).val() === optionsList.val()) return;
+    // Otherwise, set the value of the select element to the value of its sole option and trigger a change event on it.
+    $(elt).val(optionsList.val()).trigger("change");
   }
+};
 
-  destroyInputs = () => {
-    if ($(this.selector).first().data('select2') != undefined)
-      $(this.selector).select2('destroy')
-  }
+const initInputs = () => {
+  document.querySelectorAll(SELECTOR).forEach(initInput)
+};
 
-  autoSelectSoleOption = (elt, options) => {
-    // This code checks if a select element (represented by the `elt` variable) has only one option.
-    // return all options if it is ajax
-    const isAjax = elt.dataset.select2Config?.includes("ajax");
-    if (isAjax) return;
+const destroyInputs = () => {
+  if ($(SELECTOR).first().data("select2") != undefined)
+    $(SELECTOR).select2("destroy")
+};
 
-    // Get all options and remove blank values if exists (placeholders)
-    const optionsList = $(elt).find("option").filter(function() {
-      return $(this).val() !== "";
-    });
-    if (optionsList.length === 1) {
-      // if one option is already selected, return
-      if ($(elt).val() === optionsList.val()) return;
-      // Otherwise, set the value of the select element to the value of its sole option and trigger a change event on it.
-      $(elt).val(optionsList.val()).trigger('change');
-    }
-  }
-}
+const focusSearchInput = (e) => {
+  const selectId = e.target.id
+  $(".select2-search__field[aria-controls='select2-" + selectId + "-results']").each(function (key,value,) {
+    value.focus()
+  })
+};
 
-export { Select2Inputs };
+const initializeSelect2 = () => {
+  initInputs()
+  $(document).on("turbolinks:load", initInputs)
+  $(document).on("shown.bs.modal", ".modal", initInputs)
+  $(document).on("turbolinks:before-cache", destroyInputs)
+  $(document).on("select2:open", focusSearchInput)
+};
+
+export { initializeSelect2 };

--- a/app/javascript/components/select2-inputs.js
+++ b/app/javascript/components/select2-inputs.js
@@ -1,6 +1,14 @@
-const SELECTOR = ".select2-input";
+export const initializeSelect2 = () => {
+  initInputs()
+  $(document).on("turbolinks:load", initInputs)
+  $(document).on("shown.bs.modal", ".modal", initInputs)
+  $(document).on("turbolinks:before-cache", destroyInputs)
+  $(document).on("select2:open", focusSearchInput)
+};
 
-const initInput = (elt) => {
+export const SELECTOR = ".select2-input";
+
+export const initInput = (elt) => {
   const config = getInputConfig(elt)
   $(elt).select2(config)
   if (elt.dataset.autoSelectSoleOption) {
@@ -80,13 +88,3 @@ const focusSearchInput = (e) => {
     value.focus()
   })
 };
-
-const initializeSelect2 = () => {
-  initInputs()
-  $(document).on("turbolinks:load", initInputs)
-  $(document).on("shown.bs.modal", ".modal", initInputs)
-  $(document).on("turbolinks:before-cache", destroyInputs)
-  $(document).on("select2:open", focusSearchInput)
-};
-
-export { initializeSelect2 };


### PR DESCRIPTION
# Contexte

Tout comme dans #5669, je fais en sorte ici d'extraire dans  une petite PR un travail nécessaire à la PR de feature #5637. Le but est donc de limiter les risques en déployant de petites PR.

# Solution

Dans cette petit PR, je fais en sorte d'exposer les méthodes présentes dans `select2-inputs.js` pour qu'elles puissent être réutilisées.

Avant : le fichier définit une classe `Select2Inputs` qui contient toutes les méthodes et les utilise en interne (appels à `this.maMethode()`)
Après : le fichier définit un ensemble de méthodes assignées à des `const`, et donc exportables donc réutilisables

J'ai aussi fait du sélecteur `".select2-input"` une constante `SELECTOR` que j'ai mis en tête de fichier.

# Testé ?

On a 35 occurrences de `select2` dans nos specs, ce qui est rassurant.

J'ai testé à la main les comportements suivants :
- on auto-submit la recherche quand on sélctionne un usager à fusionner (code qui gère `change->`)
- l'affichage de "Commencez à taper pour rechercher" quand on ouvre un select Ajax sans option
- la sélection du seul lieu de mon orga sur le formulaire de création de RDV collectif (`autoSelectSoleOption`)
- Le champ de recherche est bien mis en focus quand on ouvre un select (`focusSearchInput`)