### PR TITLE
Amélioration des explications des absences créées pour la migration des conums.

### DIFF
--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -43,7 +43,6 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
       rdv = Rdv.find(rdv_id)
       rdv.agents.each do |agent|
         params = {
-          title: "RDV pris sur #{domain.name}",
           first_day: rdv.starts_at.strftime("%Y-%m-%d"),
           end_day: rdv.starts_at.strftime("%Y-%m-%d"),
           start_time: rdv.starts_at.strftime("%H:%M"),
@@ -53,6 +52,15 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
             external_url: Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
           },
         }
+        params[:title] = if rdv.collectif?
+                           if rdv.title.present?
+                             "#{rdv.motif_name} : #{rdv.title}"
+                           else
+                             rdv.motif_name
+                           end
+                         else
+                           "RDV pris sur #{domain.name}"
+                         end
 
         if agent != instance_export.agent
           params[:agent_email] = agent.email

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -1,8 +1,10 @@
 class CopyPlanningToNewInstanceJob < ApplicationJob
   def self.agent_might_have_rdvs_on_old_instance?(agent, start_date)
-    agent.absences.joins(external_references: :oauth_application).where("first_day >= ?", start_date)
-      .where("external_references.external_id ilike ?", "#{CopyRdvAsAbsenceJob::EXTERNAL_ID_PREFIX}%")
-      .where(oauth_applications: { name: "RDV Aide Numérique" }).any?
+    Rails.cache.fetch("CopyPlanningToNewInstanceJob:#{agent.id}:#{start_date.to_date}", expires_in: 24.hours) do
+      agent.absences.joins(external_references: :oauth_application).where("first_day >= ?", start_date)
+        .where("external_references.external_id ilike ?", "#{CopyRdvAsAbsenceJob::EXTERNAL_ID_PREFIX}%")
+        .where(oauth_applications: { name: "RDV Aide Numérique" }).any?
+    end
   end
 
   def self.external_reference_to_rdv_on_old_instance(absence)

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -5,6 +5,12 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
       .where(oauth_applications: { name: "RDV Aide Numérique" }).any?
   end
 
+  def self.external_reference_to_rdv_on_old_instance(absence)
+    absence.external_references.joins(:oauth_application)
+      .where("external_references.external_id ilike ?", "#{CopyRdvAsAbsenceJob::EXTERNAL_ID_PREFIX}%")
+      .where(oauth_applications: { name: "RDV Aide Numérique" }).first
+  end
+
   # Les objets qu'on copie dans ce job (rdvs, plage ouverture, absence) ont besoin que les objets
   # de configuration (agents, motifs, lieux) soient déjà créés dans la nouvelle organisation.
   # On les copie donc dans ce deuxième batch, après que le premier ai copié tous les objets de config.

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -1,4 +1,11 @@
 class CopyPlanningToNewInstanceJob < ApplicationJob
+  # Cette méthode permet de savoir sur la nouvelle instance s'il est possible que des absences aient été créées par ce job
+  def self.agent_might_have_rdvs_on_old_instance?(agent, start_date)
+    agent.absences.joins(external_references: :oauth_application).where("first_day >= ?", start_date)
+      .where("external_references.external_id ilike ?", "rdv:%")
+      .where(oauth_applications: { name: "RDV Aide Numérique" }).any?
+  end
+
   # Les objets qu'on copie dans ce job (rdvs, plage ouverture, absence) ont besoin que les objets
   # de configuration (agents, motifs, lieux) soient déjà créés dans la nouvelle organisation.
   # On les copie donc dans ce deuxième batch, après que le premier ai copié tous les objets de config.

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -68,7 +68,7 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
         }
 
         rdv_title = ApplicationController.helpers.rdv_title_for_agent(rdv)
-        params[:title] = "#{rdv_title} (sur #{domain.name})"
+        params[:title] = "RDV avec #{rdv_title} (sur #{domain.name})"
 
         if agent != instance_export.agent
           params[:agent_email] = agent.email

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -1,8 +1,7 @@
 class CopyPlanningToNewInstanceJob < ApplicationJob
-  # Cette méthode permet de savoir sur la nouvelle instance s'il est possible que des absences aient été créées par ce job
   def self.agent_might_have_rdvs_on_old_instance?(agent, start_date)
     agent.absences.joins(external_references: :oauth_application).where("first_day >= ?", start_date)
-      .where("external_references.external_id ilike ?", "rdv:%")
+      .where("external_references.external_id ilike ?", "#{CopyRdvAsAbsenceJob::EXTERNAL_ID_PREFIX}%")
       .where(oauth_applications: { name: "RDV Aide Numérique" }).any?
   end
 
@@ -44,6 +43,8 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
   class CopyRdvAsAbsenceJob < ApplicationJob
     queue_as :latency_5m
 
+    EXTERNAL_ID_PREFIX = "rdv:".freeze
+
     def perform(instance_export_id, rdv_id, domain_id)
       domain = Domain.find(domain_id)
       instance_export = InstanceExport.find(instance_export_id)
@@ -55,7 +56,7 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
           start_time: rdv.starts_at.strftime("%H:%M"),
           end_time: rdv.ends_at.strftime("%H:%M"),
           external_reference: {
-            external_id: "rdv:#{rdv_id}", # on créera aussi des external_reference pour des absences, donc on préfixe par "rdv"
+            external_id: "#{EXTERNAL_ID_PREFIX}#{rdv_id}", # on créera aussi des external_reference pour des absences, donc on préfixe par "rdv"
             external_url: Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
           },
         }

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -52,15 +52,9 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
             external_url: Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
           },
         }
-        params[:title] = if rdv.collectif?
-                           if rdv.title.present?
-                             "#{rdv.motif_name} : #{rdv.title}"
-                           else
-                             rdv.motif_name
-                           end
-                         else
-                           "RDV pris sur #{domain.name}"
-                         end
+
+        rdv_title = ApplicationController.helpers.rdv_title_for_agent(rdv)
+        params[:title] = "#{rdv_title} (sur #{domain.name})"
 
         if agent != instance_export.agent
           params[:agent_email] = agent.email

--- a/app/models/concerns/agent/feature_flags.rb
+++ b/app/models/concerns/agent/feature_flags.rb
@@ -1,7 +1,7 @@
 module Agent::FeatureFlags
   extend ActiveSupport::Concern
 
-  AVAILABLE_FEATURES = %w[new_planning instance_migration].freeze
+  AVAILABLE_FEATURES = %w[new_planning].freeze
 
   def feature_enabled?(feature)
     feature_flags && feature_flags[feature] == true

--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -85,7 +85,7 @@
             h3.fr-tile__title
               = link_to("Réservation en ligne", admin_organisation_online_booking_path(current_organisation))
 
-    - if current_agent.feature_enabled?("instance_migration") && current_domain == Domain::RDV_AIDE_NUMERIQUE
+    - if current_domain == Domain::RDV_AIDE_NUMERIQUE
       .fr-col-12.fr-col-md-4.fr-mb-2w
         .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
           .fr-tile__body

--- a/app/views/admin/planning/absences/edit.html.slim
+++ b/app/views/admin/planning/absences/edit.html.slim
@@ -20,6 +20,14 @@
   - @absence.external_references.each do |reference|
     = link_to("Voir sur #{reference.oauth_application.name}", reference.external_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-mr-2w")
 
+- reference_to_rdv_on_old_instance = CopyPlanningToNewInstanceJob.external_reference_to_rdv_on_old_instance(@absence)
+- if reference_to_rdv_on_old_instance
+  .fr-notice.fr-notice--info.fr-mb-3w.fr-mt-2w
+    .fr-notice__body
+      p.fr-mb-0.fr-mx-2w
+        span.fr-notice__desc
+        | Cette indisponibilité correspond à un rendez-vous pris sur RDV Aide Numérique avant la migration sur RDV Service Public.
+
 .row.justify-content-center
   .col-md-6
     .card

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -50,6 +50,13 @@
             i.fa.fa-print>
 
   = render "admin/rdvs/rdv_visibility"
+  - if CopyPlanningToNewInstanceJob.agent_might_have_rdvs_on_old_instance?(current_agent, @form.start || Time.zone.today)
+    .fr-notice.fr-notice--info.fr-mb-3w.fr-mt-2w
+      .fr-notice__body
+        p.fr-mb-0.fr-mx-2w
+          span.fr-notice__desc
+            | Il est possible que vous ayez des RDV prévus sur RDV Aide Numérique avant votre migration sur RDV Service Public.
+          = link_to  "Ouvrir RDV Aide Numérique", "https://#{Domain::RDV_AIDE_NUMERIQUE.host_name}", class: "fr-btn fr-btn--secondary fr-m-1w"
 
   - if @rdvs.total_count > 0
     .mb-2

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -37,6 +37,14 @@
             = f.submit "Filtrer", class: "fr-btn fr-btn--secondary"
 
   .card-body
+    - if CopyPlanningToNewInstanceJob.agent_might_have_rdvs_on_old_instance?(current_agent, @form.from_date)
+      .fr-notice.fr-notice--info
+        .fr-notice__body
+          p.fr-mb-0.fr-mx-2w
+            span.fr-notice__desc
+              | Il est possible que vous ayez des RDV collectifs prévus sur RDV Aide Numérique avant votre migration sur RDV Service Public.
+            = link_to  "Ouvrir RDV Aide Numérique", "https://#{Domain::RDV_AIDE_NUMERIQUE.host_name}", class: "fr-btn fr-btn--secondary fr-m-1w"
+
     - if @rdvs.any?
       = render(partial: "admin/rdvs_collectifs/rdv", collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :services))
       .d-flex.justify-content-center= paginate @rdvs, theme: "dsfr"

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -38,7 +38,7 @@
 
   .card-body
     - if CopyPlanningToNewInstanceJob.agent_might_have_rdvs_on_old_instance?(current_agent, @form.from_date)
-      .fr-notice.fr-notice--info
+      .fr-notice.fr-notice--info.fr-mb-3w
         .fr-notice__body
           p.fr-mb-0.fr-mx-2w
             span.fr-notice__desc

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -11,8 +11,12 @@ header.header.bg-white
       ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
         = render "layouts/rdv_a_renseigner", organisation: defined?(current_organisation) && current_organisation
         li.list-inline-item
-          #js-headway-anchor.btn.text-primary-blue.link-dsfr.d-flex.justify-content-center
-            | Nouveautés
+          - if current_domain != Domain::RDV_AIDE_NUMERIQUE
+            #js-headway-anchor.btn.text-primary-blue.link-dsfr.d-flex.justify-content-center
+              | Nouveautés
+          - elsif defined?(current_organisation) && current_organisation && current_agent.organisations.count <= 1
+            = link_to "Passer à RDV Service Public", admin_organisation_instance_exports_path(current_organisation), class: "btn text-primary-blue link-dsfr"
+
         li#rdv-account-dropdown.list-inline-item.dropdown.mr-2
           button.link-dsfr.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false"
             = current_agent.full_name

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -14,7 +14,7 @@ header.header.bg-white
           - if current_domain != Domain::RDV_AIDE_NUMERIQUE
             #js-headway-anchor.btn.text-primary-blue.link-dsfr.d-flex.justify-content-center
               | Nouveautés
-          - elsif defined?(current_organisation) && current_organisation && current_agent.organisations.count <= 1
+          - elsif defined?(current_organisation) && current_organisation && current_agent.organisations.count <= 1 && current_agent.admin_in_organisation?(current_organisation)
             = link_to "Passer à RDV Service Public", admin_organisation_instance_exports_path(current_organisation), class: "btn text-primary-blue link-dsfr"
 
         li#rdv-account-dropdown.list-inline-item.dropdown.mr-2

--- a/spec/features/autodoc/liens_vers_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/liens_vers_rdv_aide_num_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", js: true do
+  # Pour simplifier les test, on crée deux agents sur la même instance
+  let(:organisation) do
+    create(:organisation, name: "France Service de Montreuil")
+  end
+
+  let!(:agent) do
+    create(:agent, first_name: "Francis", last_name: "Factice", basic_role_in_organisations: [organisation])
+  end
+  let!(:oauth_application) { create(:oauth_application, name: "RDV Aide Numérique") }
+
+  let!(:absence_representing_rdv) { create(:absence, :no_recurrence, agent: agent) }
+
+  before do
+    create(:external_reference, item: absence_representing_rdv, external_id: "#{CopyPlanningToNewInstanceJob::CopyRdvAsAbsenceJob::EXTERNAL_ID_PREFIX}1", oauth_application:)
+    create(:motif, :collectif, organisation:)
+  end
+
+  specify do
+    doc = Autodoc.start_scenario("Liens vers RDV Aide Numérique après une migration", self)
+
+    doc.start_section("Introduction")
+    doc.add_text(<<~TEXT
+      Lors d'une copie des données depuis RDV Aide Numérique vers RDV Service Public, les rendez-vous ne sont pas copiés parce que ça serait trop compliqué à gérer.
+      Par contre, on crée pour chaque rendez-vous à venir sur RDV Aide Numérique une indisponibilité correspondant sur RDV Service Public.
+      Pour rendre ce fonctionnement plus facile à comprendre, on ajoute différentes explications dans le produit.
+    TEXT
+                )
+
+    login_as(agent, scope: :agent)
+
+    doc.start_section("Liste des rendez-vous")
+    visit admin_organisation_rdvs_path(organisation)
+
+    doc.add_screenshot(page,
+                       text: "On ajoute une bannière s'il y a des absences à venir qui sont liées à des RDV sur l'ancienne instance",
+                       wait_for: "Il est possible que vous ayez des RDV prévus sur RDV Aide Numérique avant votre migration sur RDV Service Public.")
+
+    doc.start_section("Liste des rendez-vous collectif")
+    visit admin_organisation_rdvs_collectifs_path(organisation)
+
+    doc.add_screenshot(page,
+                       text: "On ajoute une bannière similaire",
+                       wait_for: "Il est possible que vous ayez des RDV collectifs prévus sur RDV Aide Numérique avant votre migration sur RDV Service Public.")
+
+    doc.start_section("Détails de l'indisponibilité")
+
+    visit edit_admin_organisation_planning_absence_path(organisation, absence_representing_rdv)
+
+    doc.add_screenshot(page,
+                       text: "On ajoute une bannière similaire sur la page de détails de l'indispo. C'est sur cette page qu'on arrive si on clique sur l'indispo dans le calendrier.",
+                       wait_for: "Cette indisponibilité correspond à un rendez-vous pris sur RDV Aide Numérique avant la migration sur RDV Service Public.")
+  end
+end

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   end
   let!(:lieu) { create(:lieu, organisation: organisation_rdv_aide_num) }
   let!(:motif) { create(:motif, organisation: organisation_rdv_aide_num) }
+  let!(:motif_collectif) { create(:motif, :collectif, organisation: organisation_rdv_aide_num) }
 
   let!(:users) do
     create_list(:user, 3, organisations: [organisation_rdv_aide_num])
@@ -24,6 +25,9 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
 
   let!(:future_rdv) do
     create(:rdv, agents: [collegue], users: [users.last], starts_at: 2.weeks.from_now, motif:, lieu:, organisation: organisation_rdv_aide_num)
+  end
+  let!(:future_rdv_collectif) do
+    create(:rdv, agents: [collegue], users: [], starts_at: 2.weeks.from_now, motif: motif_collectif, lieu:, organisation: organisation_rdv_aide_num)
   end
 
   let!(:absence) { create(:absence, :no_recurrence, agent: agent_rdv_aide_num) }
@@ -139,12 +143,13 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     expect(created_lieu).to have_attributes(name: lieu.name)
     expect(created_lieu.external_references.last).to have_attributes(external_id: lieu.id.to_s)
 
-    created_motif = created_organisation.motifs.sole
+    created_motif = created_organisation.motifs.individuel.sole
     expect(created_motif).to have_attributes(name: motif.name)
 
     # On crée des absences qui permettent de retrouver les rendez-vous sur l'ancienne instance
-    expect(collegue.absences.where(title: "RDV pris sur RDV Aide Numérique").last.starts_at).to be_within(1.minute).of(future_rdv.starts_at)
-    expect(collegue.absences.where(title: "RDV pris sur RDV Aide Numérique").last.external_references.last.external_url).to eq "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{future_rdv.id}"
+    absence_representing_rdv = collegue.absences.find_by(title: "#{future_rdv.users.first.full_name} (sur RDV Aide Numérique)")
+    expect(absence_representing_rdv.starts_at).to be_within(1.minute).of(future_rdv.starts_at)
+    expect(absence_representing_rdv.external_references.last.external_url).to eq "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{future_rdv.id}"
 
     # On crée aussi des copies des absences futures
     expect(agent_rdv_sp.absences.exceptionnelles.first.starts_at).to eq absence.starts_at

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     expect(created_motif).to have_attributes(name: motif.name)
 
     # On crée des absences qui permettent de retrouver les rendez-vous sur l'ancienne instance
-    absence_representing_rdv = collegue.absences.find_by(title: "#{future_rdv.users.first.full_name} (sur RDV Aide Numérique)")
+    absence_representing_rdv = collegue.absences.find_by(title: "RDV avec #{future_rdv.users.first.full_name} (sur RDV Aide Numérique)")
     expect(absence_representing_rdv.starts_at).to be_within(1.minute).of(future_rdv.starts_at)
     expect(absence_representing_rdv.external_references.last.external_url).to eq "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{future_rdv.id}"
 


### PR DESCRIPTION
# Contexte

Lors d'une copie des données depuis RDV Aide Numérique vers RDV Service Public, les rendez-vous ne sont pas copiés parce que ça serait trop compliqué à gérer. Par contre, on crée pour chaque rendez-vous à venir sur RDV Aide Numérique une indisponibilité correspondant sur RDV Service Public. Pour rendre ce fonctionnement plus facile à comprendre, on ajoute différentes explications dans le produit.

On a effectivement constaté que c'était mal compris, et que ça serait un frein à la migration (verbatim d'un conum vu la semaine dernière : "on ne peut pas migrer tant qu'on n'a pas nos rdvs collectifs sur RDV Service Public).

On améliore aussi les intitulés de ces absences pour qu'ils ressemblent à des intitulés de rdv (ce qui devient acceptable en terme de données personnelles grâce à https://github.com/betagouv/rdv-service-public/pull/5673)

Suite à toutes ces améliorations, on peut mettre la fonctionnalité de migration plus en avant. Pour le moment elle est visible uniquement dans la configuration, donc on ajoute un lien depuis le header.
<img width="397" height="64" alt="Screenshot 2025-09-29 at 16 26 13" src="https://github.com/user-attachments/assets/b95790c8-aaee-42c7-b206-b2bf6ceff7ba" />



## Captures d'écran

Merci l'autodoc
<img width="1280" height="720" alt="scenario_da539df9a_section_2_step_0" src="https://github.com/user-attachments/assets/f0d62fc8-72a2-4a50-8da7-35918f317ddf" />
<img width="1280" height="720" alt="scenario_da539df9a_section_3_step_0" src="https://github.com/user-attachments/assets/d849d217-b509-4aaf-90b0-7c84dd58ecae" />

<img width="1280" height="720" alt="scenario_da539df9a_section_4_step_0" src="https://github.com/user-attachments/assets/020f9b92-bb55-42b0-b57a-96476f187275" />
