### PR TITLE
Ne pas proposer à la réservation publique des créneaux pour des agents invités n’ayant pas accepté

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -123,7 +123,7 @@ class Agent < ApplicationRecord
   scope :active, -> { where(deleted_at: nil) }
   scope :excluding_pending_invitation, lambda {
     where(invitation_sent_at: nil) # permet de ne pas inclure les intervenants & les ProConnectés
-      .or(Agent.where.not(confirmed_at: nil)) # plus générique que invitation_sent_at, évite les faux négatifs
+      .or(where.not(confirmed_at: nil)) # plus générique que invitation_sent_at, évite les faux négatifs
   }
 
   ## -

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -121,7 +121,7 @@ class Agent < ApplicationRecord
     where("invitation_sent_at IS NULL OR invitation_accepted_at IS NOT NULL")
   }
   scope :active, -> { where(deleted_at: nil) }
-  scope :invited_but_not_accepted, lambda {
+  scope :excluding_pending_invitation, lambda {
     where(invitation_sent_at: nil) # permet de ne pas inclure les intervenants & les ProConnectés
       .or(Agent.where.not(confirmed_at: nil)) # plus générique que invitation_sent_at, évite les faux négatifs
   }

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -121,6 +121,10 @@ class Agent < ApplicationRecord
     where("invitation_sent_at IS NULL OR invitation_accepted_at IS NOT NULL")
   }
   scope :active, -> { where(deleted_at: nil) }
+  scope :invited_but_not_accepted, lambda {
+    where(invitation_sent_at: nil) # permet de ne pas inclure les intervenants & les ProConnectés
+      .or(Agent.where.not(confirmed_at: nil)) # plus générique que invitation_sent_at, évite les faux négatifs
+  }
 
   ## -
 

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -15,7 +15,7 @@ module CreneauxSearch::Calculator
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
         .includes(:agent)
-        .where(agent: Agent.invited_but_not_accepted)
+        .where(agent: Agent.excluding_pending_invitation)
       scope = scope.includes(:organisation, organisation: :territory) if motif.organisation.territory.visioplainte?
       scope = scope.where(agent: agents) if agents&.any?
       scope = scope.where(lieu: lieu) if lieu.present?

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -14,7 +14,12 @@ module CreneauxSearch::Calculator
       scope = PlageOuverture.not_expired
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
+        .joins(agent: [:roles])
         .includes(:agent)
+        .where(agent_roles: { organisation_id: motif.organisation_id })
+      scope = scope
+        .where.not(agent: { confirmed_at: nil })
+        .or(scope.where(agent_roles: { access_level: "intervenant" }))
       scope = scope.includes(:organisation, organisation: :territory) if motif.organisation.territory.visioplainte?
       scope = scope.where(agent: agents) if agents&.any?
       scope = scope.where(lieu: lieu) if lieu.present?

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -15,10 +15,7 @@ module CreneauxSearch::Calculator
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
         .includes(:agent)
-        .where( # cette condition filtre les agents n’ayant pas accepté encore l’invitation
-          agent: Agent.where(invitation_sent_at: nil) # permet de ne pas impacter les intervenants & les ProConnectés
-                   .or(Agent.where.not(confirmed_at: nil)) # plus générique que invitation_sent_at, évite les faux positifs
-        )
+        .where(agent: Agent.invited_but_not_accepted)
       scope = scope.includes(:organisation, organisation: :territory) if motif.organisation.territory.visioplainte?
       scope = scope.where(agent: agents) if agents&.any?
       scope = scope.where(lieu: lieu) if lieu.present?

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -14,12 +14,11 @@ module CreneauxSearch::Calculator
       scope = PlageOuverture.not_expired
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
-        .joins(agent: [:roles])
         .includes(:agent)
-        .where(agent_roles: { organisation_id: motif.organisation_id })
-      scope = scope
-        .where.not(agent: { confirmed_at: nil })
-        .or(scope.where(agent_roles: { access_level: "intervenant" }))
+        .where( # cette condition filtre les agents n’ayant pas accepté encore l’invitation
+          agent: Agent.where(invitation_sent_at: nil) # permet de ne pas impacter les intervenants & les ProConnectés
+                   .or(Agent.where.not(confirmed_at: nil)) # plus générique que invitation_sent_at, évite les faux positifs
+        )
       scope = scope.includes(:organisation, organisation: :territory) if motif.organisation.territory.visioplainte?
       scope = scope.where(agent: agents) if agents&.any?
       scope = scope.where(lieu: lieu) if lieu.present?

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -222,6 +222,20 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
 
       expect(plage_ouvertures).to eq([matching_po])
     end
+
+    it "excludes plage ouvertures for unconfirmed agents" do
+      agent1 = create(:agent, organisations: [organisation])
+      po1 = create(:plage_ouverture, agent_id: agent1.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
+      agent2_not_confirmed = create(:agent, organisations: [organisation], confirmed_at: nil)
+      po2 = create(:plage_ouverture, agent_id: agent2_not_confirmed.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
+      agent3_intervenant = create(:agent, :intervenant, organisations: [organisation], confirmed_at: nil)
+      po3 = create(:plage_ouverture, agent_id: agent3_intervenant.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
+
+      plage_ouvertures = described_class.plage_ouvertures_for(motif, lieu, date_range, [])
+      expect(plage_ouvertures).to include(po1)
+      expect(plage_ouvertures).to include(po3)
+      expect(plage_ouvertures).not_to include(po2)
+    end
   end
 
   describe "#free_times_from" do

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -223,36 +223,52 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
       expect(plage_ouvertures).to eq([matching_po])
     end
 
-    it "excludes plage ouvertures for unconfirmed agents" do
-      agent1 = create(:agent, organisations: [organisation])
-      po1 = create(:plage_ouverture, agent_id: agent1.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
-      agent2_not_confirmed = create(
-        :agent,
-        organisations: [organisation],
-        invitation_sent_at: first_day - 48.hours,
-        invitation_accepted_at: nil,
-        confirmed_at: nil
+    it "excludes plage ouvertures for agents with a pending invitation" do
+      po1_agent_normal = create(
+        :plage_ouverture,
+        agent: create(:agent, organisations: [organisation]),
+        lieu: lieu, motifs: [motif], first_day: first_day,
+        start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)
       )
-      po2 = create(:plage_ouverture, agent_id: agent2_not_confirmed.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
-      agent3_intervenant = create(
-        :agent, :intervenant,
-        organisations: [organisation],
-        confirmed_at: nil,
-        invitation_sent_at: nil
+      po2_agent_pending_invitation = create(
+        :plage_ouverture,
+        agent: create(
+          :agent,
+          organisations: [organisation],
+          invitation_sent_at: first_day - 48.hours,
+          invitation_accepted_at: nil,
+          confirmed_at: nil
+        ),
+        lieu: lieu, motifs: [motif], first_day: first_day,
+        start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)
       )
-      po3 = create(:plage_ouverture, agent_id: agent3_intervenant.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
-      agent4_confirmed = create(
-        :agent,
-        organisations: [organisation],
-        invitation_sent_at: first_day - 48.hours,
-        invitation_accepted_at: first_day - 24.hours,
-        confirmed_at: first_day - 24.hours
+      po3_agent_intervenant = create(
+        :plage_ouverture,
+        agent: create(
+          :agent, :intervenant,
+          organisations: [organisation],
+          confirmed_at: nil,
+          invitation_sent_at: nil
+        ),
+        lieu: lieu, motifs: [motif], first_day: first_day,
+        start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)
       )
-      po4 = create(:plage_ouverture, agent_id: agent4_confirmed.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
+      po4_agent_invited_accepted = create(
+        :plage_ouverture,
+        agent: create(
+          :agent,
+          organisations: [organisation],
+          invitation_sent_at: first_day - 48.hours,
+          invitation_accepted_at: first_day - 24.hours,
+          confirmed_at: first_day - 24.hours
+        ),
+        lieu: lieu, motifs: [motif], first_day: first_day,
+        start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)
+      )
 
       plage_ouvertures = described_class.plage_ouvertures_for(motif, lieu, date_range, [])
-      expect(plage_ouvertures).to include(po1, po3, po4)
-      expect(plage_ouvertures).not_to include(po2)
+      expect(plage_ouvertures).to include(po1_agent_normal, po3_agent_intervenant, po4_agent_invited_accepted)
+      expect(plage_ouvertures).not_to include(po2_agent_pending_invitation)
     end
   end
 

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -224,51 +224,42 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
     end
 
     it "excludes plage ouvertures for agents with a pending invitation" do
-      po1_agent_normal = create(
-        :plage_ouverture,
-        agent: create(:agent, organisations: [organisation]),
-        lieu: lieu, motifs: [motif], first_day: first_day,
-        start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)
-      )
-      po2_agent_pending_invitation = create(
-        :plage_ouverture,
-        agent: create(
+      agents = {
+        normal: create(:agent, organisations: [organisation]),
+        pending_invitation: create(
           :agent,
           organisations: [organisation],
           invitation_sent_at: first_day - 48.hours,
           invitation_accepted_at: nil,
           confirmed_at: nil
         ),
-        lieu: lieu, motifs: [motif], first_day: first_day,
-        start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)
-      )
-      po3_agent_intervenant = create(
-        :plage_ouverture,
-        agent: create(
+        intervenant: create(
           :agent, :intervenant,
           organisations: [organisation],
           confirmed_at: nil,
           invitation_sent_at: nil
         ),
-        lieu: lieu, motifs: [motif], first_day: first_day,
-        start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)
-      )
-      po4_agent_invited_accepted = create(
-        :plage_ouverture,
-        agent: create(
+        invited_accepted: create(
           :agent,
           organisations: [organisation],
           invitation_sent_at: first_day - 48.hours,
           invitation_accepted_at: first_day - 24.hours,
           confirmed_at: first_day - 24.hours
         ),
-        lieu: lieu, motifs: [motif], first_day: first_day,
-        start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)
-      )
+      }
+      plage_ouvertures = agents.transform_values do |agent|
+        create(
+          :plage_ouverture,
+          agent:,
+          lieu: lieu, motifs: [motif],
+          first_day: first_day,
+          start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)
+        )
+      end
 
-      plage_ouvertures = described_class.plage_ouvertures_for(motif, lieu, date_range, [])
-      expect(plage_ouvertures).to include(po1_agent_normal, po3_agent_intervenant, po4_agent_invited_accepted)
-      expect(plage_ouvertures).not_to include(po2_agent_pending_invitation)
+      filtered_plage_ouvertures = described_class.plage_ouvertures_for(motif, lieu, date_range, [])
+      expect(filtered_plage_ouvertures).to include(plage_ouvertures[:normal], plage_ouvertures[:intervenant], plage_ouvertures[:invited_accepted])
+      expect(filtered_plage_ouvertures).not_to include(plage_ouvertures[:pending_invitation])
     end
   end
 

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -226,14 +226,32 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
     it "excludes plage ouvertures for unconfirmed agents" do
       agent1 = create(:agent, organisations: [organisation])
       po1 = create(:plage_ouverture, agent_id: agent1.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
-      agent2_not_confirmed = create(:agent, organisations: [organisation], confirmed_at: nil)
+      agent2_not_confirmed = create(
+        :agent,
+        organisations: [organisation],
+        invitation_sent_at: first_day - 48.hours,
+        invitation_accepted_at: nil,
+        confirmed_at: nil
+      )
       po2 = create(:plage_ouverture, agent_id: agent2_not_confirmed.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
-      agent3_intervenant = create(:agent, :intervenant, organisations: [organisation], confirmed_at: nil)
+      agent3_intervenant = create(
+        :agent, :intervenant,
+        organisations: [organisation],
+        confirmed_at: nil,
+        invitation_sent_at: nil
+      )
       po3 = create(:plage_ouverture, agent_id: agent3_intervenant.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
+      agent4_confirmed = create(
+        :agent,
+        organisations: [organisation],
+        invitation_sent_at: first_day - 48.hours,
+        invitation_accepted_at: first_day - 24.hours,
+        confirmed_at: first_day - 24.hours
+      )
+      po4 = create(:plage_ouverture, agent_id: agent4_confirmed.id, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
 
       plage_ouvertures = described_class.plage_ouvertures_for(motif, lieu, date_range, [])
-      expect(plage_ouvertures).to include(po1)
-      expect(plage_ouvertures).to include(po3)
+      expect(plage_ouvertures).to include(po1, po3, po4)
       expect(plage_ouvertures).not_to include(po2)
     end
   end


### PR DESCRIPTION
# description du problème

closes #5665 

# description du changement

J’ai fait une condition `invitation jamais envoyée OU compte confirmé` 

J’ai vérifié sur les envs de prod : 100% des agents qui ont `invitation_accepted_at` non nul ont aussi `confirmed_at` non nul. 

Le fait de filtrer sur `confirmed_at` plutôt que `invitation_accepted_at` permet de ne pas rendre inactif les PO d’agents qui sont dans des cas mystérieux (invités, jamais acceptés, mais confirmés) : 

```rb
Agent
  .where(invitation_accepted_at: nil)
  .where.not(invitation_created_at: nil)
  .where(deleted_at: nil)
  .where.not(confirmed_at: nil)
  .where("connected_with_agent_connect": false)
  .order("confirmed_at DESC")
  .count
=> 295
```

cf https://mattermost.incubateur.net/betagouv/pl/he31ptezfffgpjohpyfgwkeufc

## Impact en prod

Cette PR rendra ineffectives 21 PO sur RDVS et 25 sur RDVSP: 

```rb
PlageOuverture.not_expired.joins(:agent).where(agent: Agent.where.not(invitation_sent_at: nil).where(confirmed_at: nil)).count
```

## Chemin parcouru dans cette PR

Dans les deux premiers commits j’avais exploré une autre solution avec une condition plus large : `compte confirmé OU agent intervenant`. C’était plus compliqué à écrire, ça cassait beaucoup d’autres tests, ce qui signalait probablement des faux négatifs. 

J’ai préféré faire cette solution, plus prudente. 

## Screenshots

Côté usagers 

<img width="2614" height="883" alt="image" src="https://github.com/user-attachments/assets/04042435-9af6-4e95-a615-6c44c7326946" />


Côté agents

<img width="2589" height="944" alt="image" src="https://github.com/user-attachments/assets/e59c340d-326c-4177-8298-0b095ab85cf1" />

## Pour plus tard

Ça serait bien d’expliquer aux agents qui posent des PO pour leurs collègues invités mais pas acceptés ce qui va se passer
Peut-être avec un avertissement contournable lors de la création de la PO

Vu le comportement actuel ça me paraît être une amélioration sur l’existant importante de livrer cette PR qui ne fait que corriger le comportement en bout de chaîne, et de reléguer à plus tard l’implem de cet avertissement.