### PR TITLE
App Scalingo dédiée pour les review apps (plutôt que la démo)

### DIFF
--- a/docs/4-notes-techniques.md
+++ b/docs/4-notes-techniques.md
@@ -124,7 +124,7 @@ Les review apps ne sont pas créées automatiquement pour chaque PR pour économ
 La commande pour créer une review app pour la PR #4242 est
 
 ```bash
-scalingo --region osc-secnum-fr1 --app demo-rdv-solidarites integration-link-manual-review-app 4242
+scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app integration-link-manual-review-app 4242
 ```
 
 Un raccourci existe pour retrouver le numéro de la PR correspondant à la branche courante automatiquement : `make review_app`
@@ -132,7 +132,7 @@ Un raccourci existe pour retrouver le numéro de la PR correspondant à la branc
 Par défaut, seul un worker web est activé, si vous souhaitez que les jobs s’exécutent il faut activer un worker jobs depuis le dashboard ou avec cette commande :
 
 ```sh
-scalingo --region osc-secnum-fr1 --app demo-rdv-solidarites-pr4242 scale jobs:1
+scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app-pr4242 scale jobs:1
 ```
 
 Le fichier `scalingo.json` décrit la configuration initiale et les variables d’environnement des review apps.
@@ -144,8 +144,8 @@ L’envoi d’email est désactivé par défaut sur les review apps.
 Pour l’activer vous pouvez utiliser cette commande :
 
 ```sh
-    scalingo --region osc-secnum-fr1 --app demo-rdv-solidarites-pr4242 env-unset DISABLE_SENDING_EMAILS && \
-    scalingo --region osc-secnum-fr1 --app demo-rdv-solidarites-pr4242 restart
+    scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app-pr4242 env-unset DISABLE_SENDING_EMAILS && \
+    scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app-pr4242 restart
 ```
 
 ## Search Contexts

--- a/docs/architecture-technique.md
+++ b/docs/architecture-technique.md
@@ -313,6 +313,7 @@ Nous avons les applications suivantes :
 - `osc-secnum-fr1/production-rdv-mairie` : appli métier de production
 - `osc-secnum-fr1/demo-rdv-solidarites` : appli métier de préproduction
 - `osc-secnum-fr1/staging-rdv-service-public` : appli métier de préproduction
+- `osc-secnum-fr1/rdv-service-public-review-app` : appli template pour générer les review apps
 - `osc-secnum-fr1/rdv-service-public-etl` : appli de tooling de production
 - `osc-secnum-fr1/rdv-service-public-etl-staging` : appli de tooling de préproduction
 - `osc-secnum-fr1/rdv-service-public-metabase` : appli de tooling de production
@@ -355,7 +356,7 @@ notre checklist d'onboarding un point précisant qu'il faut impérativement acti
 TOTP, Scalingo propose une procédure qui inclut la vérification de l'identité de l'utilisateur concerné par la
 transmission d'un document d'identité.
 
-Note : les review apps sont créées manuellement et héritent de l'app de démo. Le fichier `scalingo.json` contient la liste des variables d'environnement qu'il ne faut pas hériter de l'app de démo lors de la création d'une review app. Les review apps sont automatiquement détruites lors de la fermeture d'une PR.
+Note : les review apps sont créées manuellement et héritent de l'app `rdv-service-public-review-app`. Le fichier `scalingo.json` contient la liste des variables nécessaires au fonctionnement d'une review app. Une review app est automatiquement détruite lors de la fermeture de la PR liée.
 
 ### Détection de fuite de secrets
 

--- a/docs/charger-territoire-sur-review-app.md
+++ b/docs/charger-territoire-sur-review-app.md
@@ -21,7 +21,7 @@ bundle exec rails runner scripts/tronquer_et_anonymiser_db.rb ID_TERRITOIRE
 Il faut d'abord supprimer les données existantes sur la review app. Pour ce faire, lancer une console
 
 ```bash
-REVIEW_APP_NAME=demo-rdv-solidarites-prXXXX
+REVIEW_APP_NAME=rdv-service-public-review-app-prXXXX
 scalingo --app $REVIEW_APP_NAME --region osc-secnum-fr1 pgsql-console
 ```
 

--- a/scalingo.json
+++ b/scalingo.json
@@ -7,6 +7,11 @@
       "generator": "url"
     },
 
+    "DB_SEEDS_USERS_AND_AGENTS_PASSWORD": {
+      "description": "Mot de passe par défaut pour tous les comptes agents des seeds",
+      "value": "Rdvservicepublictest1!"
+    },
+
     "ADMIN_BASIC_AUTH_PASSWORD": {
       "description": "Basic auth password for review apps super admin",
       "generator": "secret"

--- a/scalingo.json
+++ b/scalingo.json
@@ -16,10 +16,24 @@
       "description": "Basic auth password for review apps super admin",
       "generator": "secret"
     },
+
     "SECRET_KEY_BASE": {
       "description": "See: https://guides.rubyonrails.org/security.html#custom-credentials",
       "generator": "secret"
     },
+    "ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY": {
+      "description": "See: https://guides.rubyonrails.org/active_record_encryption.html#setup",
+      "generator": "secret"
+    },
+    "ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT": {
+      "description": "See: https://guides.rubyonrails.org/active_record_encryption.html#setup",
+      "generator": "secret"
+    },
+    "ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY": {
+      "description": "See: https://guides.rubyonrails.org/active_record_encryption.html#setup",
+      "generator": "secret"
+    },
+
     "RDV_SOLIDARITES_INSTANCE_NAME": {
       "description": "Indicate that this is not the production website.",
       "generator": "template",

--- a/scalingo.json
+++ b/scalingo.json
@@ -35,60 +35,6 @@
     "DISABLE_SENDING_EMAILS": {
       "description": "Delete that variable (and setup Sendinblue password) to enable sending email in a review app",
       "value": "true"
-    },
-    "SENDINBLUE_PASSWORD": {
-      "description": "Password pour Sendinblue",
-      "value": "change_me_if_needed"
-    },
-
-    "ALTERNATE_SMTP_USERNAME": {
-      "description": "Config SMTP du système SFR with mail2SMS - seulement utilisée par le 92",
-      "value": "change_me_if_needed"
-    },
-    "ALTERNATE_SMTP_PASSWORD": {
-      "description": "Config SMTP du système SFR with mail2SMS - seulement utilisée par le 92",
-      "value": "change_me_if_needed"
-    },
-
-    "DEFAULT_SMS_PROVIDER": {
-      "description": "Système d'envoi des SMS par défaut : cette valeur ne fait que logger l'envoi mais n'envoie rien",
-      "value": "debug_logger"
-    },
-    "DEFAULT_SMS_PROVIDER_KEY": {
-      "description": "Credentials des SMS par défaut : définir cette valeur si l'on veut tester un système d'envoi",
-      "value": "change_me_if_needed"
-    },
-
-    "FRANCECONNECT_V2_BASE_URL": {
-      "description": "Environnement de sandbox, il est possible de créer des apps librement sur https://espace.partenaires.franceconnect.gouv.fr",
-      "value": "https://fcp-low.sbx.dev-franceconnect.fr/api/v2"
-    },
-    "FRANCECONNECT_V2_CLIENT_ID": {
-      "description": "Environnement de sandbox, il est possible de créer des apps librement sur https://espace.partenaires.franceconnect.gouv.fr",
-      "value": "change_me_if_needed"
-    },
-    "FRANCECONNECT_V2_CLIENT_SECRET": {
-      "description": "Environnement de sandbox, il est possible de créer des apps librement sur https://espace.partenaires.franceconnect.gouv.fr",
-      "value": "change_me_if_needed"
-    },
-
-    "GITHUB_APP_ID": {
-      "description": " Identifiant de notre app GitHub utilisée pour se connecter en super admin. Nous avons une app pour la prod, une pour la démo, mais rien pour les review apps.",
-      "value": "change_me_if_needed"
-    },
-      "GITHUB_APP_SECRET": {
-      "description": " Password de notre app GitHub utilisée pour se connecter en super admin. Nous avons une app pour la prod, une pour la démo, mais rien pour les review apps.",
-      "value": "change_me_if_needed"
-    },
-
-    "BREVO_INBOUND_PASSWORD": {
-      "description": "Cette valeur est passée en paramètre dans le webhook que nous avons défini chez SendInBlue. C'est un secret, donc non hérité en review app.",
-      "value": "change_me_if_needed"
-    },
-
-    "SKYLIGHT_AUTHENTICATION": {
-      "description": "Pas besoin de skylight en review app, sauf cas particulier.",
-      "value": "change_me_if_needed"
     }
   },
   "scripts": {

--- a/scalingo.json
+++ b/scalingo.json
@@ -8,7 +8,7 @@
     },
 
     "DB_SEEDS_USERS_AND_AGENTS_PASSWORD": {
-      "description": "Mot de passe par défaut pour tous les comptes agents des seeds",
+      "description": "Mot de passe par défaut pour tous les comptes agents et usagers des seeds",
       "value": "Rdvservicepublictest1!"
     },
 

--- a/scripts/create_review_app.sh
+++ b/scripts/create_review_app.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-scalingo --region osc-secnum-fr1 --app demo-rdv-solidarites integration-link-manual-review-app `gh pr view --json number --jq '.number'` &&
+scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app integration-link-manual-review-app `gh pr view --json number --jq '.number'` &&
 gh pr edit -b "$(gh pr view --json body --jq '.body' | sed "1i\\
-[Review app](https://demo-rdv-solidarites-pr`gh pr view --json number --jq '.number'`.osc-secnum-fr1.scalingo.io/) \\
+[Review app](https://rdv-service-public-review-app-pr`gh pr view --json number --jq '.number'`.osc-secnum-fr1.scalingo.io/) \\
 
 ")"

--- a/scripts/review_app_super_admin_password.sh
+++ b/scripts/review_app_super_admin_password.sh
@@ -5,7 +5,7 @@ if (( $# == 0 )); then
   echo "Usage: $0 <pr-number>"; exit
 fi
 
-REVIEW_APP=demo-rdv-solidarites-pr"$1"
+REVIEW_APP=rdv-service-public-review-app-pr"$1"
 REGION=osc-secnum-fr1
 PASSWORD=$(scalingo env --region $REGION --app "$REVIEW_APP" | grep ADMIN_BASIC_AUTH_PASSWORD | sed 's/.*=//')
 USERNAME=rdv-solidarites


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr5677.osc-secnum-fr1.scalingo.io/) 



# Le problème

Les variables d'ENV de l'app de démo sont héritées par les review apps, ce qui crée un risque de fuite (si quelqu'un crée une review app, alors iel a accès aux variables d'ENV de la démo).

# La solution

La solution actuelle a été mise en place dans #2819 : utiliser `scalingo.json` pour shadow les variables sensibles. Le problème c'est qu'il faut penser à mettre à jour ce fichier quand on introduit une nouvelle variable.

Mais puisqu'on a désormais le droit de créer des apps, je propose ici d'avoir une app dédiée au review app. Cette solution avait déjà été [suggérée](https://github.com/betagouv/rdv-service-public/pull/2819#issuecomment-1249276328) mais on avait pas les droits à l'époque. Je l'ai créée, c'est [`osc-secnum-fr1/rdv-service-public-review-app`](https://dashboard.scalingo.com/apps/osc-secnum-fr1/rdv-service-public-review-app/environment), je vous ai ajoutés en collaborateurs.

Cette nouvelle app a seulement `SENTRY_DSN_RAILS` comme variable d'env, puisque c'est une donnée semi-sensible : on ne veut pas la commiter, mais c'est pas un drame si elle fuite.
