### PR TITLE
Unfreeze httpclient gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,9 +158,6 @@ gem "icalendar", "~> 2.5"
 # Tame Rails' multi-line logging into a single line per request
 gem "lograge"
 
-# TODO: retirer cette ligne quand une nouvelle version de httpclient est released
-gem "httpclient", git: "https://github.com/nahi/httpclient.git", ref: "d57cc6d"
-
 # Utilisée pour les imports
 gem "csv"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,6 @@ GIT
       launchy
 
 GIT
-  remote: https://github.com/nahi/httpclient.git
-  revision: d57cc6d5ffee1b566b5c189fe6dc8cc89570b812
-  ref: d57cc6d
-  specs:
-    httpclient (2.8.3)
-      mutex_m
-      webrick
-
-GIT
   remote: https://github.com/rdv-solidarites/axiom-types.git
   revision: b9b204cebda7af20feea40c6c3e2dadb5766480f
   ref: b9b204c
@@ -286,6 +277,8 @@ GEM
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     htmlentities (4.3.4)
+    httpclient (2.9.0)
+      mutex_m
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     icalendar (2.8.0)
@@ -730,7 +723,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.2)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -782,7 +774,6 @@ DEPENDENCIES
   groupdate (~> 6.1)
   hirb
   hotwire-rails
-  httpclient!
   icalendar (~> 2.5)
   jb
   jsbundling-rails


### PR DESCRIPTION
# Contexte

Nous avions freeze la version de la Gem httpclient et utilisé un commit de la branche principale pour fixer un warning : https://github.com/betagouv/rdv-service-public/pull/4145

Une nouvelle version de la Gem a été realese, et corrige le problème.

# Solution

Je propose donc de repasser sur la version de Gem qui est disponible sur rubygems.

