### PR TITLE
Ajout de la possibilité de filtrer les rendez-vous par statut

### DIFF
--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
   def index
-    rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).where(params.permit(:organisation_id, :status))
+    rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).where(params.permit(:organisation_id))
 
     rdvs = rdvs.starts_after(Time.zone.parse(params[:starts_after])) if params[:starts_after].present?
     rdvs = rdvs.starts_before(Time.zone.parse(params[:starts_before])) if params[:starts_before].present?
@@ -17,6 +17,10 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
 
     if params[:agent_id].present?
       rdvs = rdvs.where(agents: { id: params[:agent_id] })
+    end
+
+    if params[:status].present?
+      rdvs = rdvs.where(status: params[:status])
     end
 
     render_collection(rdvs)

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
   def index
-    rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).where(params.permit(:organisation_id))
+    rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).where(params.permit(:organisation_id, :status))
 
     rdvs = rdvs.starts_after(Time.zone.parse(params[:starts_after])) if params[:starts_after].present?
     rdvs = rdvs.starts_before(Time.zone.parse(params[:starts_before])) if params[:starts_before].present?

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe "RDV API" do
     let!(:rdv_with_other_user_and_agent) { create(:rdv, organisation: organisation, motif: motif, users: [other_user], agents: [agent]) }
     let!(:rdv_with_other_user_and_other_agent) { create(:rdv, organisation: organisation, motif: motif, users: [other_user], agents: [other_agent]) }
 
+    let!(:cancelled_rdv) { create(:rdv, organisation:, motif:, agents: [agent], status: :excused) }
+
     it "filters by agent and user id" do
       get "/api/v1/rdvs", headers: headers, params: { user_id: user.id, agent_id: agent.id }, as: :json
       expect(parsed_response_body["rdvs"].count).to eq 1
@@ -48,6 +50,13 @@ RSpec.describe "RDV API" do
       get "/api/v1/rdvs", headers: headers, params: { id: rdv_with_user_and_agent.id }, as: :json
       expect(parsed_response_body["rdvs"].count).to eq 1
       expect(parsed_response_body["rdvs"].first["id"]).to eq rdv_with_user_and_agent.id
+    end
+
+    it "filters by statuses" do
+      get "/api/v1/rdvs", headers: headers, params: { status: "excused" }, as: :json
+
+      expect(parsed_response_body["rdvs"].count).to eq 1
+      expect(parsed_response_body["rdvs"].first["id"]).to eq cancelled_rdv.id
     end
   end
 end

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
                 example: 456, required: false
       parameter name: :status, in: :query,
                 description: <<~DOC,
-                  Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.
+                  Filtre les rendez-vous par statut.
                   Vous pouvez passer soit une seule chaine de caractères, soit un tableau de chaines de caractères.
                   Les différentes valeurs possibles sont #{Rdv.statuses.keys}.
                   Si vous passez un tableau, le format attendu est status[]=excused&status[]=revoked

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
       parameter name: :agent_id, in: :query, type: :integer,
                 description: "Filtre pour obtenir uniquement les rendez-vous de l'agent qui a cet id",
                 example: 456, required: false
+      parameter name: :status, in: :query,
+                description: <<~DOC,
+                  Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.
+                  Vous pouvez passer soit une seule chaine de caractères, soit un tableau de chaines de caractères.
+                  Les différentes valeurs possibles sont #{Rdv.statuses.keys}.
+                  Si vous passez un tableau, le format attendu est status[]=excused&status[]=revoked
+                DOC
+                example: "seen ou status[]=excused&status[]=revoked", required: false
+
       parameter name: :id, in: :query,
                 description: <<~DOC,
                   Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -2821,6 +2821,13 @@
             }
           },
           {
+            "name": "status",
+            "in": "query",
+            "description": "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.\nVous pouvez passer soit une seule chaine de caractères, soit un tableau de chaines de caractères.\nLes différentes valeurs possibles sont [\"unknown\", \"seen\", \"excused\", \"revoked\", \"noshow\"].\nSi vous passez un tableau, le format attendu est status[]=excused&status[]=revoked\n",
+            "example": "seen ou status[]=excused&status[]=revoked",
+            "required": false
+          },
+          {
             "name": "id",
             "in": "query",
             "description": "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.\nVous pouvez passer soit un tableau d'entier pour obtenir plusieurs rdvs, soit un seul entier pour obtenir un seul rdv.\nSi vous passez un tableau d'entier, le format attendu est id[]=1234&id[]=5678\n",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -2823,7 +2823,7 @@
           {
             "name": "status",
             "in": "query",
-            "description": "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.\nVous pouvez passer soit une seule chaine de caractères, soit un tableau de chaines de caractères.\nLes différentes valeurs possibles sont [\"unknown\", \"seen\", \"excused\", \"revoked\", \"noshow\"].\nSi vous passez un tableau, le format attendu est status[]=excused&status[]=revoked\n",
+            "description": "Filtre les rendez-vous par statut.\nVous pouvez passer soit une seule chaine de caractères, soit un tableau de chaines de caractères.\nLes différentes valeurs possibles sont [\"unknown\", \"seen\", \"excused\", \"revoked\", \"noshow\"].\nSi vous passez un tableau, le format attendu est status[]=excused&status[]=revoked\n",
             "example": "seen ou status[]=excused&status[]=revoked",
             "required": false
           },


### PR DESCRIPTION
Cette PR est très similaire à ce qu'on a fait il y a quelques mois pour Démarches Simplifiées https://github.com/betagouv/rdv-service-public/pull/5395 (et qui est réutilisé par la coop 🎉 )

L'équipe tech de la coop de la mednum a besoin de filtrer les rendez-vous par statut pour pouvoir proposer la création de comptes-rendus d'activité pour les rendez-vous qui sont on eu lieu, et inciter les agents à remplir le statut des rendez-vous quand c'est nécessaire.

On leur ajoute donc cette possibilité dans l'api.