### PR TITLE
Mise en avant de l'appel à agir dans la page d'atterrissage de la migration d'instances

### DIFF
--- a/app/views/admin/instance_exports/index.html.slim
+++ b/app/views/admin/instance_exports/index.html.slim
@@ -1,5 +1,7 @@
 - content_for :title, "Migration vers RDV Service Public"
 
+- instance_export = InstanceExport.find_by(agent: current_agent, source_organisation: current_organisation)
+
 .card.fr-mb-8w
   .card-body
     h2.fr-h3 Pourquoi passer à RDV Service Public ?
@@ -14,6 +16,12 @@
       li.fr-mb-2w
         b Inviter vos collègues
         |  qui travaillent dans d'autre domaines que la médiation numérique à rejoindre votre organisation sur RDV Service Public.
+
+    .rdv-text-align-center
+      - if instance_export
+        = link_to "Continuer la migration", admin_organisation_instance_export_path(current_organisation, instance_export.id), class: "fr-btn fr-btn--lg"
+      - else
+        = link_to  "Commencer la migration", new_admin_organisation_instance_export_path, class: "fr-btn fr-btn--lg"
 
 .card
   .card-body
@@ -42,8 +50,7 @@
       | Vos données sur #{current_domain.name} seront conservées, et resteront accessibles même après la migration.
 
     .rdv-text-align-center
-      - instance_export = InstanceExport.find_by(agent: current_agent, source_organisation: current_organisation)
       - if instance_export
-        = link_to "Continuer la migration", admin_organisation_instance_export_path(current_organisation, instance_export.id)
+        = link_to "Continuer la migration", admin_organisation_instance_export_path(current_organisation, instance_export.id), class: "fr-btn fr-btn--lg"
       - else
-        = link_to  "Commencer la migration", new_admin_organisation_instance_export_path, class: "fr-btn"
+        = link_to  "Commencer la migration", new_admin_organisation_instance_export_path, class: "fr-btn fr-btn--lg"

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
 
     Capybara.page.current_window.resize_to(1280, 720)
 
-    click_on "Commencer"
+    click_on "Commencer", match: :first
 
     doc.add_screenshot(page,
                        text: "On m'explique l'étape suivante. Je clique sur le bouton de connexion",


### PR DESCRIPTION
Les conums cliquent pas assez, on ajoute des gros boutons bien mis en avant (et pas planqué à la fin de la page) pour qu'ils cliquent plus. 📈 

Avant | Après
:- | -:
<img width="1422" height="762" alt="Screenshot 2025-10-01 at 14 16 49" src="https://github.com/user-attachments/assets/b03e0e22-6467-497a-bc69-ccda48e212e3" />|<img width="1415" height="775" alt="Screenshot 2025-10-01 at 14 16 37" src="https://github.com/user-attachments/assets/94dc5bd0-5e22-4978-9101-b35da5bfc74e" />

