### PR TITLE
Correction nom du territoire paramétre espace -> agents

### DIFF
--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -23,7 +23,7 @@ h1
         .row
           .col.text-right
             - if can_edit_services
-              = f.submit class: "btn btn-primary", value: "Enregistrer les services"
+              = f.submit class: "fr-btn", value: "Enregistrer les services"
             - else
               .fr-mb-0.fr-text--sm.text-muted
                 | Vous n’avez pas les droits nécessaires pour modifier les services des agents
@@ -34,14 +34,14 @@ h1
       = t(".agent_access_rights_legend")
     = simple_form_for @agent.agent_territorial_access_rights.find_by(territory: current_territory), url: admin_territory_agent_territorial_access_right_path do |f|
       .card-body
-        = f.input :allow_to_manage_teams, as: :boolean, hint: t(".hint_allow_to_manage_teams", territory_name: current_territory), disabled: !can_edit_access_rights
-        = f.input :allow_to_manage_access_rights, as: :boolean, hint: t(".hint_allow_to_manage_access_rights", territory_name: current_territory), disabled: !can_edit_access_rights
-        = f.input :allow_to_invite_agents, as: :boolean, hint: t(".hint_allow_to_invite_agents", territory_name: current_territory), disabled: !can_edit_access_rights
+        = f.input :allow_to_manage_teams, as: :boolean, hint: "Créer, supprimer, modifier toutes les équipes de #{current_territory.name_for_agent}", disabled: !can_edit_access_rights
+        = f.input :allow_to_manage_access_rights, as: :boolean, hint: "Modifier les droits d'accès et les services de tous les agents de #{current_territory.name_for_agent}", disabled: !can_edit_access_rights
+        = f.input :allow_to_invite_agents, as: :boolean, hint: "Inviter d'autre personne sur l'espace, les affecter ou retirer de chacune des organisations de #{current_territory.name_for_agent}", disabled: !can_edit_access_rights
       .card-footer
         .row
           .col.text-right
             - if can_edit_access_rights
-              = f.submit class: "btn btn-primary", value: "Enregistrer les droits d'accès"
+              = f.submit class: "fr-btn", value: "Enregistrer les droits d'accès"
             - else
               .fr-mb-0.fr-text--sm.text-muted
                 | Vous n’avez pas les droits nécessaires pour modifier les droits d’accès des agents
@@ -55,14 +55,14 @@ h1
         .card-body
           = check_box_tag :territorial_admin, 1, @agent.territorial_admin_in?(current_territory)
           span>
-          = label_tag :territorial_admin, "Administrateur de l'espace #{current_territory}"
+          = label_tag :territorial_admin, "Administrateur de #{current_territory.name_for_agent}"
           small.form-text.text-muted
             | Ce status d'agent ouvre un large accès à la création d'organisation, la gestion de la sectorisation, la gestion des webhook, la configuration de ce qui est visible dans une fiche usager, une fiche RDV, la visiblité des catégories de motif, …
 
         .card-footer
           .row
             .col.text-right
-              = f.submit class: "btn btn-primary"
+              = f.submit class: "fr-btn"
 
   - if Agent::TerritoryPolicy.new(current_agent, current_territory).allow_to_manage_teams?
     .card.m-2.rounded
@@ -80,7 +80,7 @@ h1
         .card-footer
           .row
             .col.text-right
-              = f.submit class: "btn btn-primary"
+              = f.submit class: "fr-btn"
 
   .card.m-2.rounded
     h2.card-header
@@ -104,7 +104,7 @@ h1
                 .card-footer
                   .row
                     .col.text-left
-                      = link_to t(".delete_agent_role"), admin_territory_agent_role_path(current_territory, role), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Vous confirmez retirer l'agent #{@agent.full_name_or_email} de l'organisation #{role.organisation.name} ?"}
+                      = link_to t(".delete_agent_role"), admin_territory_agent_role_path(current_territory, role), class: "fr-btn fr-btn--tertiary", data: { turbo_confirm: "Vous confirmez retirer l'agent #{@agent.full_name_or_email} de l'organisation #{role.organisation.name} ?", turbo_method: :delete }
                     .col.text-right
                       = f.button :submit, t(".submit")
 
@@ -117,7 +117,7 @@ h1
           = f.input :organisation_id, collection: available_other_organisations, include_blank: "-- sélectionner une organisation --",
                   required: false,
                   label: false
-          = f.submit "Affecter cette organisation", class: "btn btn-outline-primary"
+          = f.submit "Affecter cette organisation", class: "fr-btn fr-btn--secondary"
       - elsif Agent::TerritoryPolicy.new(current_agent, current_territory).allow_to_manage_access_rights?
         => t(".no_other_organisation")
         = link_to t(".create_organisation"), new_admin_organisation_path(territory_id: current_territory.id)

--- a/config/locales/views/admin_territories_agents.yml
+++ b/config/locales/views/admin_territories_agents.yml
@@ -14,6 +14,3 @@ fr:
           organisations:
             submit: Enregistrer
           delete_agent_role: Retirer
-          hint_allow_to_manage_teams: "Créer, supprimer, modifier toutes les équipes de l'espace %{territory_name}"
-          hint_allow_to_manage_access_rights: "Modifier les droits d'accès et les services de tous les agents de l'espace %{territory_name}"
-          hint_allow_to_invite_agents: "Inviter d'autre personne sur l'espace, les affecter ou retirer de chacune des organisations de l'espace %{territory_name}"

--- a/spec/features/agents/editing_territorial_admins_spec.rb
+++ b/spec/features/agents/editing_territorial_admins_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Admin can configure the organisation" do
 
   it "can give territorial admin access to other agent" do
     visit edit_admin_territory_agent_path(territory, other_agent)
-    check("Administrateur de l'espace")
+    check("Administrateur de #{territory.name_for_agent}")
     within(".agent-territorial") do
       expect { click_on("Enregistrer") }.to change { other_agent.reload.territorial_admin_in?(territory) }.to(true)
     end
@@ -19,7 +19,7 @@ RSpec.describe "Admin can configure the organisation" do
 
   it "can't remove the last territorial admin" do
     visit edit_admin_territory_agent_path(territory, agent)
-    uncheck("Administrateur de l'espace")
+    uncheck("Administrateur de #{territory.name_for_agent}")
     within(".agent-territorial") do
       click_on("Enregistrer")
     end


### PR DESCRIPTION
# Contexte

Je me suis aperçu que l’affichage du nom de l’espace était incorrect dans les paramètres de l’espace au niveau de la gestion des agents. 
De plus, en testant, je me suis également aperçu que le bouton pour retire un agent d’une organisation ne fonctionnait plus (certainement depuis que nous avons ajouté Turbo).

# Solution

- Correction du nom de l’espace. Maintenant que le nom est facultatif, j’utilise la nouvelle méthode `name_for_agent` et j’ai changé légèrement le wording pour éviter d’avoir « de l’espace votre espace ».
- Passage des boutons au DSFR (on en profite)
- Correction des attributs pour le bouton permettant de retirer un agent d’une organisation.

## Captures d'écran

Avant | Après
:- | -:
<img width="1030" height="639" alt="image" src="https://github.com/user-attachments/assets/b43da879-8b9f-4b4b-8f3d-178b9419ae3e" /> | <img width="1036" height="644" alt="image" src="https://github.com/user-attachments/assets/ec3a6314-e357-4b75-95e6-ae91f7f6bbf7" />

