### PR TITLE
Définir comme ACCEPTED la participation de l’agent dans l’ICS

### DIFF
--- a/app/services/ical_formatters/ics.rb
+++ b/app/services/ical_formatters/ics.rb
@@ -53,7 +53,7 @@ module IcalFormatters
         event.dtend = dtend
       end
       if payload[:attendees].present?
-        payload[:attendees].each { |attendee| event.append_attendee("mailto:#{attendee}") }
+        payload[:attendees].each { |attendee| event.append_attendee("PARTSTAT=ACCEPTED;mailto:#{attendee}") }
       end
       event.summary = payload[:summary]
       event.location = payload[:location]


### PR DESCRIPTION
# Contexte

Lors des premiers tests en production de la synchro Caldav, nous nous sommes rendus compte que la participation par défaut d’un agent n’était pas définie dans l’ICS. 
Cela lui demande donc d’accepter le RDV dans son agenda professionnel, ce qui n’a pas de sens.
<img width="865" height="678" alt="image" src="https://github.com/user-attachments/assets/00103f95-4a4e-46ea-aa7a-7ce2a6ddddfc" />

En effet, quelle que soit la réponse de l’agent sur sa présence ou non au RDV dans son agenda professionnel, cela n’aura aucune incidence sur son RDV dans RDV SP, ce qui peut amener à confusion.

Voir : https://www.kanzaki.com/docs/ical/partstat.html

# Solution

On définit comme ACCEPTED, la participation des agents dans l’ICS.


