### PR TITLE
Vérification de la configuration Caldav avant de la sauvegarder

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -14,7 +14,7 @@ class Agents::CaldavSyncController < AgentAuthController
       caldav_username: params[:caldav_username],
       caldav_password: params[:caldav_password]
     )
-    if check_caldav_configuration?
+    if caldav_config_ok?
       current_agent.save!
       Caldav::MassCreateEventJob.perform_later(current_agent)
     else
@@ -33,7 +33,7 @@ class Agents::CaldavSyncController < AgentAuthController
 
   private
 
-  def check_caldav_configuration?
+  def caldav_config_ok?
     # Pour vérifier la configuration Caldav, on tente de récupérer l'URL principale.
     current_agent.caldav_client.principal_url
 

--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -9,12 +9,18 @@ class Agents::CaldavSyncController < AgentAuthController
 
   def update
     skip_authorization
-    current_agent.update!(
+    current_agent.assign_attributes(
       caldav_agenda_url: params[:caldav_agenda_url],
       caldav_username: params[:caldav_username],
       caldav_password: params[:caldav_password]
     )
-    Caldav::MassCreateEventJob.perform_later(current_agent)
+    if check_caldav_configuration?
+      current_agent.save!
+      Caldav::MassCreateEventJob.perform_later(current_agent)
+    else
+      flash[:alert] = "La connexion au calendrier a échoué. Veuillez vérifier vos informations et réessayer."
+    end
+
     redirect_to agents_calendar_sync_caldav_sync_path
   end
 
@@ -26,6 +32,15 @@ class Agents::CaldavSyncController < AgentAuthController
   end
 
   private
+
+  def check_caldav_configuration?
+    # Pour vérifier la configuration Caldav, on tente de récupérer l'URL principale.
+    current_agent.caldav_client.principal_url
+
+    true
+  rescue StandardError
+    false
+  end
 
   def pundit_user
     AgentContext.new(current_agent)


### PR DESCRIPTION
# Contexte

Dans la première version de la synchronisation Caldav, on partait du principe que les informations de connexion étaient correctes. Dans le cas où des informations incorrectes étaient saisies, on lançait tout de même les jobs de synchro, ce qui aboutissait systématiquement sur des échecs. L’idée est donc d’appeler une première fois le serveur Caldav pour être sur qu’il n’y ait pas de problème.

# Solution

Comme suggéré dans la doc de la Gem calendav, on appelle le point qui permet de récupérer l’URL de l’agenda principal. Si une quelconque erreur se produit, on affiche un message à l’agent.
Cette petite implémentation rustique, permet de couvrir les erreurs de mots de passe comme les URLs invalides.
