### PR TITLE
Correction texte invisible côté usagers (bg-info)

### DIFF
--- a/app/views/users/rdvs/_creneaux.html.slim
+++ b/app/views/users/rdvs/_creneaux.html.slim
@@ -1,7 +1,10 @@
 - if @all_creneaux.blank?
-  .bg-info.rdv-color-white.p-2.mb-3 Malheureusement, tous les créneaux sont pris. Vous recevrez d'autres propositions si un créneau se libère. La date de votre RDV reste le #{I18n.l(@rdv.starts_at, format: :human)}.
-  .py-4.border-bottom.rdv-text-align-center
-    = link_to "Retour au RDV", users_rdv_path(@rdv), class: "fr-btn"
+  .fr-grid-row
+    .fr-col-12.fr-col-md-8
+      .fr-highlight
+        | Malheureusement, tous les créneaux sont pris. Vous recevrez d'autres propositions si un créneau se libère. La date de votre RDV reste le #{I18n.l(@rdv.starts_at, format: :human)}.
+      .fr-py-4w.border-bottom
+        = link_to "Retour au RDV", users_rdv_path(@rdv), class: "fr-btn"
 - else
   .card
     .card-body


### PR DESCRIPTION
WIP

# Contexte

Il y a du texte invisible côté usagers, à cause de `.bg-info`, une classe bootstrap qui n’est plus exposée dans le CSS. 

<img width="1002" height="669" alt="image" src="https://github.com/user-attachments/assets/d73320e6-37e1-46ed-aaa4-fe5434fa6fe3" />


# Solution

|Avant|Après|
|-|-|
|<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/5c3e647e-4002-4aee-9e8d-7b759b59ada0" />|<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/9e4050d6-6e34-4b5d-ab1f-4234467d98aa" />|

C’est la seule occurence de `bg-info` côté usagers.
Côté agents, la classe `bg-info` est bien définie.

J’ai choisi le composant « mise en exergue » ça me paraissait pertinent : https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/mise-en-exergue

J’en ai profité pour ramener des alignements à gauche, ma petite passion 👼 