### PR TITLE
Fix CronJob::SendMattermostNotificationsForZammadTicketsJob

### DIFF
--- a/app/jobs/cron_job/send_mattermost_notifications_for_zammad_tickets_job.rb
+++ b/app/jobs/cron_job/send_mattermost_notifications_for_zammad_tickets_job.rb
@@ -1,4 +1,4 @@
-class SendMattermostNotificationsForZammadTicketsJob < ApplicationJob
+class CronJob::SendMattermostNotificationsForZammadTicketsJob < CronJob
   include  ActionView::Helpers::DateHelper
   queue_as :latency_5m
 


### PR DESCRIPTION
# Contexte

Après le déploiement de #5687 , une erreur est apparue lors du lancement du cron job ce matin. 

En effet je n’avais tout simplement pas placé le job dans le bon namespace 🤦 

# Solution

Déplacer le job, le mettre dans le bon namespace et le faire hériter du bon job parent 