### PR TITLE
Ajout du fuseau horaire au niveau de l’organisation

### DIFF
--- a/app/dashboards/organisation_dashboard.rb
+++ b/app/dashboards/organisation_dashboard.rb
@@ -20,6 +20,9 @@ class OrganisationDashboard < Administrate::BaseDashboard
     email: Field::String,
     territory: Field::BelongsTo,
     verticale: EnumField,
+    time_zone: Field::Select.with_options(
+      collection: ActiveSupport::TimeZone.all.map(&:tzinfo).map(&:identifier).sort
+    ),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -49,6 +52,7 @@ class OrganisationDashboard < Administrate::BaseDashboard
     lieux
     ants_connectable
     verticale
+    time_zone
     created_at
     updated_at
   ].freeze
@@ -64,6 +68,7 @@ class OrganisationDashboard < Administrate::BaseDashboard
     ants_connectable
     verticale
     territory
+    time_zone
   ].freeze
 
   # Overwrite this method to customize how super admins are displayed

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -44,6 +44,11 @@ class Organisation < ApplicationRecord
   validates :external_id, uniqueness: { scope: :territory, allow_nil: true }
   validate :validate_organisation_phone_number
   validate :validate_at_least_one_user_type
+  validates :time_zone,
+            presence: true,
+            inclusion: {
+              in: ActiveSupport::TimeZone.all.map(&:tzinfo).map(&:identifier),
+            }
 
   # Scopes
   scope :attributed_to_sectors, lambda { |sectors:, most_relevant: false|

--- a/db/migrate/20251007143412_add_time_zone_in_organisation.rb
+++ b/db/migrate/20251007143412_add_time_zone_in_organisation.rb
@@ -1,0 +1,5 @@
+class AddTimeZoneInOrganisation < ActiveRecord::Migration[7.2]
+  def change
+    add_column :organisations, :time_zone, :string, null: false, default: "Europe/Paris"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_30_140515) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_07_143412) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -560,6 +560,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_30_140515) do
     t.boolean "online_booking_for_particuliers", default: true, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des particuliers, et donc qu'on propose le bouton FranceConnect lors de la prise de rendez-vous en ligne.\n"
     t.boolean "online_booking_for_professionnels", default: false, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des professionnels, et donc qu'on propose le bouton ProConnect lors de la prise de rendez-vous en ligne.\n"
     t.datetime "disabled_at", comment: "Date de fermeture de l'organisation"
+    t.string "time_zone", default: "Europe/Paris", null: false
     t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["name", "territory_id"], name: "index_organisations_on_name_and_territory_id", unique: true
     t.index ["territory_id"], name: "index_organisations_on_territory_id"


### PR DESCRIPTION
# Contexte

Nous avons eu plusieurs retours d’agents qui nous utilisent dans les DROM-COM.
Ils n’ont pas spécifiquement de problèmes avec le fait qu’on ne gère pas les différents fuseaux horaires sauf quand ils essaient de charger l’ICS dans leur agenda. 
Cela provient du fait que quand on génère l’ICS, on indique la timezone de Paris ici : https://github.com/betagouv/rdv-service-public/blob/89d13fd46b7a5ae452383f7107e6c707331deb94/app/services/ical_formatters/ics.rb#L47 et ici https://github.com/betagouv/rdv-service-public/blob/89d13fd46b7a5ae452383f7107e6c707331deb94/app/services/ical_formatters/ics.rb#L52

# Solution

On propose donc de stocker à l’échelle de l’organisation la timezone.
Cela va nous permettre d’envoyer la bonne timezone dans l’ICS (et éventuellement dans la synchronisation Outlook).

Dans un premier temps, le changement ne se fait que côté SuperAdmin pour qu’on puisse faire le test avec les agents qui nous, on fait ces retours. À terme, on aimerait donner la main directement à l'admin d’orga.

Si un jour nous avons besoin de stocker les RDV, les plages d’ouverture et les absences avec leur timezone, on aura déjà toutes les infos sur les organisations qui ne sont pas en Europe/Paris.

