### PR TITLE
Limiter l’éxécution du job de rappels Zammad à un env en prod

### DIFF
--- a/app/jobs/cron_job/send_mattermost_notifications_for_zammad_tickets_job.rb
+++ b/app/jobs/cron_job/send_mattermost_notifications_for_zammad_tickets_job.rb
@@ -2,17 +2,34 @@ class CronJob::SendMattermostNotificationsForZammadTicketsJob < CronJob
   include  ActionView::Helpers::DateHelper
 
   queue_as :latency_5m
+  attr_reader :new_and_open_tickets, :tickets_counts_by_owner
 
   def perform
     return if Rails.env.production? && # on veut pouvoir exécuter ce job en dev
               ENV["HOST"] != "https://rdv.anct.gouv.fr" # en prod on ne veut pas l’éxécuter sur chaque app scalingo
 
     Rails.logger.debug "Fetching data from Zammad…"
-    new_and_open_tickets = ZammadApiClient.search_new_and_open_tickets
-    tickets_counts_by_owner = new_and_open_tickets.map(&:owner).tally
+    @new_and_open_tickets = ZammadApiClient.search_new_and_open_tickets
+    @tickets_counts_by_owner = new_and_open_tickets.map(&:owner).tally
     Rails.logger.debug { "Done fetching data from Zammad. Got #{new_and_open_tickets.count} new and open tickets" }
 
     Rails.logger.debug "Building message…"
+    message = build_message
+    Rails.logger.debug "Done building message."
+
+    Rails.logger.debug "Sending message to Mattermost channel"
+    MattermostApiClient.send_message(
+      channel: "startup-rdv-service-public-dev-notifs",
+      text: message,
+      username: "Zammad",
+      icon_url: "https://raw.githubusercontent.com/zammad/zammad/refs/heads/develop/public/assets/images/logo.svg"
+    )
+    Rails.logger.debug "Done sending message to Mattermost."
+  end
+
+  private
+
+  def build_message
     agent_emails = tickets_counts_by_owner.keys.sort.map do |agent_email|
       agent_email == "-" ? " non assignés" : agent_email.split("@").first.split(".").first
     end
@@ -20,8 +37,7 @@ class CronJob::SendMattermostNotificationsForZammadTicketsJob < CronJob
       count = tickets_counts_by_owner[owner]
       "#{count}&nbsp;ticket#{'s' if count > 1}"
     end
-    message = <<~MSG
-
+    <<~MSG
       | #{agent_emails.join(' | ')} |
       | - | - |
       | #{ticket_counts.join(' | ')} |
@@ -33,15 +49,5 @@ class CronJob::SendMattermostNotificationsForZammadTicketsJob < CronJob
       - [Voir les #{new_and_open_tickets.count} tickets en attente de réponse](https://zammad10.ethibox.fr/#ticket/view/all_open)
       - [Voir mes tickets en attente de réponse](https://zammad10.ethibox.fr/#ticket/view/my_assigned)
     MSG
-    Rails.logger.debug "Done building message."
-
-    Rails.logger.debug "Sending message to Mattermost channel"
-    MattermostApiClient.send_message(
-      channel: "startup-rdv-service-public-dev-notifs",
-      text: message,
-      username: "Zammad",
-      icon_url: "https://raw.githubusercontent.com/zammad/zammad/refs/heads/develop/public/assets/images/logo.svg"
-    )
-    Rails.logger.debug "Done sending message to Mattermost."
   end
 end

--- a/app/jobs/cron_job/send_mattermost_notifications_for_zammad_tickets_job.rb
+++ b/app/jobs/cron_job/send_mattermost_notifications_for_zammad_tickets_job.rb
@@ -1,8 +1,12 @@
 class CronJob::SendMattermostNotificationsForZammadTicketsJob < CronJob
   include  ActionView::Helpers::DateHelper
+
   queue_as :latency_5m
 
   def perform
+    return if Rails.env.production? && # on veut pouvoir exécuter ce job en dev
+              ENV["HOST"] != "https://rdv.anct.gouv.fr" # en prod on ne veut pas l’éxécuter sur chaque app scalingo
+
     Rails.logger.debug "Fetching data from Zammad…"
     unassigned_tickets = ZammadApiClient.search_unassigned_tickets
     assigned_tickets = ZammadApiClient.search_assigned_tickets


### PR DESCRIPTION
J’avais oublié de limiter l’éxécution du job qui va envoyer des rappels sur les tickets ouverts Zammad dans Mattermost : 
- on veut pouvoir l’éxecuter en prod
- mais sur Scalingo on ne veut qu’il s’éxécute qu’une fois, sur un seul env

J’ai choisi de manière arbitraire l’env prod-rdv-mairie, je ne sais pas s’il y a une meilleure manière de le spécifier que via la var d’env `HOST`