### PR TITLE
Réservation en ligne : amélioration des cartes du lien de réservation et des profils d'usagers

### DIFF
--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -6,11 +6,15 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
     set_motifs
   end
 
-  def update
-    authorize(@organisation, policy_class: Agent::OrganisationPolicy)
+  def edit_user_type
+    authorize(@organisation, :edit?, policy_class: Agent::OrganisationPolicy)
+  end
+
+  def update_user_type
+    authorize(@organisation, :update?, policy_class: Agent::OrganisationPolicy)
 
     if @organisation.update(permitted_params)
-      flash[:success] = "Configuration mise à jour"
+      flash[:success] = "Profil des usagers mis à jour"
       redirect_to admin_organisation_online_booking_path(@organisation)
     else
       flash[:error] = @organisation.errors.full_messages.to_sentence

--- a/app/javascript/components/copy_to_clipboard_button.js
+++ b/app/javascript/components/copy_to_clipboard_button.js
@@ -3,7 +3,7 @@ export default () => {
 
     button.addEventListener('click', e => {
       navigator.clipboard.writeText(button.dataset.clipboardContent)
-      button.innerHTML = "copié"
+      button.innerHTML = '<span class="fr-icon-check-line fr-icon--sm fr-mr-1v" aria-hidden="true"></span> copié'
     })
 
   })

--- a/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
+++ b/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
@@ -12,12 +12,12 @@
   .fr-col-12.fr-col-lg-10
     .card
       .card-body
-        h3.fr-h4 Profil des usagers
+        h2.fr-h4 Profil des usagers
 
         p Qui participe aux rendez-vous avec les agents de votre organisation ?
         = simple_form_for @organisation, url: update_user_type_admin_organisation_online_booking_path(@organisation), builder: Dsfr::FormBuilder  do |f|
           = f.dsfr_check_box :online_booking_for_particuliers, label: "des particuliers", hint: sanitize("On leur proposera la connexion avec #{dsfr_link_to('FranceConnect', 'https://franceconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
           = f.dsfr_check_box :online_booking_for_professionnels, label: "des professionnels", hint: sanitize("On leur proposera la connexion avec #{dsfr_link_to('ProConnect', 'https://www.proconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
           .d-flex.rdv-justify-content-space-between
-            = link_to("Annuler", admin_organisation_online_booking_path(current_organisation), class: "fr-icon-arrow-left-line fr-btn--icon-left fr-btn fr-btn--tertiary-no-outline")
+            = link_to("Annuler", admin_organisation_online_booking_path(current_organisation), class: "fr-btn fr-btn--tertiary-no-outline")
             = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
+++ b/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
@@ -1,0 +1,23 @@
+- titles_and_paths = [["Accueil", root_path], ["Configuration", admin_organisation_configuration_path(current_organisation)], ["Réservation en ligne", admin_organisation_online_booking_path(current_organisation)]]
+
+- content_for :fil_ariane do
+  = render "common/fil_ariane", titles_and_paths: titles_and_paths, current_page_title: "Profil des usagers"
+
+- content_for(:menu_item) { "menu-settings" }
+
+- content_for :title do
+  | Réservation en ligne
+
+.fr-grid-row
+  .fr-col-12.fr-col-lg-10
+    .card
+      .card-body
+        h3.fr-h4 Profil des usagers
+
+        p Qui participe aux rendez-vous avec les agents de votre organisation ?
+        = simple_form_for @organisation, url: update_user_type_admin_organisation_online_booking_path(@organisation), builder: Dsfr::FormBuilder  do |f|
+          = f.dsfr_check_box :online_booking_for_particuliers, label: "des particuliers", hint: sanitize("On leur proposera la connexion avec #{dsfr_link_to('FranceConnect', 'https://franceconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
+          = f.dsfr_check_box :online_booking_for_professionnels, label: "des professionnels", hint: sanitize("On leur proposera la connexion avec #{dsfr_link_to('ProConnect', 'https://www.proconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
+          .d-flex.rdv-justify-content-space-between
+            = link_to("Annuler", admin_organisation_online_booking_path(current_organisation), class: "fr-icon-arrow-left-line fr-btn--icon-left fr-btn fr-btn--tertiary-no-outline")
+            = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -6,7 +6,7 @@
 
 .card
   .card-body
-    h3.fr-h4 Lien de réservation
+    h2.fr-h4 Lien de réservation
 
     - if current_organisation.sectorized?
       p Cette organisation est sectorisée, les usagers peuvent prendre rendez-vous en saisissant leur adresse sur la page d'accueil&nbsp;:
@@ -22,7 +22,7 @@
 .card
   .card-body
     .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
-      h3.fr-h4 Profil des usagers
+      h2.fr-h4 Profil des usagers
       = link_to "Modifier", edit_user_type_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
     - if @organisation.online_booking_for_particuliers && @organisation.online_booking_for_professionnels
       p La réservation en ligne est ouverte pour les <b>particuliers</b> et les <b>professionnels</b>. Il pourront se connecter avec #{dsfr_link_to("FranceConnect", "https://franceconnect.gouv.fr/", target: :_blank)} ou #{dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank)}.
@@ -38,7 +38,7 @@ ul.list-group.my-1
     li.card
       .card-header.d-flex.align-items-center
         - slots_count = available_slots_count(motif)
-        h4.mr-2
+        h3.mr-2
           - if motif.bookable_by_everyone_or_bookable_by_invited_users? && slots_count > 0
             i.fa-solid.fa-circle-check.color-scheme-green.mr-1
           - else

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -21,11 +21,15 @@
 
 .card
   .card-body
-    p Qui participe aux rendez-vous avec les agents de votre organisation ?
-    = simple_form_for @organisation, url: admin_organisation_online_booking_path(@organisation)  do |f|
-      = f.input :online_booking_for_particuliers, label: "des particuliers", hint: sanitize("On leur proposera la connexion avec #{dsfr_link_to('FranceConnect', 'https://franceconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
-      = f.input :online_booking_for_professionnels, label: "des professionnels", hint: sanitize("On leur proposera la connexion avec #{dsfr_link_to('ProConnect', 'https://www.proconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
-      = f.submit "Enregistrer", class: "fr-btn"
+    .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
+      h3.fr-h4 Profil des usagers
+      = link_to "Modifier", edit_user_type_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
+    - if @organisation.online_booking_for_particuliers && @organisation.online_booking_for_professionnels
+      p La réservation en ligne est ouverte pour les <b>particuliers</b> et les <b>professionnels</b>. Il pourront se connecter avec #{dsfr_link_to("FranceConnect", "https://franceconnect.gouv.fr/", target: :_blank)} ou #{dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank)}.
+    - elsif @organisation.online_booking_for_particuliers
+      p La réservation en ligne est ouverte pour les <b>particuliers</b>. Il pourront se connecter avec #{dsfr_link_to("FranceConnect", "https://franceconnect.gouv.fr/", target: :_blank)}.
+    - elsif @organisation.online_booking_for_professionnels
+      p La réservation en ligne est ouverte pour les <b>professionnels</b>. Il pourront se connecter avec #{dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank)}.
 
 ul.list-group.my-1
   - if @motifs.none?

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -6,17 +6,18 @@
 
 .card
   .card-body
-    p Permettez à vos usagers de prendre rendez-vous en ligne, sur les créneaux qui vous conviennent.
-
-    p La réservation en ligne peut être configurée pour chaque motif de rendez-vous.
+    h3.fr-h4 Lien de réservation
 
     - if current_organisation.sectorized?
       p Cette organisation est sectorisée, les usagers peuvent prendre rendez-vous en saisissant leur adresse sur la page d'accueil&nbsp;:
       = render partial: "admin/organisations/online_bookings/booking_link", locals: { booking_link: prendre_rdv_url }
     - else
-      p Une fois qu'elle est activée, vous pouvez envoyer ce lien à vos usagers pour qu'ils prennent rendez-vous&nbsp;:
       - org_booking_link = public_link_to_org_url(organisation_id: current_organisation.id, org_slug: current_organisation.slug)
       = render partial: "admin/organisations/online_bookings/booking_link", locals: { booking_link: org_booking_link }
+
+    p.fr-mt-2w Ce lien permet de  prendre rendez-vous avec votre organisation sur les plages d'ouverture disponibles.
+
+    p Vous pouvez l'intégrer à votre site internet, votre signature d'email, ou l'envoyer directement à vos usagers.
 
 .card
   .card-body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -268,7 +268,12 @@ Rails.application.routes.draw do
           end
         end
         scope module: "organisations" do
-          resource :online_booking, only: %i[show update]
+          resource :online_booking, only: %i[show] do
+            member do
+              get :edit_user_type
+              patch :update_user_type
+            end
+          end
           resource :configuration, only: [:show]
           resources :stats, only: :index do
             collection do

--- a/spec/features/agents/agent_can_configure_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_configure_online_booking_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Agents can configure online booking" do
   describe "choix du type d'usager qui participer au rendez-vous" do
     before do
       login_as(agent, scope: :agent)
-      visit admin_organisation_online_booking_path(organisation)
+      visit edit_user_type_admin_organisation_online_booking_path(organisation)
     end
 
     it "permet de passer de particulier à professionnel" do
@@ -109,7 +109,7 @@ RSpec.describe "Agents can configure online booking" do
       find("label", text:  "des professionnels").click
       click_on "Enregistrer"
 
-      expect(page).to have_content "Configuration mise à jour"
+      expect(page).to have_content "Profil des usagers mis à jour"
 
       expect(organisation.reload).to have_attributes(
         online_booking_for_particuliers: false,

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     click_on "Réservation en ligne"
 
-    doc.add_screenshot(page, text: "J'ouvre le menu de réservation en ligne", wait_for: "Permettez à vos usagers de prendre rendez-vous en ligne")
+    doc.add_screenshot(page, text: "J'ouvre le menu de réservation en ligne", wait_for: "Ce lien permet de prendre rendez-vous avec votre organisation sur les plages d'ouverture disponibles.")
 
     click_on "modifier"
 
@@ -112,15 +112,18 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     doc.add_screenshot(page,
                        text: "Je retourne sur la page de configuration de la prise de rendez-vous en ligne",
-                       wait_for: "Permettez à vos usagers de prendre rendez-vous en ligne")
+                       wait_for: "Ce lien permet de prendre rendez-vous avec votre organisation sur les plages d'ouverture disponibles.")
+
+    click_on "Modifier"
 
     find(:label, text: "des particuliers").click
     find(:label, text: "des professionnels").click
-    click_on "Enregistrer"
 
     doc.add_screenshot(page,
                        text: "Je sélectionne la prise de rendez-vous par des professionnels et j'enregistre.",
-                       wait_for: "Configuration mise à jour")
+                       wait_for: "Qui participe aux rendez-vous avec les agents de votre organisation ?")
+
+    click_on "Enregistrer"
 
     doc.add_text("Je transmets le lien de prise de rendez-vous à un de mes usagers")
 

--- a/spec/features/autodoc/self_onboarding_spec.rb
+++ b/spec/features/autodoc/self_onboarding_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Configuration initiale", js: true do
 
     doc.add_screenshot(page,
                        text: "Réservation en ligne",
-                       wait_for: "Permettez à vos usagers de prendre rendez-vous en ligne")
+                       wait_for: "Ce lien permet de prendre rendez-vous avec votre organisation")
 
     expect(page).to have_content("Pour ouvrir la réservation en ligne, vous devez d'abord créer un motif de rendez-vous")
 


### PR DESCRIPTION
## Captures d'écran

Avant | Après
:- | -:
<img width="1280" height="720" alt="avant" src="https://github.com/user-attachments/assets/166bac25-dcbe-4972-8709-398c444ed0e7" />|<img width="1280" height="720" alt="apres" src="https://github.com/user-attachments/assets/a033d67c-502f-4b96-99ee-61f4a96aa019" />


<img width="1280" height="720" alt="form" src="https://github.com/user-attachments/assets/6429e09b-7dbe-49ea-8cf1-786372935c2b" />

Review app : https://rdv-service-public-review-app-pr5714.osc-secnum-fr1.scalingo.io/

On rend la page de réservation en ligne plus lisible pour améliorer la compréhension de cette partie de l'appli.
Ça permet aussi de préparer le travail qui va venir sur l'activation de la prise de rdv en ligne.
