### PR TITLE
Amélioration des sujets des tickets Zammad

### DIFF
--- a/app/form_models/demande_support_form.rb
+++ b/app/form_models/demande_support_form.rb
@@ -29,7 +29,7 @@ class DemandeSupportForm
       email:,
       subject: sujet,
       body: ticket_body,
-      tags: [current_domain.to_s]
+      tags: [current_domain.to_s, "Formulaire Demande Support"]
     )
   end
 

--- a/app/form_models/demande_support_form.rb
+++ b/app/form_models/demande_support_form.rb
@@ -36,7 +36,7 @@ class DemandeSupportForm
   private
 
   def ticket_subject
-    "Demande Support #{role.to_s.capitalize} - #{first_name} #{last_name} - #{sujet}"
+    "#{sujet} – depuis le formulaire de demande de support"
   end
 
   # Nous utilisons cette méthode uniquement pour Zammad car Crisp permet de stocker les informations de contact

--- a/app/form_models/demande_support_form.rb
+++ b/app/form_models/demande_support_form.rb
@@ -27,17 +27,13 @@ class DemandeSupportForm
     CreateZammadTicketJob.perform_later(
       sender_role: role,
       email:,
-      subject: ticket_subject,
+      subject: sujet,
       body: ticket_body,
       tags: [current_domain.to_s]
     )
   end
 
   private
-
-  def ticket_subject
-    "#{sujet} – depuis le formulaire de demande de support"
-  end
 
   # Nous utilisons cette méthode uniquement pour Zammad car Crisp permet de stocker les informations de contact
   # dans les métadonnées de la conversation


### PR DESCRIPTION
# Contexte

Les sujets des tickets Zammad commencent actuellement tous par « Demande Support Usager/Agent - Jeanne BARRET - #{sujet} »

Ça n’est pas pratique car la partie différanciante est à la fin, et l’espace en colonnes est assez limité sur Zammad.

# Solution

Je propose de simplement utiliser le sujet entré par l’usager. Il y a aussi des sujets pré-définis dans le formulaire de demande support.

- L’info Agent / Usager est déjà présente dans une étiquette
- L’info nom prénom est présente dans la fiche « client » Zammad 
- L’info depuis le formulaire de demande de support est présente dans le message