### PR TITLE
simplification du message Mattermost de rappel des tickets ouverts Zammad

### DIFF
--- a/app/jobs/cron_job/send_mattermost_notifications_for_zammad_tickets_job.rb
+++ b/app/jobs/cron_job/send_mattermost_notifications_for_zammad_tickets_job.rb
@@ -4,26 +4,30 @@ class CronJob::SendMattermostNotificationsForZammadTicketsJob < CronJob
 
   def perform
     Rails.logger.debug "Fetching data from Zammad…"
-    unassigned_tickets = ZammadApiClient.search_unassigned_tickets
-    assigned_tickets = ZammadApiClient.search_assigned_tickets
-    assigned_tickets_counts_by_agent_email = assigned_tickets.map(&:owner).tally
-    Rails.logger.debug { "Done fetching data from Zammad. Got #{unassigned_tickets.count} unassigned tickets and #{assigned_tickets.count} assigned tickets." }
+    new_and_open_tickets = ZammadApiClient.search_new_and_open_tickets
+    tickets_counts_by_owner = new_and_open_tickets.map(&:owner).tally
+    Rails.logger.debug { "Done fetching data from Zammad. Got #{new_and_open_tickets.count} new and open tickets" }
 
     Rails.logger.debug "Building message…"
-    agent_emails = assigned_tickets_counts_by_agent_email.keys.sort.map do |agent_email|
-      agent_email == "-" ? "N/A" : agent_email.split("@").first.split(".").first
+    agent_emails = tickets_counts_by_owner.keys.sort.map do |agent_email|
+      agent_email == "-" ? " non assignés" : agent_email.split("@").first.split(".").first
     end
-    ticket_counts = assigned_tickets_counts_by_agent_email.keys.sort.map { "#{assigned_tickets_counts_by_agent_email[_1]}&nbsp;ticket(s)" }
+    ticket_counts = tickets_counts_by_owner.keys.sort.map do |owner|
+      count = tickets_counts_by_owner[owner]
+      "#{count}&nbsp;ticket#{'s' if count > 1}"
+    end
     message = <<~MSG
-      #{unassigned_tickets.count} tickets non-assignés en attente de réponse. Le plus ancien attend une réponse depuis #{time_ago_in_words(unassigned_tickets.map(&:awaiting_response_since).min)} [Voir ces #{unassigned_tickets.count} tickets](https://zammad10.ethibox.fr/#ticket/view/all_unassigned)
-
-      #{assigned_tickets.count} tickets assignés en attente de réponse. Le plus ancien attend depuis #{time_ago_in_words(assigned_tickets.map(&:awaiting_response_since).min)}.
 
       | #{agent_emails.join(' | ')} |
       | - | - |
       | #{ticket_counts.join(' | ')} |
 
-      [Voir les tickets qui vous sont assignés](https://zammad10.ethibox.fr/#ticket/view/my_assigned)
+      Au total **#{new_and_open_tickets.count} tickets** attendent une réponse.
+
+      Le plus ancien attend une réponse depuis **#{time_ago_in_words(new_and_open_tickets.map(&:awaiting_response_since).min)}**
+
+      - [Voir les #{new_and_open_tickets.count} tickets en attente de réponse](https://zammad10.ethibox.fr/#ticket/view/all_open)
+      - [Voir mes tickets en attente de réponse](https://zammad10.ethibox.fr/#ticket/view/my_assigned)
     MSG
     Rails.logger.debug "Done building message."
 

--- a/app/lib/zammad_api_client.rb
+++ b/app/lib/zammad_api_client.rb
@@ -41,21 +41,10 @@ class ZammadApiClient
     connection.post("api/v1/tickets/search?#{query}", { condition: }).body
   end
 
-  def self.search_assigned_tickets
+  def self.search_new_and_open_tickets
     search_tickets(
       condition: {
         "ticket.state_id": { operator: "is", value: [1, 2] }, # new or open
-        "ticket.owner_id": { operator: "is not", value: [1] },
-      },
-      query: "per_page=200&expand=true" # 200 seems to be the max
-    ).map { Ticket.new(_1) }
-  end
-
-  def self.search_unassigned_tickets
-    search_tickets(
-      condition: {
-        "ticket.state_id": { operator: "is", value: [1, 2] }, # new or open
-        "ticket.owner_id": { operator: "is", value: [1] },
       },
       query: "per_page=200&expand=true" # 200 seems to be the max
     ).map { Ticket.new(_1) }


### PR DESCRIPTION
# Contexte

Je propose de simplifier (et collectiviser) la gestion de nos tickets Zammad

# Solution

Je propose de traiter plus ou moins de la même manière les tickets qu’ils soient assignés ou non, ouverts ou nouveaux.

**L’idée est de tout regrouper sous un label « en attente de réponse ».**

J’ai simplifié les filtres par défaut sur Zammad : 

<img width="1673" height="782" alt="image" src="https://github.com/user-attachments/assets/d819544a-f92c-4adc-ad56-8d33f39c703c" />

Les deux premiers et principaux affichent : 
- les nouveaux tickets, càd jamais répondus
- ET les tickets ouverts, càd déjà répondus par un agent mais re-répondus par l’usager ou bien pas fermés par oubli par l’agent

Je propose dans cette PR de simplifier le message de rappel quotidien en conséquence : 

<img width="777" height="242" alt="image" src="https://github.com/user-attachments/assets/d152b5ac-e8ca-453a-bd62-35cd5e5df852" />

