### PR TITLE
Réservation en ligne : formulaire d'activation des motifs

### DIFF
--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -4,6 +4,39 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
   def show
     authorize(@organisation, policy_class: Agent::OrganisationPolicy)
     set_motifs
+
+    if @motifs.bookable_by_everyone.none?
+      @online_booking_motifs_form = Admin::OnlineBookingMotifsForm.new(current_organisation)
+
+      @cancel_path = admin_organisation_configuration_path(current_organisation)
+      render :form
+    else
+      @open_motifs = @motifs.bookable_by_everyone
+      @closed_motifs = @motifs.where.not(bookable_by: :everyone)
+
+      @banner = OnlineBookingOnboardingBanner.new(current_organisation)
+    end
+  end
+
+  def edit
+    authorize(@organisation, :edit?, policy_class: Agent::OrganisationPolicy)
+    set_motifs
+
+    @online_booking_motifs_form = Admin::OnlineBookingMotifsForm.new(current_organisation)
+
+    @cancel_path = admin_organisation_online_booking_path(current_organisation)
+    render :form
+  end
+
+  def update
+    authorize(@organisation, :edit?, policy_class: Agent::OrganisationPolicy)
+    set_motifs
+
+    form = Admin::OnlineBookingMotifsForm.new(current_organisation)
+
+    form.submit(params.dig(:admin_online_booking_motifs_form, :motif_ids), flash)
+
+    redirect_to admin_organisation_online_booking_path(current_organisation)
   end
 
   def edit_user_type
@@ -18,8 +51,7 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
       redirect_to admin_organisation_online_booking_path(@organisation)
     else
       flash[:error] = @organisation.errors.full_messages.to_sentence
-      set_motifs
-      render :show
+      render :edit_user_type
     end
   end
 

--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -34,7 +34,7 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
 
     form = Admin::OnlineBookingMotifsForm.new(current_organisation)
 
-    form.submit(params.dig(:admin_online_booking_motifs_form, :motif_ids), flash)
+    form.submit(params.dig(:admin_online_booking_motifs_form, :motif_ids), flash, session)
 
     redirect_to admin_organisation_online_booking_path(current_organisation)
   end

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -63,6 +63,7 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
     if @plage_ouverture.save
       Notifiers::PlageOuvertureCreated.new(@plage_ouverture).perform
       flash[:success] = "Plage d'ouverture créée"
+      update_online_booking_banner_display
       redirect_to admin_organisation_planning_plage_ouvertures_path(organisation_id: @plage_ouverture.organisation, agent_id: @plage_ouverture.agent_id)
     else
       render :new
@@ -74,6 +75,7 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
     if @plage_ouverture.update(plage_ouverture_params)
       Notifiers::PlageOuvertureUpdated.new(@plage_ouverture).perform
       flash[:success] = "La plage d'ouverture a été modifiée."
+      update_online_booking_banner_display
       redirect_to admin_organisation_planning_plage_ouvertures_path(organisation_id: @plage_ouverture.organisation, agent_id: @plage_ouverture.agent_id)
     else
       render :edit
@@ -93,6 +95,16 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
   end
 
   private
+
+  def update_online_booking_banner_display
+    if session["OnlineBookingMotifsForm:completed"]
+      banner = OnlineBookingOnboardingBanner.new(current_organisation)
+      # S'il n'y a plus besoin de la bannière, on arrête de l'afficher
+      unless banner.display?
+        session.delete("OnlineBookingMotifsForm:completed")
+      end
+    end
+  end
 
   def set_plage_ouverture
     @plage_ouverture = PlageOuverture.find(params[:id])

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -100,7 +100,7 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
     if session["OnlineBookingMotifsForm:completed"]
       banner = OnlineBookingOnboardingBanner.new(current_organisation)
       # S'il n'y a plus besoin de la bannière, on arrête de l'afficher
-      unless banner.display?
+      unless banner.availabilities_needed?
         session.delete("OnlineBookingMotifsForm:completed")
       end
     end

--- a/app/form_models/admin/online_booking_motifs_form.rb
+++ b/app/form_models/admin/online_booking_motifs_form.rb
@@ -1,0 +1,54 @@
+class Admin::OnlineBookingMotifsForm
+  include ActiveModel::Model
+
+  attr_reader :motif_ids
+
+  def initialize(organisation)
+    @organisation = organisation
+    @motif_ids = motifs.bookable_by_everyone.pluck(:id)
+  end
+
+  def submit(new_motif_ids, flash)
+    new_motif_ids ||= []
+
+    motifs_open_before_update = motifs.bookable_by_everyone.any?
+
+    motifs.bookable_by_everyone.where.not(id: new_motif_ids).each do |motif_to_close|
+      motif_to_close.update(bookable_by: :agents)
+    end
+
+    motifs.where(id: new_motif_ids).each do |motif_to_open|
+      motif_to_open.update(bookable_by: :everyone)
+    end
+
+    motifs_open_after_update = motifs.bookable_by_everyone.any?
+
+    prepare_flash(flash, motifs_open_before_update, motifs_open_after_update)
+  end
+
+  private
+
+  def motifs
+    @motifs ||= @organisation.motifs.active
+  end
+
+  def prepare_flash(flash, motifs_open_before_update, motifs_open_after_update)
+    if motifs_open_before_update
+      if motifs_open_after_update
+        flash[:success] = "La liste des motifs ouverts à la réservation en ligne a été mise à jour."
+      else
+        flash[:notice] = "La réservation en ligne a été fermée"
+      end
+    elsif motifs_open_after_update
+
+      banner = OnlineBookingOnboardingBanner.new(@organisation)
+
+      # Si on affiche la bannière, on ne met pas le flash, parce que ça fait doublon d'avoir une confirmation au dessus du titre et un avertissement sous le titre
+      unless banner.display?
+        flash[:success] = "Les motifs #{motifs.bookable_by_everyone.pluck(:name).to_sentence} sont ouverts pour la réservation en ligne."
+      end
+    else
+      flash[:error] = "Vous devez choisir au moins un motif pour ouvrir la réservation en ligne"
+    end
+  end
+end

--- a/app/form_models/admin/online_booking_motifs_form.rb
+++ b/app/form_models/admin/online_booking_motifs_form.rb
@@ -40,17 +40,26 @@ class Admin::OnlineBookingMotifsForm
         flash[:notice] = "La réservation en ligne a été fermée"
       end
     elsif motifs_open_after_update
-
-      banner = OnlineBookingOnboardingBanner.new(@organisation)
-
-      # Si on affiche la bannière, on ne met pas le flash, parce que ça fait doublon d'avoir une confirmation au dessus du titre et un avertissement sous le titre
-      if banner.display?
-        session["OnlineBookingMotifsForm:completed"] = true
-      else
-        flash[:success] = "Les motifs #{motifs.bookable_by_everyone.pluck(:name).to_sentence} sont ouverts pour la réservation en ligne."
-      end
+      prepare_flash_and_session_for_activation(flash, session)
     else
       flash[:error] = "Vous devez choisir au moins un motif pour ouvrir la réservation en ligne"
+    end
+  end
+
+  def prepare_flash_and_session_for_activation(flash, session)
+    banner = OnlineBookingOnboardingBanner.new(@organisation)
+
+    if banner.availabilities_needed?
+      # Si on affiche la bannière, on ne met pas le flash, parce que ça fait doublon d'avoir une confirmation au dessus du titre et un avertissement sous le titre
+      session["OnlineBookingMotifsForm:completed"] = true
+    else
+      motif_names = motifs.bookable_by_everyone.pluck(:name)
+      flash[:success] = if motif_names.count == 1
+                          "Le motif #{motif_names.first} est ouvert pour la réservation en ligne."
+                        else
+                          "Les motifs #{motif_names.to_sentence} sont ouverts pour la réservation en ligne."
+                        end
+
     end
   end
 end

--- a/app/form_models/admin/online_booking_motifs_form.rb
+++ b/app/form_models/admin/online_booking_motifs_form.rb
@@ -8,7 +8,7 @@ class Admin::OnlineBookingMotifsForm
     @motif_ids = motifs.bookable_by_everyone.pluck(:id)
   end
 
-  def submit(new_motif_ids, flash)
+  def submit(new_motif_ids, flash, session)
     new_motif_ids ||= []
 
     motifs_open_before_update = motifs.bookable_by_everyone.any?
@@ -23,7 +23,7 @@ class Admin::OnlineBookingMotifsForm
 
     motifs_open_after_update = motifs.bookable_by_everyone.any?
 
-    prepare_flash(flash, motifs_open_before_update, motifs_open_after_update)
+    prepare_flash_and_session(flash, session, motifs_open_before_update, motifs_open_after_update)
   end
 
   private
@@ -32,7 +32,7 @@ class Admin::OnlineBookingMotifsForm
     @motifs ||= @organisation.motifs.active
   end
 
-  def prepare_flash(flash, motifs_open_before_update, motifs_open_after_update)
+  def prepare_flash_and_session(flash, session, motifs_open_before_update, motifs_open_after_update)
     if motifs_open_before_update
       if motifs_open_after_update
         flash[:success] = "La liste des motifs ouverts à la réservation en ligne a été mise à jour."
@@ -44,7 +44,9 @@ class Admin::OnlineBookingMotifsForm
       banner = OnlineBookingOnboardingBanner.new(@organisation)
 
       # Si on affiche la bannière, on ne met pas le flash, parce que ça fait doublon d'avoir une confirmation au dessus du titre et un avertissement sous le titre
-      unless banner.display?
+      if banner.display?
+        session["OnlineBookingMotifsForm:completed"] = true
+      else
         flash[:success] = "Les motifs #{motifs.bookable_by_everyone.pluck(:name).to_sentence} sont ouverts pour la réservation en ligne."
       end
     else

--- a/app/helpers/dsfr_helper.rb
+++ b/app/helpers/dsfr_helper.rb
@@ -42,4 +42,17 @@ module DsfrHelper
   def external_link_to(name, url, html_options = {})
     link_to(name, url, { target: "_blank", rel: "noopener", title: "#{name} - nouvel onglet" }.merge(html_options))
   end
+
+  def location_type_icon(location_type, html_options = {})
+    case location_type.to_sym
+    when :public_office
+      lieu_icon(html_options)
+    when :phone
+      phone_icon(html_options)
+    when :home
+      home_icon(html_options)
+    when :visio
+      visio_icon(html_options)
+    end
+  end
 end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -262,6 +262,14 @@ class Motif < ApplicationRecord
     Motif.find_by(id: duplicated_from_motif_id) if duplicated_from_motif_id
   end
 
+  def upcoming_availabilities
+    if collectif?
+      rdvs.collectif_and_available_for_reservation
+    else
+      plage_ouvertures.in_range(Time.zone.now..)
+    end
+  end
+
   private
 
   def booking_delay_validation

--- a/app/presenters/online_booking_onboarding_banner.rb
+++ b/app/presenters/online_booking_onboarding_banner.rb
@@ -3,7 +3,7 @@ class OnlineBookingOnboardingBanner
     @organisation = organisation
   end
 
-  def display?
+  def availabilities_needed?
     motifs_with_missing_availabilities.any?
   end
 

--- a/app/presenters/online_booking_onboarding_banner.rb
+++ b/app/presenters/online_booking_onboarding_banner.rb
@@ -1,0 +1,15 @@
+class OnlineBookingOnboardingBanner
+  def initialize(organisation)
+    @organisation = organisation
+  end
+
+  def display?
+    motifs_with_missing_availabilities.any?
+  end
+
+  def motifs_with_missing_availabilities
+    @motifs_with_missing_availabilities ||= @organisation.motifs.bookable_by_everyone.select do |motif|
+      motif.upcoming_availabilities.none?
+    end
+  end
+end

--- a/app/presenters/online_booking_onboarding_banner.rb
+++ b/app/presenters/online_booking_onboarding_banner.rb
@@ -8,7 +8,7 @@ class OnlineBookingOnboardingBanner
   end
 
   def motifs_with_missing_availabilities
-    @motifs_with_missing_availabilities ||= @organisation.motifs.bookable_by_everyone.select do |motif|
+    @motifs_with_missing_availabilities ||= @organisation.motifs.active.bookable_by_everyone.select do |motif|
       motif.upcoming_availabilities.none?
     end
   end

--- a/app/views/admin/organisations/online_bookings/_motif_card.html.slim
+++ b/app/views/admin/organisations/online_bookings/_motif_card.html.slim
@@ -1,0 +1,40 @@
+li.card
+  .card-header.d-flex.align-items-center
+    - slots_count = available_slots_count(motif)
+    h3.mr-2
+      - if motif.bookable_by_everyone_or_bookable_by_invited_users? && slots_count > 0
+        i.fa-solid.fa-circle-check.color-scheme-green.mr-1
+      - else
+        i.fa-regular.fa-circle-xmark.color-scheme-red.mr-1
+      = motif.name
+    .mr-1 = motif.human_attribute_value(:location_type)
+    .mr-1 = "#{motif.default_duration_in_min} min."
+  .card-body
+    .row.mb-1
+      .col-12.d-flex.align-items-center
+        - if motif.bookable_by_everyone_or_bookable_by_invited_users?
+          i.fa-solid.fa-circle-check.color-scheme-green.mr-1
+          .mr-2 Réservable en ligne
+        - else
+          i.fa-regular.fa-circle-xmark.color-scheme-red.mr-1
+          .mr-2 Ce motif n'est pas réservable en ligne
+        = link_to "modifier", edit_admin_organisation_motif_path(motif.organisation, motif, anchor: "tab_resa_en_ligne")
+
+    .row
+      .col-12.d-flex.align-items-center
+        - if motif.collectif?
+          - if slots_count > 0
+            i.fa-solid.fa-circle-check.color-scheme-green.mr-1
+            .mr-2 #{slots_count} rendez-vous avec des places disponibles
+          - else
+            i.fa-regular.fa-circle-xmark.color-scheme-red.mr-1
+            .mr-2 Aucun rendez-vous avec des places disponibles
+          = link_to "ajouter", new_admin_organisation_rdvs_collectif_path(current_organisation, current_agent, motif_id: motif.id)
+        - else
+          - if slots_count > 0
+            i.fa-solid.fa-circle-check.color-scheme-green.mr-1
+            .mr-2 #{pluralize(slots_count, "plage", plural: "plages")} d'ouverture
+          - else
+            i.fa-regular.fa-circle-xmark.color-scheme-red.mr-1
+            .mr-2 Pas de plages d'ouverture
+          = link_to "ajouter",  new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: current_agent, motif_ids: [motif.id])

--- a/app/views/admin/organisations/online_bookings/_motif_card.html.slim
+++ b/app/views/admin/organisations/online_bookings/_motif_card.html.slim
@@ -29,7 +29,7 @@ li.card
           - else
             i.fa-regular.fa-circle-xmark.color-scheme-red.mr-1
             .mr-2 Aucun rendez-vous avec des places disponibles
-          = link_to "ajouter", new_admin_organisation_rdvs_collectif_path(current_organisation, current_agent, motif_id: motif.id)
+          = link_to "ajouter", new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: motif.id)
         - else
           - if slots_count > 0
             i.fa-solid.fa-circle-check.color-scheme-green.mr-1

--- a/app/views/admin/organisations/online_bookings/_motif_card.html.slim
+++ b/app/views/admin/organisations/online_bookings/_motif_card.html.slim
@@ -1,7 +1,7 @@
 li.card
-  .card-header.d-flex.align-items-center
+  .card-header.d-flex.rdv-align-items-baseline
     - slots_count = available_slots_count(motif)
-    h3.mr-2
+    h3.fr-h6.mr-2.fr-mb-1v
       - if motif.bookable_by_everyone_or_bookable_by_invited_users? && slots_count > 0
         i.fa-solid.fa-circle-check.color-scheme-green.mr-1
       - else

--- a/app/views/admin/organisations/online_bookings/form.html.slim
+++ b/app/views/admin/organisations/online_bookings/form.html.slim
@@ -12,7 +12,7 @@
 
       .card
         .card-body
-          h4.fr-h5 Permettez à vos usagers de prendre rendez-vous en autonomie
+          h2.fr-h5 Permettez à vos usagers de prendre rendez-vous en autonomie
 
           = form_for @online_booking_motifs_form, url: admin_organisation_online_booking_path(current_organisation), method: :patch, builder: Dsfr::FormBuilder do |f|
             fieldset.fr-fieldset aria-labelledby="checkboxes-legend checkboxes-messages"
@@ -34,5 +34,5 @@
             p Vous gardez le contrôle : la prise de rendez-vous sera possible uniquement sur les plages d'ouverture de votre choix, et pour les motifs de votre choix.
 
             .d-flex.rdv-justify-content-space-between
-              = link_to("Annuler", @cancel_path, class: "fr-icon-arrow-left-line fr-btn--icon-left fr-btn fr-btn--tertiary-no-outline")
+              = link_to("Annuler", @cancel_path, class: "fr-btn fr-btn--tertiary-no-outline")
               = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/organisations/online_bookings/form.html.slim
+++ b/app/views/admin/organisations/online_bookings/form.html.slim
@@ -1,0 +1,38 @@
+= render "admin/organisations/configurations/fil_ariane", current_page_title: "Réservation en ligne"
+- content_for(:menu_item) { "menu-settings" }
+
+- content_for :title do
+  | Réservation en ligne
+
+.fr-grid-row
+  .fr-col-12.fr-col-lg-10
+    - if @motifs.none?
+      = render "admin/motifs/creation_needed_callout", motivation_text: "Pour ouvrir la réservation en ligne, vous devez d'abord créer un motif de rendez-vous."
+    - else
+
+      .card
+        .card-body
+          h4.fr-h5 Permettez à vos usagers de prendre rendez-vous en autonomie
+
+          = form_for @online_booking_motifs_form, url: admin_organisation_online_booking_path(current_organisation), method: :patch, builder: Dsfr::FormBuilder do |f|
+            fieldset.fr-fieldset aria-labelledby="checkboxes-legend checkboxes-messages"
+              legend.fr-fieldset__legend--regular.fr-fieldset__legend#checkboxes-legend
+                | Pour quels motifs souhaitez-vous activer la prise de rendez-vous en ligne ?
+
+              - @motifs.each do |motif|
+                .fr-fieldset__element
+                  .fr-checkbox-group
+                    = f.check_box :motif_ids, { multiple: true }, motif.id, false
+                    = f.label "motif_ids_#{motif.id}", class: "fr-label" do
+                      = motif.name
+                      span.fr-hint-text
+                        = location_type_icon(motif.location_type, class: "fr-mr-1w fr-icon--sm")
+                        = motif.human_attribute_value(:location_type)
+                        = " · "
+                        = "#{motif.default_duration_in_min} mn"
+
+            p Vous gardez le contrôle : la prise de rendez-vous sera possible uniquement sur les plages d'ouverture de votre choix, et pour les motifs de votre choix.
+
+            .d-flex.rdv-justify-content-space-between
+              = link_to("Annuler", @cancel_path, class: "fr-icon-arrow-left-line fr-btn--icon-left fr-btn fr-btn--tertiary-no-outline")
+              = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -4,7 +4,7 @@
 - content_for :title do
   | Réservation en ligne
 
-- if @banner.display? &&  session["OnlineBookingMotifsForm:completed"]
+- if @banner.availabilities_needed? && session["OnlineBookingMotifsForm:completed"]
   .fr-callout.fr-pb-2w
     p 🎉 Vous y êtes presque !
 
@@ -12,7 +12,7 @@
       p Le motif <b>#{@banner.motifs_with_missing_availabilities.first.name}</b> est ouvert pour la réservation en ligne.
     - else
       - bold_motif_names = @banner.motifs_with_missing_availabilities.pluck(:name).map { |name| tag.b(name) }
-      p Les motifs #{bold_motif_names.to_sentence} sont ouverts pour la réservation en ligne.
+      p Les motifs #{sanitize(bold_motif_names.to_sentence)} sont ouverts pour la réservation en ligne.
 
     - if @banner.motifs_with_missing_availabilities.any?(&:individuel?)
       p Vous devez maintenant ouvrir une plage d'ouverture pour que la réservation en ligne soit possible.

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -4,7 +4,7 @@
 - content_for :title do
   | Réservation en ligne
 
-- if @banner.display?
+- if @banner.display? &&  session["OnlineBookingMotifsForm:completed"]
   .fr-callout.fr-pb-2w
     p 🎉 Vous y êtes presque !
 

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -9,10 +9,10 @@
     p 🎉 Vous y êtes presque !
 
     - if @banner.motifs_with_missing_availabilities.count == 1
-      p = sanitize("Le motif <b>#{@banner.motifs_with_missing_availabilities.first.name}</b> est ouvert pour la réservation en ligne.")
+      p Le motif <b>#{@banner.motifs_with_missing_availabilities.first.name}</b> est ouvert pour la réservation en ligne.
     - else
       - bold_motif_names = @banner.motifs_with_missing_availabilities.pluck(:name).map { |name| tag.b(name) }
-      p = sanitize("Les motifs #{bold_motif_names.to_sentence} sont ouverts pour la réservation en ligne.")
+      p Les motifs #{bold_motif_names.to_sentence} sont ouverts pour la réservation en ligne.
 
     - if @banner.motifs_with_missing_availabilities.any?(&:individuel?)
       p Vous devez maintenant ouvrir une plage d'ouverture pour que la réservation en ligne soit possible.

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -16,11 +16,17 @@
     - if @banner.motifs_with_missing_availabilities.any?(&:individuel?)
       p Vous devez maintenant ouvrir une plage d'ouverture pour que la réservation en ligne soit possible.
 
-      = link_to "Ouvrir une plage d'ouverture", admin_organisation_planning_plage_ouvertures_path(current_organisation), class: "fr-btn"
-
     - if @banner.motifs_with_missing_availabilities.any?(&:collectif?)
-      p Pour les motifs de rendez-vous collectifs, vous devez planifier des prochains rendez-vous
+      p Pour les motifs de rendez-vous collectifs, vous devez planifier des prochains rendez-vous.
+
+    - if @banner.motifs_with_missing_availabilities.all?(&:individuel?)
+      = link_to "Ouvrir une plage d'ouverture", admin_organisation_planning_plage_ouvertures_path(current_organisation), class: "fr-btn"
+    - elsif @banner.motifs_with_missing_availabilities.all?(&:collectif?)
       = link_to "Planifier un rendez-vous collectif", admin_organisation_rdvs_collectif_motifs_path(current_organisation), class: "fr-btn"
+    - else
+      .fr-btns-group.fr-btns-group--inline
+        = link_to "Ouvrir une plage d'ouverture", admin_organisation_planning_plage_ouvertures_path(current_organisation), class: "fr-btn fr-btn--secondary"
+        = link_to "Planifier un rendez-vous collectif", admin_organisation_rdvs_collectif_motifs_path(current_organisation), class: "fr-btn fr-btn--secondary"
 
 .card
   .card-body

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -9,9 +9,10 @@
     p 🎉 Vous y êtes presque !
 
     - if @banner.motifs_with_missing_availabilities.count == 1
-      p = "Le motif #{@banner.motifs_with_missing_availabilities.first.name} est ouvert pour la réservation en ligne."
+      p = sanitize("Le motif <b>#{@banner.motifs_with_missing_availabilities.first.name}</b> est ouvert pour la réservation en ligne.")
     - else
-      p = "Les motifs #{@banner.motifs_with_missing_availabilities.pluck(:name).to_sentence} sont ouverts pour la réservation en ligne."
+      - bold_motif_names = @banner.motifs_with_missing_availabilities.pluck(:name).map { |name| tag.b(name) }
+      p = sanitize("Les motifs #{bold_motif_names.to_sentence} sont ouverts pour la réservation en ligne.")
 
     - if @banner.motifs_with_missing_availabilities.any?(&:individuel?)
       p Vous devez maintenant ouvrir une plage d'ouverture pour que la réservation en ligne soit possible.

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -4,6 +4,24 @@
 - content_for :title do
   | Réservation en ligne
 
+- if @banner.display?
+  .fr-callout.fr-pb-2w
+    p 🎉 Vous y êtes presque !
+
+    - if @banner.motifs_with_missing_availabilities.count == 1
+      p = "Le motif #{@banner.motifs_with_missing_availabilities.first.name} est ouvert pour la réservation en ligne."
+    - else
+      p = "Les motifs #{@banner.motifs_with_missing_availabilities.pluck(:name).to_sentence} sont ouverts pour la réservation en ligne."
+
+    - if @banner.motifs_with_missing_availabilities.any?(&:individuel?)
+      p Vous devez maintenant ouvrir une plage d'ouverture pour que la réservation en ligne soit possible.
+
+      = link_to "Ouvrir une plage d'ouverture", admin_organisation_planning_plage_ouvertures_path(current_organisation), class: "fr-btn"
+
+    - if @banner.motifs_with_missing_availabilities.any?(&:collectif?)
+      p Pour les motifs de rendez-vous collectifs, vous devez planifier des prochains rendez-vous
+      = link_to "Planifier un rendez-vous collectif", admin_organisation_rdvs_collectif_motifs_path(current_organisation), class: "fr-btn"
+
 .card
   .card-body
     h2.fr-h4 Lien de réservation
@@ -31,47 +49,21 @@
     - elsif @organisation.online_booking_for_professionnels
       p La réservation en ligne est ouverte pour les <b>professionnels</b>. Il pourront se connecter avec #{dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank)}.
 
-ul.list-group.my-1
-  - if @motifs.none?
-    = render "admin/motifs/creation_needed_callout", motivation_text: "Pour ouvrir la réservation en ligne, vous devez d'abord créer un motif de rendez-vous."
-  - @motifs.each do |motif|
-    li.card
-      .card-header.d-flex.align-items-center
-        - slots_count = available_slots_count(motif)
-        h3.mr-2
-          - if motif.bookable_by_everyone_or_bookable_by_invited_users? && slots_count > 0
-            i.fa-solid.fa-circle-check.color-scheme-green.mr-1
-          - else
-            i.fa-regular.fa-circle-xmark.color-scheme-red.mr-1
-          = motif.name
-        .mr-1 = motif.human_attribute_value(:location_type)
-        .mr-1 = "#{motif.default_duration_in_min} min."
-      .card-body
-        .row.mb-1
-          .col-12.d-flex.align-items-center
-            - if motif.bookable_by_everyone_or_bookable_by_invited_users?
-              i.fa-solid.fa-circle-check.color-scheme-green.mr-1
-              .mr-2 Réservable en ligne
-            - else
-              i.fa-regular.fa-circle-xmark.color-scheme-red.mr-1
-              .mr-2 Ce motif n'est pas réservable en ligne
-            = link_to "modifier", edit_admin_organisation_motif_path(motif.organisation, motif, anchor: "tab_resa_en_ligne")
+.card
+  .card-body
+    .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
+      h3.fr-h4 Motifs ouverts à la réservation en ligne
+      = link_to "Modifier", edit_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
+    ul.list-group.my-1
+      - @open_motifs.each do |motif|
+        = render "motif_card", motif:
 
-        .row
-          .col-12.d-flex.align-items-center
-            - if motif.collectif?
-              - if slots_count > 0
-                i.fa-solid.fa-circle-check.color-scheme-green.mr-1
-                .mr-2 #{slots_count} rendez-vous avec des places disponibles
-              - else
-                i.fa-regular.fa-circle-xmark.color-scheme-red.mr-1
-                .mr-2 Aucun rendez-vous avec des places disponibles
-              = link_to "ajouter", new_admin_organisation_rdvs_collectif_path(current_organisation, current_agent, motif_id: motif.id)
-            - else
-              - if slots_count > 0
-                i.fa-solid.fa-circle-check.color-scheme-green.mr-1
-                .mr-2 #{pluralize(slots_count, "plage", plural: "plages")} d'ouverture
-              - else
-                i.fa-regular.fa-circle-xmark.color-scheme-red.mr-1
-                .mr-2 Pas de plages d'ouverture
-              = link_to "ajouter",  new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: current_agent, motif_ids: [motif.id])
+- if @closed_motifs.present?
+  .card
+    .card-body
+      .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
+        h3.fr-h4 Motifs fermés à la réservation en ligne
+        = link_to "Modifier", edit_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
+      ul.list-group.my-1
+        - @closed_motifs.each do |motif|
+          = render "motif_card", motif:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -268,7 +268,7 @@ Rails.application.routes.draw do
           end
         end
         scope module: "organisations" do
-          resource :online_booking, only: %i[show] do
+          resource :online_booking, only: %i[show edit update] do
             member do
               get :edit_user_type
               patch :update_user_type

--- a/spec/features/agents/agent_can_configure_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_configure_online_booking_spec.rb
@@ -55,6 +55,36 @@ RSpec.describe "Agents can configure online booking" do
     end
   end
 
+  describe "availabilities banner" do
+    let!(:lieu) { create(:lieu, organisation:) }
+
+    it "shows the banner when needed, until the availabilities are open" do
+      visit admin_organisation_online_booking_path(organisation)
+      find("label", text: motif.name).click
+      click_on "Enregistrer"
+
+      expect(page).to have_content("Le motif Motif individuel est ouvert pour la réservation en ligne.")
+
+      # La bannière est encore là si on recharge la page
+      visit admin_organisation_online_booking_path(organisation)
+      expect(page).to have_content("Le motif Motif individuel est ouvert pour la réservation en ligne.")
+
+      click_on "Ouvrir une plage d'ouverture"
+      click_on "Renseigner mes disponibilités"
+      find("label", text: motif.name).click
+      find("label", text: "Lundi").click
+
+      select(lieu.name, from: "Lieu")
+      click_on "Créer la plage d'ouverture"
+
+      expect(page).to have_content "Plage d'ouverture créée"
+
+      # La bannière ne s'affiche plus
+      visit admin_organisation_online_booking_path(organisation)
+      expect(page).not_to have_content("Le motif Motif individuel est ouvert pour la réservation en ligne.")
+    end
+  end
+
   context "motif individuel" do
     it "displays the motif's status" do
       visit admin_organisation_online_booking_path(organisation)

--- a/spec/features/agents/agent_can_configure_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_configure_online_booking_spec.rb
@@ -1,29 +1,67 @@
 RSpec.describe "Agents can configure online booking" do
   let!(:organisation) { create(:organisation) }
+  let!(:motif) do
+    create(:motif, organisation: organisation, service: agent.services.first, bookable_by: :agents, collectif: false, name: "Motif individuel")
+  end
   let!(:agent) { create(:agent, :cnfs, admin_role_in_organisations: [organisation]) }
 
-  context "motif individuel" do
-    let!(:motif) do
-      create(:motif, organisation: organisation, service: agent.services.first, bookable_by: :agents, collectif: false, name: "Motif individuel")
+  before { login_as(agent, scope: :agent) }
+
+  describe "full lifecycle" do
+    let!(:motif_for_prescripteurs) do
+      create(:motif, organisation: organisation, service: agent.services.first, bookable_by: :agents_and_prescripteurs, collectif: false, name: "Suivi de dossier")
     end
 
+    specify do
+      visit admin_organisation_online_booking_path(organisation)
+
+      expect(page).to have_content("Pour quels motifs souhaitez-vous activer la prise de rendez-vous en ligne ?")
+
+      click_on "Enregistrer"
+
+      expect(page).to have_content("Vous devez choisir au moins un motif pour ouvrir la réservation en ligne")
+      expect(page).to have_content("Pour quels motifs souhaitez-vous activer la prise de rendez-vous en ligne ?")
+
+      find("label", text: motif.name).click
+      click_on "Enregistrer"
+
+      expect(page).to have_content("Le motif Motif individuel est ouvert pour la réservation en ligne.")
+      expect(motif.reload).to have_attributes(bookable_by: "everyone")
+      expect(motif_for_prescripteurs.reload).to have_attributes(bookable_by: "agents_and_prescripteurs") # Les motifs qui ne sont pas bookable_by_everyone ne changent pas de niveau de réservation.
+
+      expect(page).to have_content("Ouvrir une plage d'ouverture")
+
+      visit edit_admin_organisation_online_booking_path(organisation)
+
+      find("label", text: motif.name).click
+      find("label", text: motif_for_prescripteurs.name).click
+      click_on "Enregistrer"
+
+      expect(motif.reload).to have_attributes(bookable_by: "agents")
+      expect(motif_for_prescripteurs.reload).to have_attributes(bookable_by: "everyone")
+
+      expect(page).to have_content("La liste des motifs ouverts à la réservation en ligne a été mise à jour.")
+
+      visit edit_admin_organisation_online_booking_path(organisation)
+
+      find("label", text: motif_for_prescripteurs.name).click
+      click_on "Enregistrer"
+
+      expect(page).to have_content("La réservation en ligne a été fermée")
+      expect(motif.reload).to have_attributes(bookable_by: "agents")
+      expect(motif_for_prescripteurs.reload).to have_attributes(bookable_by: "agents")
+
+      expect(page).to have_content("Pour quels motifs souhaitez-vous activer la prise de rendez-vous en ligne ?")
+    end
+  end
+
+  context "motif individuel" do
     it "displays the motif's status" do
-      login_as(agent, scope: :agent)
       visit admin_organisation_online_booking_path(organisation)
 
-      # On a 3 croix qui indiquent respectivement :
-      # - le motif n'est pas réservable en ligne
-      # - c'est parce que l'option n'a pas été activée via le formulaire du motif
-      # - il n'y a pas de plages d'ouverture
-      expect(page).to have_css("i.fa-regular.fa-circle-xmark.color-scheme-red", count: 3)
+      find("label", text: motif.name).click
+      click_on "Enregistrer"
 
-      expect(page).to have_content("Ce motif n'est pas réservable en ligne")
-      expect(page).to have_link("modifier")
-      expect(page).to have_content("Pas de plages d'ouverture")
-
-      motif.update!(bookable_by: :everyone)
-
-      visit admin_organisation_online_booking_path(organisation)
       expect(page).to have_content("Réservable en ligne")
 
       expect(page).to have_css("i.fa-solid.fa-circle-check.color-scheme-green", count: 1)
@@ -43,8 +81,8 @@ RSpec.describe "Agents can configure online booking" do
     it "doesn't show plages d'ouverture in the past" do
       create(:plage_ouverture, motifs: [motif], agent: agent, organisation: organisation, first_day: 20.days.from_now)
       create(:plage_ouverture, motifs: [motif], agent: agent, organisation: organisation, first_day: 10.days.ago)
+      motif.update!(bookable_by: :everyone)
 
-      login_as(agent, scope: :agent)
       visit admin_organisation_online_booking_path(organisation)
 
       expect(page).to have_content("1 plage d'ouverture")
@@ -53,17 +91,14 @@ RSpec.describe "Agents can configure online booking" do
 
   context "motif collectif" do
     let!(:motif) do
-      create(:motif, organisation: organisation, service: agent.services.first, collectif: true, name: "Motif collectif")
+      create(:motif, organisation: organisation, service: agent.services.first, collectif: true, name: "Motif collectif", bookable_by: :agents)
     end
 
     it "displays the motif's status" do
-      login_as(agent, scope: :agent)
-
       visit admin_organisation_online_booking_path(organisation)
-      expect(page).to have_css("i.fa-solid.fa-circle-check.color-scheme-green", count: 1)
-      expect(page).to have_css("i.fa-regular.fa-circle-xmark.color-scheme-red", count: 2)
-      expect(page).to have_content("Réservable en ligne")
-      expect(page).to have_content("Aucun rendez-vous avec des places disponibles")
+
+      find("label", text: motif.name).click
+      click_on "Enregistrer"
 
       create(:rdv, motif: motif, max_participants_count: 5, organisation:)
 
@@ -75,6 +110,8 @@ RSpec.describe "Agents can configure online booking" do
   end
 
   describe "booking link" do
+    before { motif.update!(bookable_by: :everyone) }
+
     context "when organisation is sectorized" do
       before do
         sector = create(:sector, territory: organisation.territory)
@@ -83,15 +120,12 @@ RSpec.describe "Agents can configure online booking" do
       end
 
       it "points to the public booking home page" do
-        login_as(agent, scope: :agent)
         visit admin_organisation_online_booking_path(organisation)
-        expect(page).to have_content("http://www.rdv-solidarites-test.localhost:#{Capybara.server_port}/prendre_rdv")
       end
     end
 
     context "when organisation is not sectorized" do
       it "points to the public booking home page" do
-        login_as(agent, scope: :agent)
         visit admin_organisation_online_booking_path(organisation)
         expect(page).to have_content("http://www.rdv-solidarites-test.localhost:#{Capybara.server_port}/org/#{organisation.id}/#{organisation.slug}")
       end
@@ -100,7 +134,6 @@ RSpec.describe "Agents can configure online booking" do
 
   describe "choix du type d'usager qui participer au rendez-vous" do
     before do
-      login_as(agent, scope: :agent)
       visit edit_user_type_admin_organisation_online_booking_path(organisation)
     end
 

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
                        text: "Je retourne sur la page de configuration de la prise de rendez-vous en ligne",
                        wait_for: "Ce lien permet de prendre rendez-vous avec votre organisation sur les plages d'ouverture disponibles.")
 
-    click_on "Modifier"
+    click_on "Modifier", match: :first
 
     find(:label, text: "des particuliers").click
     find(:label, text: "des professionnels").click

--- a/spec/features/autodoc/self_onboarding_spec.rb
+++ b/spec/features/autodoc/self_onboarding_spec.rb
@@ -66,9 +66,7 @@ RSpec.describe "Configuration initiale", js: true do
 
     doc.add_screenshot(page,
                        text: "Réservation en ligne",
-                       wait_for: "Ce lien permet de prendre rendez-vous avec votre organisation")
-
-    expect(page).to have_content("Pour ouvrir la réservation en ligne, vous devez d'abord créer un motif de rendez-vous")
+                       wait_for: "Pour ouvrir la réservation en ligne, vous devez d'abord créer un motif de rendez-vous")
 
     doc.start_section("Configuration")
 


### PR DESCRIPTION
Review app : https://rdv-service-public-review-app-pr5721.osc-secnum-fr1.scalingo.io

<img width="1420" height="765" alt="Screenshot 2025-10-13 at 20 25 00" src="https://github.com/user-attachments/assets/3c397329-fe32-415a-84d1-3035f886af53" />

<img width="1424" height="689" alt="Screenshot 2025-10-13 at 20 25 19" src="https://github.com/user-attachments/assets/8c860b76-7cbb-4f0e-b3b2-6472485e781a" />

# Contexte

Cette Pr est la suite directe de https://github.com/betagouv/rdv-service-public/pull/5714
Conformément aux discussions avec Téo et Mehdi, cette PR ajoute un formulaire d'activation de la réservation en ligne pour des motifs.

Lors des rendez-vous d'accompagement avec les agents, on a vu qu'ils avaient beaucoup de mal à comprendre la page de réservation en ligne, donc on espère qu'un formulaire qui leur propose explicitement d'activer la réservation en ligne sera une amélioration.

Une fois que ce formulaire est validé, on affiche une bannière s'il est nécessaire d'ajouter des disponibilités (plage d'ouverture, rdv collectif, ou les deux).
Ça devrait clarifier les opérations à faire pour activer la réservation en ligne.
