### PR TITLE
Restreindre les permissions de l’action GitHub de rappel des PR

### DIFF
--- a/.github/workflows/pull_requests_reminder.yml
+++ b/.github/workflows/pull_requests_reminder.yml
@@ -1,4 +1,6 @@
 name: Pull Requests Reminder
+permissions:
+  pull-requests: read
 on:
   schedule:
     - cron: "0 8 * * 1-4"

--- a/.github/workflows/pull_requests_reminder.yml
+++ b/.github/workflows/pull_requests_reminder.yml
@@ -18,4 +18,4 @@ jobs:
           webhook-url: ${{ secrets.PR_REMINDER_WEBHOOK_URL }}
           provider: slack
           github-provider-map: "francois-ferrandis:francois.ferrandis,victormours:victor.mours,aminedhobb:amine.dhobb,Holist:romain.neuville,Michaelvilleneuve:michael.villeneuve,AntoineGirard:agd,Teodora-Stanki:teodora.stankiewicz"
-          channel: "@adipasquale"
+          channel: "startup-rdv-service-public-dev"

--- a/.github/workflows/pull_requests_reminder.yml
+++ b/.github/workflows/pull_requests_reminder.yml
@@ -18,4 +18,4 @@ jobs:
           webhook-url: ${{ secrets.PR_REMINDER_WEBHOOK_URL }}
           provider: slack
           github-provider-map: "francois-ferrandis:francois.ferrandis,victormours:victor.mours,aminedhobb:amine.dhobb,Holist:romain.neuville,Michaelvilleneuve:michael.villeneuve,AntoineGirard:agd,Teodora-Stanki:teodora.stankiewicz"
-          channel: "startup-rdv-service-public-dev"
+          channel: "@adipasquale"


### PR DESCRIPTION
cf https://github.com/betagouv/rdv-service-public/security/code-scanning/36

j’ai testé : 
- en mettant le channel `@adipasquale` pour ne pas polluer le channel commun
- en déclenchant le workflow manuellement sur la branche depuis https://github.com/betagouv/rdv-service-public/actions/workflows/pull_requests_reminder.yml 

