### PR TITLE
Refacto de Agent::OrganisationPolicy pour arrêter d'utiliser un AgentContext

### DIFF
--- a/app/controllers/admin/organisations/configurations_controller.rb
+++ b/app/controllers/admin/organisations/configurations_controller.rb
@@ -27,6 +27,6 @@ class Admin::Organisations::ConfigurationsController < AgentAuthController
   private
 
   def pundit_user
-    AgentContext.new(current_agent)
+    current_agent
   end
 end

--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -25,6 +25,10 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
 
   private
 
+  def pundit_user
+    current_agent
+  end
+
   def set_motifs
     @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif)
       .available_motifs_for_organisation_and_agent(current_organisation, current_agent)

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -72,4 +72,8 @@ class Admin::OrganisationsController < AgentAuthController
   def new_organisation_params
     params.require(:organisation).permit(:name, :territory_id)
   end
+
+  def pundit_user
+    current_agent
+  end
 end

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -127,7 +127,8 @@ class Admin::RdvsController < AgentAuthController
 
   def set_scoped_organisations
     @selected_organisations_ids = params[:scoped_organisation_ids]&.compact_blank
-    accessible_organisations = policy_scope(Organisation, policy_scope_class: Agent::OrganisationPolicy::Scope)
+    skip_policy_scope # on fait un policy scope à la ligne suivante
+    accessible_organisations = Agent::OrganisationPolicy::Scope.apply(current_agent, Organisation)
     @scoped_organisations = if @selected_organisations_ids.blank?
                               # l'agent n'a pas accès au filtre d'organisations ou a réinitialisé la page
                               # Nous sélectionnons par défaut l'organisation courante

--- a/app/controllers/admin/territories/organisations_controller.rb
+++ b/app/controllers/admin/territories/organisations_controller.rb
@@ -75,8 +75,4 @@ class Admin::Territories::OrganisationsController < Admin::Territories::BaseCont
       .where(territory: current_territory)
       .ordered_by_name
   end
-
-  def pundit_user
-    AgentContext.new(current_agent)
-  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -120,7 +120,10 @@ class Admin::UsersController < AgentAuthController
 
   def link_to_organisation
     @user = User.find(params.require(:id))
-    authorize(current_organisation, policy_class: Agent::OrganisationPolicy)
+
+    # On fait un appel à Pundit.authorize parce que le pundit_user est un AgentOrganisationContext
+    Pundit.authorize(current_agent, current_organisation, :show?, policy_class: Agent::OrganisationPolicy)
+    skip_authorization
 
     Redis.with_connection do |redis|
       matching_user_id = redis.get("link_to_organisation:secure_key:#{params[:secure_key]}")

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -33,8 +33,7 @@ class AgentAuthController < ApplicationController
   end
 
   def authorize_organisation
-    # on n’utilise pas le helper authorize directement car le pundit_user défini plus haut a comme contexte
-    # l’organisation elle même, ici on veut un contexte d’agent sans organisation
-    Pundit.authorize(AgentContext.new(current_agent), current_organisation, :show?, policy_class: Agent::OrganisationPolicy)
+    # on n’utilise pas le helper authorize directement pour obliger à faire un autre appel à authorize avec la ressource qui sera réellement utilisée par l'action (par exemple le motif ou le rdv)
+    Pundit.authorize(current_agent, current_organisation, :show?, policy_class: Agent::OrganisationPolicy)
   end
 end

--- a/app/controllers/agents/agendas_controller.rb
+++ b/app/controllers/agents/agendas_controller.rb
@@ -16,6 +16,6 @@ class Agents::AgendasController < AgentAuthController
   private
 
   def pundit_user
-    AgentContext.new(current_agent)
+    current_agent
   end
 end

--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -31,7 +31,7 @@ class Agents::PagesController < AgentAuthController
   private
 
   def pundit_user
-    AgentContext.new(current_agent)
+    current_agent
   end
 
   # << REMOVE AFTER 01/01/2026

--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -78,4 +78,8 @@ class Api::V1::OrganisationsController < Api::V1::AgentAuthBaseController
   def geo_params?
     [params[:city_code], params[:street_ban_id]].any?(&:present?)
   end
+
+  def pundit_user
+    current_agent
+  end
 end

--- a/app/policies/agent/organisation_policy.rb
+++ b/app/policies/agent/organisation_policy.rb
@@ -1,9 +1,9 @@
-class Agent::OrganisationPolicy < DefaultAgentPolicy
-  def link_to_organisation?
+class Agent::OrganisationPolicy < ApplicationPolicy
+  def in_organisation?
     current_agent.organisation_ids.include?(@record.id)
   end
 
-  def admin_in_record_organisation?
+  def admin_in_organisation?
     current_agent.roles.access_level_admin.pluck(:organisation_id).include?(record.id)
   end
 
@@ -11,40 +11,29 @@ class Agent::OrganisationPolicy < DefaultAgentPolicy
     current_agent.territorial_admin_in?(record.territory)
   end
 
-  alias creneau_availability? link_to_organisation?
+  alias show? in_organisation?
+  alias creneau_availability? in_organisation?
+
+  alias edit? admin_in_organisation?
+  alias update? admin_in_organisation?
+  alias versions? admin_in_organisation?
 
   alias new? territorial_admin?
   alias create? territorial_admin?
   alias close? territorial_admin?
   alias reopen? territorial_admin?
 
+  alias current_agent pundit_user
+
   def destroy?
     false
-  end
-
-  def users?
-    admin?
-  end
-
-  def rdvs?
-    admin?
-  end
-
-  def versions?
-    admin?
-  end
-
-  def update?
-    admin_in_record_organisation?
-  end
-
-  def show?
-    link_to_organisation?
   end
 
   class Scope < Scope
     def resolve
       scope.merge(current_agent.organisations)
     end
+
+    alias current_agent pundit_user
   end
 end


### PR DESCRIPTION
Pour les améliorations de la réservation en ligne, je vais avoir besoin d'avoir des appels à authorize sur des organisations et des motifs dans le OnlineBookingController.
Le problème est qu'actuellement ces deux policy attendent des pundit_user différents : `MotifPolicy` utilise un agent, alors que `OrganisationPolicy` utilise un `AgentContext`.

Pour rappel, le `AgentContext` est juste un wrapper autour de l'agent, hérité de l'époque où on mélangeait le contexte de la navigation avec les policies.

Cette PR fait donc pour la OrganisationPolicy le refactor qui a été fait il ya longtemps sur `MotifPolicy` pour qu'elle puisse utiliser un agent.