### PR TITLE
Permettre un délai de réservation de 6 semaines pour l'insertion

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -67,7 +67,7 @@ module MotifsHelper
     [["1/2 heure", 30.minutes], ["1 heure", 1.hour], ["2 heures", 2.hours],
      ["3 heures", 3.hours], ["6 heures", 6.hours], ["12 heures", 12.hours],
      ["1 jour", 1.day], ["2 jours", 2.days], ["3 jours", 3.days], ["1 semaine", 1.week], ["2 semaines", 2.weeks], ["3 semaines", 3.weeks],
-     ["1 mois", 1.month], ["2 mois", 2.months], ["3 mois", 3.months], ["6 mois", 6.months], ["1 an", 1.year],]
+     ["1 mois", 1.month], ["6 semaines", 6.weeks], ["2 mois", 2.months], ["3 mois", 3.months], ["6 mois", 6.months], ["1 an", 1.year],]
   end
 
   def min_max_delay_int_to_human(int_value)


### PR DESCRIPTION
# Contexte

Dans le cadre de l'insertion, les conseils départementaux ont une obligation légale d'orienter le bénéficiaire en 6 semaines (le délai est dans le texte de loi), pour ne pas perdre la compétence.
Aujourd'hui, on propose 1 mois ou 2 mois de délai de réservation, mais rien entre les deux.
C'est donc embêtant pour les conseils départementaux : soit ils mettent un mois comme délai, mais ça limite les options pour les bénéficaires, soit ils mettent eux mois, mais ils risquent de sortir du cadre de la loi, et ça a l'air de poser un assez gros problème.

Vu le ratio problème solution, on ajoute cette option à la liste actuelle.

Voir aussi https://www.notion.so/rdvs/Plus-de-gradualit-dans-le-d-lais-de-r-servation-maximum-1292b05ced4180df86a3cb1ac694ea58

## Captures d'écran

Avant | Après
:- | -:
<img width="832" height="590" alt="Screenshot 2025-10-14 at 14 41 19" src="https://github.com/user-attachments/assets/7662dba7-6eb5-41b4-8698-82ebd4876347" />|<img width="818" height="611" alt="Screenshot 2025-10-14 at 14 40 53" src="https://github.com/user-attachments/assets/2153d232-1f58-47bf-a4f6-abeeed033521" />

