### PR TITLE
Déblocage des contacts Brevo lors du renvoi d’invitation agent

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -52,9 +52,8 @@ DEFAULT_SMS_PROVIDER_KEY=
 DEFAULT_SMS_PROVIDER_API_URL=
 FORCE_SMS_PROVIDER=debug_logger
 
-## Emails
-SENDINBLUE_PASSWORD=change_me
-SENDINBLUE_USERNAME=change_me
+# API Brevo
+BREVO_API_KEY=change_me
 
 ## Alternate email to send text plain email (needed for 92 mail2sms today)
 ALTERNATE_SMTP_USERNAME=

--- a/.env.sample
+++ b/.env.sample
@@ -53,6 +53,7 @@ DEFAULT_SMS_PROVIDER_API_URL=
 FORCE_SMS_PROVIDER=debug_logger
 
 # API Brevo
+# https://app.brevo.com/settings/keys/api (en utilisant les crédentials du compte disponible dans Vaultwarden)
 BREVO_API_KEY=change_me
 
 ## Alternate email to send text plain email (needed for 92 mail2sms today)

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -11,6 +11,7 @@ class Admin::InvitationsController < AgentAuthController
   def reinvite
     @agent = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(params[:id])
     authorize(@agent, policy_class: Agent::AgentPolicy)
+    UnblockBrevoTransactionnalContact.new(@agent.email).call
     @agent.invite!(current_agent, validate: false)
     flash[:success] = "Une nouvelle invitation a été envoyée à l'agent #{@agent.email}."
     redirect_to admin_organisation_invitations_path(current_organisation)

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -11,7 +11,7 @@ class Admin::InvitationsController < AgentAuthController
   def reinvite
     @agent = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(params[:id])
     authorize(@agent, policy_class: Agent::AgentPolicy)
-    UnblockBrevoTransactionnalContact.new(@agent.email).call
+    UnblockBrevoTransactionalContact.new(@agent.email).call
     @agent.invite!(current_agent, validate: false)
     flash[:success] = "Une nouvelle invitation a été envoyée à l'agent #{@agent.email}."
     redirect_to admin_organisation_invitations_path(current_organisation)

--- a/app/services/unblock_brevo_transactional_contact.rb
+++ b/app/services/unblock_brevo_transactional_contact.rb
@@ -5,6 +5,11 @@ class UnblockBrevoTransactionalContact
   end
 
   def call
+    if ENV["BREVO_API_KEY"].blank?
+      Sentry.capture_message("BREVO_API_KEY is not set, cannot unblock Brevo transactional contact", level: :error) if Rails.env.production?
+      return
+    end
+
     response = Faraday.delete("https://api.brevo.com/v3/smtp/blockedContacts/#{CGI.escape(@email)}") do |req|
       req.headers["accept"] = "application/json"
       req.headers["api-key"] = ENV["BREVO_API_KEY"]

--- a/app/services/unblock_brevo_transactional_contact.rb
+++ b/app/services/unblock_brevo_transactional_contact.rb
@@ -1,5 +1,5 @@
 # https://developers.brevo.com/reference/delete_smtp-blockedcontacts-email
-class UnblockBrevoTransactionnalContact
+class UnblockBrevoTransactionalContact
   def initialize(email)
     @email = email
   end

--- a/app/services/unblock_brevo_transactionnal_contact.rb
+++ b/app/services/unblock_brevo_transactionnal_contact.rb
@@ -10,7 +10,9 @@ class UnblockBrevoTransactionnalContact
       req.headers["api-key"] = ENV["BREVO_API_KEY"]
     end
 
-    unless response.status.in?([204])
+    # On reçoit une 204 si le contact a été débloqué avec succès et une 404 si le contact n’était pas bloqué
+    # Dans les deux cas, on considère que l’opération est un succès. Dans les autres cas, on logue l’erreur dans Sentry.
+    unless response.status.in?([204, 404])
       Sentry.capture_message("Failed to unblock Brevo transactional contact", level: :error, extra: { email: @email, status: response.status, body: response.body })
     end
   end

--- a/app/services/unblock_brevo_transactionnal_contact.rb
+++ b/app/services/unblock_brevo_transactionnal_contact.rb
@@ -1,0 +1,17 @@
+# https://developers.brevo.com/reference/delete_smtp-blockedcontacts-email
+class UnblockBrevoTransactionnalContact
+  def initialize(email)
+    @email = email
+  end
+
+  def call
+    response = Faraday.delete("https://api.brevo.com/v3/smtp/blockedContacts/#{CGI.escape(@email)}") do |req|
+      req.headers["accept"] = "application/json"
+      req.headers["api-key"] = ENV["BREVO_API_KEY"]
+    end
+
+    unless response.status.in?([204])
+      Sentry.capture_message("Failed to unblock Brevo transactional contact", level: :error, extra: { email: @email, status: response.status, body: response.body })
+    end
+  end
+end

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe Admin::InvitationsController, type: :controller do
   describe "POST #reinvite" do
     let(:agent_invitee) { create(:agent, invited_by: agent, confirmed_at: nil, first_name: nil, last_name: nil, allow_blank_name: true, basic_role_in_organisations: [organisation]) }
 
+    before do
+      allow(UnblockBrevoTransactionnalContact).to receive(:new).and_return(instance_double(UnblockBrevoTransactionnalContact, call: true))
+    end
+
     it "returns a success response" do
       post :reinvite, params: { organisation_id: organisation.id, id: agent_invitee.to_param }
       expect(response).to redirect_to(admin_organisation_invitations_path(organisation))

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Admin::InvitationsController, type: :controller do
     let(:agent_invitee) { create(:agent, invited_by: agent, confirmed_at: nil, first_name: nil, last_name: nil, allow_blank_name: true, basic_role_in_organisations: [organisation]) }
 
     before do
-      allow(UnblockBrevoTransactionnalContact).to receive(:new).and_return(instance_double(UnblockBrevoTransactionnalContact, call: true))
+      allow(UnblockBrevoTransactionalContact).to receive(:new).and_return(instance_double(UnblockBrevoTransactionalContact, call: true))
     end
 
     it "returns a success response" do

--- a/spec/services/unblock_brevo_transactional_contact_spec.rb
+++ b/spec/services/unblock_brevo_transactional_contact_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe UnblockBrevoTransactionalContact, type: :service do
+  subject { described_class.new(email) }
+
+  let(:email) { "test@example.com" }
+
+  context "quand la clé n'est pas set" do
+    stub_env_with(BREVO_API_KEY: nil)
+
+    it "n'envoie rien si on n'est pas en production" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+      expect(Sentry).not_to receive(:capture_message)
+      subject.call
+    end
+
+    it "envoie un Sentry si on est en production" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+      expect(Sentry).to receive(:capture_message).with(
+        "BREVO_API_KEY is not set, cannot unblock Brevo transactional contact",
+        level: :error
+      )
+      subject.call
+    end
+  end
+
+  context "quand la clé est set" do
+    stub_env_with(BREVO_API_KEY: "fake-key")
+
+    it "fait l'appel Faraday" do
+      stub = instance_double(Faraday::Response, status: 204)
+      faraday_double = instance_double(Faraday::Connection, headers: {})
+      allow(faraday_double).to receive(:headers=)
+      expect(Faraday).to receive(:delete).with("https://api.brevo.com/v3/smtp/blockedContacts/#{CGI.escape(email)}")
+        .and_yield(faraday_double)
+        .and_return(stub)
+      subject.call
+    end
+  end
+end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr5728.osc-secnum-fr1.scalingo.io/) 

# Contexte

On reçoit régulièrement des messages au support d’agents ni n’arrivent pas à faire partir les invitations, car le contact a été mis dans la blocklist Brevo à cause d’un Hard Bounce. 
Le Hard Bounce est souvent déclenché par un blocage du côté de la boîte du destinataire (souvent dû à des règles fixés par l’administrateur du domaine).
L’agent essaye alors de renvoyer l’invitation, mais une fois l’adresse email bloquée, il faut que nous intervenions manuellement dans l’admin Brevo pour que les mails partent à nouveau.

# Solution

Pour simplifier la vie des agents et diminuer le taux de contact, je propose donc que nous fassions le déblocage côté Brevo par voie d’API dès que l’agent essaye de renvoyer l’invitation.
Compte tenu du fait qu’il ne soit pas possible de vérifier facilement si un mail est en blocklist ou non, je propose ainsi de faire le call systématiquement. Si le mail est en blocklist, celui-ci sera débloqué et s'il ne l’est pas, cela ne fera rien.
De même, je propose de ne pas prendre en considération la réponse de Brevo pour le déroulement du process afin qu’un défaut d’API ne bloque pas les agents pour renvoyer des invitations.

