### PR TITLE
Réservation en ligne : bannière après la création de plage d'ouverture

### DIFF
--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -22,6 +22,7 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
       .where(expired_cached: filter_params[:current_tab] == "expired")
       .page(page_number)
     @plage_ouvertures_before_text_search = @plage_ouvertures
+
     @plage_ouvertures = @plage_ouvertures.search_by_text(params[:search]) if params[:search].present?
     @display_tabs = all_plage_ouvertures.where(expired_cached: true).any? || params[:current_tab] == "expired"
   end

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -102,6 +102,7 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
       # S'il n'y a plus besoin de la bannière, on arrête de l'afficher
       unless banner.availabilities_needed?
         session.delete("OnlineBookingMotifsForm:completed")
+        flash[:onboarding] = "online_booking_ready"
       end
     end
   end

--- a/app/views/admin/organisations/online_bookings/form.html.slim
+++ b/app/views/admin/organisations/online_bookings/form.html.slim
@@ -17,7 +17,7 @@
           = form_for @online_booking_motifs_form, url: admin_organisation_online_booking_path(current_organisation), method: :patch, builder: Dsfr::FormBuilder do |f|
             fieldset.fr-fieldset aria-labelledby="checkboxes-legend checkboxes-messages"
               legend.fr-fieldset__legend--regular.fr-fieldset__legend#checkboxes-legend
-                | Pour quels motifs souhaitez-vous activer la prise de rendez-vous en ligne ?
+                | Pour quels motifs souhaitez-vous ouvrir la prise de rendez-vous en ligne ?
 
               - @motifs.each do |motif|
                 .fr-fieldset__element
@@ -31,7 +31,7 @@
                         = " · "
                         = "#{motif.default_duration_in_min} mn"
 
-            p Vous gardez le contrôle : la prise de rendez-vous sera possible uniquement sur les plages d'ouverture de votre choix, et pour les motifs de votre choix.
+            p Vous gardez le contrôle : la prise de rendez-vous ne sera possible que sur les plages d'ouverture et les motifs de votre choix. Vous pouvez changer ces paramètres à tout moment.
 
             .d-flex.rdv-justify-content-space-between
               = link_to("Annuler", @cancel_path, class: "fr-btn fr-btn--tertiary-no-outline")

--- a/app/views/admin/planning/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_form.html.slim
@@ -6,7 +6,7 @@
 
         .card
           .card-body
-            h3.card-title Motifs
+            h2.card-title Motifs
             - if plage_ouverture.agent == current_agent
               p.mb-4 Pour quels motifs de rendez-vous êtes-vous disponible ?
             - else
@@ -15,6 +15,7 @@
             = collapsible_form_fields_for_warnings(plage_ouverture) do
               = f.hidden_field :agent_id
               - motifs_by_services = plage_ouverture.available_motifs.group_by(&:service)
+              - lieu_required = plage_ouverture.available_motifs.all?(&:public_office?)
               - sort_motifs_by_service(motifs_by_services).each do |service, motifs|
                 .form-group data-controller="checkbox-select-all"
                   label.h4.d-flex
@@ -28,7 +29,7 @@
                     .pl-4
                       = f.check_box :motif_ids, { multiple: true, class: "form-check-input #{motif.location_type}", data: { checkbox_select_all_target: "checkbox" } }, motif.id, false
                       = f.label "motif_ids_#{motif.id}", motif_name_with_location_type_and_badges(motif), class: "form-check-label"
-              .collapse.js-lieu-field
+              .js-lieu-field[class="#{:collapse unless lieu_required}"]
                 = f.association :lieu,
                   collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name,
                   label_method: :full_name,
@@ -37,7 +38,8 @@
                       data: { \
                         placeholder: "Sélectionnez un lieu", \
                         "select2-config": { disableSearch: true }, \
-                        "allow-clear": true, \
+                        "auto-select-sole-option": lieu_required,
+                        "allow-clear": !lieu_required, \
                       }, \
                     }
 
@@ -67,9 +69,9 @@
             .col.text-left
               = link_to "Annuler", \
                 admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: current_agent), \
-                class: "btn btn-link"
+                class: "fr-btn fr-btn--tertiary-no-outline"
             .col.text-right
-              = f.button :submit, "Créer la plage d'ouverture"
+              = f.submit "Créer la plage d'ouverture", class: "fr-btn"
 - else
   .card
     .card-body

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -19,6 +19,7 @@
 - if flash[:onboarding] == "online_booking_ready"
   - content_for :onboarding_banner do
     .fr-callout.fr-pb-2w
+      h2.fr-h6 Vous avez terminé !
       p La réservation en ligne est maintenant disponible grâce à cette plage d'ouverture !
       = link_to("Voir la réservation en ligne", admin_organisation_online_booking_path(current_organisation), class: "fr-btn")
 

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -16,6 +16,12 @@
       = link_to t(".calendar_view"), calendar_admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: @agent.id), class: "fr-btn fr-btn--secondary fr-icon-calendar-fill mb-0"
       = link_to t(".create_plage_ouverture"),  new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: @agent.id), class: "fr-btn fr-btn--secondary mb-0"
 
+- if flash[:onboarding] == "online_booking_ready"
+  - content_for :onboarding_banner do
+    .fr-callout.fr-pb-2w
+      p La réservation en ligne est maintenant disponible grâce à cette plage d'ouverture !
+      = link_to("Voir la réservation en ligne", admin_organisation_online_booking_path(current_organisation), class: "fr-btn")
+
 .card
   - if @display_tabs
     ul.nav.nav-tabs.px-2.mt-2

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -30,7 +30,8 @@
       li.nav-item
         = active_link_to t(".past"), admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: @agent.id, current_tab: "expired", search: params[:search]), class: "nav-link", active: { current_tab: "expired" }
 
-  - if @plage_ouvertures_before_text_search.any?
+  - enough_records_to_need_search = @plage_ouvertures_before_text_search.limit(5).pluck(:id) == 5 # On espere que le pluck et le limit coute moins cher en perf qu'un count
+  - if enough_records_to_need_search
     .m-2.d-flex.justify-content-end
       div= link_to t("helpers.reset"), admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: @agent.id), class: class_names("btn", "btn-link", "d-none": params[:search].blank?)
       = simple_form_for "", url: admin_organisation_planning_plage_ouvertures_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -30,7 +30,7 @@
       li.nav-item
         = active_link_to t(".past"), admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: @agent.id, current_tab: "expired", search: params[:search]), class: "nav-link", active: { current_tab: "expired" }
 
-  - enough_records_to_need_search = @plage_ouvertures_before_text_search.limit(5).pluck(:id) == 5 # On espere que le pluck et le limit coute moins cher en perf qu'un count
+  - enough_records_to_need_search = @plage_ouvertures_before_text_search.limit(5).pluck(:id).count == 5 # On espere que le pluck et le limit coute moins cher en perf qu'un count
   - if enough_records_to_need_search
     .m-2.d-flex.justify-content-end
       div= link_to t("helpers.reset"), admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: @agent.id), class: class_names("btn", "btn-link", "d-none": params[:search].blank?)

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -24,6 +24,7 @@ html lang="fr"
             = content_for :fil_ariane
             .container-fluid
               = render "layouts/flash"
+              = content_for :onboarding_banner
               - if content_for :title
                 .page-title-box
                   h1.fr-h2= yield :title

--- a/spec/features/agents/agent_can_configure_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_configure_online_booking_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe "Agents can configure online booking" do
       click_on "Enregistrer"
 
       expect(page).to have_content("Le motif Motif individuel est ouvert pour la réservation en ligne.")
+      expect(page).to have_content("Vous devez maintenant ouvrir une plage d'ouverture")
 
       # La bannière est encore là si on recharge la page
       visit admin_organisation_online_booking_path(organisation)
@@ -79,9 +80,11 @@ RSpec.describe "Agents can configure online booking" do
 
       expect(page).to have_content "Plage d'ouverture créée"
 
-      # La bannière ne s'affiche plus
-      visit admin_organisation_online_booking_path(organisation)
-      expect(page).not_to have_content("Le motif Motif individuel est ouvert pour la réservation en ligne.")
+      expect(page).to have_content "La réservation en ligne est maintenant disponible"
+      click_on "Voir la réservation en ligne"
+
+      # La bannière d'avertissement pour les disponibilités ne s'affiche plus
+      expect(page).not_to have_content("Vous devez maintenant ouvrir une plage d'ouverture")
     end
   end
 

--- a/spec/features/agents/agent_can_configure_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_configure_online_booking_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe "Agents can configure online booking" do
     specify do
       visit admin_organisation_online_booking_path(organisation)
 
-      expect(page).to have_content("Pour quels motifs souhaitez-vous activer la prise de rendez-vous en ligne ?")
+      expect(page).to have_content("Pour quels motifs souhaitez-vous ouvrir la prise de rendez-vous en ligne ?")
 
       click_on "Enregistrer"
 
       expect(page).to have_content("Vous devez choisir au moins un motif pour ouvrir la réservation en ligne")
-      expect(page).to have_content("Pour quels motifs souhaitez-vous activer la prise de rendez-vous en ligne ?")
+      expect(page).to have_content("Pour quels motifs souhaitez-vous ouvrir la prise de rendez-vous en ligne ?")
 
       find("label", text: motif.name).click
       click_on "Enregistrer"
@@ -51,7 +51,7 @@ RSpec.describe "Agents can configure online booking" do
       expect(motif.reload).to have_attributes(bookable_by: "agents")
       expect(motif_for_prescripteurs.reload).to have_attributes(bookable_by: "agents")
 
-      expect(page).to have_content("Pour quels motifs souhaitez-vous activer la prise de rendez-vous en ligne ?")
+      expect(page).to have_content("Pour quels motifs souhaitez-vous ouvrir la prise de rendez-vous en ligne ?")
     end
   end
 

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -235,21 +235,39 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
     let!(:avocat) { create(:service, name: "Avocat") }
     let!(:notaire) { create(:service, name: "Notaire") }
 
-    let!(:motif_1_service_avocat) { create(:motif, organisation: organisation, service: avocat) }
-    let!(:motif_2_service_avocat) { create(:motif, organisation: organisation, service: avocat) }
+    context "when some motifs don't need a lieu" do
+      let!(:motif_public_office) { create(:motif, organisation: organisation, service: avocat, location_type: :public_office) }
+      let!(:motif_phone) { create(:motif, organisation: organisation, service: avocat, location_type: :phone) }
 
-    it "works", js: true do
-      visit new_admin_organisation_planning_plage_ouverture_path(organisation, agent_id: agent)
-      expect(page).not_to have_content("Lieu")
-      check avocat.name
-      expect(page).to have_checked_field(motif_1_service_avocat.name)
-      expect(page).to have_checked_field(motif_2_service_avocat.name)
-      expect(page).not_to have_checked_field(motif.name)
-      expect(page).to have_content("Lieu")
-      select(lieu.full_name, from: "plage_ouverture_lieu_id")
-      click_on "Créer la plage d'ouverture"
-      expect(page).to have_content("Plage d'ouverture créée")
-      expect(PlageOuverture.last.motifs).to contain_exactly(motif_1_service_avocat, motif_2_service_avocat)
+      it "only displays the lieu input when necessary and allows selecting multiple motifs", js: true do
+        visit new_admin_organisation_planning_plage_ouverture_path(organisation, agent_id: agent)
+        expect(page).not_to have_content("Lieu")
+        check avocat.name
+        expect(page).to have_checked_field(motif_public_office.name)
+        expect(page).to have_checked_field(motif_phone.name)
+        expect(page).not_to have_checked_field(motif.name)
+        expect(page).to have_content("Lieu")
+        select(lieu.full_name, from: "plage_ouverture_lieu_id")
+        click_on "Créer la plage d'ouverture"
+        expect(page).to have_content("Plage d'ouverture créée")
+        expect(PlageOuverture.last.motifs).to contain_exactly(motif_public_office, motif_phone)
+      end
+    end
+
+    context "when all motifs are public_office" do
+      let!(:motif_public_office) { create(:motif, organisation: organisation, service: avocat, location_type: :public_office) }
+      let!(:other_motif_public_office) { create(:motif, organisation: organisation, service: avocat, location_type: :public_office) }
+
+      it "displays the lieu input (because it will always be necessary) and auto-selects the only option", js: true do
+        visit new_admin_organisation_planning_plage_ouverture_path(organisation, agent_id: agent)
+        expect(page).to have_content("Lieu")
+
+        check avocat.name
+
+        click_on "Créer la plage d'ouverture"
+        expect(page).to have_content("Plage d'ouverture créée")
+        expect(PlageOuverture.last.lieu).to eq lieu
+      end
     end
   end
 

--- a/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "Agent can search plage ouverture" do
   let!(:expired_perm_scolaire) { create(:plage_ouverture, :expired, title: "Permanence Scolaire passée", agent: agent, organisation: organisation) }
 
   let!(:additional_po_to_show_search) do
-    create(:plage_ouverture, title: "Permanence", agent: agent, organisation: organisation)
+    # Pour s'assurer que le champs de recherche s'affiche
+    create_list(:plage_ouverture, 4, title: "Permanence", agent:, organisation:)
   end
 
   before do

--- a/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe "Agent can search plage ouverture" do
   let!(:expired_perm_enfance) { create(:plage_ouverture, :expired, title: "Permanence Enfance passée", agent: agent, organisation: organisation) }
   let!(:expired_perm_scolaire) { create(:plage_ouverture, :expired, title: "Permanence Scolaire passée", agent: agent, organisation: organisation) }
 
+  let!(:additional_po_to_show_search) do
+    create(:plage_ouverture, title: "Permanence", agent: agent, organisation: organisation)
+  end
+
   before do
     login_as(agent, scope: :agent)
     visit admin_organisation_planning_plage_ouvertures_path(organisation, agent_id: agent)


### PR DESCRIPTION
Review app : https://rdv-service-public-review-app-pr5730.osc-secnum-fr1.scalingo.io/

<img width="1423" height="722" alt="Screenshot 2025-10-15 at 11 48 41" src="https://github.com/user-attachments/assets/856e6b19-e7e1-4c1c-96b1-6b130d992fcf" />

Suite de https://github.com/betagouv/rdv-service-public/pull/5721

On ajoute une bannière après la création de plage d'ouverture qui indique que la réservation en ligne fonctionne.
Le texte est pas parfait, je suis preneur de formulations alternatives.

On ajoute un `content_for :onboarding_banner`, en espérant qu'on le réutilise bientôt pour le reste de l'onboarding.

Au passage je fais une petite amélioration sur le formulaire de plage d'ouverture : si tous les motifs sont sur place (ce qui représente une partie considérable des orgas sur RDVSP), on affiche tout de suite le champs lieu plutôt que de le cacher alors qu'il sera nécessaire.
