### PR TITLE
Corrige la fermeture des alertes DSFR

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -12,6 +12,7 @@ import { Modal } from './components/modal';
 import { NameInitialsForm } from './components/name-initials-form';
 import CounterField from './components/counter-field';
 import DsfrNewPassword from "./components/dsfr-new-password";
+import DsfrAlertClose from "./components/dsfr-alert-close";
 import PreventDefault from "./components/prevent-default";
 import './components/browser-detection';
 import 'bootstrap';
@@ -26,6 +27,7 @@ $(document).on('turbolinks:load', function() {
   new NameInitialsForm();
   CounterField();
   DsfrNewPassword();
+  DsfrAlertClose();
   PreventDefault();
 
   const whereInput = document.querySelector('#search_where');

--- a/app/javascript/application_agent.js
+++ b/app/javascript/application_agent.js
@@ -14,6 +14,7 @@ import 'select2/dist/js/i18n/fr.js'
 import { Datetimepicker } from './components/datetimepicker'
 import { Menu } from './components/menu'
 import { Modal } from './components/modal'
+import DsfrAlertClose from "./components/dsfr-alert-close";
 import { ServiceFilterForMotifsSelects } from './components/service-filter-for-motifs-selects'
 import { SubmitOnChange } from './components/submit-on-change'
 import { PlacesInputs } from './components/places-inputs.js'
@@ -130,4 +131,5 @@ $(document).on('turbolinks:load', function() {
   new UnCheckAll()
 
   Tooltips()
+  DsfrAlertClose();
 })

--- a/app/javascript/application_agent_config.js
+++ b/app/javascript/application_agent_config.js
@@ -8,6 +8,7 @@ import "@hotwired/turbo-rails"
 Turbo.session.drive = false
 
 import DsfrNewPassword from "./components/dsfr-new-password";
+import DsfrAlertClose from "./components/dsfr-alert-close";
 import { Modal } from './components/modal';
 import './components/browser-detection';
 import 'select2/dist/js/select2.min.js';
@@ -24,6 +25,7 @@ initializeSelect2();
 
 $(document).on('turbolinks:load', function () {
   DsfrNewPassword();
+  DsfrAlertClose();
 
   setupCopyToClipBoardButtons()
 });

--- a/app/javascript/components/dsfr-alert-close.js
+++ b/app/javascript/components/dsfr-alert-close.js
@@ -1,5 +1,5 @@
 export default function DsfrAlertClose() {
-  document.querySelectorAll(".fr-btn--close").forEach(closeButton => {
+  document.querySelectorAll(".fr-alert > .fr-btn--close").forEach(closeButton => {
     closeButton.addEventListener("click", event => {
       const alert = event.target.parentNode;
       alert.parentNode.removeChild(alert);

--- a/app/javascript/components/dsfr-alert-close.js
+++ b/app/javascript/components/dsfr-alert-close.js
@@ -1,0 +1,8 @@
+export default function DsfrAlertClose() {
+  document.querySelectorAll(".fr-btn--close").forEach(closeButton => {
+    closeButton.addEventListener("click", event => {
+      const alert = event.target.parentNode;
+      alert.parentNode.removeChild(alert);
+    });
+  });
+}


### PR DESCRIPTION
# Problème

Depuis la merveilleuse PR #5470 qui retire `unsafe_inline` de notre CSP, la fermeture des alertes ne fonctionne plus, car elle est basée sur du JS inline ajouté par la gem [dsfr-view-components](https://github.com/betagouv/dsfr-view-components/blob/315a3aa62e97834abfbf53ea615d8e5150bb88c6/app/components/dsfr_component/alert_component.rb#L95) :

```
<button class="fr-btn--close" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
```



# Solution

J'ajoute ce même code dans un listener fait main. On en a en besoin dans `application.js` car on inclut la partial `layouts/flash` dans notre layout usager également.

# Illustration

C'est typiquement ce bouton qui ne marchait plus, ce qui rendait fou les gens qui comme moi ne peuvent pas s'empêcher de virer le nudges.

<img width="2877" height="505" alt="image" src="https://github.com/user-attachments/assets/324af242-62bd-4f72-ae72-cc4986d4dec5" />
