### PR TITLE
Retrait de la mauvaise date affichée sur la page d’accessibilité

### DIFF
--- a/app/views/static_pages/accessibilite.html.slim
+++ b/app/views/static_pages/accessibilite.html.slim
@@ -2,7 +2,6 @@
 
 .fr-grid-row
   .fr-col-md-8
-    p Établie le 16 avril 2025.
     p
       b> L’Agence Nationale de la Cohésion des Territoires (ANCT) et la direction interministérielle du numérique (DINUM)
       | s’engagent à rendre leur service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.


### PR DESCRIPTION
# Contexte

Une petite erreur s’est glissé dans la déclaration d’accessibilité.
J’avais laissé l’ancienne date en haut. La nouvelle date est dispo plus bas.