### PR TITLE
Ajout du champ d’adresse optionnel dans l’espace

### DIFF
--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -90,6 +90,7 @@ class Territory < ApplicationRecord
   }.freeze
 
   OPTIONAL_FIELD_TOGGLES = {
+    enable_address_field: :address,
     enable_notes_field: :annotation_content,
     enable_logement_field: :logement,
     enable_birth_date_field: :birth_date,
@@ -98,7 +99,7 @@ class Territory < ApplicationRecord
   # Nous voulons permettre à tous les espaces d'activer ou non ces champs, qualifiés de "légitimes"
   # En revanche, les autres champs listés ci-dessus sont considérés comme "legacy" et seulement
   # affichés aux espaces qui les avaient déjà activés.
-  legitimate_toggle_keys = %i[enable_birth_date_field enable_address_details enable_case_number]
+  legitimate_toggle_keys = %i[enable_birth_date_field enable_address_field enable_address_details enable_case_number]
   LEGITIMATE_TOGGLES = OPTIONAL_FIELD_TOGGLES.slice(*legitimate_toggle_keys).freeze
   LEGACY_TOGGLES = OPTIONAL_FIELD_TOGGLES.except(*legitimate_toggle_keys).freeze
 

--- a/app/views/admin/territories/user_fields/edit.html.slim
+++ b/app/views/admin/territories/user_fields/edit.html.slim
@@ -4,7 +4,7 @@
   .col-md-6
     .card
       .card-body
-        = simple_form_for current_territory, url: admin_territory_user_fields_path(current_territory) do |f|
+        = form_for current_territory, url: admin_territory_user_fields_path(current_territory), builder: Dsfr::FormBuilder do |f|
           = render "model_errors", model: current_territory
 
           h5.card-title= t(".card_title")
@@ -12,13 +12,13 @@
           p.text-muted.font-14= t(".hint_1")
           p.text-muted.font-14= t(".hint_2")
           - Territory::LEGITIMATE_TOGGLES.each do |toggle, field_name|
-            = f.input toggle, label: User.human_attribute_name(field_name)
+            = f.dsfr_check_box toggle, label: User.human_attribute_name(field_name)
 
           - if current_territory.any_legacy_fields_enabled?
             p.text-muted.font-14= t(".legacy_toggles_explanations")
             - Territory::LEGACY_TOGGLES.each do |toggle, field_name|
               - if current_territory.send(toggle)
-                = f.input toggle, label: User.human_attribute_name(field_name)
+                = f.dsfr_check_box toggle, label: User.human_attribute_name(field_name)
 
           .text-right
-            = f.button :submit
+            = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -47,7 +47,7 @@
   .mt-1.text-muted
     | L'usager ayant validé son compte, vous ne pouvez plus modifier ses préférences
 
-- unless current_domain == Domain::RDV_MAIRIE
+- if current_territory.enable_address_field?
   = f.input :address, **(input_opts.deep_merge(input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }))
 
   = f.input :city_code, as: :hidden, **input_opts

--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -6,7 +6,8 @@ ul.list-unstyled.mb-5
   li.mb-2= object_attribute_tag(user, :birth_name)
   - if current_territory.enable_birth_date_field?
     li.mb-2= object_attribute_tag(user, :birth_date, birth_date_and_age(user))
-  li.mb-2= object_attribute_tag(user, :address)
+  - if current_territory.enable_address_field?
+    li.mb-2= object_attribute_tag(user, :address)
   li.mb-2= object_attribute_tag(user, :preferred_email, clickable_user_email(user))
   - if user.preferred_email.present?
     li.mb-2= object_attribute_tag(user, :notify_by_email, notify_by_email_description(user))

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -36,7 +36,7 @@ ruby:
   div.mb-2 Préférences de notifications
   div= f.dsfr_check_box :notify_by_email
   div= f.dsfr_check_box :notify_by_sms
-  - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
+  - unless current_user.signed_in_with_invitation_token? || territories.map(&:enable_address_field).none?
     - address_value = rdv_wizard.present? && user.address.nil? ? rdv_wizard.to_query[:where] : user.address
     = f.dsfr_text_field :address, value: address_value, required: rdv_wizard&.motif&.home?, data: { "address-autocomplete": "on" }, autocomplete: "street-address", dir: "ltr"
 

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -36,7 +36,7 @@ ruby:
   div.mb-2 Préférences de notifications
   div= f.dsfr_check_box :notify_by_email
   div= f.dsfr_check_box :notify_by_sms
-  - unless current_user.signed_in_with_invitation_token? || territories.map(&:enable_address_field).none?
+  - unless current_user.signed_in_with_invitation_token? || !rdv_wizard&.motif&.organisation&.territory&.enable_address_field?
     - address_value = rdv_wizard.present? && user.address.nil? ? rdv_wizard.to_query[:where] : user.address
     = f.dsfr_text_field :address, value: address_value, required: rdv_wizard&.motif&.home?, data: { "address-autocomplete": "on" }, autocomplete: "street-address", dir: "ltr"
 

--- a/db/migrate/20251016161600_add_address_optinal_field.rb
+++ b/db/migrate/20251016161600_add_address_optinal_field.rb
@@ -1,0 +1,13 @@
+class AddAddressOptinalField < ActiveRecord::Migration[7.2]
+  def change
+    add_column :territories, :enable_address_field, :boolean, default: false
+
+    up_only do
+      # Historiquement, le champ adresse n’était affiché que sur RDV Solidarités/RDV Aide Numérique
+      # On active donc ce champ pour tous les espaces existants de l’instance historique.
+      if ENV.fetch("HOST", nil) == "https://www.rdv-solidarites.fr"
+        Territory.update_all(enable_address_field: true)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_13_161513) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_16_161600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -566,8 +566,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_13_161513) do
     t.boolean "ants_connectable", default: false, null: false, comment: "Autorise l'organisation à être branchée sur le moteur de recherche de l'ANTS sur https://rendezvouspasseport.ants.gouv.fr/. Pour éviter de brancher n'importe qui sur ce moteur de recherche, cette option n'est pas activable par les agents.\n"
     t.boolean "online_booking_for_particuliers", default: true, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des particuliers, et donc qu'on propose le bouton FranceConnect lors de la prise de rendez-vous en ligne.\n"
     t.boolean "online_booking_for_professionnels", default: false, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des professionnels, et donc qu'on propose le bouton ProConnect lors de la prise de rendez-vous en ligne.\n"
-    t.datetime "disabled_at", comment: "Date de fermeture de l'organisation"
     t.string "time_zone", default: "Europe/Paris", null: false
+    t.datetime "disabled_at", comment: "Date de fermeture de l'organisation"
     t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["name", "territory_id"], name: "index_organisations_on_name_and_territory_id", unique: true
     t.index ["territory_id"], name: "index_organisations_on_territory_id"
@@ -792,6 +792,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_13_161513) do
     t.boolean "visible_users_throughout_the_territory", default: false
     t.boolean "enable_birth_date_field", default: false
     t.string "category", comment: "La catégorie permet classifier les différents territoires principalement pour faire des statistiques dans metabase,\net pour avoir un suivi approprié de chaque territoire pour notre équipe déploiement et support. Par exemple, les besoins d'une commune\nne seront pas les mêmes que ceux d'un service de l'état.\n"
+    t.boolean "enable_address_field", default: false
     t.index ["departement_number"], name: "index_territories_on_departement_number", where: "((departement_number)::text <> ''::text)"
   end
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Admin::UsersController, type: :controller do
   render_views
 
-  let(:organisation) { create(:organisation) }
+  let(:territory) { create(:territory) }
+  let(:organisation) { create(:organisation, territory:) }
   let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 
   before do
@@ -37,6 +38,24 @@ RSpec.describe Admin::UsersController, type: :controller do
       expect do
         delete :destroy, params: { organisation_id: organisation.id, id: user.id }
       end.not_to change { User.unscoped.count }
+    end
+  end
+
+  describe "GET new" do
+    it "n’affiche pas le champ d’adresse par défaut" do
+      get :new, params: { organisation_id: organisation.id }
+      expect(response).to be_successful
+      expect(response.body).not_to include("Adresse")
+    end
+
+    context "l’espace a le champ d’adresse activé" do
+      let(:territory) { create(:territory, enable_address_field: true) }
+
+      it "affiche le champ d’adresse" do
+        get :new, params: { organisation_id: organisation.id }
+        expect(response).to be_successful
+        expect(response.body).to include("Adresse")
+      end
     end
   end
 
@@ -156,6 +175,23 @@ RSpec.describe Admin::UsersController, type: :controller do
         get :show, params: { organisation_id: organisation.id, id: user.id }
         expect(response).to be_successful
         expect(response.body).to include("Lola")
+      end
+
+      it "n'affiche pas l’adresse de l’usager par défaut" do
+        get :show, params: { organisation_id: organisation.id, id: user.id }
+        expect(response).to be_successful
+        expect(response.body).not_to include("Adresse")
+      end
+
+      context "l’espace a le champ d’adresse activé" do
+        let(:territory) { create(:territory, enable_address_field: true) }
+
+        it "montre l’adresse de l’usager" do
+          user.update(address: "10 rue des Lilas")
+          get :show, params: { organisation_id: organisation.id, id: user.id }
+          expect(response).to be_successful
+          expect(response.body).to include("10 rue des Lilas")
+        end
       end
     end
 

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "User can search for rdvs" do
   describe "Prise de RDV en ligne" do
     let!(:service) { create(:service) }
     let!(:territory) do
-      create(:territory, departement_number: "92", enable_birth_date_field: true)
+      create(:territory, departement_number: "92", enable_birth_date_field: true, enable_address_field: true)
     end
 
     let!(:first_organisation_with_po) { create(:organisation, :with_contact, territory: territory) }


### PR DESCRIPTION
# Contexte

Historiquement, nous avons un champ d’adresse sur RDVS. Côté RDV-SP, nous avons une incohérence, car nous permettons de voir l’adresse sur la fiche de l’usager, mais il n’y aucun endroit où on peut la saisir.
Nous avons une remontée Zammad et un cas d’usage qui nécessite de faire des RDV à domicile sur RDVSP. On ajoute donc la possibilité d’activer ce champ au niveau de l’espace.

# Solution

- Ajout d’une colonne permettant de rendre le champ d’adresse optionnel
- Passage du formulaire de configuration de fiche usager au DSFR
- Pour la migration, on active le champ d’adresse sur tous les espaces de RDVS car c’est déjà une fonctionnalité auxquels ils ont accès et on laisse désactivé pour tous les espaces RDVSP
- Par défaut pour tous les territoires, ce champ est optionnel

## Captures d'écran

Avant | Après
:- | -:
<img width="957" height="533" alt="image" src="https://github.com/user-attachments/assets/68199575-e1a6-4c52-973b-3f930118d2af" /> | <img width="896" height="570" alt="image" src="https://github.com/user-attachments/assets/92ce7728-6e08-460b-811d-a7278efb3a92" />
