### PR TITLE
Remplacement d'icônes font-awesome par du dsfr

### DIFF
--- a/app/helpers/dsfr_helper.rb
+++ b/app/helpers/dsfr_helper.rb
@@ -19,6 +19,14 @@ module DsfrHelper
     icon("fr-icon-building-fill", html_options)
   end
 
+  def user_icon(html_options = {})
+    icon("fr-icon-user-fill", html_options)
+  end
+
+  def calendar_icon(html_options = {})
+    icon("fr-icon-calendar-fill", html_options)
+  end
+
   def visio_icon(html_options = {})
     icon("fr-icon-mac-fill", html_options)
   end

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -9,7 +9,7 @@
 
 - if agent_can_create_motif?
   - content_for :breadcrumb do
-    = link_to t("admin.motifs.actions.new"), new_admin_organisation_motif_path(current_organisation), class:"btn btn-outline-primary"
+    = link_to t("admin.motifs.actions.new"), new_admin_organisation_motif_path(current_organisation), class:"fr-btn fr-btn--secondary"
 
 = simple_form_for "", url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
   = f.hidden_field :current_tab, value: @current_tab
@@ -20,9 +20,9 @@
       / Le margin-bottom négatif compense la hauteur des onglets
       .fr-mt-2w.d-flex.justify-content-end[style="margin-bottom: -32px"]
         - if [params[:search], params[:online_filter], params[:service_filter], params[:location_type_filter]].compact_blank.any?
-          div = link_to "Réinitialiser", admin_organisation_motifs_path(current_organisation, current_tab: @current_tab), class: "btn btn-link"
+          div = link_to "Réinitialiser", admin_organisation_motifs_path(current_organisation, current_tab: @current_tab), class: "fr-btn fr-btn--tertiary-no-outline"
         = f.input :search, placeholder: "ex. Être appelé par la MDS", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
-        = f.button :submit, "Rechercher"
+        = f.submit "Rechercher", class: "fr-btn"
 
     ul.nav.nav-tabs.fr-mt-2w
       - [[:active, "Actifs", @filtered_motifs.active.count], [:archived, "Archivés", @filtered_motifs.archived.count]].each do |value, label, count|
@@ -94,11 +94,11 @@
                     p.mb-2.lead Aucun motif ne correspond à votre filtre
                   - if agent_can_create_motif?
                     .rdv-text-align-center.m-3
-                      = link_to t("admin.motifs.actions.new"), new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"
+                      = link_to t("admin.motifs.actions.new"), new_admin_organisation_motif_path(current_organisation), class: "fr-btn"
 
     - if @motifs_page.any?
       .d-flex.justify-content-center
         = paginate @motifs_page, theme: "dsfr"
       - if agent_can_create_motif? && @current_tab == :active
         .rdv-text-align-center.m-3
-          = link_to t("admin.motifs.actions.new"), new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"
+          = link_to t("admin.motifs.actions.new"), new_admin_organisation_motif_path(current_organisation), class: "fr-btn"

--- a/app/views/admin/prescription/confirmation.html.slim
+++ b/app/views/admin/prescription/confirmation.html.slim
@@ -1,42 +1,41 @@
-h1 Nouveau RDV par prescription
+- content_for(:title) do
+  | Nouveau RDV par prescription
 main.container
   .row.justify-content-center.mt-4
     .col-lg-7.col-md-10.col-sm-11
       .card
         .card-body
-          h3
-            i.fa.fa-check-circle
+          h2.fr-h3
+            = icon("fr-icon-checkbox-fill", class: "fr-mr-1w")
             |< Rendez-vous confirmé
           - rdv = @rdv
           ul.list-group.list-group-flush
             li.list-group-item
-              .fa.fa-calendar>
+              = calendar_icon(class: "fr-mr-1w")
               = rdv_title(rdv)
-              = rdv_tag(rdv)
 
             - if rdv.public_office?
               li.list-group-item
-                .fa.fa-map-marker-alt>
+                = lieu_icon(class: "fr-mr-1w")
                 = human_location(rdv)
                 - if rdv.lieu&.phone_number
-                  span>
-                  span.fa.fa-phone>
+                  = phone_icon(class: "fr-mr-1w")
                   = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"
 
             - elsif rdv.phone?
               li.list-group-item
-                .fa.fa-phone>
+                = phone_icon(class: "fr-mr-1w")
                 | RDV Téléphonique
 
             li.list-group-item
-              .fa.fa-user>
+              = user_icon(class: "fr-mr-1w")
               = @rdv.users.first.full_name
               = " (#{@rdv.users.first.phone_number})" if @rdv.users.first.phone_number.present?
 
             li.list-group-item
               .row
                 .col-auto.pr-0
-                  i.fa.fa-info-circle>
+                  = motif_icon(class: "fr-mr-1w")
                 .col-auto.pl-1
                   = rdv.motif.name
                   - if current_territory.enable_context_field && @rdv.context.present?
@@ -51,4 +50,4 @@ main.container
             li.list-group-item
               |> Besoin de déplacer le rendez-vous ou de corriger un détail ?
               = link_to "Contactez-nous", new_aide_demande_support_path(role: :agent, sujet: "Déplacer ou corriger un RDV pris via prescription (RDV ID: #{rdv.id})")
-          .mt-4.rdv-text-align-center= link_to "Retour à l'accueil", admin_organisation_planning_agenda_path(current_organisation)
+          .mt-4.rdv-text-align-center= link_to "Retour à l'accueil", admin_organisation_planning_agenda_path(current_organisation), class: "fr-btn fr-btn--tertiary-no-outline"

--- a/app/views/admin/prescription/recapitulatif.html.slim
+++ b/app/views/admin/prescription/recapitulatif.html.slim
@@ -1,10 +1,12 @@
-h1 Nouveau RDV par prescription
+- content_for(:title) do
+  | Nouveau RDV par prescription
+
 main.container
   .row.justify-content-center.mt-4
     .col-lg-7.col-md-10.col-sm-11
       .card
         .card-body
-          h3 Récapitulatif
+          h2.fr-h3 Récapitulatif
 
           = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard
 
@@ -29,4 +31,4 @@ main.container
 
           .row.mt-2
             .col.text-right
-              = button_to("Confirmer le rdv", create_rdv_admin_organisation_prescription_path(@rdv_wizard.query_params), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter…"})
+              = button_to("Confirmer le rdv", create_rdv_admin_organisation_prescription_path(@rdv_wizard.query_params), method: :post, class: "fr-btn", data: { disable_with: "Veuillez patienter…"})

--- a/app/views/admin/prescription/search_creneau.html.slim
+++ b/app/views/admin/prescription/search_creneau.html.slim
@@ -1,4 +1,9 @@
-h1 Nouveau RDV par prescription
+- content_for(:title) do
+  | Nouveau RDV par prescription
+  / On ajoute des br pour espacer ce titre et celui qui est ajouté par le partial search/#{current_step}
+  br
+  br
+
 - if @context.user
   h6.card-subtitle.mt-2 = t("admin.creneaux_search.index.search_for_slots_subtitle", users_fullname: @context.user.full_name)
   p

--- a/app/views/admin/prescription/user_selection.html.slim
+++ b/app/views/admin/prescription/user_selection.html.slim
@@ -1,4 +1,5 @@
-h1 Nouveau RDV par prescription
+- content_for(:title) do
+  | Nouveau RDV par prescription
 main.container
   .row.justify-content-center.mt-4
     .col-lg-8.col-md-10.col-sm-11
@@ -7,7 +8,7 @@ main.container
           = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard
 
           hr.my-0.pb-3
-          h3.card-title Pour quel usager prenez-vous RDV ?
+          h2.fr-h4 Pour quel usager prenez-vous RDV ?
           = form_with(url: recapitulatif_admin_organisation_prescription_path(organisation_id: current_organisation.id), html: { method: :get }) do |f|
 
             = render "admin/prescription/hidden_fields", attributes_to_hide: @rdv_wizard.query_params.except(:user_ids)
@@ -32,4 +33,4 @@ main.container
 
             .form-group
               .float-right
-                = submit_tag "Continuer", class: "btn btn-primary"
+                = submit_tag "Continuer", class: "fr-btn"

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -26,7 +26,7 @@ turbo-frame.card.rdv-item[id= "rdv-#{rdv.id}" target="_top"]
             = link_to("Voir sur #{rdv.rdv_plan.oauth_application&.name}", rdv.rdv_plan&.dossier_url, target: :_blank, class: "fr-btn fr-btn--tertiary fr-mb-2w")
         .d-flex.justify-content-between.flex-wrap.mb-1
           p.card-text
-            i.fa.fa-fw.fa-calendar.mr-1.text-primary-blue
+            = calendar_icon(class: "text-primary-blue fr-mr-1w")
             = rdv_starts_at_and_duration(rdv, :time_only)
             - if rdv.agents.first
               |&nbsp;

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -1,30 +1,29 @@
 - if rdv.created_by_user?
-  p.card-text
+  p
     i.fa.fa-fw.fa-at.text-primary-blue>
     | RDV pris sur Internet
 
-.d-flex.card-text.mb-1
-  div.mr-1
-    i.fa.fa-fw.fa-info-circle.text-primary-blue>
+.d-flex.fr-mb-1w
+  = motif_icon(class: "text-primary-blue fr-mr-1w")
   div
     = motif_name_with_status(rdv.motif)
     = motif_badges(rdv.motif)
-    - if current_organisation.territory.enable_context_field
-      div
-        - if rdv.context.blank?
-          .text-muted = t(".empty_context")
-        - else
-          .text-muted Contexte&nbsp;:
-          .border-left.pl-2.mb-1= simple_format(rdv.context, {}, wrapper_tag: :span)
+  - if current_organisation.territory.enable_context_field
+    div
+      - if rdv.context.blank?
+        .text-muted = t(".empty_context")
+      - else
+        .text-muted Contexte&nbsp;:
+        .border-left.pl-2.mb-1= simple_format(rdv.context, {}, wrapper_tag: :span)
 
 - if rdv.phone?
   p.card-text
-    i.fa.fa-fw.fa-phone.text-primary-blue>
+    = phone_icon(class: "text-primary-blue fr-mr-1w")
     | RDV téléphonique
 - elsif rdv.motif.visio?
   p.card-text.mb-0
     - should_display_link = current_agent.in?(rdv.agents) || current_agent.secretaire?
-    i.fa.fa-video-camera.text-primary-blue>
+    = visio_icon(class: "text-primary-blue fr-mr-1w")
     |> Par visioconférence
     - if should_display_link
       = link_to("démarrer la visioconférence ", rdv.visio_url, target: :_blank)
@@ -33,18 +32,15 @@
       small.text-muted = "Le lien de visioconférence s'affiche uniquement pour l'agent qui assure le RDV et les secrétaires."
 
 - else
-  .d-flex.card-text.mb-1
-    div.mr-1
-      i.fa.fa-fw.fa-map-marker.text-primary-blue>
-    p.card-text
-      - if rdv.home?
-        | RDV à domicile&nbsp;:
-        = human_location(rdv)
-      - elsif rdv.public_office?
-        = human_location(rdv)
+  .d-flex.mb-1
+    = location_type_icon(rdv.motif.location_type, class: "text-primary-blue fr-mr-1w")
+    - if rdv.home?
+      |> RDV à domicile&nbsp;:
+      = human_location(rdv)
+    - elsif rdv.public_office?
+      = human_location(rdv)
 .d-flex.card-text
-  div.mr-1
-    i.fa.fa-fw.fa-user.text-primary-blue>
+  = user_icon(class: "text-primary-blue fr-mr-1w")
   div
     strong
       => "Agent".pluralize(rdv.agents.size)

--- a/app/views/agents/rdv_plans/rdv.html.slim
+++ b/app/views/agents/rdv_plans/rdv.html.slim
@@ -22,7 +22,7 @@
           = "Motif : #{@rdv.motif.name}"
 
         .fr-mt-2w
-          span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
+          = user_icon(class: "fr-mr-1w")
           |> Usager :
           = @rdv_plan.user.full_name
           .fr-ml-4w= @rdv_plan.user.preferred_email


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="679" height="231" alt="Screenshot 2025-10-17 at 16 22 34" src="https://github.com/user-attachments/assets/738ca7ad-930c-4a98-a199-77bf74910908" />|<img width="634" height="238" alt="Screenshot 2025-10-17 at 16 22 08" src="https://github.com/user-attachments/assets/ca660bd2-b5c8-4d6b-a533-416bd148ab57" />
<img width="765" height="341" alt="Screenshot 2025-10-17 at 16 23 41" src="https://github.com/user-attachments/assets/19bca402-ef4f-4785-85e9-59566cde6028" />|<img width="824" height="433" alt="Screenshot 2025-10-17 at 16 23 58" src="https://github.com/user-attachments/assets/cd17e63e-ac4d-41d2-bd54-351a30dc2b92" />
<img width="696" height="473" alt="Screenshot 2025-10-17 at 16 24 57" src="https://github.com/user-attachments/assets/637caecc-86a0-43c3-9e1a-ed2dc39dcddd" />|<img width="736" height="519" alt="Screenshot 2025-10-17 at 16 24 36" src="https://github.com/user-attachments/assets/2ff5c1d8-d006-4cd9-8943-d78f049ba83d" />

Petite PR d'avant les congés : on remplace des icônes font-awesome par du dsfr, et au passage je corrige quelques trucs évidents sur la prescription interne.

Mon but principal était d'uniformiser l'icône de motif pour qu'on ai la même entre la configuration et les détails du rdv.