### PR TITLE
Permettre à certains espaces le travail le dimanche et les jours fériés

### DIFF
--- a/app/dashboards/territory_dashboard.rb
+++ b/app/dashboards/territory_dashboard.rb
@@ -17,6 +17,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     roles: Field::HasMany,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
+    work_on_sunday: Field::Boolean,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -38,6 +39,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     name
     departement_number
     category
+    work_on_sunday
     roles
     organisations
     created_at
@@ -52,6 +54,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     admin_agents
     departement_number
     category
+    work_on_sunday
   ].freeze
 
   def display_resource(territory)

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -111,10 +111,6 @@ class Territory < ApplicationRecord
     name == CNFS_NAME
   end
 
-  def visioplainte?
-    name == VISIOPLAINTE_NAME
-  end
-
   def sectorized?
     sectors.joins(:attributions).any? && motifs.active.sectorized.any?
   end

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -16,7 +16,7 @@ module CreneauxSearch::Calculator
         .in_range(datetime_range)
         .includes(:agent)
         .where(agent: Agent.excluding_pending_invitation)
-      scope = scope.includes(:organisation, organisation: :territory) if motif.organisation.territory.visioplainte?
+      scope = scope.includes(:organisation, organisation: :territory) if motif.organisation.territory.work_on_sunday?
       scope = scope.where(agent: agents) if agents&.any?
       scope = scope.where(lieu: lieu) if lieu.present?
       scope
@@ -178,7 +178,7 @@ module CreneauxSearch::Calculator
     end
 
     def busy_times_from_off_days
-      return [] if @plage_ouverture.organisation.territory.visioplainte?
+      return [] if @plage_ouverture.organisation.territory.work_on_sunday?
 
       OffDays.all_in_date_range(range).map do |off_day|
         BusyTime.new(off_day.beginning_of_day, off_day.end_of_day)

--- a/app/views/admin/planning/absences/index.html.slim
+++ b/app/views/admin/planning/absences/index.html.slim
@@ -62,6 +62,6 @@
       - else
         | Créer une indisponibilité pour #{@agent.full_name_or_email}
 
-- unless current_territory.visioplainte?
+- unless current_territory.work_on_sunday?
   = dsfr_alert type: :info, size: :sm, html_attributes: { class: "fr-mb-2v" } do
     |< Les jours fériés sont automatiquement considérés comme indisponibles.

--- a/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
+++ b/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
@@ -8,7 +8,7 @@ ruby:
     admin_api_agenda_absences_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, format: :json),
     admin_api_agenda_plage_ouvertures_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, mixed_with_rdvs: true, format: :json),
   ]
-  event_sources.push(OffDays.to_full_calendar_array) unless current_territory.visioplainte?
+  event_sources.push(OffDays.to_full_calendar_array) unless current_territory.work_on_sunday?
   resources = @agents.map { { id: _1.id, title: _1.full_name_or_email } }
 
 #agenda-multi-agent.mt-2[

--- a/app/views/admin/planning/agendas/show.html.slim
+++ b/app/views/admin/planning/agendas/show.html.slim
@@ -18,7 +18,7 @@ ruby:
     admin_api_agenda_absences_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json),
     admin_api_agenda_plage_ouvertures_path(agent_id: @agent, organisation_id: current_organisation.id, mixed_with_rdvs: true, format: :json),
   ]
-  event_sources.push(OffDays.to_full_calendar_array) unless current_territory.visioplainte?
+  event_sources.push(OffDays.to_full_calendar_array) unless current_territory.work_on_sunday?
 
 #calendar[
   data-default-date-json="#{@date&.to_json}"
@@ -26,7 +26,7 @@ ruby:
   data-selected-event-id="#{@selected_event_id}"
   data-organisation-id="#{@organisation.id}"
   data-display-saturdays="#{current_agent.display_saturdays}"
-  data-display-sundays="#{current_territory.visioplainte?}"
+  data-display-sundays="#{current_territory.work_on_sunday?}"
   data-event-sources-json="#{event_sources.to_json}"
   data-sign-in-path="#{new_agent_session_path}"
 ]

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -37,7 +37,7 @@
 
       .weekly-select
         - weekdays = { Lundi: "monday", Mardi: "tuesday", Mercredi: "wednesday", Jeudi: "thursday", Vendredi: "friday", Samedi: "saturday" }
-        - weekdays[:Dimanche] = "sunday" if current_territory.visioplainte?
+        - weekdays[:Dimanche] = "sunday" if current_territory.work_on_sunday?
         = n.input :on, as: :check_boxes, label: "Répéter les", collection: weekdays, include_blank: false, input_html: { data: { target: "recurrence.on", action: "recurrence#updateRecurrence" }, class: "js-recurrence-on js-recurrence-input" }
 
       .monthly-select.form-group

--- a/db/migrate/20251017142741_add_work_on_sunday_in_territory.rb
+++ b/db/migrate/20251017142741_add_work_on_sunday_in_territory.rb
@@ -1,0 +1,5 @@
+class AddWorkOnSundayInTerritory < ActiveRecord::Migration[7.2]
+  def change
+    add_column :territories, :work_on_sunday, :boolean, default: false
+  end
+end

--- a/db/migrate/20251017142741_add_work_on_sunday_in_territory.rb
+++ b/db/migrate/20251017142741_add_work_on_sunday_in_territory.rb
@@ -1,5 +1,9 @@
 class AddWorkOnSundayInTerritory < ActiveRecord::Migration[7.2]
   def change
     add_column :territories, :work_on_sunday, :boolean, default: false
+
+    up_only do
+      Territory.where(name: Territory::VISIOPLAINTE_NAME).update_all(work_on_sunday: true)
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_16_161600) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_17_142741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -793,6 +793,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_16_161600) do
     t.boolean "enable_birth_date_field", default: false
     t.string "category", comment: "La catégorie permet classifier les différents territoires principalement pour faire des statistiques dans metabase,\net pour avoir un suivi approprié de chaque territoire pour notre équipe déploiement et support. Par exemple, les besoins d'une commune\nne seront pas les mêmes que ceux d'un service de l'état.\n"
     t.boolean "enable_address_field", default: false
+    t.boolean "work_on_sunday", default: false
     t.index ["departement_number"], name: "index_territories_on_departement_number", where: "((departement_number)::text <> ''::text)"
   end
 

--- a/db/seeds/visioplainte.rb
+++ b/db/seeds/visioplainte.rb
@@ -1,6 +1,6 @@
 territory = Territory.create(name: "placeholder")
 
-territory.update_columns(name: Territory::VISIOPLAINTE_NAME) # rubocop:disable Rails/SkipsModelValidations
+territory.update_columns(name: Territory::VISIOPLAINTE_NAME, work_on_sunday: true) # rubocop:disable Rails/SkipsModelValidations
 
 service_gendarmerie = Service.find_or_create_by!(name: "Gendarmerie Nationale", short_name: "Gendarmerie")
 

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -413,7 +413,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
       expect(computed_dates.call).to eq(xmas_week.to_a - [Date.new(2024, 12, 25)])
 
       # Les agents de visioplainte travaillent les jours fériés
-      plage_ouverture.organisation.territory.update_columns(name: Territory::VISIOPLAINTE_NAME) # rubocop:disable Rails/SkipsModelValidations
+      plage_ouverture.organisation.territory.update_columns(work_on_sunday: true) # rubocop:disable Rails/SkipsModelValidations
       expect(computed_dates.call).to eq(xmas_week.to_a)
     end
   end


### PR DESCRIPTION
# Contexte

Nous avons reçu un Zammad d’une section de la Gendarmerie qui nous utilise et qui travaille le dimanche.
Cela remet donc en question notre petit if territory.visioplainte? pour savoir si oui ou non, nous affichons les dimanches (et nous mettons des indispo auto sur les jours fériés).

# Solution

- Je retire la méthode `visioplainte?`
- Je range une colonne sur l’espace qui est utilisée pour afficher les éléments d’interface et gérer les calculs de créneau
- Afin de garder notre ligne « on ne veut pas mettre en avant le travail le dimanche » cette option n’est activable que par les super admins.

