### PR TITLE
Nettoyage post-deploy du nouveau code Headway

### DIFF
--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -3,11 +3,6 @@ class BlogPost < ApplicationRecord
 
   def self.new_content_for_agent?(agent)
     return false unless latest_post_at
-
-    # Ce return permet de considérer que les posts Headway postés jusqu'ici ont déjà été lus.
-    # TODO: Supprimer cette ligne lorsque l'on poste sur Headway la prochaine fois.
-    return false if latest_post_at < Time.zone.parse("2025-10-15")
-
     return true if agent.blog_read_at.nil?
 
     latest_post_at > agent.blog_read_at


### PR DESCRIPTION
On avait ajouté ce if pour éviter que les agents voient le badge qui indique une  nouveauté, mais comme Mehdi a posté une nouveauté vendredi, ce if est désormais obsolète.