### PR TITLE
Permettre de voir les attributs non filtrés en console

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,0 +1,5 @@
+Rails.application.console do
+  # Afin de pouvoir déboguer plus facilement en console, on désactive le filtrage des attributs
+  # (filter_attributes permet de masquer certains attributs à l’appel de #inspect sur un objet).
+  ActiveRecord::Base.filter_attributes = []
+end


### PR DESCRIPTION
# Contexte

Depuis que nous sommes passés à Rails 7.2, lorsque nous inspectons des éléments dans la console, nous avons beaucoup d’attributs filtrés. Cela est pénible pour le débogage.

# Solution

Suite au dernier point tech, nous avons acté que nous désactivions les attributs filtrés en console.