### PR TITLE
Correction verticale utilisée pour les organisation RDV-AN -> RDV-SP

### DIFF
--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::OrganisationsController < Api::V1::AgentAuthBaseController
+  include DomainDetection
   before_action :set_organisation, only: %i[show update]
 
   def index
@@ -22,7 +23,7 @@ class Api::V1::OrganisationsController < Api::V1::AgentAuthBaseController
       if doorkeeper_token&.application&.name == "RDV Aide Numérique"
         # Pour garder le même fonctionnement que sur le territoire historique des cnfs, on active ce champs dans la config
         @organisation.territory.update!(enable_context_field: true)
-        @organisation.verticale = "rdv_mairie"
+        @organisation.verticale = current_domain.verticale
       end
       @organisation.save!
 

--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -22,6 +22,7 @@ class Api::V1::OrganisationsController < Api::V1::AgentAuthBaseController
       if doorkeeper_token&.application&.name == "RDV Aide Numérique"
         # Pour garder le même fonctionnement que sur le territoire historique des cnfs, on active ce champs dans la config
         @organisation.territory.update!(enable_context_field: true)
+        @organisation.verticale = "rdv_mairie"
       end
       @organisation.save!
 

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -132,7 +132,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
       name: "France Service de Montreuil",
       phone_number: "01 22 33 44 55",
       website: "www.montreuil.fr/france-service",
-      email: "contact@exemple.montreuil.fr"
+      email: "contact@exemple.montreuil.fr",
+      verticale: "rdv_mairie"
     )
 
     expect(created_organisation.users.last.notification_email).to be_present


### PR DESCRIPTION
# Contexte

Suite au Zammad d’un agent, je me suis aperçu que les organisations qui avaient été transférées de RDV Aide Numérique vers RDV Service Public n’avaient pas la bonne verticale. 
En effet, nous utilisons la verticale pour générer le lien qu’on envoie aux usagers par SMS. Les usagers reçoivent alors dès liens qui mènent vers l’instance historique plutôt que d’emmener vers RDV-SP.

# Solution

On set la bonne verticale lors de la création de l’organisation.