### PR TITLE
Correction d’affichage pour les agents travaillant de le dimanche

### DIFF
--- a/app/views/admin/planning/agendas/show.html.slim
+++ b/app/views/admin/planning/agendas/show.html.slim
@@ -26,7 +26,7 @@ ruby:
   data-selected-event-id="#{@selected_event_id}"
   data-organisation-id="#{@organisation.id}"
   data-display-saturdays="#{current_agent.display_saturdays}"
-  data-display-sundays="#{current_territory.work_on_sunday?}"
+  data-display-sundays="#{current_territory.work_on_sunday? && current_agent.display_saturdays}"
   data-event-sources-json="#{event_sources.to_json}"
   data-sign-in-path="#{new_agent_session_path}"
 ]
@@ -38,7 +38,16 @@ ruby:
   .m-2
     = simple_form_for [:admin, current_agent], url: admin_organisation_planning_toggle_displays_path(params.permit(:selected_event_id, :date)), method: :put, html: {id: "edit_agent_#{current_agent.id}_saturday_preferences"} do |f|
       = f.hidden_field :display_saturdays, value: !current_agent.display_saturdays
-      = f.submit Agent.human_attribute_value(:display_saturdays, !current_agent.display_saturdays), class: "fr-btn fr-btn--tertiary"
+      - if current_territory.work_on_sunday?
+        - if current_agent.display_saturdays
+          = f.submit "Ne pas afficher les week-ends", class: "fr-btn fr-btn--tertiary"
+        - else
+          = f.submit "Afficher les week-ends", class: "fr-btn fr-btn--tertiary"
+      - else
+        - if current_agent.display_saturdays
+          = f.submit "Ne pas afficher les samedis", class: "fr-btn fr-btn--tertiary"
+        - else
+          = f.submit "Afficher les samedis", class: "fr-btn fr-btn--tertiary"
 
 .mt-2
   = link_to admin_organisation_rdvs_path(current_organisation, agent_id: @agent.id, start: @date, end: @date, breadcrumb_page: "agenda"), class: "js-link-print-rdvs" do

--- a/app/views/admin/planning/plage_ouvertures/calendar.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/calendar.html.slim
@@ -19,5 +19,6 @@
   data-agent-id="#{@agent.id}"
   data-organisation-id="#{@current_organisation.id}"
   data-display-saturdays="#{current_agent.display_saturdays}"
+  data-display-sundays="#{current_territory.work_on_sunday? && current_agent.display_saturdays}"
   data-event-sources-json="#{[admin_api_agenda_plage_ouvertures_path(agent_id: @agent, organisation_id: current_organisation.id), OffDays.to_full_calendar_array].to_json}"
 ]

--- a/config/locales/models/agent.fr.yml
+++ b/config/locales/models/agent.fr.yml
@@ -30,9 +30,6 @@ fr:
       agent/display_cancelled_rdvs:
         true: "Afficher les RDV annulés"
         false: "Ne pas afficher les RDV annulés"
-      agent/display_saturdays:
-        true: "Afficher les samedis"
-        false: "Ne pas afficher les samedis"
     errors:
       models:
         agent:


### PR DESCRIPTION
# Contexte

Nous avons mis en place permettant aux quelques organisations qui travaillent le dimanche de pouvoir le voir sur leur planning. Cependant, nous avions une petite incohérence d’affichage pour ces agents quand ils cliquaient sur « Masquer les samedis ».

<img width="1207" height="895" alt="image" src="https://github.com/user-attachments/assets/b5fbdf31-98dc-4f55-84d7-be128a52a4a2" />

# Solution

J’ai fait le choix de changer le texte du bouton pour les territoires qui travaillent le dimanche « Afficher/Ne pas afficher les samedis » → « Afficher/Ne pas afficher les week-ends ». On affiche alors le dimanche si on affiche le samedi et que le territoire à l’option `work_on_sunday`.



J’ai également profité pour rajouter le dimanche sur la vue calendrier des indispos pour ces agents qui travaillent le dimanche.