### PR TITLE
Formulaire de contact : ajout du lien de provenance erreur 404

### DIFF
--- a/app/views/errors/not_found.html.slim
+++ b/app/views/errors/not_found.html.slim
@@ -16,7 +16,7 @@
       = mail_to(current_domain.support_email, current_domain.support_email)
 
     .fr-btns-group.fr-btns-group--inline
-      = link_to "Contactez-nous", new_aide_demande_support_path(sujet: "Erreur 404"), class: "fr-btn"
+      = link_to "Contactez-nous", new_aide_demande_support_path(sujet: "Erreur 404", message: "\n\n--- votre message au-dessus ---\n\nErreur rencontrée sur la page : #{request.original_url}"), class: "fr-btn"
       = link_to("Retour à l'accueil", root_path, class: "fr-btn fr-btn--secondary")
 
   .fr-col-0.fr-col-md-4


### PR DESCRIPTION
# Contexte

Nous avons régulièrement des Zammad ayant pour titre « Erreur 404 ». Afin de mieux étudier les cas, je propose que nous ajoutions le lien de provenance dans le message Zammad.

# Solution

Ceci est une solution très simple pour voir si cela nous aide à comprendre l’origine de ces 404 et éventuellement à mieux les gérer.
Si on voit que cette solution apporte de l’aide, nous pourrons réfléchir à ajouter un champ personnalisé dans Zammad a l’échelle du ticket et à passer cette URL de manière cachée.
