### PR TITLE
Utiliser le sub OpenID pour la réconciliation ProConnect

### DIFF
--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -190,7 +190,7 @@ class AgentConnectController < ApplicationController
 
   def generic_error_message
     support_link = new_aide_demande_support_path(role: "agent", sujet: "Connexion ProConnect")
-    %(Nous n'avons pas pu vous authentifier. #{view_context.link_to('Contactez le support', support_link, class: "fr-link")} si le problème persiste.)
+    %(Nous n'avons pas pu vous authentifier. #{view_context.link_to('Contactez le support', support_link, class: 'fr-link')} si le problème persiste.)
   end
 
   def link_to_demande_support(name, callback_client)

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -117,53 +117,76 @@ class AgentConnectController < ApplicationController
     redirect_to after_sign_in_path_for(user)
   end
 
+  # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
   def connect_agent(callback_client)
-    agent_by_sub = Agent.active.find_by(pro_connect_openid_sub: callback_client.openid_sub)
+    sub = callback_client.openid_sub
+    agent_by_sub = Agent.active.find_by(pro_connect_openid_sub: sub)
     agent_by_email = Agent.active.find_by(email: callback_client.user_email)
+    Sentry.set_user({ email: callback_client.user_email })
 
-    # Edge case : on trouve un agent par e-mail et cet agent porte un autre sub.
-    # Il faudrait inviter l'agent à se connecter par e-mail à cet autre compte et à unlink.
-    if agent_by_email&.pro_connect_openid_sub && agent_by_email.pro_connect_openid_sub != callback_client.openid_sub
-      flash[:error] = "Ce compte ProConnect est lié à l'adresse e-mail #{callback_client.user_email}.<br />" \
-                      "Or cette adresse est déjà liée à compte existant qui est connecté avec un autre compte ProConnect.<br />" \
-                      "Nous vous invitons à vous connecter par email + mot de passe avec cet e-mail.<br />" \
-                      "Vous pouvez contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a>."
-      Sentry.capture_message("L'email ProConnect est attribué à un agent qui porte un autre sub.", extra: { email_from_pro_connect: callback_client.user_email })
+    # On trouve un agent vie le sub, et un autre agent via l'e-mail
+    if agent_by_email && agent_by_sub && agent_by_email != agent_by_sub
+      error_message = <<~ERROR
+        Il existe deux comptes correspondant : #{agent_by_email.email} et #{agent_by_sub.email}.
+        Nous vous invitons à contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a>.
+      ERROR
+      Sentry.capture_message(error_message, extra: { user_info: callback_client.user_info })
+      flash[:error] = error_message
+      redirect_to new_agent_session_path and return
+    end
+
+    # On trouve un agent par e-mail et cet agent porte un autre sub.
+    if agent_by_email&.pro_connect_openid_sub && agent_by_email.pro_connect_openid_sub != sub
+      error_message = <<~ERROR
+        Ce compte ProConnect est lié à l'adresse e-mail #{callback_client.user_email}.<br />
+        Or cette adresse est déjà liée à compte existant qui est connecté avec un autre compte ProConnect.<br />
+        Nous vous invitons à contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a>.
+      ERROR
+      Sentry.capture_message(error_message, extra: { user_info: callback_client.user_info })
+      flash[:error] = error_message
       redirect_to new_agent_session_path and return
     end
 
     agent = agent_by_sub || agent_by_email
 
-    if current_domain.allow_self_onboarding
-      agent ||= Agent.new(email: callback_client.user_email, password: SecureRandom.base64(32))
+    if agent.nil?
+      if current_domain.allow_self_onboarding
+        agent ||= Agent.new(email: callback_client.user_email, password: SecureRandom.base64(32))
+      else
+        # On pourrait améliorer le cas d'erreur décrit dans https://github.com/betagouv/rdv-service-public/issues/4360
+        flash[:error] = <<~ERROR
+          Il n'y a pas de compte agent pour l'adresse mail #{callback_client.user_email}.<br />
+          Vous devez utiliser ProConnect avec l'adresse mail à laquelle vous avez reçu votre invitation sur #{current_domain.name}.<br />
+          Vous pouvez également contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a> si le problème persiste.
+        ERROR
+        redirect_to new_agent_session_path and return
+      end
     end
 
-    if agent
-      agent.skip_confirmation!
-      agent.skip_reconfirmation!
-      agent.update!(
-        pro_connect_openid_sub: callback_client.openid_sub,
-        email: callback_client.user_email,
-        first_name: callback_client.user_first_name,
-        last_name: callback_client.user_last_name,
-        proconnect_siret: callback_client.user_siret,
-        invitation_token: nil, # Pour désactiver les anciens liens d'invitation
-        invitation_accepted_at: agent.invitation_accepted_at || Time.zone.now,
-        confirmed_at: agent.confirmed_at || Time.zone.now,
-        last_sign_in_at: Time.zone.now
-      )
-
-      bypass_sign_in agent, scope: :agent
-      session[:agent_connect_id_token] = callback_client.id_token_for_logout
-      redirect_to after_sign_in_path_for(agent)
-    else
-      # On pourrait améliorer le cas d'erreur décrit dans https://github.com/betagouv/rdv-service-public/issues/4360
-      flash[:error] = "Il n'y a pas de compte agent pour l'adresse mail #{callback_client.user_email}.<br />" \
-                      "Vous devez utiliser ProConnect avec l'adresse mail à laquelle vous avez reçu votre invitation sur #{current_domain.name}.<br />" \
-                      "Vous pouvez également contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a> si le problème persiste."
-      redirect_to new_agent_session_path
+    if agent.email != callback_client.user_email
+      flash[:info] = "Note : votre adresse e-mail a été mise à jour depuis ProConnect. Ancienne adresse : #{agent.email}, nouvelle adresse : #{callback_client.user_email}"
     end
+
+    agent.assign_attributes(
+      pro_connect_openid_sub: sub,
+      email: callback_client.user_email,
+      first_name: callback_client.user_first_name,
+      last_name: callback_client.user_last_name,
+      proconnect_siret: callback_client.user_siret,
+      invitation_token: nil, # Pour désactiver les anciens liens d'invitation
+      invitation_accepted_at: agent.invitation_accepted_at || Time.zone.now,
+      confirmed_at: agent.confirmed_at || Time.zone.now,
+      last_sign_in_at: Time.zone.now
+    )
+    agent.skip_confirmation!
+    agent.skip_reconfirmation!
+    agent.save!
+
+    bypass_sign_in agent, scope: :agent
+    session[:agent_connect_id_token] = callback_client.id_token_for_logout
+    redirect_to after_sign_in_path_for(agent)
   end
+  # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 
   def generic_error_message
     support_email = current_domain.support_email

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -138,7 +138,7 @@ class AgentConnectController < ApplicationController
     # On trouve un agent par e-mail et cet agent porte un autre sub.
     if agent_by_email&.pro_connect_openid_sub && agent_by_email.pro_connect_openid_sub != sub
       error_message = <<~ERROR
-        Ce compte ProConnect est lié à l'adresse e-mail #{callback_client.user_email}.<br />
+        Votre compte ProConnect est lié à l'adresse e-mail #{callback_client.user_email}.<br />
         Or cette adresse est déjà liée à compte existant qui est connecté avec un autre compte ProConnect.<br />
         Nous vous invitons à contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a>.
       ERROR

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -178,7 +178,6 @@ class AgentConnectController < ApplicationController
       confirmed_at: agent.confirmed_at || Time.zone.now,
       last_sign_in_at: Time.zone.now
     )
-    agent.skip_confirmation!
     agent.skip_reconfirmation!
     agent.save!
 

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -128,7 +128,7 @@ class AgentConnectController < ApplicationController
     if agent_by_email && agent_by_sub && agent_by_email != agent_by_sub
       error_message = <<~ERROR
         Il existe deux comptes correspondant : #{agent_by_email.email} et #{agent_by_sub.email}.
-        Nous vous invitons à contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a>.
+        Nous vous invitons à #{link_to_demande_support('contacter le support', callback_client)}.
       ERROR
       Sentry.capture_message(error_message, extra: { user_info: callback_client.user_info })
       flash[:error] = error_message
@@ -140,7 +140,7 @@ class AgentConnectController < ApplicationController
       error_message = <<~ERROR
         Votre compte ProConnect est lié à l'adresse e-mail #{callback_client.user_email}.<br />
         Un compte agent existe déjà sur #{current_domain.name} pour cette adresse email, cependant il est lié à un autre compte ProConnect.<br />
-        Nous vous invitons à contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a>.
+        Nous vous invitons à #{link_to_demande_support('contacter le support', callback_client)}.
       ERROR
       Sentry.capture_message(error_message, extra: { user_info: callback_client.user_info })
       flash[:error] = error_message
@@ -157,7 +157,7 @@ class AgentConnectController < ApplicationController
         flash[:error] = <<~ERROR
           Il n'y a pas de compte agent pour l'adresse mail #{callback_client.user_email}.<br />
           Vous devez utiliser ProConnect avec l'adresse mail à laquelle vous avez reçu votre invitation sur #{current_domain.name}.<br />
-          Vous pouvez également contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a> si le problème persiste.
+          Vous pouvez également #{link_to_demande_support('contacter le support', callback_client)} si le problème persiste.
         ERROR
         redirect_to new_agent_session_path and return
       end
@@ -189,7 +189,21 @@ class AgentConnectController < ApplicationController
   # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 
   def generic_error_message
-    support_email = current_domain.support_email
-    %(Nous n'avons pas pu vous authentifier. Contactez le support à l'adresse <a href="mailto:#{support_email}">#{support_email}</a> si le problème persiste.)
+    support_link = new_aide_demande_support_path(role: "agent", sujet: "Connexion ProConnect")
+    %(Nous n'avons pas pu vous authentifier. #{view_context.link_to('Contactez le support', support_link, class: "fr-link")} si le problème persiste.)
+  end
+
+  def link_to_demande_support(name, callback_client)
+    view_context.link_to(
+      name,
+      new_aide_demande_support_path(
+        role: "agent",
+        sujet: "Réconciliation ProConnect",
+        email: callback_client.user_email,
+        first_name: callback_client.user_first_name,
+        last_name: callback_client.user_last_name
+      ),
+      class: "fr-link"
+    )
   end
 end

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -118,17 +118,32 @@ class AgentConnectController < ApplicationController
   end
 
   def connect_agent(callback_client)
-    # Agent Connect recommande de faire la réconciliation sur l'email et non pas sur le sub
-    # voir https://github.com/numerique-gouv/agentconnect-documentation/blob/main/doc_fs/donnees_fournies.md#le-champ-sub
-    agent = Agent.active.find_by(email: callback_client.user_email)
+    agent_by_sub = Agent.active.find_by(pro_connect_openid_sub: callback_client.openid_sub)
+    agent_by_email = Agent.active.find_by(email: callback_client.user_email)
+
+    # Edge case : on trouve un agent par e-mail et cet agent porte un autre sub.
+    # Il faudrait inviter l'agent à se connecter par e-mail à cet autre compte et à unlink.
+    if agent_by_email&.pro_connect_openid_sub && agent_by_email.pro_connect_openid_sub != callback_client.openid_sub
+      flash[:error] = "Ce compte ProConnect est lié à l'adresse e-mail #{callback_client.user_email}.<br />" \
+                      "Or cette adresse est déjà liée à compte existant qui est connecté avec un autre compte ProConnect.<br />" \
+                      "Nous vous invitons à vous connecter par email + mot de passe avec cet e-mail.<br />" \
+                      "Vous pouvez contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a>."
+      Sentry.capture_message("L'email ProConnect est attribué à un agent qui porte un autre sub.", extra: { email_from_pro_connect: callback_client.user_email })
+      redirect_to new_agent_session_path and return
+    end
+
+    agent = agent_by_sub || agent_by_email
 
     if current_domain.allow_self_onboarding
       agent ||= Agent.new(email: callback_client.user_email, password: SecureRandom.base64(32))
     end
 
     if agent
+      agent.skip_confirmation!
+      agent.skip_reconfirmation!
       agent.update!(
-        connected_with_agent_connect: true,
+        pro_connect_openid_sub: callback_client.openid_sub,
+        email: callback_client.user_email,
         first_name: callback_client.user_first_name,
         last_name: callback_client.user_last_name,
         proconnect_siret: callback_client.user_siret,

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -139,7 +139,7 @@ class AgentConnectController < ApplicationController
     if agent_by_email&.pro_connect_openid_sub && agent_by_email.pro_connect_openid_sub != sub
       error_message = <<~ERROR
         Votre compte ProConnect est lié à l'adresse e-mail #{callback_client.user_email}.<br />
-        Or cette adresse est déjà liée à compte existant qui est connecté avec un autre compte ProConnect.<br />
+        Un compte agent existe déjà sur #{current_domain.name} pour cette adresse email, cependant il est lié à un autre compte ProConnect.<br />
         Nous vous invitons à contacter le support à l'adresse <a href='mailto:#{current_domain.support_email}'>#{current_domain.support_email}</a>.
       ERROR
       Sentry.capture_message(error_message, extra: { user_info: callback_client.user_info })

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,7 +1,7 @@
 class SoftDeleteError < StandardError; end
 
 class Agent < ApplicationRecord
-  self.ignored_columns += %w[external_id]
+  self.ignored_columns += %w[connected_with_agent_connect]
   include Agent::CaldavConfiguration
   include Agent::FeatureFlags
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -12,7 +12,7 @@ class Agent < ApplicationRecord
     only: %w[
       email unconfirmed_email
       first_name last_name
-      proconnect_siret
+      pro_connect_openid_sub proconnect_siret
       invitation_sent_at invitation_accepted_at
     ]
   )

--- a/app/services/agent_connect_open_id_client/callback.rb
+++ b/app/services/agent_connect_open_id_client/callback.rb
@@ -13,7 +13,7 @@ module AgentConnectOpenIdClient
       @client_secret = client_secret
     end
 
-    attr_reader :id_token_for_logout
+    attr_reader :id_token_for_logout, :user_info
 
     def fetch_user_info_from_code!(code)
       validate_state!

--- a/app/views/agents/registrations/_infos.html.slim
+++ b/app/views/agents/registrations/_infos.html.slim
@@ -8,6 +8,6 @@
   = f.input :first_name, placeholder: "Prénom", disabled: true
   = f.input :last_name, placeholder: "Nom", disabled: true
   = f.association :services, collection: resource.services, disabled: true, input_html: { class: "select2-input" }
-  - if resource.connected_with_agent_connect?
+  - if resource.pro_connect_openid_sub
     .form-text.text-muted.mb-2
       | Les informations de votre compte proviennent de ProConnect.

--- a/app/views/agents/registrations/edit.html.slim
+++ b/app/views/agents/registrations/edit.html.slim
@@ -1,6 +1,6 @@
 - content_for :title, "Votre compte"
 
-- if resource.connected_with_agent_connect?
+- if resource.pro_connect_openid_sub
   = render "infos", resource: resource, resource_name: resource_name, devise_mapping: devise_mapping
 - else
   = render "form", resource: resource, resource_name: resource_name, devise_mapping: devise_mapping

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -102,6 +102,7 @@ tables:
       - microsoft_graph_token
       - refresh_microsoft_graph_token
       - remember_created_at
+      - pro_connect_openid_sub
     non_anonymized_column_names:
       - reset_password_sent_at
       - last_sign_in_at

--- a/db/migrate/20251021160825_add_pro_connect_openid_sub_to_agents.rb
+++ b/db/migrate/20251021160825_add_pro_connect_openid_sub_to_agents.rb
@@ -1,0 +1,8 @@
+class AddProConnectOpenidSubToAgents < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :agents, :pro_connect_openid_sub, :string
+    add_index :agents, :pro_connect_openid_sub, algorithm: :concurrently, where: "pro_connect_openid_sub IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_17_142741) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_21_160825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -240,6 +240,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_17_142741) do
     t.string "caldav_password"
     t.boolean "caldav_disconnect_in_progress", default: false, null: false
     t.datetime "blog_read_at"
+    t.string "pro_connect_openid_sub"
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true
@@ -248,6 +249,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_17_142741) do
     t.index ["invited_by_id"], name: "index_agents_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_agents_on_invited_by_type_and_invited_by_id"
     t.index ["last_name"], name: "index_agents_on_last_name"
+    t.index ["pro_connect_openid_sub"], name: "index_agents_on_pro_connect_openid_sub", where: "(pro_connect_openid_sub IS NOT NULL)"
     t.index ["proconnect_siret"], name: "index_agents_on_proconnect_siret"
     t.index ["reset_password_token"], name: "index_agents_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_agents_on_uid_and_provider", unique: true, where: "(uid IS NOT NULL)"

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -118,19 +118,71 @@ RSpec.describe AgentConnectController do
       session[:agent_return_to] = "/agents/edit" # Pour simuler le retour vers la page demandée avant la connexion
     end
 
-    it "updates and logs in the agent" do
-      agent = create(:agent, email: "francis.factice@exemple.gouv.fr")
-      get :callback, params: { state: state, code: code }
+    describe "agent login" do
+      def expect_agent_to_be_updated_and_logged_in(agent)
+        expected_attrs = {
+          pro_connect_openid_sub: user_info["sub"],
+          email: user_info["email"],
+          first_name: "Francis",
+          last_name: "Factice",
+          confirmed_at: be_within(10.seconds).of(Time.zone.now),
+        }
+        expect(agent).to have_attributes(expected_attrs)
+        expect(current_agent_id).to eq(agent.id)
+        expect(session["agent_connect_id_token"]).to be_present
+        expect(response).to redirect_to("/agents/edit")
+      end
 
-      expect(agent.reload).to have_attributes(
-        connected_with_agent_connect: true,
-        first_name: "Francis",
-        last_name: "Factice",
-        last_sign_in_at: be_within(10.seconds).of(Time.zone.now)
-      )
-      expect(session["agent_connect_id_token"]).to be_present
+      context "when agent does not exist for email nor sub" do
+        it "displays an error if the domain does not allow self-onboarding" do
+          allow(Domain::RDV_MAIRIE).to receive(:allow_self_onboarding).and_return(false)
+          expect do
+            get :callback, params: { state:, code: }
+          end.not_to change(Agent, :count)
+          expect(flash[:error]).to include("Il n'y a pas de compte agent pour l'adresse mail francis.factice@exemple.gouv.fr")
+          expect(current_agent_id).to be_nil
+        end
 
-      expect(response).to redirect_to("/agents/edit")
+        it "creates the agent if the domain allows it" do
+          allow(Domain::RDV_MAIRIE).to receive(:allow_self_onboarding).and_return(true)
+          expect do
+            get :callback, params: { state:, code: }
+          end.to change(Agent, :count).by(1)
+          agent = Agent.last
+          expect_agent_to_be_updated_and_logged_in(agent)
+        end
+      end
+
+      context "when an agent exists with the given email address and no sub" do
+        it "updates the existing agent's sub" do
+          agent = create(:agent, email: "francis.factice@exemple.gouv.fr")
+          expect do
+            get :callback, params: { state:, code: }
+          end.to change { agent.reload.pro_connect_openid_sub }.to(user_info["sub"])
+          expect_agent_to_be_updated_and_logged_in(agent)
+        end
+      end
+
+      context "when an agent exists with the given sub and another email address" do
+        it "replaces the agents email address with the one from ProConnect" do
+          agent = create(:agent, pro_connect_openid_sub: user_info["sub"], email: "ancienne@exemple.fr")
+          expect do
+            get :callback, params: { state:, code: }
+          end.to change { agent.reload.email }.from("ancienne@exemple.fr").to(user_info["email"])
+          expect_agent_to_be_updated_and_logged_in(agent)
+        end
+      end
+
+      context "when an agent exists with the given email but with another sub" do
+        it "raises an error" do
+          create(:agent, pro_connect_openid_sub: "another_sub", email: user_info["email"])
+          expect do
+            get :callback, params: { state:, code: }
+          end.not_to change { Agent.maximum(:updated_at) }
+          expect(flash[:error]).to include("Ce compte ProConnect est lié à l'adresse e-mail #{user_info["email"]}.")
+          expect(current_agent_id).to be_nil
+        end
+      end
     end
 
     context "when logging in a user" do

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe AgentConnectController do
         "email" => "francis.factice@exemple.gouv.fr",
         "given_name" => "Francis Factice",
         "usual_name" => "Factice",
+        "siret" => "13002526500013",
         "aud" => "4ec41582-1d60-4f12-a63b-d8abaace16ba",
         "exp" => 1717595030, "iat" => 1717594970, "iss" => "https://fca.integ01.dev-agentconnect.fr/api/v2",
       }
@@ -133,13 +134,13 @@ RSpec.describe AgentConnectController do
         expect(response).to redirect_to("/agents/edit")
       end
 
-      context "when agent does not exist for email nor sub" do
+      context "when no existing agent matches email nor sub" do
         it "displays an error if the domain does not allow self-onboarding" do
           allow(Domain::RDV_MAIRIE).to receive(:allow_self_onboarding).and_return(false)
           expect do
             get :callback, params: { state:, code: }
           end.not_to change(Agent, :count)
-          expect(flash[:error]).to include("Il n'y a pas de compte agent pour l'adresse mail francis.factice@exemple.gouv.fr")
+          expect(flash[:error]).to include("Il n'y a pas de compte agent pour l'adresse mail #{user_info['email']}")
           expect(current_agent_id).to be_nil
         end
 
@@ -155,7 +156,7 @@ RSpec.describe AgentConnectController do
 
       context "when an agent exists with the given email address and no sub" do
         it "updates the existing agent's sub" do
-          agent = create(:agent, email: "francis.factice@exemple.gouv.fr")
+          agent = create(:agent, email: user_info["email"])
           expect do
             get :callback, params: { state:, code: }
           end.to change { agent.reload.pro_connect_openid_sub }.to(user_info["sub"])
@@ -170,40 +171,53 @@ RSpec.describe AgentConnectController do
             get :callback, params: { state:, code: }
           end.to change { agent.reload.email }.from("autre@exemple.fr").to(user_info["email"])
           expect_agent_to_be_updated_and_logged_in(agent)
+          expect(flash[:info]).to include("Note : votre adresse e-mail a été mise à jour depuis ProConnect. Ancienne adresse : autre@exemple.fr, nouvelle adresse : #{user_info['email']}")
         end
       end
 
       context "when an agent exists with the given email but with another sub" do
-        it "raises an error" do
+        it "displays an error and warns Sentry" do
           create(:agent, pro_connect_openid_sub: "another_sub", email: user_info["email"])
           expect do
             get :callback, params: { state:, code: }
           end.not_to change { Agent.maximum(:updated_at) }
-          expect(flash[:error]).to include("cette adresse est déjà liée à compte existant")
-          expect(current_agent_id).to be_nil
-        end
-      end
-
-      context "when an agent exists with the given email but with another sub, and another agent exists with the given sub but another email" do
-        it "raises an error" do
-          create(:agent, pro_connect_openid_sub: "another_sub", email: user_info["email"])
-          create(:agent, pro_connect_openid_sub: user_info["sub"], email: "autre@exemple.fr")
-          expect do
-            get :callback, params: { state:, code: }
-          end.not_to change { Agent.maximum(:updated_at) }
-          expect(flash[:error]).to include("cette adresse est déjà liée à compte existant")
+          expected_error_message = "cette adresse est déjà liée à compte existant qui est connecté avec un autre compte ProConnect"
+          expect(flash[:error]).to include(expected_error_message)
+          expect(sentry_events.last.message).to include(expected_error_message)
+          expect(sentry_events.last.extra).to eq({ user_info: })
+          expect(sentry_events.last.user[:email]).to eq(user_info["email"])
           expect(current_agent_id).to be_nil
         end
       end
 
       context "when an agent exists with the given sub, and another agent exists with the given email" do
-        it "raises an error" do
-          create(:agent, pro_connect_openid_sub: user_info["sub"])
-          create(:agent, email: user_info["email"])
+        it "displays an error and warns Sentry" do
+          agent_by_sub = create(:agent, pro_connect_openid_sub: user_info["sub"])
+          agent_by_email = create(:agent, email: user_info["email"])
           expect do
             get :callback, params: { state:, code: }
           end.not_to change { Agent.maximum(:updated_at) }
-          expect(flash[:error]).to include("cette adresse est déjà liée à compte existant")
+          expected_error_message = "Il existe deux comptes correspondant : #{agent_by_email.email} et #{agent_by_sub.email}"
+          expect(flash[:error]).to include(expected_error_message)
+          expect(sentry_events.last.message).to include(expected_error_message)
+          expect(sentry_events.last.extra).to eq({ user_info: })
+          expect(sentry_events.last.user[:email]).to eq(user_info["email"])
+          expect(current_agent_id).to be_nil
+        end
+      end
+
+      context "when an agent exists with the given email but with another sub, and another agent exists with the given sub but another email" do
+        it "displays an error and warns Sentry" do
+          create(:agent, pro_connect_openid_sub: "another_sub", email: user_info["email"])
+          create(:agent, pro_connect_openid_sub: user_info["sub"], email: "autre@exemple.fr")
+          expect do
+            get :callback, params: { state:, code: }
+          end.not_to change { Agent.maximum(:updated_at) }
+          expected_error_message = "Il existe deux comptes correspondant : #{user_info['email']} et autre@exemple.fr"
+          expect(flash[:error]).to include(expected_error_message)
+          expect(sentry_events.last.message).to include(expected_error_message)
+          expect(sentry_events.last.extra).to eq({ user_info: })
+          expect(sentry_events.last.user[:email]).to eq(user_info["email"])
           expect(current_agent_id).to be_nil
         end
       end
@@ -286,7 +300,7 @@ RSpec.describe AgentConnectController do
         end
 
         context "when the super admin already exists" do
-          let!(:super_admin) { create(:super_admin, email: "francis.factice@exemple.gouv.fr") }
+          let!(:super_admin) { create(:super_admin, email: user_info["email"]) }
 
           it "redirects to the super admin agents page" do
             get :callback, params: { state: state, code: code }
@@ -308,7 +322,7 @@ RSpec.describe AgentConnectController do
 
             expect(SuperAdmin.count).to eq(1)
             expect(SuperAdmin.last).to have_attributes(
-              email: "francis.factice@exemple.gouv.fr"
+              email: user_info["email"]
             )
             expect(session["agent_connect_id_token"]).to be_present
             expect(response).to redirect_to("/super_admins/lieux?search=arques")

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -126,7 +126,6 @@ RSpec.describe AgentConnectController do
           email: user_info["email"],
           first_name: "Francis",
           last_name: "Factice",
-          confirmed_at: be_within(10.seconds).of(Time.zone.now),
         }
         expect(agent).to have_attributes(expected_attrs)
         expect(current_agent_id).to eq(agent.id)

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe AgentConnectController do
           expect do
             get :callback, params: { state:, code: }
           end.not_to change { Agent.maximum(:updated_at) }
-          expected_error_message = "cette adresse est déjà liée à compte existant qui est connecté avec un autre compte ProConnect"
+          expected_error_message = "Un compte agent existe déjà sur RDV Service Public pour cette adresse email"
           expect(flash[:error]).to include(expected_error_message)
           expect(sentry_events.last.message).to include(expected_error_message)
           expect(sentry_events.last.extra).to eq({ user_info: })

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -165,10 +165,10 @@ RSpec.describe AgentConnectController do
 
       context "when an agent exists with the given sub and another email address" do
         it "replaces the agents email address with the one from ProConnect" do
-          agent = create(:agent, pro_connect_openid_sub: user_info["sub"], email: "ancienne@exemple.fr")
+          agent = create(:agent, pro_connect_openid_sub: user_info["sub"], email: "autre@exemple.fr")
           expect do
             get :callback, params: { state:, code: }
-          end.to change { agent.reload.email }.from("ancienne@exemple.fr").to(user_info["email"])
+          end.to change { agent.reload.email }.from("autre@exemple.fr").to(user_info["email"])
           expect_agent_to_be_updated_and_logged_in(agent)
         end
       end
@@ -179,7 +179,31 @@ RSpec.describe AgentConnectController do
           expect do
             get :callback, params: { state:, code: }
           end.not_to change { Agent.maximum(:updated_at) }
-          expect(flash[:error]).to include("Ce compte ProConnect est lié à l'adresse e-mail #{user_info["email"]}.")
+          expect(flash[:error]).to include("cette adresse est déjà liée à compte existant")
+          expect(current_agent_id).to be_nil
+        end
+      end
+
+      context "when an agent exists with the given email but with another sub, and another agent exists with the given sub but another email" do
+        it "raises an error" do
+          create(:agent, pro_connect_openid_sub: "another_sub", email: user_info["email"])
+          create(:agent, pro_connect_openid_sub: user_info["sub"], email: "autre@exemple.fr")
+          expect do
+            get :callback, params: { state:, code: }
+          end.not_to change { Agent.maximum(:updated_at) }
+          expect(flash[:error]).to include("cette adresse est déjà liée à compte existant")
+          expect(current_agent_id).to be_nil
+        end
+      end
+
+      context "when an agent exists with the given sub, and another agent exists with the given email" do
+        it "raises an error" do
+          create(:agent, pro_connect_openid_sub: user_info["sub"])
+          create(:agent, email: user_info["email"])
+          expect do
+            get :callback, params: { state:, code: }
+          end.not_to change { Agent.maximum(:updated_at) }
+          expect(flash[:error]).to include("cette adresse est déjà liée à compte existant")
           expect(current_agent_id).to be_nil
         end
       end

--- a/spec/jobs/outlook/sync_event_job_spec.rb
+++ b/spec/jobs/outlook/sync_event_job_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Outlook::SyncEventJob do
 
         expect(agents_rdv.reload.outlook_id).to be_nil
         expect(sentry_events.last.exception.values.first.value).to eq("Outlook api error! (RuntimeError)")
+        expect(sentry_events.last.user).to eq({ email: agents_rdv.agent.email, id: agents_rdv.agent.id, role: "Agent" })
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveJob::TestHelper
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include WardenControllerHelper, type: :controller
   config.include Warden::Test::Helpers, type: :feature
   config.include FillInReadOnlyInputHelper, type: :feature
   config.include Sentry::TestHelper

--- a/spec/support/warden_controller_helper.rb
+++ b/spec/support/warden_controller_helper.rb
@@ -1,0 +1,5 @@
+module WardenControllerHelper
+  def current_agent_id
+    session["warden.user.agent.key"]&.first&.sole
+  end
+end


### PR DESCRIPTION
Closes #5716

# Contexte (copié depuis l'issue)

Actuellement on utilise l’email pour réconcilier les comptes agents connecté via ProConnect cf ce commit https://github.com/betagouv/rdv-service-public/pull/4309/files#diff-9c6d55bcbeff608c0b02433b954dfc524bef7cce084a9dd210a50cc007186fb5R26-R28

C’était la recommendation de ProConnect jusqu’en septembre 2024 : https://github.com/proconnect-gouv/proconnect-documentation/commit/2dde51593d287271afd4da62745399a54c553e89

Il faudrait maintenant utiliser le `sub` plutôt que l’email. Cela permettra aux agents de changer d’email sur ProConnect mais qu’ils puissent continuer à accéder à leur compte RDVSP sans changement.

Cette agent d’une mairie qui utilise ProConnect nous indique ne plus arriver à se connecter depuis que son email a changé sur ProConnect : https://zammad10.ethibox.fr/#ticket/zoom/28816

# Solution

Nous avons les happy paths suivants : 
- on retrouve l'agent via le sub : on met à jour son nom et son e-mail (et on le prévient si son mail a changé)
- on retrouve l'agent via l'e-mail : on ajoute le sub sur cet agent
- on ne trouve aucun agent par sub ou e-mail : le comportement ne change pas, c'est à dire qu'on lui crée un compte (instance RDV-SP) ou on affiche un message d'erreur (instance RDV-Solidarités)

Pour ce qui est des edge cases, nous avons réfléchi avec Adrien et Antoine et avos pensé aux cas suivants (merci Adrien pour le schéma) :

<img width="1636" height="2261" alt="image" src="https://github.com/user-attachments/assets/86e03cb3-64f3-4a9a-ac4a-e2d446c059c7" />

Nous avons décidé que le mieux à faire dans ces cas serait pour l'instant de prévenir Sentry et d'inciter à contacter le support, car nous n'arrivons pas à imaginer de façon automatique de résoudre ces situations. Nous pouvons imaginer dans le futur que l'appli propose à l'agent de fusionner ses comptes, mais ça parait bien trop complexe pour le moment. Nous allons donc fusionner à la main pour le moment d'après les remontés au support et Sentry, et une fois que nous aurons une meilleure vision du volume et de la nature des cas problématiques, nous aviserons.

## Détails techniques

Comme vous le voyez j'ai tout mis dans une grosse méthode de controller, pour éviter de créer de l'indirection. J'ai vaguement essayé d'introduire un service object pour encapsuler les logiques d'upsert (un équivalent de `UpsertUserForFranceconnectService` mais pour ProConnect), mais ça ne rendait pas le code plus facile à comprendre. Je suis ouvert aux suggestions. :handshake: 