### PR TITLE
Retrait d'une URL utilisée par `selenium-webdriver`

### DIFF
--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -1,4 +1,8 @@
-WebMock.disable_net_connect!(allow: ["www.rdv-solidarites-test.localhost"])
+WebMock.disable_net_connect!(allow: [
+                               "127.0.0.1",
+                               "localhost",
+                               "www.rdv-solidarites-test.localhost",
+                             ])
 
 def new_capybara_driver(app, **)
   Capybara::Playwright::Driver.new(

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -2,7 +2,6 @@ WebMock.disable_net_connect!(allow: [
                                "127.0.0.1",
                                "localhost",
                                "www.rdv-solidarites-test.localhost",
-                               "chromedriver.storage.googleapis.com", # Autorise à télécharger le binaire chromedriver pour l'exécution de la CI
                              ])
 
 def new_capybara_driver(app, **)

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -1,8 +1,4 @@
-WebMock.disable_net_connect!(allow: [
-                               "127.0.0.1",
-                               "localhost",
-                               "www.rdv-solidarites-test.localhost",
-                             ])
+WebMock.disable_net_connect!(allow: ["www.rdv-solidarites-test.localhost"])
 
 def new_capybara_driver(app, **)
   Capybara::Playwright::Driver.new(


### PR DESCRIPTION
Cette URL était utilisée par la gem `selenium-webdriver` pour télécharger Chrome. Désormais le téléchargement de Chrome se fait via une commande `playwright install` [dans notre config CI](https://github.com/betagouv/rdv-service-public/pull/5484/files#diff-82a43d8a19c7cf8dbbfa74d160ef5dfc17a923d46b728f77bc2cb0a014815d4cR18) (et explicitement en local).

Puisque le téléchargement de Chrome ne se fait plus pendant les tests, nous n'avons plus besoin d'indiquer à Capybara qu'il faut autoriser les vrais appels à ce domaine. :wink: 