### PR TITLE
Retrait d’un lien de contact non utilisé

### DIFF
--- a/app/views/prescripteur_rdv_wizard/confirmation.html.slim
+++ b/app/views/prescripteur_rdv_wizard/confirmation.html.slim
@@ -48,14 +48,4 @@
                 last_name: @prescripteur.last_name,
                 phone_number: @prescripteur.phone_number,
                 email: @prescripteur.phone_number)
-        li.list-group-item
-          |> Vous pouvez aussi
-          => link_to "nous écrire",
-            new_aide_demande_support_path(role: :agent,
-              sujet: "Avis sur la prise de RDV par prescription",
-              first_name: @prescripteur.first_name,
-              last_name: @prescripteur.last_name,
-              phone_number: @prescripteur.phone_number,
-              email: @prescripteur.phone_number)
-          | pour nous donner votre avis sur la prise de rendez-vous.
       .mt-4.rdv-text-align-center= link_to "Retour à l'accueil", prendre_rdv_prescripteur_path(rdv.territory.departement_number)


### PR DESCRIPTION
# Contexte

En commençant à enquêter sur la possibilité de donner de l’autonomie aux prescripteurs, je me suis rendu compte que nous avions un lien qui invite ces derniers à donner leur avis sur le parcours de prescription. 

<img width="883" height="556" alt="image" src="https://github.com/user-attachments/assets/d0d3e4df-3bb8-47d2-84fd-d922f95e6a87" />

Ce lien n’a jamais été utilisé depuis qu’il a été mis en place en janvier.

# Solution

Je propose donc de le retirer, car il alourdit l’interface.
