### PR TITLE
Ajout de l’auteur paper trail lors de la prescription

### DIFF
--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -5,6 +5,7 @@ class PrescripteurRdvWizardController < ApplicationController
   before_action :check_rdv_wizard_attributes, except: %i[start confirmation]
   before_action :set_rdv_wizard, only: %i[new_prescripteur new_beneficiaire create_rdv]
   before_action :redirect_if_creneau_unavailable, only: %i[new_prescripteur new_beneficiaire create_rdv]
+  before_action :set_paper_trail_whodunnit
 
   def start
     session[:rdv_wizard_attributes] = params.permit(
@@ -92,5 +93,9 @@ class PrescripteurRdvWizardController < ApplicationController
       flash[:error] = "Ce créneau n'est plus disponible. Veuillez en choisir un autre."
       redirect_to path_to_creneau_selection(@rdv_wizard.params_to_selections)
     end
+  end
+
+  def user_for_paper_trail
+    @rdv_wizard.prescripteur.name_for_paper_trail if @rdv_wizard&.prescripteur
   end
 end

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -14,10 +14,12 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
     ActiveRecord::Base.transaction do
       find_or_create_user
 
-      if @rdv.collectif?
-        create_participation!
-      else
-        create_rdv!
+      PaperTrail.request(whodunnit: @prescripteur.name_for_paper_trail) do
+        if @rdv.collectif?
+          create_participation!
+        else
+          create_rdv!
+        end
       end
     end
 

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -14,12 +14,10 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
     ActiveRecord::Base.transaction do
       find_or_create_user
 
-      PaperTrail.request(whodunnit: @prescripteur.name_for_paper_trail) do
-        if @rdv.collectif?
-          create_participation!
-        else
-          create_rdv!
-        end
+      if @rdv.collectif?
+        create_participation!
+      else
+        create_rdv!
       end
     end
 

--- a/app/models/prescripteur.rb
+++ b/app/models/prescripteur.rb
@@ -9,4 +9,8 @@ class Prescripteur < ApplicationRecord
   has_one :user, through: :participation
 
   validates :first_name, :last_name, :email, presence: true
+
+  def name_for_paper_trail
+    "[Prescripteur] #{full_name}"
+  end
 end

--- a/app/views/prescripteur_rdv_wizard/confirmation.html.slim
+++ b/app/views/prescripteur_rdv_wizard/confirmation.html.slim
@@ -48,4 +48,4 @@
                 last_name: @prescripteur.last_name,
                 phone_number: @prescripteur.phone_number,
                 email: @prescripteur.phone_number)
-      .mt-4.rdv-text-align-center= link_to "Retour à l'accueil", prendre_rdv_prescripteur_path(rdv.territory.departement_number)
+      .fr-mt-6v.rdv-text-align-center= link_to "Retour à l'accueil", prendre_rdv_prescripteur_path(rdv.territory.departement_number)

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -88,6 +88,8 @@ RSpec.describe "prescripteur can create RDV for a user" do
     expect(created_rdv.created_by_prescripteur?).to be(true)
     expect(created_rdv.participations.first.created_by_prescripteur?).to be(true)
 
+    expect(created_rdv.versions.first.whodunnit).to eq("[Prescripteur] Alex PRESCRIPTEUR")
+
     perform_enqueued_jobs(only: ApplicationMailerDeliveryJob)
     expect(first_email_sent_to(agent.email).subject).to include("Nouveau RDV ajouté sur votre agenda RDV Service Public")
     expect(first_email_sent_to("alex@prescripteur.fr").subject).to include("RDV confirmé")


### PR DESCRIPTION
# Contexte

En testant le parcours de prescription, je me suis aperçu qu’on ne définissait pas l’auteur dans PaperTrail.

# Solution

J’ai fait le choix de le définir directement dans le Wizard et non dans le contrôleur.
En effet, le prescripteur n’étant pas un type d’utilisateur connecté, ça faisait beaucoup de logique pour définir déjà l’objet prescripteur puis l’utiliser dans PaperTrail.