### PR TITLE
Annulation d’un RDV en tant que prescripteur (sans compte Agent)

### DIFF
--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -86,7 +86,12 @@ class PrescripteurRdvWizardController < ApplicationController
   end
 
   def show
-    @prescripteur = Prescripteur.find(session[:prescripteur_id])
+    if params[:token].present?
+      @prescripteur = Prescripteur.find_by(token: params[:token])
+      session[:prescripteur_id] = @prescripteur.id
+    else
+      @prescripteur = Prescripteur.find(session[:prescripteur_id])
+    end
   end
 
   private

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -82,16 +82,20 @@ class PrescripteurRdvWizardController < ApplicationController
   end
 
   def confirmation
-    @prescripteur = Prescripteur.find(session[:prescripteur_id])
+    prescripteur = Prescripteur.find(session[:prescripteur_id])
+
+    render locals: { prescripteur: }
   end
 
   def show
     if params[:token].present?
-      @prescripteur = Prescripteur.find_by(token: params[:token])
-      session[:prescripteur_id] = @prescripteur.id
+      prescripteur = Prescripteur.find_by(token: params[:token])
+      session[:prescripteur_id] = prescripteur.id
     else
-      @prescripteur = Prescripteur.find(session[:prescripteur_id])
+      prescripteur = Prescripteur.find(session[:prescripteur_id])
     end
+
+    render locals: { prescripteur: }
   end
 
   private

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -2,7 +2,7 @@ class PrescripteurRdvWizardController < ApplicationController
   include SearchContextHelper
 
   before_action :log_session_to_sentry
-  before_action :check_rdv_wizard_attributes, except: %i[start confirmation]
+  before_action :check_rdv_wizard_attributes, except: %i[start confirmation cancel_rdv show]
   before_action :set_rdv_wizard, only: %i[new_prescripteur new_beneficiaire create_rdv]
   before_action :redirect_if_creneau_unavailable, only: %i[new_prescripteur new_beneficiaire create_rdv]
   before_action :set_paper_trail_whodunnit
@@ -66,7 +66,26 @@ class PrescripteurRdvWizardController < ApplicationController
     end
   end
 
+  def cancel_rdv
+    @prescripteur = Prescripteur.find(session[:prescripteur_id])
+
+    if @prescripteur.rdv.cancellable_by_user?
+      PaperTrail.request(whodunnit: @prescripteur.name_for_paper_trail) do
+        @prescripteur.rdv.excused!
+        flash[:success] = "Le rendez-vous a bien été annulé."
+      end
+    else
+      flash[:error] = "Le rendez-vous ne peut plus être annulé."
+    end
+
+    redirect_to prescripteur_show_path
+  end
+
   def confirmation
+    @prescripteur = Prescripteur.find(session[:prescripteur_id])
+  end
+
+  def show
     @prescripteur = Prescripteur.find(session[:prescripteur_id])
   end
 

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -84,7 +84,7 @@ class PrescripteurRdvWizardController < ApplicationController
 
   def show
     if params[:token].present?
-      prescripteur = Prescripteur.find_by(token: params[:token])
+      prescripteur = Prescripteur.find_by!(token: params[:token])
       session[:prescripteur_id] = prescripteur.id
     else
       prescripteur = Prescripteur.find(session[:prescripteur_id])

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -69,7 +69,7 @@ class PrescripteurRdvWizardController < ApplicationController
 
   def cancel_rdv
     if @prescripteur.rdv.cancellable_by_user?
-      @prescripteur.rdv.excused!
+      @prescripteur.rdv.update_and_notify(@prescripteur, status: "excused")
       flash[:success] = "Le rendez-vous a bien été annulé."
     else
       flash[:error] = "Le rendez-vous ne peut plus être annulé."

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -4,6 +4,7 @@ class PrescripteurRdvWizardController < ApplicationController
   before_action :log_session_to_sentry
   before_action :check_rdv_wizard_attributes, except: %i[start confirmation cancel_rdv show]
   before_action :set_rdv_wizard, only: %i[new_prescripteur new_beneficiaire create_rdv]
+  before_action :set_prescripteur_from_session, only: %i[confirmation cancel_rdv]
   before_action :redirect_if_creneau_unavailable, only: %i[new_prescripteur new_beneficiaire create_rdv]
   before_action :set_paper_trail_whodunnit
 
@@ -67,13 +68,9 @@ class PrescripteurRdvWizardController < ApplicationController
   end
 
   def cancel_rdv
-    @prescripteur = Prescripteur.find(session[:prescripteur_id])
-
     if @prescripteur.rdv.cancellable_by_user?
-      PaperTrail.request(whodunnit: @prescripteur.name_for_paper_trail) do
-        @prescripteur.rdv.excused!
-        flash[:success] = "Le rendez-vous a bien été annulé."
-      end
+      @prescripteur.rdv.excused!
+      flash[:success] = "Le rendez-vous a bien été annulé."
     else
       flash[:error] = "Le rendez-vous ne peut plus être annulé."
     end
@@ -82,9 +79,7 @@ class PrescripteurRdvWizardController < ApplicationController
   end
 
   def confirmation
-    prescripteur = Prescripteur.find(session[:prescripteur_id])
-
-    render locals: { prescripteur: }
+    render locals: { prescripteur: @prescripteur }
   end
 
   def show
@@ -123,7 +118,15 @@ class PrescripteurRdvWizardController < ApplicationController
     end
   end
 
+  def set_prescripteur_from_session
+    @prescripteur = Prescripteur.find(session[:prescripteur_id])
+  end
+
   def user_for_paper_trail
-    @rdv_wizard.prescripteur.name_for_paper_trail if @rdv_wizard&.prescripteur
+    if @rdv_wizard&.prescripteur
+      @rdv_wizard.prescripteur.name_for_paper_trail
+    elsif @prescripteur
+      @prescripteur.name_for_paper_trail
+    end
   end
 end

--- a/app/mailers/prescripteur_mailer.rb
+++ b/app/mailers/prescripteur_mailer.rb
@@ -5,6 +5,7 @@ class PrescripteurMailer < ApplicationMailer
 
   def rdv_created(participation, domain_id)
     @domain = Domain.find(domain_id)
+    @prescripteur = participation.created_by
     @user = participation.user
     @rdv = participation.rdv
     mail(

--- a/app/models/prescripteur.rb
+++ b/app/models/prescripteur.rb
@@ -10,7 +10,17 @@ class Prescripteur < ApplicationRecord
 
   validates :first_name, :last_name, :email, presence: true
 
+  encrypts :token, deterministic: true
+
+  before_save :set_token
+
   def name_for_paper_trail
     "[Prescripteur] #{full_name}"
+  end
+
+  def set_token
+    return if token
+
+    self.token = SecureRandom.hex(48)
   end
 end

--- a/app/services/notifiers/rdv_cancelled.rb
+++ b/app/services/notifiers/rdv_cancelled.rb
@@ -6,8 +6,8 @@ class Notifiers::RdvCancelled < Notifiers::RdvBase
   end
 
   def notify_user_by_sms(user)
-    # Only send sms for excused cancellations by an Agent (not for no-show, not for self-cancellation)
-    return unless @author.is_a? Agent
+    # On envoie des SMS de notification de RDV annulé uniquement si l'auteur de l'annulation est un Agent ou un Prescripteur et qu’il ne s’agit pas d’un no-show.
+    return unless @author.is_a?(Agent) || @author.is_a?(Prescripteur)
     return unless notify_cancellation?
 
     Users::RdvSms.rdv_cancelled(@rdv, user, @participations_tokens_by_user_id[user.id]).deliver_later

--- a/app/views/mailers/prescripteur_mailer/rdv_created.html.slim
+++ b/app/views/mailers/prescripteur_mailer/rdv_created.html.slim
@@ -4,8 +4,12 @@ div
   p
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
-  |> Besoin de déplacer le rendez-vous ou de corriger un détail ?
-  = link_to("Contactez-nous", new_aide_demande_support_url(role: :agent, sujet: "Déplacer ou corriger un RDV pris via prescription (RDV ID: #{@rdv.id})"))
+  .btn-wrapper
+    = link_to "Annuler le rendez-vous", prescripteur_show_url(token: @prescripteur.token), class: "btn btn-primary"
+
+  p
+    |> Besoin de corriger un détail ?
+    = link_to("Contactez-nous", new_aide_demande_support_url(role: :agent, sujet: "Corriger un RDV pris via prescription (RDV ID: #{@rdv.id})"))
   br
   br
   = t("mailers.common.farewell_html", domain_name: domain.name)

--- a/app/views/prescripteur_rdv_wizard/_rdv.html.slim
+++ b/app/views/prescripteur_rdv_wizard/_rdv.html.slim
@@ -1,0 +1,50 @@
+/# locals: (prescripteur:)
+- rdv = prescripteur.rdv
+ul.list-group.list-group-flush.fr-mt-0
+  li.list-group-item
+    span.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
+    = rdv_title(rdv)
+    = rdv_tag(rdv)
+
+  - if rdv.public_office?
+    li.list-group-item
+      span.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
+      = human_location(rdv)
+      - if rdv.lieu&.phone_number
+        br
+        span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
+        = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"
+
+  - elsif rdv.phone?
+    li.list-group-item
+      span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
+      | RDV Téléphonique
+
+  li.list-group-item
+    span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
+    = prescripteur.user.full_name
+    = " (#{prescripteur.user.phone_number})" if prescripteur.user.phone_number.present?
+  li.list-group-item
+    span.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
+    = rdv.motif.name
+  - if rdv.motif.instruction_for_rdv.present?
+    li.list-group-item
+      span.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
+      strong Informations supplémentaires&nbsp;:
+      .pl-3.pt-1
+        = instruction_for_rdv_to_html(rdv.motif)
+.fr-mt-4v
+  ul.fr-btns-group.fr-btns-group--inline
+    li
+    - if prescripteur.rdv.cancellable_by_user?
+      li
+        = link_to "Annuler le rendez-vous", prescripteur_cancel_rdv_path, class: "fr-btn fr-btn--secondary", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ?", method: :delete }
+p
+  |> Besoin de corriger un détail ?
+  = link_to "Contactez-nous", new_aide_demande_support_path(role: :agent,
+          sujet: "Corriger un RDV pris via prescription (RDV ID: #{rdv.id})",
+          first_name: prescripteur.first_name,
+          last_name: prescripteur.last_name,
+          phone_number: prescripteur.phone_number,
+          email: prescripteur.phone_number)
+.fr-mt-6v.rdv-text-align-center= link_to "Retour à l'accueil", prendre_rdv_prescripteur_path(rdv.territory.departement_number)

--- a/app/views/prescripteur_rdv_wizard/confirmation.html.slim
+++ b/app/views/prescripteur_rdv_wizard/confirmation.html.slim
@@ -1,3 +1,5 @@
+/# locals: (prescripteur:)
+
 .fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
   = dsfr_stepper(title: "Confirmation", value: 4, max: 4)
   .card
@@ -5,4 +7,4 @@
       h3
         span.fr-icon--lg.fr-icon-success-fill[aria-hidden="true"]
         |< Rendez-vous confirmé
-      = render partial: "rdv", locals: { prescripteur: @prescripteur }
+      = render partial: "rdv", locals: { prescripteur: }

--- a/app/views/prescripteur_rdv_wizard/confirmation.html.slim
+++ b/app/views/prescripteur_rdv_wizard/confirmation.html.slim
@@ -5,47 +5,4 @@
       h3
         span.fr-icon--lg.fr-icon-success-fill[aria-hidden="true"]
         |< Rendez-vous confirmé
-      - rdv = @prescripteur.rdv
-      ul.list-group.list-group-flush.fr-mt-0
-        li.list-group-item
-          span.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
-          = rdv_title(rdv)
-          = rdv_tag(rdv)
-
-        - if rdv.public_office?
-          li.list-group-item
-            span.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
-            = human_location(rdv)
-            - if rdv.lieu&.phone_number
-              br
-              span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
-              = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"
-
-        - elsif rdv.phone?
-          li.list-group-item
-            span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
-            | RDV Téléphonique
-
-        li.list-group-item
-          span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
-          = @prescripteur.user.full_name
-          = " (#{@prescripteur.user.phone_number})" if @prescripteur.user.phone_number.present?
-        li.list-group-item
-          span.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
-          = rdv.motif.name
-        - if rdv.motif.instruction_for_rdv.present?
-          li.list-group-item
-            span.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
-            strong Informations supplémentaires&nbsp;:
-            .pl-3.pt-1
-              = instruction_for_rdv_to_html(rdv.motif)
-        li.list-group-item
-          |> Besoin de déplacer le rendez-vous ou de corriger un détail ?
-          = link_to "Contactez-nous",
-              new_aide_demande_support_path(role: :agent,
-                sujet: "Déplacer ou corriger un RDV pris via prescription (RDV ID: #{rdv.id})",
-                first_name: @prescripteur.first_name,
-                last_name: @prescripteur.last_name,
-                phone_number: @prescripteur.phone_number,
-                email: @prescripteur.phone_number)
-      .fr-mt-6v.rdv-text-align-center= link_to "Retour à l'accueil", prendre_rdv_prescripteur_path(rdv.territory.departement_number)
+      = render partial: "rdv", locals: { prescripteur: @prescripteur }

--- a/app/views/prescripteur_rdv_wizard/show.html.slim
+++ b/app/views/prescripteur_rdv_wizard/show.html.slim
@@ -1,5 +1,7 @@
+/# locals: (prescripteur:)
+
 .fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
   .card
     .card-body
       h1.fr-h3 Détails du rendez-vous
-      = render partial: "rdv", locals: { prescripteur: @prescripteur }
+      = render partial: "rdv", locals: { prescripteur: }

--- a/app/views/prescripteur_rdv_wizard/show.html.slim
+++ b/app/views/prescripteur_rdv_wizard/show.html.slim
@@ -1,0 +1,5 @@
+.fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
+  .card
+    .card-body
+      h1.fr-h3 Détails du rendez-vous
+      = render partial: "rdv", locals: { prescripteur: @prescripteur }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -354,7 +354,9 @@ Rails.application.routes.draw do
     post "store_prescripteur_in_session"
     get "new_beneficiaire"
     post "create_rdv"
+    delete "cancel_rdv"
     get "confirmation"
+    get "show"
   end
 
   %w[mds accessibilite mentions_legales cgu cgu_agent politique_de_confidentialite domaines].each do |page_name|

--- a/db/migrate/20251022160200_add_token_on_prescripteur.rb
+++ b/db/migrate/20251022160200_add_token_on_prescripteur.rb
@@ -1,0 +1,5 @@
+class AddTokenOnPrescripteur < ActiveRecord::Migration[7.2]
+  def change
+    add_column :prescripteurs, :token, :string
+  end
+end

--- a/db/migrate/20251022160200_add_token_on_prescripteur.rb
+++ b/db/migrate/20251022160200_add_token_on_prescripteur.rb
@@ -1,5 +1,9 @@
 class AddTokenOnPrescripteur < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
   def change
     add_column :prescripteurs, :token, :string
+
+    add_index :prescripteurs, :token, algorithm: :concurrently, where: "token IS NOT NULL"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -638,6 +638,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_22_160200) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "token"
+    t.index ["token"], name: "index_prescripteurs_on_token", where: "(token IS NOT NULL)"
   end
 
   create_table "rdv_plans", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_21_160825) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_22_160200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -637,6 +637,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_21_160825) do
     t.string "phone_number_formatted"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "token"
   end
 
   create_table "rdv_plans", force: :cascade do |t|

--- a/spec/features/prescripteurs/can_cancel_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_cancel_rdv_for_a_user_spec.rb
@@ -40,6 +40,9 @@ RSpec.describe "un prescripteur peut annuler un rendez-vous qu’il a pris pour 
     click_link "Annuler le rendez-vous"
 
     expect(page).to have_content("Le rendez-vous a bien été annulé.")
+
+    expect(Rdv.last.status).to eq("excused")
+    expect(Rdv.last.versions.last.whodunnit).to eq("[Prescripteur] Alex PRESCRIPTEUR")
   end
 
   it "lorsqu’il revient plus tard via son lien de confirmation" do
@@ -51,5 +54,8 @@ RSpec.describe "un prescripteur peut annuler un rendez-vous qu’il a pris pour 
     click_link "Annuler le rendez-vous"
 
     expect(page).to have_content("Le rendez-vous a bien été annulé.")
+
+    expect(Rdv.last.status).to eq("excused")
+    expect(Rdv.last.versions.last.whodunnit).to eq(prescripteur.name_for_paper_trail)
   end
 end

--- a/spec/features/prescripteurs/can_cancel_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_cancel_rdv_for_a_user_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe "un prescripteur peut annuler un rendez-vous qu’il a pris pour un usager" do
+  before do
+    travel_to(Time.zone.parse("2022-11-07 15:00"))
+  end
+
+  let!(:territory) { create(:territory, departement_number: "75") }
+  let!(:organisation) { create(:organisation, territory: territory) }
+  let!(:agent) { create(:agent, :cnfs, admin_role_in_organisations: [organisation], rdv_notifications_level: "all") }
+  let(:bookable_by) { "everyone" }
+  let!(:motif) do
+    create(:motif, organisation: organisation, service: agent.services.first, bookable_by: bookable_by, instruction_for_rdv: "Instructions après confirmation", name: "Formation emails")
+  end
+  let!(:lieu) { create(:lieu, organisation: organisation, name: "Bureau") }
+  let!(:plage_ouverture) { create(:plage_ouverture, organisation: organisation, agent: agent, motifs: [motif], lieu: lieu) }
+
+  it "lorsqu’il vient de prendre le rendez-vous" do
+    visit "http://www.rdv-aide-numerique-test.localhost/org/#{organisation.id}"
+
+    click_on "Formation emails" # choix du motif
+    click_on lieu.name
+    click_on "08:00" # choix du créneau
+    click_on "Je suis un prescripteur qui oriente un bénéficiaire" # page de login
+
+    fill_in "Votre prénom", with: "Alex"
+    fill_in "Votre nom", with: "Prescripteur"
+    fill_in "Votre email professionnel", with: "alex@prescripteur.fr"
+    fill_in "Votre numéro de téléphone", with: "0611223344"
+    click_on "Continuer"
+
+    expect(page).to have_content("Prescripteur : Alex PRESCRIPTEUR")
+    fill_in "Prénom", with: "Patricia"
+    fill_in "Nom", with: "Duroy"
+    fill_in "Téléphone", with: "0611223344"
+
+    expect { click_on "Confirmer le rendez-vous" }.to change(Rdv, :count).by(1).and(change(User, :count).by(1))
+
+    expect(page).to have_content("Rendez-vous confirmé")
+
+    # Sur la page de confirmation, le prescripteur doit pouvoir annuler le rdv
+    click_link "Annuler le rendez-vous"
+
+    expect(page).to have_content("Le rendez-vous a bien été annulé.")
+  end
+
+  it "lorsqu’il revient plus tard via son lien de confirmation" do
+    prescripteur = build(:prescripteur)
+    create(:rdv, created_by: prescripteur)
+
+    visit prescripteur_show_path(token: prescripteur.token)
+
+    click_link "Annuler le rendez-vous"
+
+    expect(page).to have_content("Le rendez-vous a bien été annulé.")
+  end
+end

--- a/spec/features/prescripteurs/can_cancel_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_cancel_rdv_for_a_user_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "un prescripteur peut annuler un rendez-vous qu’il a pris pour 
 
     expect(Rdv.last.status).to eq("excused")
     expect(Rdv.last.versions.last.whodunnit).to eq("[Prescripteur] Alex PRESCRIPTEUR")
+    expect_sms_enqueued(phone_number: Rdv.last.users.first.phone_number_formatted, content: /a été annulé./)
   end
 
   it "lorsqu’il revient plus tard via son lien de confirmation" do

--- a/spec/features/prescripteurs/can_cancel_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_cancel_rdv_for_a_user_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "un prescripteur peut annuler un rendez-vous qu’il a pris pour 
 
   it "lorsqu’il revient plus tard via son lien de confirmation" do
     prescripteur = build(:prescripteur)
-    create(:rdv, created_by: prescripteur)
+    rdv = create(:rdv, created_by: prescripteur)
 
     visit prescripteur_show_path(token: prescripteur.token)
 
@@ -57,5 +57,6 @@ RSpec.describe "un prescripteur peut annuler un rendez-vous qu’il a pris pour 
 
     expect(Rdv.last.status).to eq("excused")
     expect(Rdv.last.versions.last.whodunnit).to eq(prescripteur.name_for_paper_trail)
+    expect_sms_enqueued(phone_number: rdv.users.first.phone_number_formatted, content: /a été annulé./)
   end
 end

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "prescripteur can create RDV for a user" do
+RSpec.describe "un prescripteur peut prendre rendez-vous pour un usager" do
   before do
     travel_to(Time.zone.parse("2022-11-07 15:00"))
   end

--- a/spec/models/prescripteur_spec.rb
+++ b/spec/models/prescripteur_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Prescripteur, type: :model do
+  describe "#set_token" do
+    it "ajoute le token si celui-ci n’existe pas" do
+      prescripteur = described_class.new(first_name: "John", last_name: "Doe", email: "john@doe.fr")
+      expect(prescripteur.token).to be_nil
+      prescripteur.save!
+      expect(prescripteur.reload.token).not_to be_nil
+    end
+
+    it "ne modifie pas le token s’il existe déjà" do
+      prescripteur = described_class.new(first_name: "John", last_name: "Doe", email: "john@doe.fr", token: "existing")
+      prescripteur.save!
+      expect(prescripteur.reload.token).to eq("existing")
+    end
+  end
+end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr5758.osc-secnum-fr1.scalingo.io/)

# Contexte

Nous recevons régulièrement des Zammad de prescripteurs qui veulent annuler le rendez-vous qu’ils ont pris pour le compte d’un usager (généralement, car ils ont fait une erreur). 
Dans ces cas, nous transférons la demande à l’agent ou nous effectuons nous même l’annulation. Afin de réduire le volume de demandes, et de rendre les prescripteurs + autonomes, nous leur permettons d’annuler le RDV.

# Solution

- Vu que le prescripteur agit pour le compte de l’usager, nous appliquons les mêmes règles d’annulations que si c’était l’usager qui annulait lui-même
- Nous notifions l’usager de l’annulation par SMS
- On ajoute un CTA avec un token dans le mail du prescripteur pour lui permettre de faire l’annulation après avoir quitté la page de confirmation

<img width="635" height="842" alt="image" src="https://github.com/user-attachments/assets/806bfd09-80b9-4553-9a6d-e0d5b1dac1c7" />
<img width="909" height="598" alt="image" src="https://github.com/user-attachments/assets/849ba3d3-0a26-4000-885b-b211f1374144" />
