### PR TITLE
Rendre idempotentes les méthodes de Agent::FeatureFlags

### DIFF
--- a/app/controllers/concerns/admin/planning/set_agents_concern.rb
+++ b/app/controllers/concerns/admin/planning/set_agents_concern.rb
@@ -3,7 +3,7 @@ module Admin::Planning::SetAgentsConcern
 
   included do
     before_action do
-      @beta_planning_layout = current_agent.feature_enabled?("new_planning")
+      @beta_planning_layout = current_agent.feature_enabled?(Agent::FeatureFlags::NEW_PLANNING)
     end
   end
 
@@ -19,7 +19,7 @@ module Admin::Planning::SetAgentsConcern
       @agent = scope.where(id: agents).first
       @agents = [@agent]
     else
-      if current_agent.feature_enabled?("new_planning")
+      if current_agent.feature_enabled?(Agent::FeatureFlags::NEW_PLANNING)
         @agents = scope.where(id: agents)
       else
         # Si l'agent courant n'a pas activé la feature on ne considère qu'il n'y

--- a/app/controllers/super_admins/agents_controller.rb
+++ b/app/controllers/super_admins/agents_controller.rb
@@ -60,14 +60,13 @@ module SuperAdmins
       agent = Agent.find(params[:agent_id])
       feature = params[:feature]
 
-      agent.toggle_feature!(feature)
-
-      flash[:notice] =
-        if agent.feature_enabled?(feature)
-          "#{feature} activé pour #{agent.email}"
-        else
-          "#{feature} désactivé pour #{agent.email}"
-        end
+      if params[:set_to] == "true"
+        agent.enable_feature!(feature)
+        flash[:notice] = "#{feature} activé pour #{agent.email}"
+      else
+        agent.disable_feature!(feature)
+        flash[:notice] = "#{feature} désactivé pour #{agent.email}"
+      end
 
       redirect_to super_admins_agent_path(agent)
     end

--- a/app/models/concerns/agent/feature_flags.rb
+++ b/app/models/concerns/agent/feature_flags.rb
@@ -30,6 +30,8 @@ module Agent::FeatureFlags
   end
 
   def validate_feature_names
+    return unless feature_flags_changed?
+
     invalid_features = feature_flags.keys - AVAILABLE_FEATURES
     invalid_features.each { errors.add(:feature_flags, "Invalid feature name: #{_1.inspect}") }
   end

--- a/app/models/concerns/agent/feature_flags.rb
+++ b/app/models/concerns/agent/feature_flags.rb
@@ -7,28 +7,27 @@ module Agent::FeatureFlags
   AVAILABLE_FEATURES = [CALDAV_SYNC, NEW_PLANNING].freeze
 
   def feature_enabled?(feature)
-    feature_flags && feature_flags[feature] == true
+    validate_feature_name(feature)
+    feature_flags[feature] == true
   end
 
-  def toggle_feature!(feature)
-    if feature_enabled?(feature)
-      disable_feature(feature)
-    else
-      enable_feature(feature)
-    end
-    update!(feature_flags: feature_flags)
+  def enable_feature!(feature)
+    set_feature!(feature, true)
+  end
+
+  def disable_feature!(feature)
+    set_feature!(feature, false)
   end
 
   private
 
-  def enable_feature(feature)
-    return unless AVAILABLE_FEATURES.include?(feature)
-
-    self.feature_flags ||= {}
-    self.feature_flags[feature] = true
+  def set_feature!(feature, set_to)
+    validate_feature_name(feature)
+    feature_flags[feature] = set_to
+    update!(feature_flags: feature_flags)
   end
 
-  def disable_feature(feature)
-    self.feature_flags&.delete(feature)
+  def validate_feature_name(feature)
+    Sentry.capture_message("Invalid feature: #{feature.inspect}") unless feature.in?(AVAILABLE_FEATURES)
   end
 end

--- a/app/models/concerns/agent/feature_flags.rb
+++ b/app/models/concerns/agent/feature_flags.rb
@@ -6,10 +6,6 @@ module Agent::FeatureFlags
 
   AVAILABLE_FEATURES = [CALDAV_SYNC, NEW_PLANNING].freeze
 
-  included do
-    before_save :validate_feature_names
-  end
-
   def feature_enabled?(feature)
     feature_flags[feature] == true
   end
@@ -25,14 +21,9 @@ module Agent::FeatureFlags
   private
 
   def set_feature!(feature, set_to)
+    raise "Invalid feature name: #{feature.inspect}" unless feature.in?(AVAILABLE_FEATURES)
+
     feature_flags[feature] = set_to
     update!(feature_flags: feature_flags)
-  end
-
-  def validate_feature_names
-    return unless feature_flags_changed?
-
-    invalid_features = feature_flags.keys - AVAILABLE_FEATURES
-    invalid_features.each { errors.add(:feature_flags, "Invalid feature name: #{_1.inspect}") }
   end
 end

--- a/app/models/concerns/agent/feature_flags.rb
+++ b/app/models/concerns/agent/feature_flags.rb
@@ -6,8 +6,11 @@ module Agent::FeatureFlags
 
   AVAILABLE_FEATURES = [CALDAV_SYNC, NEW_PLANNING].freeze
 
+  included do
+    before_save :validate_feature_names
+  end
+
   def feature_enabled?(feature)
-    validate_feature_name(feature)
     feature_flags[feature] == true
   end
 
@@ -22,12 +25,12 @@ module Agent::FeatureFlags
   private
 
   def set_feature!(feature, set_to)
-    validate_feature_name(feature)
     feature_flags[feature] = set_to
     update!(feature_flags: feature_flags)
   end
 
-  def validate_feature_name(feature)
-    Sentry.capture_message("Invalid feature: #{feature.inspect}") unless feature.in?(AVAILABLE_FEATURES)
+  def validate_feature_names
+    invalid_features = feature_flags.keys - AVAILABLE_FEATURES
+    invalid_features.each { errors.add(:feature_flags, "Invalid feature name: #{_1.inspect}") }
   end
 end

--- a/app/policies/super_admin/agent_policy.rb
+++ b/app/policies/super_admin/agent_policy.rb
@@ -8,5 +8,5 @@ class SuperAdmin::AgentPolicy < DefaultSuperAdminPolicy
   alias edit? team_member?
   alias update? team_member?
   alias destroy? team_member?
-  alias toggle_feature? team_member?
+  alias set_feature? team_member?
 end

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -28,7 +28,7 @@ nav.left-side-menu-wrapper
           = render "layouts/left_menu/organisation_switcher"
 
         li.fr-pb-0
-          - if current_agent.feature_enabled?("new_planning")
+          - if current_agent.feature_enabled?(Agent::FeatureFlags::NEW_PLANNING)
             = active_link_to(admin_organisation_planning_agenda_path(current_organisation), active: @beta_planning_layout, class: "side-menu__item")
               span.fr-icon-calendar-event-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
               | Planning

--- a/app/views/super_admins/agents/show.html.slim
+++ b/app/views/super_admins/agents/show.html.slim
@@ -36,9 +36,9 @@ section.main-content__body
             tr
               td= feature
               td Activée
-              td= link_to "Désactiver", toggle_feature_super_admins_agent_path(agent_id: page.resource.id, feature: feature), method: :post, class: "button"
+              td= link_to "Désactiver", toggle_feature_super_admins_agent_path(agent_id: page.resource.id, feature: feature, set_to: "false"), method: :post, class: "button"
           - else
             tr
               td= feature
               td Désactivée
-              td= link_to "Activer", toggle_feature_super_admins_agent_path(agent_id: page.resource.id, feature: feature), method: :post, class: "button"
+              td= link_to "Activer", toggle_feature_super_admins_agent_path(agent_id: page.resource.id, feature: feature, set_to: "true"), method: :post, class: "button"

--- a/spec/features/autodoc/planning_multi_agents_spec.rb
+++ b/spec/features/autodoc/planning_multi_agents_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Nouveau planning / planning multi-agents", js: true do
     #
 
     doc.start_section("Quand l'agent active la feature (actuellement faisable depuis le super-admin)")
-    agent_basique.toggle_feature!("new_planning")
+    agent_basique.enable_feature!(Agent::FeatureFlags::NEW_PLANNING)
     visit admin_organisation_planning_agenda_path(organisation)
     expect(page).to have_content("Planning de")
     doc.add_screenshot(page, text: "Une nouvelle navigation est proposée, où le choix de l'agent et du sous-menu sont dans la page principale et non plus dans le menu",

--- a/spec/models/concerns/agent/feature_flags_spec.rb
+++ b/spec/models/concerns/agent/feature_flags_spec.rb
@@ -3,65 +3,62 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
     let(:agent) { create(:agent, feature_flags: { new_planning: true }) }
 
     it "retourne true si la fonctionnalité est activée pour l’agent" do
-      expect(agent.feature_enabled?("new_planning")).to be true
+      expect(create(:agent, feature_flags: { new_planning: true }).feature_enabled?("new_planning")).to be true
     end
 
-    it "retourne false si la fonctionnalité n’est pas activée pour l’agent" do
+    it "retourne false si la fonctionnalité n'est pas activée pour l’agent" do
+      expect(create(:agent, feature_flags: {}).feature_enabled?("new_planning")).to be false
+    end
+
+    it "retourne false si la fonctionnalité est désactivée pour l’agent" do
+      expect(create(:agent, feature_flags: { new_planning: false }).feature_enabled?("new_planning")).to be false
+    end
+
+    it "retourne false et prévient Sentry si la fonctionnalité n’est pas déclarée dans les constantes" do
       expect(agent.feature_enabled?("non_existent_feature")).to be false
+      expect(sentry_events.last.message).to eq(%(Invalid feature: "non_existent_feature"))
     end
   end
 
-  describe "enable_feature" do
+  describe "enable_feature!" do
     let(:agent) { create(:agent) }
 
-    it "active la fonctionnalité" do
-      agent.send(:enable_feature, "new_planning")
+    it "active la fonctionnalité (idempotent)" do
+      expect(agent.feature_enabled?("new_planning")).to be false
+      agent.enable_feature!("new_planning")
+      expect(agent.feature_enabled?("new_planning")).to be true
+
+      # L'action est idempotente
+      agent.enable_feature!("new_planning")
       expect(agent.feature_enabled?("new_planning")).to be true
     end
 
-    it "ne fait rien si la fonctionnalité n’existe pas" do
-      agent.send(:enable_feature, "invalid_feature")
-      expect(agent.feature_enabled?("invalid_feature")).to be false
-    end
-
-    it "crée le hash si feature_flags est nil" do
-      agent.feature_flags = nil
-      agent.send(:enable_feature, "new_planning")
-      expect(agent.feature_flags).to eq({ "new_planning" => true })
+    it "ne fait rien et prévient Sentry si la fonctionnalité n’existe pas" do
+      expect(agent.feature_enabled?("new_planning")).to be false
+      agent.enable_feature!("non_existent_feature")
+      expect(agent.feature_enabled?("new_planning")).to be false
+      expect(sentry_events.last.message).to eq(%(Invalid feature: "non_existent_feature"))
     end
   end
 
-  describe "disable_feature" do
+  describe "disable_feature!" do
     let(:agent) { create(:agent, feature_flags: { new_planning: true }) }
 
-    it "désactive la fonctionnalité" do
-      agent.send(:disable_feature, "new_planning")
+    it "désactive la fonctionnalité (idempotent)" do
+      expect(agent.feature_enabled?("new_planning")).to be true
+      agent.disable_feature!("new_planning")
+      expect(agent.feature_enabled?("new_planning")).to be false
+
+      # L'action est idempotente
+      agent.disable_feature!("new_planning")
       expect(agent.feature_enabled?("new_planning")).to be false
     end
 
-    it "ne fait rien si on essaye de désactiver une fonctionnalité inexistante" do
-      expect { agent.send(:disable_feature, "non_existent_feature") }.not_to raise_error
-      expect(agent.feature_flags).to eq({ "new_planning" => true })
-    end
-  end
-
-  describe "toggle_feature!" do
-    let(:agent) { create(:agent, feature_flags: { new_planning: true }) }
-
-    it "désactive une fonctionnalité activée" do
-      agent.toggle_feature!("new_planning")
-      expect(agent.reload.feature_enabled?("new_planning")).to be false
-    end
-
-    it "active une fonctionnalité désactivée" do
-      agent.send(:disable_feature, "new_planning")
-      agent.toggle_feature!("new_planning")
-      expect(agent.reload.feature_enabled?("new_planning")).to be true
-    end
-
-    it "ne fait rien si la fonctionnalité n’existe pas" do
-      expect { agent.toggle_feature!("invalid_feature") }.not_to raise_error
-      expect(agent.reload.feature_flags).to eq({ "new_planning" => true })
+    it "ne fait rien et prévient Sentry si la fonctionnalité n’existe pas" do
+      expect(agent.feature_enabled?("new_planning")).to be true
+      agent.disable_feature!("non_existent_feature")
+      expect(agent.feature_enabled?("new_planning")).to be true
+      expect(sentry_events.last.message).to eq(%(Invalid feature: "non_existent_feature"))
     end
   end
 end

--- a/spec/models/concerns/agent/feature_flags_spec.rb
+++ b/spec/models/concerns/agent/feature_flags_spec.rb
@@ -14,9 +14,8 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
       expect(create(:agent, feature_flags: { new_planning: false }).feature_enabled?("new_planning")).to be false
     end
 
-    it "retourne false et prévient Sentry si la fonctionnalité n’est pas déclarée dans les constantes" do
+    it "retourne false si la fonctionnalité n’est pas déclarée dans les constantes" do
       expect(agent.feature_enabled?("non_existent_feature")).to be false
-      expect(sentry_events.last.message).to eq(%(Invalid feature: "non_existent_feature"))
     end
   end
 
@@ -33,11 +32,11 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
       expect(agent.feature_enabled?("new_planning")).to be true
     end
 
-    it "ne fait rien et prévient Sentry si la fonctionnalité n’existe pas" do
+    it "invalide le modèle si la fonctionnalité n’existe pas" do
       expect(agent.feature_enabled?("new_planning")).to be false
       agent.enable_feature!("non_existent_feature")
       expect(agent.feature_enabled?("new_planning")).to be false
-      expect(sentry_events.last.message).to eq(%(Invalid feature: "non_existent_feature"))
+      expect(agent.errors.sole).to have_attributes(message: %(Invalid feature name: "non_existent_feature"))
     end
   end
 
@@ -54,11 +53,11 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
       expect(agent.feature_enabled?("new_planning")).to be false
     end
 
-    it "ne fait rien et prévient Sentry si la fonctionnalité n’existe pas" do
+    it "invalide le modèle si la fonctionnalité n’existe pas" do
       expect(agent.feature_enabled?("new_planning")).to be true
       agent.disable_feature!("non_existent_feature")
       expect(agent.feature_enabled?("new_planning")).to be true
-      expect(sentry_events.last.message).to eq(%(Invalid feature: "non_existent_feature"))
+      expect(agent.errors.sole).to have_attributes(message: %(Invalid feature name: "non_existent_feature"))
     end
   end
 end

--- a/spec/models/concerns/agent/feature_flags_spec.rb
+++ b/spec/models/concerns/agent/feature_flags_spec.rb
@@ -32,11 +32,10 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
       expect(agent.feature_enabled?("new_planning")).to be true
     end
 
-    it "invalide le modèle si la fonctionnalité n’existe pas" do
-      expect(agent.feature_enabled?("new_planning")).to be false
-      agent.enable_feature!("non_existent_feature")
-      expect(agent.feature_enabled?("new_planning")).to be false
-      expect(agent.errors.sole).to have_attributes(message: %(Invalid feature name: "non_existent_feature"))
+    it "lève une erreur si la fonctionnalité n’existe pas" do
+      expect do
+        agent.enable_feature!("non_existent_feature")
+      end.to raise_error(%(Invalid feature name: "non_existent_feature"))
     end
   end
 
@@ -53,11 +52,10 @@ RSpec.describe Agent::FeatureFlags, type: :concern do
       expect(agent.feature_enabled?("new_planning")).to be false
     end
 
-    it "invalide le modèle si la fonctionnalité n’existe pas" do
-      expect(agent.feature_enabled?("new_planning")).to be true
-      agent.disable_feature!("non_existent_feature")
-      expect(agent.feature_enabled?("new_planning")).to be true
-      expect(agent.errors.sole).to have_attributes(message: %(Invalid feature name: "non_existent_feature"))
+    it "lève une erreur si la fonctionnalité n’existe pas" do
+      expect do
+        agent.disable_feature!("non_existent_feature")
+      end.to raise_error(%(Invalid feature name: "non_existent_feature"))
     end
   end
 end


### PR DESCRIPTION
# Contexte

Je travaille sur l'ajout d'un toggle qui permet aux agent d'activer le feature flag `"new_planning"` en autonomie.

Lors de la conception du controller qui permet d'effectuer ces changements, j'ai réfléchi à la façon la plus robuste et explicite de manipuler les feature flags, et je pense qu'il faut éviter la notion de "toggle". En effet, si on a des APIs (actions de controllers, mais aussi les méthodes d'instance de `Agent::FeatureFlags`) qui proposent un "toggle", alors l'**effet désiré dépend de l'état actuel de l'objet**. Autrement dit, à chaque usage de "#toggle", il faut retrouver le contexte pour savoir si on est en train d'activer ou de désactiver le booléen.

Ce design est à l'origine d'un "bug" (mineur, soyons honnêtes) : si je double-clique sur le bouton "Activer" d'une feature dans la fiche agent du super-admin, la requête est envoyée deux fois et donc la feature est activée puis désactivée d'un coup.

# Solution

Cette PR propose de passer à un système explicite : on peut soit activer une feature, soit la désactiver, mais pas la toggle.

Cela permet de simplifier et expliciter la classe `Agent::FeatureFlags`. 

# Valeur par défaut de `Agent#feature_flags`

Le nouveau code suppose que `feature_flags` n'est jamais `nil`, car de fait il ne sera jamais `nil` avec notre valeur par défaut dans Postgres. J'ai vérifié : 

```ruby
Agent.distinct(:feature_flags).pluck(:feature_flags).uniq
# => [{}, {"caldav_sync" => true, "new_planning" => true}, {"caldav_sync" => true}, {"new_planning" => true}]
```

Si vous êtes frileux je pense qu'on peut simplement rajouter `def feature_flags = super || {}`, mais je crois que c'est superflu ! :wink: 

## Constantes

J'ai utilisé les constantes partout plutôt que des `"new_planning"` qui flottent !

## Validation sur les noms de features

Sur le comportement à avoir si on passe un nom de feature invalide, j'ai essayé plusieurs versions (voir les commits), et j'ai fini par considérer que le check pouvais se faire uniquement quand on utilise les méthodes publiques, mais que si on veut bypass et écrire direct dans l'attribut `feature_flags`, c'est raisonnable.