### PR TITLE
Évite des connexions à Redis inutiles (feature salle d'attente)

### DIFF
--- a/app/models/concerns/rdv/using_waiting_room.rb
+++ b/app/models/concerns/rdv/using_waiting_room.rb
@@ -6,8 +6,10 @@ module Rdv::UsingWaitingRoom
   REDIS_WAITING_ROOM_KEY = "#{Rails.env}:users_in_waiting_room".freeze
 
   def user_in_waiting_room?
+    return false unless status == "unknown"
+
     Redis.with_connection do |redis|
-      status == "unknown" && redis.sismember(REDIS_WAITING_ROOM_KEY, id)
+      redis.sismember(REDIS_WAITING_ROOM_KEY, id)
     end
   end
 

--- a/app/models/concerns/rdv/using_waiting_room.rb
+++ b/app/models/concerns/rdv/using_waiting_room.rb
@@ -11,6 +11,9 @@ module Rdv::UsingWaitingRoom
     Redis.with_connection do |redis|
       redis.sismember(REDIS_WAITING_ROOM_KEY, id)
     end
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+    false
   end
 
   def set_user_in_waiting_room!


### PR DESCRIPTION
Deux choses sont faites ici : 
- on évite de demander une connexion dans le pool Redis si on n'en a pas besoin (`status != "unknown"`)
- si on échoue à récupérer le statut depuis Redis, on prévient Sentry et on affiche pas que le RDV a quelqu'un en salle d'attente (c'est mieux que de crasher l'agenda... peut-être ?)