### PR TITLE
Envoyer à Sentry les paramètres et le body des requêtes HTTP

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -131,3 +131,6 @@ ENABLE_PROCONNECT_SIRET=true
 
 # Password for seeding users and agents
 DB_SEEDS_USERS_AND_AGENTS_PASSWORD=Rdvservicepublictest1!
+
+# optional HTACCESS for health routes that could DDOS Sentry
+HEALTH_CONTROLLER_HTACCESS=lerdvest:partout

--- a/.env.sample
+++ b/.env.sample
@@ -132,5 +132,5 @@ ENABLE_PROCONNECT_SIRET=true
 # Password for seeding users and agents
 DB_SEEDS_USERS_AND_AGENTS_PASSWORD=Rdvservicepublictest1!
 
-# optional HTACCESS for health routes that could DDOS Sentry
-HEALTH_CONTROLLER_HTACCESS=lerdvest:partout
+# optional basic auth for health routes that could DDOS Sentry
+HEALTH_CONTROLLER_BASIC_AUTH=lerdvest:partout

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -1,7 +1,5 @@
 # Pour la doc d'Agent Connect: voir https://github.com/france-connect/Documentation-AgentConnect/blob/main/doc_fs.md#32-je-veux-savoir-comment-fonctionne-agentconnect-et-comment-identifierauthentifier-les-agents
 class AgentConnectController < ApplicationController
-  before_action :log_params_to_sentry
-
   def auth
     auth_client = AgentConnectOpenIdClient::Auth.new(
       login_hint: params[:login_hint],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,20 +40,6 @@ class ApplicationController < ActionController::Base
     @current_prescripteur ||= Prescripteur.new(session[:autocomplete_prescripteur_attributes])
   end
 
-  # By default, Sentry does not log request URL and params because they could
-  # contain personal information. See documentation for `config.send_default_pii` :
-  # https://docs.sentry.io/platforms/ruby/guides/rack/migration/#removed-processors
-  # This method is meant to be used to debug specific actions for which we have
-  # Sentry entries, and thus need more context to debug.
-  def log_params_to_sentry
-    # The Sentry scope only lives for the current request (it uses threads)
-    Sentry.configure_scope do |scope|
-      scope.set_context("params", params.to_unsafe_h)
-      scope.set_context("url", { "request.original_url" => request.original_url })
-      scope.set_context("session", { "key" => "session:#{session.id}" })
-    end
-  end
-
   def authenticate_inviter!
     authenticate_agent!(force: true)
   end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -4,9 +4,9 @@ class OnPurposeError < StandardError; end
 
 class HealthController < ApplicationController
   # this HTACCESS should be set on production to avoid DDOS of our Sentry
-  htaccess_name, htaccess_password = ENV["HEALTH_CONTROLLER_HTACCESS"]&.split(":")
-  if htaccess_name && htaccess_password
-    http_basic_authenticate_with name: htaccess_name, password: htaccess_password, only: :raise_on_purpose
+  basic_auth_name, basic_auth_password = ENV["HEALTH_CONTROLLER_BASIC_AUTH"]&.split(":")
+  if basic_auth_name && basic_auth_password
+    http_basic_authenticate_with name: basic_auth_name, password: basic_auth_password, only: :raise_on_purpose
   end
 
   def db_connection

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,10 +1,21 @@
 class JobsNotScheduledCorrectly < StandardError; end
 class JobsCongestionError < StandardError; end
+class OnPurposeError < StandardError; end
 
 class HealthController < ApplicationController
+  # this HTACCESS should be set on production to avoid DDOS of our Sentry
+  htaccess_name, htaccess_password = ENV["HEALTH_CONTROLLER_HTACCESS"]&.split(":")
+  if htaccess_name && htaccess_password
+    http_basic_authenticate_with name: htaccess_name, password: htaccess_password, only: :raise_on_purpose
+  end
+
   def db_connection
     Territory.count # cette ligne raisera en cas de problème de connexion
     render status: :ok, plain: "health OK"
+  end
+
+  def raise_on_purpose
+    raise OnPurposeError, "au 4ème top il sera #{Time.zone.now}"
   end
 
   def jobs_queues

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,6 +1,4 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  before_action :log_params_to_sentry
-
   def microsoft_graph
     if current_agent.update(microsoft_graph_token: microsoft_graph_token, refresh_microsoft_graph_token: refresh_microsoft_graph_token)
       Outlook::MassCreateEventJob.perform_later(current_agent)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -11,6 +11,14 @@ Sentry.init do |config|
   # et https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/
   config.excluded_exceptions -= ["ActiveRecord::RecordNotFound"]
 
+  # send_default_pii est désactivé par défaut
+  # L’activer envoie par défaut pour toutes les requêtes HTTP : les params, le body, les cookies, l’IP.
+  # On retire les cookies et l’IP dont on n’a pas d’utilité directe dans le before_send ci-dessous.
+  # Ça a été discuté et validé en termes de protection des données sensibles.
+  # cf https://docs.sentry.io/platforms/ruby/guides/rack/migration/#removed-processors
+  # cf https://github.com/betagouv/rdv-service-public/pull/5762
+  config.send_default_pii = true
+
   config.before_send = lambda do |event, _hint|
     return event if !event.respond_to?(:exception) || !event.exception
 
@@ -29,6 +37,11 @@ Sentry.init do |config|
       redirected_from_sign_in = referer == agent_sign_in_url
       return if record_not_found && redirected_from_sign_in
     end
+
+    # on retire les cookies et l’IP qui viennent de send_default_pii mais qu’on ne veut pas conserver
+    # les IP sont aussi filtrées côté serveur Sentry, c’est une protection supplémentaire ici
+    Sentry::RequestInterface::IP_HEADERS.each { event.request&.headers&.delete(_1) }
+    event.request&.cookies = []
 
     event
   rescue StandardError

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -374,7 +374,6 @@ Rails.application.routes.draw do
   get "health/jobs_queues" => "health#jobs_queues"
   get "health/jobs_scheduled" => "health#jobs_scheduled"
   get "health/raise_on_purpose" => "health#raise_on_purpose"
-  post "health/raise_on_purpose" => "health#raise_on_purpose"
 
   get "/budget", to: redirect("https://pad.numerique.gouv.fr/rHMnemklQm6Sww5yVCI9ow?view#RDV-Service-Public", status: 302)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -373,6 +373,8 @@ Rails.application.routes.draw do
   get "health_check" => "health#db_connection"
   get "health/jobs_queues" => "health#jobs_queues"
   get "health/jobs_scheduled" => "health#jobs_scheduled"
+  get "health/raise_on_purpose" => "health#raise_on_purpose"
+  post "health/raise_on_purpose" => "health#raise_on_purpose"
 
   get "/budget", to: redirect("https://pad.numerique.gouv.fr/rHMnemklQm6Sww5yVCI9ow?view#RDV-Service-Public", status: 302)
 


### PR DESCRIPTION
# Contexte

Depuis plusieurs années on n’envoie plus les params ni le body des requêtes HTTP à Sentry. Ces infos sont pourtant super utiles pour comprendre ce qu’il s’est passé.

Cette décision avait été prise par Sentry de changer le défaut. On l’a probablement suivie pour éviter des soucis de données confidentielles qui se retrouveraient au mauvais endroit. 

Aujourd’hui on a des conseils juridiques plus officiels. Ils nous confirment qu’on peut envoyer ces données à Sentry cf https://mattermost.incubateur.net/betagouv/pl/d1s9yrikzigmxk8y337nfqa5ja. Il faudrait rajouter le sous-traitant qui héberge sentry.incubateur.net à notre AIPD. 

On a déjà du scrubbing fait automatiquement côté Sentry pour les mots de passe et tout ce qui ressemble à un token d’authentification.

# Solution

- Activer la config `Sentry.send_default_pii` : envoi des cookies, du body, des params GET et de l’IP (voir ci-dessous)
- nettoyage de l’IP et des cookies dans `before_send` pour ne pas envoyer des infos dont on n’a pas besoin a priori
- supprimer `log_params_to_sentry`

J’ai essayé de faire dans l’autre sens : ne pas activer `send_default_pii` mais injecter les params et le body dans le before_send mais ce n’était pas évident

## scrubbing des données sensibles

Sentry côté backend est configuré pour scrubber les IP et les mots de passes et tokens :

<img width="682" height="273" alt="image" src="https://github.com/user-attachments/assets/cc3e750b-7a9e-4229-b858-0886eebd5c14" />

cf https://sentry.incubateur.net/settings/betagouv/projects/lapins/security-and-privacy/

## Nouvelle route 

Je propose aussi de rajouter une route `health/raise_on_purpose`. Je trouve ça utile pour : 

- tester que Sentry est up et fonctionnel : par ex le downtime d’il y a quelques jours
- tester notre config Sentry lorsqu’on la change : par ex maintenant tester le passage des params.

J’anticipe un peu mais pour nous prémunir d’éventuelles DDOS de Sentry je propose une HTTP Basic Auth sur cette route. ça rajoute une variable d’env 🤷 

# Tests et captures d’écran

cf https://sentry.incubateur.net/organizations/betagouv/issues/211379/?

Requête GET : 

aller sur https://rdv-service-public-review-app-pr5762.osc-secnum-fr1.scalingo.io/health/raise_on_purpose?param1=val1&param2=val2

<img width="934" height="599" alt="image" src="https://github.com/user-attachments/assets/f60d5cc9-a8a6-4c54-a77e-3a3c87b16e45" />


Requête POST : 

```sh
http post https://www.rdv-service-public-review-app-pr5762.osc-secnum-fr1.scalingo.io/health/raise_on_purpose body1=val1 body2=val2
```

ça devrait fonctionner, moi j’ai une erreur SSL certificat en local je n’ai pas envie de regarder je soupçonne openssl 3.6

testé en local ça donne ça : 

<img width="562" height="655" alt="image" src="https://github.com/user-attachments/assets/8f9fb39d-108a-424f-9a14-8e9ee7e19cab" />


