### PR TITLE
Bugfix : crash quand on visite un RDV depuis l'agenda multi-agents

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -148,7 +148,10 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def set_optional_agent
-    @agent = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(params[:agent_id]) if params[:agent_id].present?
+    agent_ids = Array(params[:agent_id]).compact_blank
+    if agent_ids.size == 1
+      @agent = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(agent_ids.sole)
+    end
   end
 
   def parse_date_from_params(date_param)

--- a/spec/features/agents/planning/keeping_agent_context_spec.rb
+++ b/spec/features/agents/planning/keeping_agent_context_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe "permettre de revenir à l'agenda d'un collègue après avoir cliqué sur un RDV pour le modifier" do
+  let(:territory) { create(:territory, work_on_sunday: true) } # nécessaire pour lancer cette spec un dimanche
+  let(:organisation) { create(:organisation) }
+  let!(:current_agent) { create(:agent, first_name: "Agent", last_name: "COURANT", admin_role_in_organisations: [organisation], display_saturdays: true) }
+  let!(:collegue) { create(:agent, first_name: "Mon", last_name: "COLLEGUE", admin_role_in_organisations: [organisation]) }
+  let!(:usager_du_rdv) { create(:user, first_name: "Usager", last_name: "DU RDV") }
+  let!(:rdv_du_collegue) do
+    create(
+      :rdv,
+      :no_service,
+      organisation:,
+      starts_at: Time.zone.today.beginning_of_day + 8.hours,
+      agents: [collegue],
+      users: [usager_du_rdv]
+    )
+  end
+
+  it "fonctionne quand j'ai un seul agent sélectionné dans l'agenda", js: true do
+    login_as(current_agent, scope: :agent)
+
+    visit admin_organisation_planning_agenda_path(organisation)
+    find("#select2-planning_agent_select-container").click
+    find(%(.select2-results__option), text: "COLLEGUE Mon").click
+    expect(page).to have_content("Agenda de Mon COLLEGUE")
+    click_on "Usager DU RDV" # on clique sur le RDV dans l'agenda
+
+    expected_fil_ariane = "Accueil  Agenda de Mon COLLEGUE  RDV Usager DU RDV"
+    expect(page).to have_content(expected_fil_ariane)
+    click_on "Modifier"
+    expect(page).to have_content(expected_fil_ariane)
+    fill_in "rdv_duration_in_min", with: "240"
+    click_on "Enregistrer"
+    click_on "Confirmer en ignorant les avertissements" if page.body.include?("Confirmer en ignorant les avertissements") # modification d'un RDV dans le passé
+    expect(rdv_du_collegue.reload.duration_in_min).to eq(240)
+    expect(page).to have_content(expected_fil_ariane)
+    click_on "Agenda de Mon COLLEGUE"
+    expect(page).to have_content("Agenda de Mon COLLEGUE")
+  end
+
+  it "fonctionne quand j'ai plusieurs agents sélectionnés dans l'agenda", js: true do
+    current_agent.enable_feature!(Agent::FeatureFlags::NEW_PLANNING)
+    login_as(current_agent, scope: :agent)
+
+    visit admin_organisation_planning_agenda_path(organisation)
+    click_on "Sélectionner plusieurs agents"
+    find("#planning_agents_select .select2-container").click
+    find(%(.select2-results__option), text: "COLLEGUE Mon").click
+    find("#submit_agents").click
+    click_on "Usager DU RDV" # on clique sur le RDV dans l'agenda
+
+    expected_fil_ariane = "Accueil  Liste des RDV  RDV Usager DU RDV"
+    expect(page).to have_content(expected_fil_ariane)
+  end
+end


### PR DESCRIPTION
# Contexte

Actuellement nous avons un bug en prod : lorsque l'on clique sur un RDV dans l'agenda multi-agents, nous avons une 500 :

https://github.com/user-attachments/assets/2c306d26-d6b1-4b24-b9a1-acb703c8d022

Pour rappel, lorsque nous arrivons sur  un show de RDV depuis un agenda, nous voulons customiser le fil d'ariane afin de permettre de revenir facilement vers l'agenda depuis le show (et le edit). Le crash est ici causé par le fait que `@agent` est parfois un tableau et que la vue ne sait pas le gérer.

# Solution

Idéalement il faudrait que la génération du fil d'ariane gère désormais le multi-agents, mais pour ce faire j'aimerais proposer un refacto plus poussé dans #5767.

Cette PR fait donc le minimum pour éviter le crash, et ne customise le fil d'ariane que si on est en mono-agent. 