### PR TITLE
Ne pas ajouter le lien "Review app" dans une PR si il existe déjà

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ rswag_api_v1: ## Re-generate swagger/v1/api.json by running API specs
 .DEFAULT_GOAL := help
 
 review_app: ## Create Scalingo review app for the PR linked to the current branch
-	/bin/sh scripts/create_review_app.sh
+	ruby scripts/create_review_app.rb
 
 enable_emails_on_review_app:
 	/bin/sh scripts/enable_emails_on_review_app.sh

--- a/scripts/create_review_app.rb
+++ b/scripts/create_review_app.rb
@@ -8,15 +8,15 @@ pr_body = `gh pr view --json body --jq '.body'`
 review_app_name = "rdv-service-public-review-app-pr#{pr_number}"
 review_app_url = "https://#{review_app_name}.osc-secnum-fr1.scalingo.io/"
 
+review_app_exists = system("scalingo --app #{review_app_name} stats", out: IO::NULL, err: IO::NULL)
+unless review_app_exists
+  puts "La review app n'existe pas, création en cours..."
+  system("scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app integration-link-manual-review-app #{pr_number}")
+end
+
 if pr_body.include?(review_app_url)
   puts "La description de PR contient déjà un lien vers la review app."
   exit(0)
-end
-
-review_app_exists = system("scalingo --app #{review_app_name} stats", out: IO::NULL, err: IO::NULL)
-unless review_app_exists
-  puts "La review app n'existe pas encore, création en cours..."
-  system("scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app integration-link-manual-review-app #{pr_number}")
 end
 
 link_to_review_app = "[Review app](#{review_app_url})"

--- a/scripts/create_review_app.rb
+++ b/scripts/create_review_app.rb
@@ -1,0 +1,26 @@
+require "shellwords"
+
+pr_number = `gh pr view --json number --jq '.number'`.strip
+exit(1) if $?.exitstatus != 0 # On quitte si aucune PR n'est liée à la branche courante
+
+pr_body = `gh pr view --json body --jq '.body'`
+review_app_name = "rdv-service-public-review-app-pr#{pr_number}"
+review_app_url = "https://#{review_app_name}.osc-secnum-fr1.scalingo.io/"
+
+if pr_body.include?(review_app_url)
+  puts "La description de PR contient déjà un lien vers la review app."
+  exit(0)
+end
+
+review_app_exists = system("scalingo --app #{review_app_name} stats", out: IO::NULL, err: IO::NULL)
+unless review_app_exists
+  puts "La review app n'existe pas encore, création en cours..."
+  system("scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app integration-link-manual-review-app #{pr_number}")
+end
+
+link_to_review_app = "[Review app](#{review_app_url})"
+new_body = "#{link_to_review_app}\n\n#{pr_body}"
+system("gh pr edit -b #{Shellwords.escape(new_body)}", out: IO::NULL, err: IO::NULL)
+puts "Lien ajouté à la description de PR : #{link_to_review_app}"
+
+exit(0)

--- a/scripts/create_review_app.rb
+++ b/scripts/create_review_app.rb
@@ -1,7 +1,8 @@
+require "English"
 require "shellwords"
 
 pr_number = `gh pr view --json number --jq '.number'`.strip
-exit(1) if $?.exitstatus != 0 # On quitte si aucune PR n'est liée à la branche courante
+exit(1) if $CHILD_STATUS.exitstatus != 0 # On quitte si aucune PR n'est liée à la branche courante
 
 pr_body = `gh pr view --json body --jq '.body'`
 review_app_name = "rdv-service-public-review-app-pr#{pr_number}"

--- a/scripts/create_review_app.sh
+++ b/scripts/create_review_app.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app integration-link-manual-review-app `gh pr view --json number --jq '.number'` &&
-gh pr edit -b "$(gh pr view --json body --jq '.body' | sed "1i\\
-[Review app](https://rdv-service-public-review-app-pr`gh pr view --json number --jq '.number'`.osc-secnum-fr1.scalingo.io/) \\
-
-")"


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr5768.osc-secnum-fr1.scalingo.io/)

J'avais envie d'un script de création de review app qui :
- n'ajoute pas le lien dans la PR si le lien est déjà là
- me donne des infos claires : si je suis sur une branche sans PR, si la review app n'existe pas, etc
- soit compréhensible pour les mortels (`sed` :skull: )