### PR TITLE
Bugfix: la synchro ICS plante durant le passage à l'heure d'hiver (LAPINS-3DA)

### DIFF
--- a/app/controllers/ics_calendar_controller.rb
+++ b/app/controllers/ics_calendar_controller.rb
@@ -65,7 +65,7 @@ class IcsCalendarController < ActionController::Base
     tzids = (@agent.organisations.pluck(:time_zone) + [Time.zone_default.tzinfo.identifier]).uniq
     tzids.each do |tzid|
       tz = TZInfo::Timezone.get(tzid)
-      ical_timezone = tz.ical_timezone(Time.zone.now)
+      ical_timezone = tz.ical_timezone(Time.zone.today.at_noon)
       cal.add_timezone(ical_timezone)
     end
   end

--- a/spec/features/agents/calendar_export_spec.rb
+++ b/spec/features/agents/calendar_export_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe "Agents can export their calendar to other tools, such as Outlook
         expect(page.body.gsub("\r\n", "\n")).to eq Rails.root.join("spec/support/calendar.ics").read
       end
 
+      it %(ne plante pas durant le passage à l'heure d'hiver, où "2h30" du mat' devient ambigu) do
+        travel_to(Time.zone.local(2025, 10, 26) + 2.hours + 30.minutes)
+        visit ics_calendar_path(agent.calendar_uid, format: :ics)
+        expect(page.body).to include("TZID:Europe/Paris")
+        expect(page.body).to include("DTSTART:20251026T020000")
+      end
+
       context "lorsque l’agent est dans une organisation ayant un fuseau horaire différent de celui de la métropole" do
         let(:organisation) { create(:organisation, time_zone: "America/Guadeloupe", id: 123_000) }
 


### PR DESCRIPTION
Issue Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/211855/

> 2025-10-26 02:59:56 is an ambiguous local time. (TZInfo::AmbiguousTime)

En préambule, je tiens à préciser que ce problème est vraiment peu important, et qu'on peut aussi décider de fermer cette PR et d'avoir une petite erreur une fois par an. :grimacing: 

# Contexte

Une fois par an, lors du passage à l'heure d'hiver, l'heure "2 heures du matin" devient ambiguë, puisqu'on passe de 02:59 à 02:00, donc on passe deux fois sur cette heure.

Le controller qui génère les flux ICS se met alors à planter car la gem `tzinfo` lève une erreur `TZInfo::AmbiguousTime` : 
https://github.com/tzinfo/tzinfo/blob/v2.0.6/lib/tzinfo/timezone.rb#L525 

# Solution

Je propose de passe `now.at_noon` plutôt que `now`.

Avantage : ça évite le crash annuel.

Inconvénient : on est pas sûrs que les tags `VTIMEZONE` seront exactement les bons quand on appelle l'endpoint entre minuit et 3h les nuis de changement d'heure. Mais bon, les `VTIMEZONE` ne sont pas utilisés par les calendriers modernes, qui ont leur propre TZINFO.