### PR TITLE
Rediriger vers l'URL initialement demandée après un login super-admin

### DIFF
--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -87,13 +87,15 @@ class AgentConnectController < ApplicationController
       SuperAdmin.create!(email: callback_client.user_email, first_name: callback_client.user_first_name, last_name: callback_client.user_last_name, role: :legacy_admin)
     end
 
+    super_admin_return_to = session.delete(:super_admin_return_to)
+
     super_admin = SuperAdmin.find_by(email: callback_client.user_email)
 
     if super_admin
       bypass_sign_in super_admin, scope: :super_admin
 
       session[:agent_connect_id_token] = callback_client.id_token_for_logout
-      redirect_to session.delete(:super_admin_return_to) || super_admins_agents_path
+      redirect_to super_admin_return_to || super_admins_agents_path
     else
       flash[:error] = "Compte ProConnect non autorisé"
       redirect_to connexion_super_admins_path

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -93,7 +93,7 @@ class AgentConnectController < ApplicationController
       bypass_sign_in super_admin, scope: :super_admin
 
       session[:agent_connect_id_token] = callback_client.id_token_for_logout
-      redirect_to super_admins_agents_path
+      redirect_to session.delete(:super_admin_return_to) || super_admins_agents_path
     else
       flash[:error] = "Compte ProConnect non autorisé"
       redirect_to connexion_super_admins_path

--- a/app/controllers/super_admins/application_controller.rb
+++ b/app/controllers/super_admins/application_controller.rb
@@ -60,7 +60,10 @@ module SuperAdmins
     end
 
     def authenticate_super_admin!
-      return redirect_to connexion_super_admins_path unless super_admin_signed_in?
+      unless super_admin_signed_in?
+        session[:super_admin_return_to] = request.fullpath
+        redirect_to connexion_super_admins_path and return
+      end
 
       super
     end

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe AgentConnectController do
           state:,
           connection_for: "super_admin",
         }
-        session[:super_admin_return_to] = "/super_admins/agents" # Pour simuler le retour vers la page demandée avant la connexion
+        session[:super_admin_return_to] = "/super_admins/lieux?search=arques" # Pour simuler le retour vers la page demandée avant la connexion
       end
 
       context "with a non 2FA account" do
@@ -216,7 +216,7 @@ RSpec.describe AgentConnectController do
             get :callback, params: { state: state, code: code }
 
             expect(session["agent_connect_id_token"]).to be_present
-            expect(response).to redirect_to("/super_admins/agents")
+            expect(response).to redirect_to("/super_admins/lieux?search=arques")
           end
         end
 
@@ -235,7 +235,7 @@ RSpec.describe AgentConnectController do
               email: "francis.factice@exemple.gouv.fr"
             )
             expect(session["agent_connect_id_token"]).to be_present
-            expect(response).to redirect_to("/super_admins/agents")
+            expect(response).to redirect_to("/super_admins/lieux?search=arques")
           end
         end
       end


### PR DESCRIPTION
# Contexte

Dans #5756, on est en train d'ajouter dans Zammad des liens vers des pages spécifiques du super admin.

Or actuellement, quand on visite une page spécifique du super admin mais qu'on nous demande de nous connecter, on perd la référence de cette page et on est redirigé⋅e vers la liste des agents.

# Solution

Très très classique : on stocke en session le path demandé originalement, puis on y redirige une fois de retour de ProConnect.

Ni veau test, c'est rigolo : on avait déjà dans les tests de callback ProConnect la ligne suivante : 

```ruby
session[:super_admin_return_to] = "/super_admins/agents" # Pour simuler le retour vers la page demandée avant la connexion
```

mais en réalité ça ne testait rien puisque `/super_admins/agents` est la redirection par défaut.

Je pense que ligne était là car les tests de callback ProConnect entre user, agent et super-admin sont similaires, et donc le copié-collé de ce setup de test avait été fait sans faire gaffe à l'URL de return to.
