### PR TITLE
Améliorer le choix de l’algorithme d’encryption ProConnect

### DIFF
--- a/app/services/agent_connect_open_id_client/callback.rb
+++ b/app/services/agent_connect_open_id_client/callback.rb
@@ -1,6 +1,6 @@
 # voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique
 module AgentConnectOpenIdClient
-  ALGORITHM = "ES256".freeze
+  ES256_ALGORITHM = "ES256".freeze
 
   class Callback
     class OpenIdFlowError < StandardError; end
@@ -118,7 +118,7 @@ module AgentConnectOpenIdClient
 
       handle_response_error(response)
 
-      JWT.decode(response.body, nil, true, algorithms: ALGORITHM, jwks: agent_connect_config.jwks).first
+      JWT.decode(response.body, nil, true, algorithms: ES256_ALGORITHM, jwks: agent_connect_config.jwks).first
     end
 
     def handle_response_error(response)

--- a/app/services/agent_connect_open_id_client/callback.rb
+++ b/app/services/agent_connect_open_id_client/callback.rb
@@ -1,5 +1,7 @@
 # voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique
 module AgentConnectOpenIdClient
+  ALGORITHM = "ES256".freeze
+
   class Callback
     class OpenIdFlowError < StandardError; end
     class ApiRequestError < StandardError; end
@@ -116,7 +118,7 @@ module AgentConnectOpenIdClient
 
       handle_response_error(response)
 
-      JWT.decode(response.body, nil, true, algorithms: agent_connect_config.jwks.first["alg"], jwks: agent_connect_config.jwks).first
+      JWT.decode(response.body, nil, true, algorithms: ALGORITHM, jwks: agent_connect_config.jwks).first
     end
 
     def handle_response_error(response)

--- a/config/initializers/agent_connect.rb
+++ b/config/initializers/agent_connect.rb
@@ -6,6 +6,10 @@ if ENV["AGENT_CONNECT_BASE_URL"].present?
   begin
     # la méthode .discover! fait un appel à l'api d'Agent Connect
     Rails.configuration.x.agent_connect_config = OpenIDConnect::Discovery::Provider::Config.discover!(ENV["AGENT_CONNECT_BASE_URL"])
+    supported_algorithms = Rails.configuration.x.agent_connect_config.id_token_signing_alg_values_supported
+    if supported_algorithms.exclude?(AgentConnectOpenIdClient::ALGORITHM)
+      raise "L'algorithme #{AgentConnectOpenIdClient::ALGORITHM} n’est pas dans la liste des algorithmes supportés par ProConnect"
+    end
   rescue StandardError => e
     error_message = <<~MSG
       Agent Connect n'est pas joignable au démarrage de l'application.

--- a/config/initializers/agent_connect.rb
+++ b/config/initializers/agent_connect.rb
@@ -7,8 +7,8 @@ if ENV["AGENT_CONNECT_BASE_URL"].present?
     # la méthode .discover! fait un appel à l'api d'Agent Connect
     Rails.configuration.x.agent_connect_config = OpenIDConnect::Discovery::Provider::Config.discover!(ENV["AGENT_CONNECT_BASE_URL"])
     supported_algorithms = Rails.configuration.x.agent_connect_config.id_token_signing_alg_values_supported
-    if supported_algorithms.exclude?(AgentConnectOpenIdClient::ALGORITHM)
-      raise "L'algorithme #{AgentConnectOpenIdClient::ALGORITHM} n’est pas dans la liste des algorithmes supportés par ProConnect"
+    if supported_algorithms.exclude?(AgentConnectOpenIdClient::ES256_ALGORITHM)
+      raise "L'algorithme #{AgentConnectOpenIdClient::ES256_ALGORITHM} n’est pas dans la liste des algorithmes supportés par ProConnect"
     end
   rescue StandardError => e
     error_message = <<~MSG


### PR DESCRIPTION
Edit : dans ma mégalomanie, j’ai tout à fait oublié de signaler ici que cette PR a été faite à deux mains avec @francois-ferrandis en pair ❤️ 

# Contexte

Je suis en train de faire fonctionner ProConnect en local pour tester la PR de François : #5716 

J’ai mis un moment à réussir à faire marcher ça et on a débloqué la situation avec François en pair. 

Il y avait un souci de décodage à cause du choix du mauvais algo. En effet, ProConnect a probablement modifié dans le formulaire l’algorithme qu’ils recommandent en premier de la liste et par défaut : c’était probablement ES256 et maintenant RS256. 

<img width="938" height="162" alt="image" src="https://github.com/user-attachments/assets/4adec5b2-817c-4197-9255-283ff3e9b363" />

# Solution

Dans le code on ne faisait pas de véritable choix de l’algo à utiliser, on appelait la méthode `jwks.first['alg']` . ça renvoie ES256 ce qui est un peu un hasard 🤷 

dans cette PR on explicite ce choix et on rajoute aussi une vérif bonus au démarrage que l’algo qu’on va utiliser pour décoder est compatible avec l’instance de ProConnect utilisée. 