### PR TITLE
Envoyer les notifs de tickets en attente Zammad vers la chaîne Mattermost de Vigie

### DIFF
--- a/app/jobs/cron_job/send_mattermost_notifications_for_zammad_tickets_job.rb
+++ b/app/jobs/cron_job/send_mattermost_notifications_for_zammad_tickets_job.rb
@@ -19,7 +19,7 @@ class CronJob::SendMattermostNotificationsForZammadTicketsJob < CronJob
 
     Rails.logger.debug "Sending message to Mattermost channel"
     MattermostApiClient.send_message(
-      channel: "startup-rdv-dev-notifs",
+      channel: "allo-vigie", # le nom de chaine est paramétrisé, les emojis disparaissent
       text: message,
       username: "Zammad",
       icon_url: "https://raw.githubusercontent.com/zammad/zammad/refs/heads/develop/public/assets/images/logo.svg"


### PR DESCRIPTION
Discuté ici https://mattermost.incubateur.net/betagouv/pl/jimawy5i3tnbur8a3gjh8p4iqe

Testé depuis le local, on peut bien poster vers une chaîne privée ✨ 