### PR TITLE
Corrige l'affichage du nom d'un espace dans les stats

### DIFF
--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -103,6 +103,8 @@ class Territory < ApplicationRecord
   LEGITIMATE_TOGGLES = OPTIONAL_FIELD_TOGGLES.slice(*legitimate_toggle_keys).freeze
   LEGACY_TOGGLES = OPTIONAL_FIELD_TOGGLES.except(*legitimate_toggle_keys).freeze
 
+  def to_s = name
+
   def mairies?
     name == MAIRIES_NAME
   end

--- a/app/views/stats/territory.html.slim
+++ b/app/views/stats/territory.html.slim
@@ -6,11 +6,11 @@
     = b.with_breadcrumb label: "Accueil", href: "/"
     = b.with_breadcrumb label: "Statistiques globales", href: stats_path
     = b.with_breadcrumb label: "Statistiques par structure", href: stats_territories_path
-    = b.with_breadcrumb label: @territory.to_s
+    = b.with_breadcrumb label: @territory.name_in_stats
 
 - content_for :title, "Statistiques par structure"
 
-h2= @territory
+h2= @territory.name_in_stats
 
 - if @territory.organisations.none?
   h3 Cette structure n'utilise pas #{current_domain.name}.


### PR DESCRIPTION
## Captures d'écran

Avant | Après
:- | -:
<img width="1438" height="704" alt="image" src="https://github.com/user-attachments/assets/284d6166-fb25-463c-b19e-fb8fd439be7a" /> | <img width="1438" height="704" alt="image" src="https://github.com/user-attachments/assets/55be67b8-396c-4761-a908-f0cc46f0aeeb" />

