### PR TITLE
Correctif de la marge pour les multi-select

### DIFF
--- a/app/javascript/stylesheets/components/_select2.scss
+++ b/app/javascript/stylesheets/components/_select2.scss
@@ -37,19 +37,24 @@
   .select2-selection--multiple
   .select2-search--inline
   .select2-search__field {
-  padding: 4px;
+  padding: 4px 4px 0 4px;
+  margin-top: 4px;
 }
 
 .select2-container--bootstrap4
   .select2-selection--multiple
   .select2-selection__choice {
   padding: 4px;
-  margin: 2px;
+  margin: 6px 2px 6px 4px;
 }
 
 .select2-dropdown {
   border-radius: 0;
   background-color: $input-bg;
+}
+
+.select2-selection__choice__remove {
+  padding-bottom: 2px;
 }
 
 // Border radius overrides


### PR DESCRIPTION

Avant | Après
:- | -:
<img width="519" height="102" alt="Screenshot 2025-10-28 at 11 30 38" src="https://github.com/user-attachments/assets/9e931f14-3cfd-46fb-b151-fed14233b879" />|<img width="469" height="97" alt="Screenshot 2025-10-28 at 11 29 35" src="https://github.com/user-attachments/assets/bfa557a9-9817-4cfd-9bca-e031e8b0cf1a" />

On est vraiment sur de la petite PR de cooldown : on corrige l'alignement des labels pour que ça soit un peu plus joli.


