### PR TITLE
Passages d'icônes de font-awesome au dsfr

### DIFF
--- a/app/helpers/dsfr_helper.rb
+++ b/app/helpers/dsfr_helper.rb
@@ -63,4 +63,9 @@ module DsfrHelper
       visio_icon(html_options)
     end
   end
+
+  def dsfr_return_btn_options
+    # On met un margin-left négatif pour conserver l'alignement quand on n'est pas en train de hover sur le bouton
+    { style: "margin-left: -16px", class: "fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-arrow-left-line" }
+  end
 end

--- a/app/javascript/stylesheets/components/_select2.scss
+++ b/app/javascript/stylesheets/components/_select2.scss
@@ -38,15 +38,13 @@
   .select2-search--inline
   .select2-search__field {
   padding: 4px;
-  padding-bottom: 0;
-  margin-top: 4px;
 }
 
 .select2-container--bootstrap4
   .select2-selection--multiple
   .select2-selection__choice {
   padding: 4px;
-  margin: 6px 2px 6px 4px;
+  margin: 2px;
 }
 
 .select2-dropdown {

--- a/app/javascript/stylesheets/components/_select2.scss
+++ b/app/javascript/stylesheets/components/_select2.scss
@@ -38,13 +38,15 @@
   .select2-search--inline
   .select2-search__field {
   padding: 4px;
+  padding-bottom: 0;
+  margin-top: 4px;
 }
 
 .select2-container--bootstrap4
   .select2-selection--multiple
   .select2-selection__choice {
   padding: 4px;
-  margin: 2px;
+  margin: 6px 2px 6px 4px;
 }
 
 .select2-dropdown {

--- a/app/views/admin/creneaux_search/_lieu_search_results.html.slim
+++ b/app/views/admin/creneaux_search/_lieu_search_results.html.slim
@@ -13,4 +13,4 @@
               br
               strong= l(next_availability.starts_at, format: :human)
             .col-auto.align-self-center
-              i.fa.fa-chevron-right
+              = icon("fr-icon-arrow-right-s-line")

--- a/app/views/admin/creneaux_search/_slots.html.slim
+++ b/app/views/admin/creneaux_search/_slots.html.slim
@@ -42,7 +42,7 @@ div id="creneaux-lieu-#{lieu&.id}"
                 br
                 strong= l(next_availability.starts_at, format: :human)
               .ml-2
-                i.fa.fa-chevron-right
+                = icon("fr-icon-arrow-right-s-line")
 
       .col-auto.d-flex.align-items-center
         = link_to admin_organisation_creneaux_search_selection_creneaux_path(search_params.merge(from_date: form.date_range.end + 1.day)), class: "btn btn-primary" do

--- a/app/views/admin/creneaux_search/_slots.html.slim
+++ b/app/views/admin/creneaux_search/_slots.html.slim
@@ -5,7 +5,7 @@ div id="creneaux-lieu-#{lieu&.id}"
     - if form.date_range.begin > Time.zone.today
       - previous_from_date = form.date_range.begin - 7.days
       .col-auto.d-flex.align-items-center
-        = link_to "Créneaux précédents", admin_organisation_creneaux_search_selection_creneaux_path(search_params.merge(from_date: previous_from_date)), class: "fr-btn fr-icon-arrow-left-line"
+        = link_to "Créneaux précédents", admin_organisation_creneaux_search_selection_creneaux_path(search_params.merge(from_date: previous_from_date)), class: "fr-btn fr-icon-arrow-left-s-line"
     .col
       .row.no-gutters.creneaux-row.lieu-creneaux-card
         - form.date_range.each do |date|
@@ -44,4 +44,4 @@ div id="creneaux-lieu-#{lieu&.id}"
                 = icon("fr-icon-arrow-right-s-line")
 
       .col-auto.d-flex.align-items-center
-        = link_to "Créneaux suivants", admin_organisation_creneaux_search_selection_creneaux_path(search_params.merge(from_date: form.date_range.end + 1.day)), class: "fr-btn fr-icon-arrow-right-line"
+        = link_to "Créneaux suivants", admin_organisation_creneaux_search_selection_creneaux_path(search_params.merge(from_date: form.date_range.end + 1.day)), class: "fr-btn fr-icon-arrow-right-s-line"

--- a/app/views/admin/creneaux_search/_slots.html.slim
+++ b/app/views/admin/creneaux_search/_slots.html.slim
@@ -5,8 +5,7 @@ div id="creneaux-lieu-#{lieu&.id}"
     - if form.date_range.begin > Time.zone.today
       - previous_from_date = form.date_range.begin - 7.days
       .col-auto.d-flex.align-items-center
-        = link_to admin_organisation_creneaux_search_selection_creneaux_path(search_params.merge(from_date: previous_from_date)), class: "btn btn-primary" do
-          i.fa.fa-arrow-left
+        = link_to "Créneaux précédents", admin_organisation_creneaux_search_selection_creneaux_path(search_params.merge(from_date: previous_from_date)), class: "fr-btn fr-icon-arrow-left-line"
     .col
       .row.no-gutters.creneaux-row.lieu-creneaux-card
         - form.date_range.each do |date|
@@ -28,7 +27,7 @@ div id="creneaux-lieu-#{lieu&.id}"
                   .text-left.m-1
                     span.strong.font-weight-bold= l(creneau.starts_at, format: "%H:%M")
                     br
-                    i class= "mr-1 fa fa-user-alt #{agent_color(agents.index(creneau.agent))}"
+                    = user_icon(class: agent_color(agents.index(creneau.agent)) + " fr-icon--sm fr-mr-1w")
                     small.text-dark= creneau.agent.short_name
 
     - if next_availability
@@ -45,5 +44,4 @@ div id="creneaux-lieu-#{lieu&.id}"
                 = icon("fr-icon-arrow-right-s-line")
 
       .col-auto.d-flex.align-items-center
-        = link_to admin_organisation_creneaux_search_selection_creneaux_path(search_params.merge(from_date: form.date_range.end + 1.day)), class: "btn btn-primary" do
-          i.fa.fa-arrow-right
+        = link_to "Créneaux suivants", admin_organisation_creneaux_search_selection_creneaux_path(search_params.merge(from_date: form.date_range.end + 1.day)), class: "fr-btn fr-icon-arrow-right-line"

--- a/app/views/admin/creneaux_search/_slots.html.slim
+++ b/app/views/admin/creneaux_search/_slots.html.slim
@@ -27,7 +27,7 @@ div id="creneaux-lieu-#{lieu&.id}"
                   .text-left.m-1
                     span.strong.font-weight-bold= l(creneau.starts_at, format: "%H:%M")
                     br
-                    = user_icon(class: agent_color(agents.index(creneau.agent)) + " fr-icon--sm fr-mr-1w")
+                    = user_icon(class:  "fr-icon--sm fr-mr-1w #{agent_color(agents.index(creneau.agent))}")
                     small.text-dark= creneau.agent.short_name
 
     - if next_availability

--- a/app/views/admin/rdv_wizard_steps/_actions.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_actions.html.slim
@@ -1,7 +1,5 @@
 .row.align-items-center.mt-3
   .col.text-left
-    = link_to(rdv_wizard_form.previous_step_path) do
-      i.fa.fa-arrow-left
-      |< Revenir en arrière
+    = link_to("Revenir en arrière", rdv_wizard_form.previous_step_path, dsfr_return_btn_options)
   .col.text-right
     = f.submit submit_value, class: "fr-btn"

--- a/app/views/admin/rdv_wizard_steps/_participation_form.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_participation_form.html.slim
@@ -8,7 +8,7 @@ div id=element_id
   = form.hidden_field :user_id
   .d-flex.mt-2.mb-1
     div
-      i.fa.fa-user-alt.mr-1
+      = user_icon(class: "fr-icon--sm fr-mr-1w")
       - if user.relative?
         = "#{user} (responsable: #{user.responsible})"
       - else

--- a/app/views/admin/rdv_wizard_steps/_stepper.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_stepper.html.slim
@@ -4,12 +4,12 @@ ul.list-group.list-group-flush
       li.list-group-item.hover-bg-light.px-3
         = link_to rdv_wizard_form.path_for_step(step[:step]), class: "text-dark" do
           .d-flex.align-items-center
-            i.far.mr-1.fa-check-circle
+            = icon("fr-icon-success-line", class: "fr-icon--sm fr-mr-1w")
             div.flex-shrink-0.mr-1= t("admin.rdv_wizard_steps.step#{step[:step]}.step_title")
             div.text-muted.text-truncate= step[:value]
     - else
       li.list-group-item.px-3
         .d-flex.align-items-center
-          i.far.mr-1.fa-circle
+          = icon("fr-icon-success-line", class: "fr-icon--sm fr-mr-1w")
           div.flex-shrink-0.mr-1= t("admin.rdv_wizard_steps.step#{step[:step]}.step_title")
           div.text-muted.text-truncate= step[:value]

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -28,7 +28,7 @@ ruby:
             remove_path_params[:user_ids].delete(user.id)
             remove_user_path = new_admin_organisation_rdv_wizard_step_path(remove_path_params)
           div.ml-2= link_to remove_user_path, title: t("helpers.remove")
-            = icon("fr-icon-close-line", clss: "fr-icon--sm")
+            = icon("fr-icon-close-line")
           / la ligne suivante gère le cas d’un usager qui ne fait pas partie de l’orga courante mais d’une autre orga dans laquelle l’agent courant a les droits suffisants pour l’éditer
           - organisation_where_editable = current_agent.organisations.to_a.prepend(current_organisation).uniq.find { |org| Agent::UserPolicy.new(AgentOrganisationContext.new(current_agent, org), user).edit? }
           - if organisation_where_editable

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -19,7 +19,7 @@ ruby:
       .my-1
         .d-flex
           div
-            i.fa.fa-user
+            = user_icon(class: "fr-icon--sm")
             | &nbsp;
             = UsersHelper.reverse_full_name_and_notification_coordinates(user)
             = relative_tag(user)
@@ -28,7 +28,7 @@ ruby:
             remove_path_params[:user_ids].delete(user.id)
             remove_user_path = new_admin_organisation_rdv_wizard_step_path(remove_path_params)
           div.ml-2= link_to remove_user_path, title: t("helpers.remove")
-            i.fa.fa-minus-circle
+            = icon("fr-icon-close-line", clss: "fr-icon--sm")
           / la ligne suivante gère le cas d’un usager qui ne fait pas partie de l’orga courante mais d’une autre orga dans laquelle l’agent courant a les droits suffisants pour l’éditer
           - organisation_where_editable = current_agent.organisations.to_a.prepend(current_organisation).uniq.find { |org| Agent::UserPolicy.new(AgentOrganisationContext.new(current_agent, org), user).edit? }
           - if organisation_where_editable
@@ -41,9 +41,8 @@ ruby:
 
     - show_add_user = @rdv.users.empty?
     .collapse.collapse-add-user-selection.no-transition class=(show_add_user ? "" : "show")
-      = link_to ".collapse-add-user-selection", data: { toggle: "collapse" }
-        i.fa.fa-plus-circle
-        span.ml-1= t("helpers.add")
+      /On met un margin-left négatif pour que l'icône du bouton soit alignée avec celle de l'usager au-dessus
+      = link_to t("helpers.add"), ".collapse-add-user-selection", style: "margin-left: -12px", class: "fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-add-circle-fill", data: { toggle: "collapse" }
     .collapse.collapse-add-user-selection.no-transition class=(show_add_user ? "show" : "")
       - if current_organisation.users.any?
         = label_tag :user_search, "Rechercher un usager", {class: "form-control-label string optional"}
@@ -76,10 +75,7 @@ ruby:
 
     .row.align-items-center.mt-3
       .col.text-left
-        = link_to(@rdv_wizard.previous_step_path) do
-          i.fa.fa-arrow-left
-          |< Revenir en arrière
-
+        = link_to("Revenir en arrière", @rdv_wizard.previous_step_path, dsfr_return_btn_options)
       - if (@rdv_wizard.validate || @rdv_wizard.errors[:users].empty?)
         .col.text-right
             = f.submit "Continuer", class: "fr-btn"

--- a/app/views/admin/rdvs/a_renseigner.html.slim
+++ b/app/views/admin/rdvs/a_renseigner.html.slim
@@ -24,8 +24,6 @@ p Merci d'indiquer si ces rendez-vous se sont bien passés comme prévu.
         .card-body
           .row.justify-content-md-center
             .col-md-6.rdv-text-align-center.my-5
-              p.mb-2.lead
-                | Aucun RDV
-              span.fa-stack.fa-4x
-                i.fa.fa-circle.fa-stack-2x.text-primary
-                i.far.fa-calendar.fa-stack-1x.text-white
+              p.mb-2
+                = icon("fr-icon-success-line", class: "fr-mr-1w")
+                | Vous êtes à jour ! Tous vos rendez-vous sont renseignés

--- a/app/views/admin/rdvs_collectifs/_participants_info.html.slim
+++ b/app/views/admin/rdvs_collectifs/_participants_info.html.slim
@@ -1,7 +1,6 @@
 .d-flex.card-text.mb-2
-    div.mr-1
-      i.fa.fa-fw.fa-users>
-    = I18n.t("rdvs.participants", count: rdv.users_count)
+  = icon("fr-icon-team-fill", class: "fr-mr-1w")
+  = I18n.t("rdvs.participants", count: rdv.users_count)
 
 .d-flex.card-text.mb-3
   - if rdv.remaining_seats? && rdv.not_cancelled?

--- a/app/views/admin/rdvs_collectifs/_rdv.html.slim
+++ b/app/views/admin/rdvs_collectifs/_rdv.html.slim
@@ -10,20 +10,17 @@
     .row
       .col-md-6
         .d-flex.card-text.mb-2
-          div.mr-1
-            i.fa.fa-fw.fa-map-marker-alt>
-            = rdv.lieu.name
+          = lieu_icon(class: "fr-mr-1w")
+          = rdv.lieu.name
 
         .d-flex.card-text.mb-2
-          div.mr-1
-            i.fa.fa-fw.fa-user>
-            strong> Animé par
-            = agents_to_sentence(rdv.agents)
+          = user_icon(class: "fr-mr-1w")
+          strong> Animé par
+          = agents_to_sentence(rdv.agents)
 
         .d-flex.card-text
-          div.mr-1
-            i.fa.fa-fw.fa-clock>
-            = "#{rdv.duration_in_min} minutes"
+          = icon("fr-icon-time-fill", class: "fr-mr-1w")
+          = "#{rdv.duration_in_min} minutes"
 
       .col-md-6
         = render "admin/rdvs_collectifs/participants_info", rdv: rdv

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -19,8 +19,7 @@
           .row.mt-3
             .col-md-6
               .d-flex.card-text.mb-2
-                div.mr-1
-                  i.fa.fa-fw.fa-users>
+                = icon("fr-icon-team-fill", class: "fr-mr-1w")
                 div
                   - if @rdv.max_participants_count
                     = I18n.t("rdvs.seats", count: @rdv.max_participants_count)
@@ -28,8 +27,7 @@
                     = "Pas de limite de places"
 
               .d-flex.card-text.mb-3
-                div.mr-1
-                  i.fa.fa-fw.fa-users>
+                = icon("fr-icon-team-fill", class: "fr-mr-1w")
                 div
                   = I18n.t("rdvs.participants", count: @rdv.users_count)
                   ul
@@ -38,30 +36,17 @@
 
             .col-md-6
               .d-flex.card-text.mb-2
-                - if @rdv.phone?
-                    i.fa.fa-fw.fa-phone>
-                    | RDV téléphonique
-                - else
-                  div.mr-1
-                    i.fa.fa-fw.fa-map-marker-alt>
-                    - if @rdv.home?
-                      | RDV à domicile
-                      = human_location(@rdv)
-                    - elsif @rdv.public_office?
-                      = @rdv.lieu.name
+                = lieu_icon(class: "fr-mr-1w")
+                = @rdv.lieu.name
 
               .d-flex.card-text.mb-2
-                div.mr-1
-                  i.fa.fa-fw.fa-user>
-                div
-                  strong> Animé par
-                  = agents_to_sentence(@rdv.agents)
+                = user_icon(class: "fr-mr-1w")
+                strong> Animé par &nbsp;
+                = agents_to_sentence(@rdv.agents)
 
               .d-flex.card-text
-                div.mr-1
-                  i.fa.fa-fw.fa-clock>
-                div
-                  = "#{@rdv.duration_in_min} minutes"
+                = icon("fr-icon-time-fill", class: "fr-mr-1w")
+                = "#{@rdv.duration_in_min} minutes"
 
         .card-footer.px-3
           = render "model_errors", model: @rdv

--- a/app/views/admin/referent_assignations/_referent_assignation_row.html.slim
+++ b/app/views/admin/referent_assignations/_referent_assignation_row.html.slim
@@ -6,10 +6,6 @@ tr id="agent_#{agent.id}"
   td.text-right
     div.mr-3
       - if action == :remove
-        = link_to admin_organisation_user_referent_assignation_path(current_organisation, @user, agent), method: :delete, class: "btn btn-danger", data: { confirm: "Voulez-vous vraiment retirer ce référent ?"} do
-          span> Retirer
-          i.fa.fa-angle-right
+        = link_to "Retirer", admin_organisation_user_referent_assignation_path(current_organisation, @user, agent), method: :delete, class: "fr-btn fr-btn--secondary", data: { confirm: "Voulez-vous vraiment retirer ce référent ?"}
       - elsif action == :add
-        = link_to admin_organisation_user_referent_assignations_path(current_organisation, @user, agent_id: agent.id),  method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter…"} do
-          span> Ajouter
-          i.fa.fa-angle-right
+        = link_to "Ajouter", admin_organisation_user_referent_assignations_path(current_organisation, @user, agent_id: agent.id),  method: :post, class: "fr-btn", data: { disable_with: "Veuillez patienter…"}


### PR DESCRIPTION
Cette PR est un peu la suite de https://github.com/betagouv/rdv-service-public/pull/5740 : on passe d'autres icônes de font-awesome au dsfr.

Dans l'immédiat, ça permet déjà d'avoir des icônes plus cohérentes. Par exemple, on utilise maintenant systématiquement l'icône dsfr des lieux pour indiquer un lieu plutôt que d'avoir plusieurs icônes différentes pour la même chose.

A terme, ça pourrait nous permettre de supprimer complètement font-awesome de notre bundle, mais on a encore pas mal de travail avant de pouvoir faire ça.