### PR TITLE
Expliciter le choix de l’algorithme de chiffrement FranceConnect

### DIFF
--- a/app/services/france_connect_v2_open_id_client/callback.rb
+++ b/app/services/france_connect_v2_open_id_client/callback.rb
@@ -1,5 +1,7 @@
 # voir https://github.com/france-connect/Documentation-AgentConnect/blob/main/doc_fs/technique_fca/endpoints.md
 module FranceConnectV2OpenIdClient
+  ALGORITHM = "ES256".freeze
+
   class Callback
     class OpenIdFlowError < StandardError; end
     class ApiRequestError < StandardError; end
@@ -88,7 +90,7 @@ module FranceConnectV2OpenIdClient
 
       handle_response_error(response)
 
-      JWT.decode(response.body, nil, true, algorithms: france_connect_v2_config.jwks.first["alg"], jwks: france_connect_v2_config.jwks).first
+      JWT.decode(response.body, nil, true, algorithms: ALGORITHM, jwks: france_connect_v2_config.jwks).first
     end
 
     def handle_response_error(response)

--- a/app/services/france_connect_v2_open_id_client/callback.rb
+++ b/app/services/france_connect_v2_open_id_client/callback.rb
@@ -1,7 +1,5 @@
 # voir https://github.com/france-connect/Documentation-AgentConnect/blob/main/doc_fs/technique_fca/endpoints.md
 module FranceConnectV2OpenIdClient
-  ES256_ALGORITHM = "ES256".freeze
-
   class Callback
     class OpenIdFlowError < StandardError; end
     class ApiRequestError < StandardError; end
@@ -90,7 +88,7 @@ module FranceConnectV2OpenIdClient
 
       handle_response_error(response)
 
-      JWT.decode(response.body, nil, true, algorithms: ES256_ALGORITHM, jwks: france_connect_v2_config.jwks).first
+      JWT.decode(response.body, nil, true, algorithms: "ES256", jwks: france_connect_v2_config.jwks).first
     end
 
     def handle_response_error(response)

--- a/app/services/france_connect_v2_open_id_client/callback.rb
+++ b/app/services/france_connect_v2_open_id_client/callback.rb
@@ -1,6 +1,6 @@
 # voir https://github.com/france-connect/Documentation-AgentConnect/blob/main/doc_fs/technique_fca/endpoints.md
 module FranceConnectV2OpenIdClient
-  ALGORITHM = "ES256".freeze
+  ES256_ALGORITHM = "ES256".freeze
 
   class Callback
     class OpenIdFlowError < StandardError; end
@@ -90,7 +90,7 @@ module FranceConnectV2OpenIdClient
 
       handle_response_error(response)
 
-      JWT.decode(response.body, nil, true, algorithms: ALGORITHM, jwks: france_connect_v2_config.jwks).first
+      JWT.decode(response.body, nil, true, algorithms: ES256_ALGORITHM, jwks: france_connect_v2_config.jwks).first
     end
 
     def handle_response_error(response)

--- a/config/initializers/france_connect_v2.rb
+++ b/config/initializers/france_connect_v2.rb
@@ -6,11 +6,6 @@ if ENV["FRANCECONNECT_V2_BASE_URL"].present?
   begin
     # la méthode .discover! fait un appel à l'api FranceConnect
     Rails.configuration.x.france_connect_v2_config = OpenIDConnect::Discovery::Provider::Config.discover!(ENV["FRANCECONNECT_V2_BASE_URL"])
-
-    supported_algorithms = Rails.configuration.x.france_connect_v2_config.id_token_signing_alg_values_supported
-    if supported_algorithms.exclude?(FranceConnectV2OpenIdClient::ES256_ALGORITHM)
-      raise "L'algorithme #{FranceConnectV2OpenIdClient::ES256_ALGORITHM} n’est pas dans la liste des algorithmes supportés par FranceConnect"
-    end
   rescue StandardError => e
     error_message = <<~MSG
       France Connect V2 n'est pas joignable au démarrage de l'application.

--- a/config/initializers/france_connect_v2.rb
+++ b/config/initializers/france_connect_v2.rb
@@ -8,8 +8,8 @@ if ENV["FRANCECONNECT_V2_BASE_URL"].present?
     Rails.configuration.x.france_connect_v2_config = OpenIDConnect::Discovery::Provider::Config.discover!(ENV["FRANCECONNECT_V2_BASE_URL"])
 
     supported_algorithms = Rails.configuration.x.france_connect_v2_config.id_token_signing_alg_values_supported
-    if supported_algorithms.exclude?(FranceConnectV2OpenIdClient::ALGORITHM)
-      raise "L'algorithme #{FranceConnectV2OpenIdClient::ALGORITHM} n’est pas dans la liste des algorithmes supportés par FranceConnect"
+    if supported_algorithms.exclude?(FranceConnectV2OpenIdClient::ES256_ALGORITHM)
+      raise "L'algorithme #{FranceConnectV2OpenIdClient::ES256_ALGORITHM} n’est pas dans la liste des algorithmes supportés par FranceConnect"
     end
   rescue StandardError => e
     error_message = <<~MSG

--- a/config/initializers/france_connect_v2.rb
+++ b/config/initializers/france_connect_v2.rb
@@ -6,6 +6,11 @@ if ENV["FRANCECONNECT_V2_BASE_URL"].present?
   begin
     # la méthode .discover! fait un appel à l'api FranceConnect
     Rails.configuration.x.france_connect_v2_config = OpenIDConnect::Discovery::Provider::Config.discover!(ENV["FRANCECONNECT_V2_BASE_URL"])
+
+    supported_algorithms = Rails.configuration.x.france_connect_v2_config.id_token_signing_alg_values_supported
+    if supported_algorithms.exclude?(FranceConnectV2OpenIdClient::ALGORITHM)
+      raise "L'algorithme #{FranceConnectV2OpenIdClient::ALGORITHM} n’est pas dans la liste des algorithmes supportés par FranceConnect"
+    end
   rescue StandardError => e
     error_message = <<~MSG
       France Connect V2 n'est pas joignable au démarrage de l'application.


### PR DESCRIPTION
Ceci est une copie exacte de la PR #5772 mais pour FranceConnect.

En synthèse : 
- on explicite dans le code qu'on utilise toujours `ES256`
- on évite d'utiliser `jwks.first`, c'est à dire de prendre la première valeur d'une liste qui provient d'une API, ça paraît plus robuste

J'ai observé `france_connect_v2_config.jwks` sur les API FranceConnect de sanbox et de prod, et dans les deux cas la réponse est : 

```ruby
[
  {
  "kty" => "EC",
  "use" => "sig",
  "kid" => "pkcs11:ES256:hsm",
  "alg" => "ES256",
  "crv" => "P-256",
  "x" => "[CACHÉ]",
  "y" => "[CACHÉ]"
  },
  {
  "kty" => "RSA",
  "use" => "sig",
  "kid" => "[CACHÉ]",
  "alg" => "RS256",
  "e" => "AQAB",
  "n" => "[CACHÉ]"
  }
]

# (oui, c'est des données publiques, mais je préfère être prudent et cacher les clés de chiffrement)
```

On voit bien que `ES256` arrive en premier ce qui explque que `jwks.first` fonctionne actuellement.