### PR TITLE
Correction de la policy de webhook_endpoints via l'api

### DIFF
--- a/app/controllers/admin/territories/webhook_endpoints_controller.rb
+++ b/app/controllers/admin/territories/webhook_endpoints_controller.rb
@@ -2,7 +2,7 @@ class Admin::Territories::WebhookEndpointsController < Admin::Territories::BaseC
   before_action :set_webhook_endpoint, only: %i[edit update destroy]
 
   def index
-    @webhooks = policy_scope(WebhookEndpoint, policy_scope_class: Agent::WebhookEndpointPolicy::EspaceAdminScope)
+    @webhooks = policy_scope(WebhookEndpoint, policy_scope_class: Agent::WebhookEndpointPolicy::Scope)
       .where(organisation: current_territory.organisations)
   end
 

--- a/app/controllers/api/v1/webhook_endpoints_controller.rb
+++ b/app/controllers/api/v1/webhook_endpoints_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::WebhookEndpointsController < Api::V1::AgentAuthBaseController
   before_action :set_organisation, only: %i[index create update]
 
   def index
-    webhook_endpoints = policy_scope(WebhookEndpoint, policy_scope_class: Agent::WebhookEndpointPolicy::ApiScope)
+    webhook_endpoints = policy_scope(WebhookEndpoint, policy_scope_class: Agent::WebhookEndpointPolicy::Scope)
       .where(organisation_id: params[:organisation_id])
     webhook_endpoints = webhook_endpoints.where(target_url: params[:target_url]) if params[:target_url].present?
     render_collection(webhook_endpoints)
@@ -30,7 +30,7 @@ class Api::V1::WebhookEndpointsController < Api::V1::AgentAuthBaseController
   end
 
   def set_webhook_endpoint
-    @webhook_endpoint = policy_scope(WebhookEndpoint, policy_scope_class: Agent::WebhookEndpointPolicy::ApiScope).find(params[:id])
+    @webhook_endpoint = policy_scope(WebhookEndpoint, policy_scope_class: Agent::WebhookEndpointPolicy::Scope).find(params[:id])
     authorize(@webhook_endpoint, policy_class: Agent::WebhookEndpointPolicy)
   end
 

--- a/app/policies/agent/webhook_endpoint_policy.rb
+++ b/app/policies/agent/webhook_endpoint_policy.rb
@@ -19,22 +19,7 @@ class Agent::WebhookEndpointPolicy < ApplicationPolicy
   alias destroy? territorial_admin?
   alias versions? territorial_admin?
 
-  # On a deux scopes différents qui correspondent à deux choix produits différents :
-  # - dans l'api on vérifie que l'agent a un rôle dans l'organisation du webhook
-  # - dans la config d'espace, on commence à permettre d'administrer un espace sans être admin de toutes
-  #   ses organisations, ce qui permet de ne pas avoir accès à toutes les données personnelles des
-  #   rdvs et de usagers
-  #
-  #   Il faudra à terme qu'on harmonise ces deux possiblités.
-  class ApiScope < Scope
-    include CurrentAgentInPolicyConcern
-
-    def resolve
-      WebhookEndpoint.where(organisation: [pundit_user.organisations])
-    end
-  end
-
-  class EspaceAdminScope
+  class Scope
     def initialize(agent, scope)
       @current_agent = agent
       @scope = scope

--- a/spec/policies/agent/webhook_endpoint_policy_spec.rb
+++ b/spec/policies/agent/webhook_endpoint_policy_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe Agent::WebhookEndpointPolicy do
   end
 end
 
-RSpec.describe Agent::WebhookEndpointPolicy::ApiScope do
+RSpec.describe Agent::WebhookEndpointPolicy::Scope do
   describe "#resolve?" do
     let(:organisation) { create(:organisation) }
 
     context "with an admin agent" do
-      let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let(:agent) { create(:agent, role_in_territories: [organisation.territory]) }
 
       it "allow to see webhook from same territory" do
         webhook = create(:webhook_endpoint, organisation: organisation)

--- a/spec/requests/api/v1/swagger_doc/webhook_endpoints_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/webhook_endpoints_request_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "WebhookEndpoints API", swagger_doc: "v1/api.json" do
 
       response 200, "Retourne des WebhookEndpoints" do
         let!(:webhook_endpoints) { create_list(:webhook_endpoint, 5, organisation: organisation) }
-        let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+        let!(:agent) { create(:agent, role_in_territories: [organisation.territory]) }
 
         schema "$ref" => "#/components/schemas/webhook_endpoints"
 
@@ -52,7 +52,7 @@ RSpec.describe "WebhookEndpoints API", swagger_doc: "v1/api.json" do
         let!(:unmatching) do
           create(:webhook_endpoint, organisation: organisation, target_url: "https://www.some-site.fr/webhooks")
         end
-        let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+        let!(:agent) { create(:agent, role_in_territories: [organisation.territory]) }
         let(:target_url) { "https://www.rdv-insertion.fr/webhooks" }
 
         run_test!


### PR DESCRIPTION
L'équipe de la Coop m'a fait remonter un bug : ils peuvent créer des webhook_endpoints via l'api, mais ils ne le voient pas quand ils font un appel à l'index.

C'est causé par un décalage entre les règles de la policy et du scope.

Je me suis plongé dans l'historique, et j'ai vérifié sur les comptes rdv-insertion, et c'est safe d'avoir un scope qui correspond aux règles de la policy (il faut être admin de territoire et pas juste d'orga).