### PR TITLE
Bump dsfr-view-components to 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,7 +133,7 @@ gem "groupdate", "~> 6.1"
 gem "rails_autolink"
 # ActionView helper to render currently active links
 gem "active_link_to"
-gem "dsfr-view-components", "~> 3.0"
+gem "dsfr-view-components", "~> 4.0"
 gem "dsfr-form_builder", "= 0.0.7" # On fixe la version tant qu’on est pas en 1.0
 
 # Easily create styled HTML emails in Rails.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,13 +227,13 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     drb (2.2.3)
-    dsfr-assets (1.13.1)
+    dsfr-assets (1.13.2)
     dsfr-form_builder (0.0.7)
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
-    dsfr-view-components (3.0.2)
-      dsfr-assets (~> 1.13)
+    dsfr-view-components (4.0)
+      dsfr-assets (~> 1.13.2)
       html-attributes-utils (~> 1)
       view_component (~> 3)
     erubi (1.13.1)
@@ -785,7 +785,7 @@ DEPENDENCIES
   doorkeeper-i18n
   dotenv-rails
   dsfr-form_builder (= 0.0.7)
-  dsfr-view-components (~> 3.0)
+  dsfr-view-components (~> 4.0)
   factory_bot
   faker
   foreman


### PR DESCRIPTION
# Contexte

On a besoin pour des raisons d’accessibilité de modifier le niveau de titre des steppers.
Cette possibilité a été intégrée à la v4.0 du DSFR view components. On fait donc la mise à jour.
