### PR TITLE
Permettre aux tests d'accessibilités de tourner dans un navigateur normal

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,7 +25,14 @@ metabase = "rdv-service-public-metabase.osc-secnum-fr1.scalingo.io"
 swagger_shas = ["'sha256-j4Lx1FqFgvYDBEjW7NQaEY7/HhCi8WVsLWkqC4+wJ3w='", "'sha256-JHKToH7KbGJj6TloPeWnKnbImDel00Whl1rRnBiTYuQ='"]
 
 # Utilisé par Axios pour les tests d'accessibilité
-test_shas = Rails.env.test? ? ["'sha256-FGXTYyJaeB4jfdFB1UEgIA517dMyyQE7JLnxRTrNdgo='"] : []
+test_shas = []
+if Rails.env.test?
+  if ENV["CI"].present?
+    test_shas << "'sha256-FGXTYyJaeB4jfdFB1UEgIA517dMyyQE7JLnxRTrNdgo='"
+  else
+    test_shas << "'sha256-3KU7bqhntlE+pVbLART2MZzvfoO4EpEvxbQQXz2vSqY='"
+  end
+end
 
 # Tant qu'on utilise les Turbolinks, c'est très difficile d'avoir des CSP différentes pour chaque pages,
 # puisque les CSP sont uniquement chargées lors de la première requête qui charle le premier document,

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,7 +25,7 @@ metabase = "rdv-service-public-metabase.osc-secnum-fr1.scalingo.io"
 swagger_shas = ["'sha256-j4Lx1FqFgvYDBEjW7NQaEY7/HhCi8WVsLWkqC4+wJ3w='", "'sha256-JHKToH7KbGJj6TloPeWnKnbImDel00Whl1rRnBiTYuQ='"]
 
 # Utilisé par Axios pour les tests d'accessibilité
-test_shas = Rails.env.test? ? ["'sha256-3KU7bqhntlE+pVbLART2MZzvfoO4EpEvxbQQXz2vSqY='"] : []
+test_shas = Rails.env.test? ? ["'sha256-gAlHn5J0eShJ54K2OjJp0+VJbxgDdUPfEacCeTjV8YU='"] : []
 
 # Tant qu'on utilise les Turbolinks, c'est très difficile d'avoir des CSP différentes pour chaque pages,
 # puisque les CSP sont uniquement chargées lors de la première requête qui charle le premier document,

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,7 +25,7 @@ metabase = "rdv-service-public-metabase.osc-secnum-fr1.scalingo.io"
 swagger_shas = ["'sha256-j4Lx1FqFgvYDBEjW7NQaEY7/HhCi8WVsLWkqC4+wJ3w='", "'sha256-JHKToH7KbGJj6TloPeWnKnbImDel00Whl1rRnBiTYuQ='"]
 
 # Utilisé par Axios pour les tests d'accessibilité
-test_shas = Rails.env.test? ? ["'sha256-gAlHn5J0eShJ54K2OjJp0+VJbxgDdUPfEacCeTjV8YU='"] : []
+test_shas = Rails.env.test? ? ["'sha256-FGXTYyJaeB4jfdFB1UEgIA517dMyyQE7JLnxRTrNdgo='"] : []
 
 # Tant qu'on utilise les Turbolinks, c'est très difficile d'avoir des CSP différentes pour chaque pages,
 # puisque les CSP sont uniquement chargées lors de la première requête qui charle le premier document,

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -24,6 +24,9 @@ metabase = "rdv-service-public-metabase.osc-secnum-fr1.scalingo.io"
 # Utilisés par swagger pour la documentation de l'api
 swagger_shas = ["'sha256-j4Lx1FqFgvYDBEjW7NQaEY7/HhCi8WVsLWkqC4+wJ3w='", "'sha256-JHKToH7KbGJj6TloPeWnKnbImDel00Whl1rRnBiTYuQ='"]
 
+# Utilisé par Axios pour les tests d'accessibilité
+test_shas = Rails.env.test? ? ["'sha256-3KU7bqhntlE+pVbLART2MZzvfoO4EpEvxbQQXz2vSqY='"] : []
+
 # Tant qu'on utilise les Turbolinks, c'est très difficile d'avoir des CSP différentes pour chaque pages,
 # puisque les CSP sont uniquement chargées lors de la première requête qui charle le premier document,
 # et pas lors des appels XHR fait par les turbolinks.
@@ -41,7 +44,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src :self, :unsafe_inline, bootstrap_cdn, unpkg_cdn
   policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
 
-  policy.script_src :self, unpkg_cdn, *swagger_shas
+  policy.script_src :self, unpkg_cdn, *swagger_shas, *test_shas
 end
 
 # If you are using UJS then enable automatic nonce generation

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -27,11 +27,11 @@ swagger_shas = ["'sha256-j4Lx1FqFgvYDBEjW7NQaEY7/HhCi8WVsLWkqC4+wJ3w='", "'sha25
 # Utilisé par Axios pour les tests d'accessibilité
 test_shas = []
 if Rails.env.test?
-  if ENV["CI"].present?
-    test_shas << "'sha256-FGXTYyJaeB4jfdFB1UEgIA517dMyyQE7JLnxRTrNdgo='"
-  else
-    test_shas << "'sha256-3KU7bqhntlE+pVbLART2MZzvfoO4EpEvxbQQXz2vSqY='"
-  end
+  test_shas << if ENV["CI"].present?
+                 "'sha256-4UywW1I9VFu7o60u4zSiU9FmUjIhiIv4N1FflQjVse0='"
+               else
+                 "'sha256-3KU7bqhntlE+pVbLART2MZzvfoO4EpEvxbQQXz2vSqY='"
+               end
 end
 
 # Tant qu'on utilise les Turbolinks, c'est très difficile d'avoir des CSP différentes pour chaque pages,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "axe-core": "^4.10.3",
+    "axe-core": "4.11.0",
     "css-loader": "^6.7.1",
     "fstream": "^1.0.12",
     "mini-css-extract-plugin": "^2.6.0",

--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "agents page", driver: :playwright_bypass_csp, js: true do
+RSpec.describe "agents page", js: true do
   it "login is accessible" do
     path = new_agent_session_path
     expect_page_to_be_axe_clean(path)

--- a/spec/features/accessibility/configuration_pages_spec.rb
+++ b/spec/features/accessibility/configuration_pages_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "configuration pages", driver: :playwright_bypass_csp, js: true do
+RSpec.describe "configuration pages", js: true do
   it "index of configuration" do
     territory = create(:territory)
     agent = create(:agent, role_in_territories: [territory])

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "public pages", driver: :playwright_bypass_csp, js: true do
+RSpec.describe "public pages", js: true do
   it "accessibilite_path page is accessible" do
     expect_page_to_be_axe_clean(accessibilite_path)
   end

--- a/spec/features/accessibility/users_pages_spec.rb
+++ b/spec/features/accessibility/users_pages_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "users pages", driver: :playwright_bypass_csp, js: true do
+RSpec.describe "users pages", js: true do
   describe "users_rdvs_path page" do
     it "without RDV is accessible" do
       user = create(:user, email: "toto@example.com")

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -4,17 +4,14 @@ WebMock.disable_net_connect!(allow: [
                                "www.rdv-solidarites-test.localhost",
                              ])
 
-def new_capybara_driver(app, **)
+Capybara.register_driver(:playwright) do |app|
   Capybara::Playwright::Driver.new(
     app,
     browser_type: ENV["PLAYWRIGHT_BROWSER"]&.to_sym || :chromium,
     headless: ENV["HEADLESS"] != "false",
-    timeout: 5,
-    **
+    timeout: 5
   )
 end
-
-Capybara.register_driver(:playwright) { |app| new_capybara_driver(app) }
 Capybara.javascript_driver = :playwright
 
 Capybara.configure do |config|
@@ -35,18 +32,6 @@ end
 
 if ENV["HEADLESS"] == "false"
   Capybara.default_driver = Capybara.javascript_driver
-end
-
-# pour les tests d’accessibilité avec aXe en script JS, on a besoin de bypasser les CSP
-Capybara.register_driver(:playwright_bypass_csp) { |app| new_capybara_driver(app, bypassCSP: true) }
-Capybara::Screenshot.class_eval do
-  # need to reconfigure capybara_save_screenshot with playwright_bypass_csp
-  # from https://github.com/mattheworiordan/capybara-screenshot/blob/master/lib/capybara-screenshot.rb#L202-L207
-  register_driver(:playwright_bypass_csp) do |driver, path|
-    driver.with_playwright_page do |page|
-      page.screenshot(path: path, fullPage: true)
-    end
-  end
 end
 
 RSpec.configure do |config|

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,10 +416,10 @@ autocomplete.js@^0.37.1:
   dependencies:
     immediate "^3.2.3"
 
-axe-core@^4.10.3:
-  version "4.10.3"
-  resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz#04145965ac7894faddbac30861e5d8f11bfd14fc"
-  integrity sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==
+axe-core@4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.11.0.tgz#16f74d6482e343ff263d4f4503829e9ee91a86b6"
+  integrity sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==
 
 balanced-match@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Cette PR édite les CSP dans l'env de test pour permettre de faire tourner les tests d'accessibilité dan un navigateur normal.

Ça va nous permettre d'ajouter des tests d'accessibilités aux tests d'intégrations normaux plutôt que de les faire vivre séparemment.