### PR TITLE
Correction des 404 sur la vérification des noms de famille

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,11 @@ Rails.application.routes.draw do
         put :cancel
       end
     end
+
     resource :user_name_initials_verification, only: %i[new create], controller: "user_name_initials_verification"
+    # pour éviter les 404 lors d’un refresh après avoir entré des lettres qui ne marchent pas
+    get :user_name_initials_verification, to: redirect(path: "/users/user_name_initials_verification/new")
+
     post "file_attente", to: "file_attentes#create_or_delete"
   end
   namespace :stats, controller: "stats", module: nil do

--- a/spec/features/users/user_can_manage_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_rdv_spec.rb
@@ -91,4 +91,29 @@ RSpec.describe "User can manage their rdvs" do
       end
     end
   end
+
+  describe "l’usager suit un lien d’annulation envoyé par SMS ou mail", js: true do
+    let(:user) { create(:user, last_name: "Factice") }
+    let!(:organisation) { create(:organisation, name: "93 Social") }
+    let(:lieu) { create(:lieu, name: "CCAS de Montreuil", organisation:) }
+    let!(:rdv) { create(:rdv, organisation:, starts_at: 4.days.from_now, users: [user], lieu:) }
+
+    it "ne fait pas d’erreur si on rafraichit la page de vérification du nom" do # refresh does not seem to work without js: true 🤷
+      visit users_rdv_path(rdv.id, invitation_token: rdv.participations.first.restricted_auth_token)
+
+      fill_in(:letter0, with: "F")
+      fill_in(:letter1, with: "A")
+      fill_in(:letter2, with: "X") # voluntary error here
+      # pas besoin de soumettre avec l’auto-soumission
+
+      expect(page).to have_content(/Les 3 lettres ne correspondent pas/)
+      refresh
+      expect(page).to have_content(/Entrez les 3 premières lettres de votre nom de famille/)
+
+      fill_in(:letter0, with: "F")
+      fill_in(:letter1, with: "A")
+      fill_in(:letter2, with: "C")
+      expect(page).to have_content "Votre RDV"
+    end
+  end
 end


### PR DESCRIPTION
PR extraite de #5783

# Contexte

Au support on voit souvent des personnes dirent qu’il n’arrivent pas à valider les trois premières lettres de leur nom de famille. Une partie de ces personnes arrivent depuis une erreur 404 dont le referer est la page de verif des initiales (on a cette info grace à @AntoineGirard merci !). 

On a évoqué des idées de comment ces erreurs pourraient se produire avec Antoine : lien expiré, rdv dans le passé… mais on n’a pas vraiment trouvé de chemin pour reproduire.

J’ai mis un moment à réaliser mais en local je me prenais aussi souvent des 404 : ça arrive quand on fait un refresh après avoir envoyé des lettres qui n’ont pas matché. 

C’est le comportemnet naturel et un peu embêtant des formulaires rails : la route en `POST /resources` est différente de `GET /resources/new` donc quand on refresh la route n’existe pas.


# Solution

Je propose dans cette PR de simplement rediriger vers la bonne route `/new` pour ce chemin ✨ 

J’ai aussi ajouté une feature spec JS en failing spec avant le fix. Je n’ai pas trouvé comment reproduire plus simplement, voici les raisons : 

- `refresh` ne fonctionne pas dans les controller specs. 
- Ça me semblait un peu contre intuitif de faire volontairement un `get "/path/cassé"` dans la controller spec
- Le comportement n’était pas reproductible sans `js: true` activé, je ne sais pas trop pourquoi 🤷 


## Autre piste

J’ai aussi réfléchi à mettre en place un `rescue StandardError` qui notifierait sentry avant de raise l’exception ici pour aider au debug mais je me dis qu’on a peut-être déjà la solution 🤞 