### PR TITLE
Correction de la factory des plages d’ouvertures pour les jours fériés

### DIFF
--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -5,7 +5,15 @@ FactoryBot.define do
     lieu { association(:lieu, organisation: organisation) }
 
     sequence(:title) { |n| random_value_in(["Plage #{n}", nil]) }
-    sequence(:first_day) { |n| Time.zone.today.next_week(:monday) + n.days } # ligne suspecte
+    sequence(:first_day) do |n|
+      # cet algo empêche de renvoyer un jour férié et évite de renvoyer le même jour pour 2 `n` consécutifs
+      day = Time.zone.today.next_week(:monday)
+      (0..n).each do
+        day += 1.day
+        day += 1.day if OffDays::JOURS_FERIES.include?(day) || day.saturday? || day.sunday?
+      end
+      day
+    end
     start_time { Tod::TimeOfDay.new(8) }
     end_time { Tod::TimeOfDay.new(12) }
     no_recurrence

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     lieu { association(:lieu, organisation: organisation) }
 
     sequence(:title) { |n| random_value_in(["Plage #{n}", nil]) }
-    sequence(:first_day) { |n| Time.zone.today.next_week(:monday) + n.days }
+    sequence(:first_day) { |n| Time.zone.today.next_week(:monday) + n.days } # ligne suspecte
     start_time { Tod::TimeOfDay.new(8) }
     end_time { Tod::TimeOfDay.new(12) }
     no_recurrence

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -6,9 +6,10 @@ FactoryBot.define do
 
     sequence(:title) { |n| random_value_in(["Plage #{n}", nil]) }
     sequence(:first_day) do |n|
-      # cet algo empêche de renvoyer un jour férié et évite de renvoyer le même jour pour 2 `n` consécutifs
       day = Time.zone.today.next_week(:monday)
-      (0..n).each do
+      day += 1.day if OffDays::JOURS_FERIES.include?(day) || day.saturday? || day.sunday?
+      # cet algo empêche de renvoyer un jour férié et évite de renvoyer le même jour pour 2 `n` consécutifs
+      (0...n).each do
         day += 1.day
         day += 1.day if OffDays::JOURS_FERIES.include?(day) || day.saturday? || day.sunday?
       end


### PR DESCRIPTION
# Contexte

Certaines features specs sont cassées aujourd’hui : https://github.com/betagouv/rdv-service-public/actions/runs/19028017531/job/54335364457

C’est dû au 11/11 férié dans 8 jours.

# Solution

La ligne coupable est dans la factory des PO :

```rb
sequence(:first_day) { |n| Time.zone.today.next_week(:monday) + n.days }
``` 

Je propose de l’améliorer pour rajouter des jours jusqu’à commencer un jour non férié non week-end