### PR TITLE
Correction du mail préscription par un agent

### DIFF
--- a/app/views/mailers/prescripteur_mailer/rdv_created.html.slim
+++ b/app/views/mailers/prescripteur_mailer/rdv_created.html.slim
@@ -4,12 +4,16 @@ div
   p
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
-  .btn-wrapper
-    = link_to "Annuler le rendez-vous", prescripteur_show_url(token: @prescripteur.token), class: "btn btn-primary"
+  - if @prescripteur.is_a?(Prescripteur)
+    .btn-wrapper
+      = link_to "Annuler le rendez-vous", prescripteur_show_url(token: @prescripteur.token), class: "btn btn-primary"
 
-  p
-    |> Besoin de corriger un détail ?
-    = link_to("Contactez-nous", new_aide_demande_support_url(role: :agent, sujet: "Corriger un RDV pris via prescription (RDV ID: #{@rdv.id})"))
+    p
+      |> Besoin de corriger un détail ?
+      = link_to("Contactez-nous", new_aide_demande_support_url(role: :agent, sujet: "Corriger un RDV pris via prescription (RDV ID: #{@rdv.id})"))
+  - else
+    |> Besoin de déplacer le rendez-vous ou de corriger un détail ?
+    = link_to("Contactez-nous", new_aide_demande_support_url(role: :agent, sujet: "Déplacer ou corriger un RDV pris via prescription (RDV ID: #{@rdv.id})"))
   br
   br
   = t("mailers.common.farewell_html", domain_name: domain.name)


### PR DESCRIPTION
# Contexte

Dans le cadre de cette PR : #5758 
Nous avons modifié le mail envoyé au prescripteur quand il crée un RDV. Néanmoins, nous nous sommes concentrés sur la prescription externe (par un `Prescripteur` et non par un `Agent`).
J’ai oublié que nous utilisions le même template de mail pour les prescriptions, faites par un `Agent`. 

# Solution

On affiche l’ancienne version du mail pour les agents et le bouton d’annulation pour les prescripteurs.

J’ai testé en local les deux cas.