### PR TITLE
correction du bouton retirer un agent d’une orga dans l’admin espace

### DIFF
--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -104,7 +104,7 @@ h1
                 .card-footer
                   .row
                     .col.text-left
-                      = link_to t(".delete_agent_role"), admin_territory_agent_role_path(current_territory, role), class: "fr-btn fr-btn--tertiary", data: { turbo_confirm: "Vous confirmez retirer l'agent #{@agent.full_name_or_email} de l'organisation #{role.organisation.name} ?", turbo_method: :delete }
+                      = link_to t(".delete_agent_role"), admin_territory_agent_role_path(current_territory, role), class: "fr-btn fr-btn--tertiary", data: { confirm: "Vous confirmez retirer l'agent #{@agent.full_name_or_email} de l'organisation #{role.organisation.name} ?", method: :delete }
                     .col.text-right
                       = f.button :submit, t(".submit")
 


### PR DESCRIPTION
# Contexte

Un agent nous a prévenu que ce bouton ne fonctionne plus

<img width="1025" height="437" alt="image" src="https://github.com/user-attachments/assets/6982b591-5812-43ad-8de7-df8299c52d43" />

cf https://zammad10.ethibox.fr/#ticket/zoom/29805

c’est du aux attributs `turbo_method` et `turbo_confirm` dépréciés

# Solution

enlever le prefixe `turbo_` 

Je n’ai pas pris le temps de rajouter des specs 🙈 