### PR TITLE
Ajout des tests d'accessibilité dans l'autodoc

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -24,7 +24,7 @@ module AgentsHelper
   end
 
   def me_tag(agent)
-    tag.span("Vous", class: "badge badge-info") if current_agent?(agent)
+    tag.span("Vous", class: "fr-badge fr-badge--info fr-badge--no-icon fr-badge--sm") if current_agent?(agent)
   end
 
   def build_link_to_rdv_wizard_params(creneau, form)

--- a/app/javascript/stylesheets/administrate/library/_variables.scss
+++ b/app/javascript/stylesheets/administrate/library/_variables.scss
@@ -33,7 +33,7 @@ $grey-2: #cfd8dc !default;
 $grey-5: #6f6f71 !default;
 $grey-7: #293f54 !default;
 
-$hint-grey: #7b808c !default;
+$hint-grey: rgb(102, 102, 102) !default;
 
 // Font Colors
 $base-font-color: $grey-7 !default;

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -10,12 +10,12 @@ tr id="agent_#{agent.id}"
         / les intervenants ne peuvent pas se connecter, il est inutile de les afficher comme "Inactif".
         - if agent.last_sign_in_at.nil? && agent.invitation_sent_at.present? && agent.invitation_accepted_at.nil?
           - if agent.invitation_due_at.past?
-            .badge.badge-warning Invitation expirée
+            .fr-badge.fr-badge--warning.fr-badge--sm Invitation expirée
           - else
-            .badge.badge-warning Invitation en attente
+            .fr-badge.fr-badge--info.fr-badge--sm Invitation en attente
         - elsif agent.last_sign_in_at.nil? || agent.last_sign_in_at <= 1.month.ago
           / le cas agent.last_sign_in_at.nil? est très rare et correspond probablement à des agents connectés avant qu’on ne commence à stocker le last_sign_in_at
-          .badge.badge-warning Pas connecté·e depuis plus d'un mois
+          .fr-badge.fr-badge--sm.badge Pas connecté·e depuis plus d'un mois
       end
     - else
       span.mr-2= agent.reverse_full_name
@@ -35,7 +35,7 @@ tr id="agent_#{agent.id}"
       - if agent_policy.create? && !agent.invitation_accepted? && !agent.is_an_intervenant?
         div.mr-3= link_to t("devise.invitations.reinvite"),
                 reinvite_admin_organisation_invitation_path(current_organisation, agent),
-                method: :post
+                method: :post, class: "fr-btn fr-btn--sm fr-btn--tertiary-no-outline"
       - if agent_policy.edit?
         div.mr-3= link_to edit_admin_organisation_agent_path(current_organisation, agent), title: t("helpers.edit") do
           i.fa.fa-edit

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -1,10 +1,10 @@
 - content_for(:menu_item) { "menu-agendas" }
 
+- content_for(:title) do
+  = t(".search_for_slots_title")
+- if @form.users.any?
+  .fr-text--xl.mb-2 = t(".search_for_slots_subtitle", users_fullname: @form.users.map(&:full_name).join(" ,"))
 .card.mt-2
-  .card-header
-    h3 = t(".search_for_slots_title")
-    - if @form.users.any?
-      h6.card-subtitle.mb-2 = t(".search_for_slots_subtitle", users_fullname: @form.users.map(&:full_name).join(" ,"))
   .card-body
     - if @motifs.none?
       = render "admin/motifs/creation_needed_callout", motivation_text: "Pour prendre un rendez-vous, vous devez d'abord créer un motif."

--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -16,7 +16,7 @@
       .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
         .fr-tile__body
           .fr-tile__content
-            h3.fr-tile__title
+            h2.fr-tile__title
               = link_to(admin_organisation_motifs_path(current_organisation)) do
                 = motif_icon(class: "fr-mr-1w")
                 | Motifs de rendez-vous
@@ -35,7 +35,7 @@
       .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
         .fr-tile__body
           .fr-tile__content
-            h3.fr-tile__title
+            h2.fr-tile__title
               = link_to(admin_organisation_lieux_path(current_organisation)) do
                 = lieu_icon(class: "fr-mr-1w")
                 | Lieux
@@ -55,7 +55,7 @@
       .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
         .fr-tile__body
           .fr-tile__content
-            h3.fr-tile__title
+            h2.fr-tile__title
               = link_to(admin_organisation_agents_path(current_organisation)) do
                 = icon("fr-icon-user-fill",class: "fr-mr-1w")
                 | Agents
@@ -69,14 +69,14 @@
       .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
         .fr-tile__body
           .fr-tile__content
-            h3.fr-tile__title
+            h2.fr-tile__title
               = link_to("Réservation en ligne", admin_organisation_online_booking_path(current_organisation))
 
     .fr-col-12.fr-col-md-4.fr-mb-2w
       .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
         .fr-tile__body
           .fr-tile__content
-            h3.fr-tile__title
+            h2.fr-tile__title
               = link_to("Informations de l'organisation", admin_organisation_path(current_organisation))
             p.fr-tile__desc
               = @organisation.name
@@ -92,7 +92,7 @@
         .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
           .fr-tile__body
             .fr-tile__content
-              h3.fr-tile__title
+              h2.fr-tile__title
                 = link_to("Migration vers RDV Service Public", admin_organisation_instance_exports_path(current_organisation))
 
   / Un bricolage pour éviter que le footer déborde sur les tuiles

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -61,10 +61,10 @@
           = t(".no_results_for_your_search")
         - else
           - if current_agent == @agent
-            h3= t(".self.not_yet_created_plage_ouverture")
+            h2= t(".self.not_yet_created_plage_ouverture")
             p = t(".self.explanation_plage_ouverture")
           - else
-            h3= t(".other_agent.not_yet_created_plage_ouverture", full_name: @agent.full_name_or_email)
+            h2= t(".other_agent.not_yet_created_plage_ouverture", full_name: @agent.full_name_or_email)
             p = t(".other_agent.explanation_plage_ouverture")
 
           - if current_organisation.motifs.active.any?

--- a/app/views/doorkeeper/authorizations/new.html.slim
+++ b/app/views/doorkeeper/authorizations/new.html.slim
@@ -1,4 +1,4 @@
-h2.rdv-text-align-center.mt-0.font-weight-bold.mb-4 Validation de permissions
+h1.fr-h2.rdv-text-align-center.mt-0.font-weight-bold.mb-4 Validation de permissions
 
 .card
   .card-body

--- a/app/views/super_admins/territory_creation_requests/index.html.slim
+++ b/app/views/super_admins/territory_creation_requests/index.html.slim
@@ -18,7 +18,7 @@ section.main-content__body.main-content__body--flush
     - if @territory_creation_requests.empty?
       p Il n'y a aucune demande avec ce statut
     - @territory_creation_requests.each do |request|
-      h3
+      h2
         = link_to(edit_super_admins_territory_creation_request_path(request.id))
           = request.territory_name || request.organisation_name
       p

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -30,7 +30,7 @@ if Rails.env.test?
   test_shas << if ENV["CI"].present?
                  "'sha256-4UywW1I9VFu7o60u4zSiU9FmUjIhiIv4N1FflQjVse0='"
                else
-                 "'sha256-3KU7bqhntlE+pVbLART2MZzvfoO4EpEvxbQQXz2vSqY='"
+                 "'sha256-MW9ENekiBxLmssEGlk+IVYZiQXOqQCOggVxAMOB1ePc='"
                end
 end
 

--- a/spec/features/autodoc/creation_espace_spec.rb
+++ b/spec/features/autodoc/creation_espace_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   specify do
-    doc = Autodoc.start_scenario("Ouverture d'un espace", self)
+    doc = Autodoc.start_scenario("Ouverture d'un espace", self, accessibility_checks: false)
 
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")

--- a/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Configuration de RDV Service Public par un administrateur de DS"
   end
 
   specify do
-    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 2) Configuration de RDV Service Public par un admin", self)
+    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 2) Configuration de RDV Service Public par un admin", self, accessibility_checks: false)
 
     login_as(agent, scope: :agent)
     visit configuration_admin_organisations_url(host: "http://www.rdv-mairie-test.localhost")

--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
   stub_env_for_proconnect
 
   specify do
-    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 1) Connexion de à RDV Service Public par un admin", self)
+    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 1) Connexion de à RDV Service Public par un admin", self, accessibility_checks: false)
 
     visit oauth_authorization_path(
       client_id: oauth_application.uid,

--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
   stub_env_for_proconnect
 
   specify do
-    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 1) Connexion de à RDV Service Public par un admin", self, accessibility_checks: false)
+    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 1) Connexion de à RDV Service Public par un admin", self)
 
     visit oauth_authorization_path(
       client_id: oauth_application.uid,

--- a/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Prise de rendez-vous par un instructeur", js: true do
   end
 
   specify do
-    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 3) Prise de RDV par un instructeur", self)
+    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 3) Prise de RDV par un instructeur", self, accessibility_checks: false)
 
     doc.start_section("Première prise de rendez-vous")
 

--- a/spec/features/autodoc/liens_vers_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/liens_vers_rdv_aide_num_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   end
 
   specify do
-    doc = Autodoc.start_scenario("Liens vers RDV Aide Numérique après une migration", self)
+    doc = Autodoc.start_scenario("Liens vers RDV Aide Numérique après une migration", self, accessibility_checks: false)
 
     doc.start_section("Introduction")
     doc.add_text(<<~TEXT

--- a/spec/features/autodoc/planning_multi_agents_spec.rb
+++ b/spec/features/autodoc/planning_multi_agents_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Nouveau planning / planning multi-agents", js: true do
 
   specify do
     login_as(agent_basique, scope: :agent)
-    doc = Autodoc.start_scenario("Nouveau planning / planning multi-agents", self)
+    doc = Autodoc.start_scenario("Nouveau planning / planning multi-agents", self, accessibility_checks: false)
 
     #
     # FEATURE FLAG DÉSACTIVÉ : on fait un tour du planning

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     login_as(agent, scope: :agent)
 
-    doc = Autodoc.start_scenario("Prise de rendez-vous entre agents", self)
+    doc = Autodoc.start_scenario("Prise de rendez-vous entre agents", self, accessibility_checks: false)
 
     doc.start_section("Côté agent")
     doc.add_text(<<~TEXT

--- a/spec/features/autodoc/self_onboarding_spec.rb
+++ b/spec/features/autodoc/self_onboarding_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Embarquement en autonomie pour les admins", js: true do
   before { login_as(agent, scope: :agent) }
 
   specify do
-    doc = Autodoc.start_scenario("Embarquement en autonomie (self-onboarding)", self)
+    doc = Autodoc.start_scenario("Embarquement en autonomie (self-onboarding)", self, accessibility_checks: false)
 
     doc.start_section("Pour un admin")
 

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -66,6 +66,7 @@ class Autodoc
         Capybara.current_session.driver.visit "file://#{page_or_email.save_page}"
         Capybara.current_session.driver.save_screenshot(path)
       else
+        @example.expect(page_or_email).to @example.be_axe_clean
         page_or_email.driver.save_screenshot(path)
       end
 

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -2,8 +2,8 @@
 class Autodoc
   @scenarios = []
 
-  def self.start_scenario(title, example)
-    scenario = Scenario.new(title, example)
+  def self.start_scenario(title, example, accessibility_checks: true)
+    scenario = Scenario.new(title, example, accessibility_checks)
     @scenarios << scenario
     scenario
   end
@@ -33,10 +33,11 @@ class Autodoc
   end
 
   class Scenario
-    def initialize(title, example)
+    def initialize(title, example, accessibility_checks)
       @title = title
       @index = Digest::SHA1.hexdigest(title)[0..8]
       @example = example
+      @accessibility_checks = accessibility_checks
       @sections = []
       @current_section = nil
     end
@@ -66,7 +67,9 @@ class Autodoc
         Capybara.current_session.driver.visit "file://#{page_or_email.save_page}"
         Capybara.current_session.driver.save_screenshot(path)
       else
-        @example.expect(page_or_email).to @example.be_axe_clean
+        if @accessibility_checks
+          @example.expect(page_or_email).to @example.be_axe_clean
+        end
         page_or_email.driver.save_screenshot(path)
       end
 


### PR DESCRIPTION
On ajoute la possibilité de lancer les tests d'accessibilités dans les specs de l'autodoc.

J'en profite pour corriger quelques détails faciles à mettre à jour dans l'interface agent.

Pour continuer, il faudra enlever le flag `accessibility_checks: false` aux scenarios et corriger les erreurs au fur et à mesure.

On passe des badges au dsfr sur l'écran des agents pour avoir assez de contraste.
Avant | Après
:- | -:
<img width="1173" height="773" alt="Screenshot 2025-11-04 at 11 20 07" src="https://github.com/user-attachments/assets/04415984-bbe2-480f-bb65-049502710c89" />|<img width="1166" height="767" alt="Screenshot 2025-11-04 at 11 19 38" src="https://github.com/user-attachments/assets/ccedfcdc-0357-43ae-bb41-c51b235262c2" />

