### PR TITLE
Ajout d'une page super admin pour les espaces à ajouter au CRM

### DIFF
--- a/app/controllers/super_admins/accounts_for_crm_controller.rb
+++ b/app/controllers/super_admins/accounts_for_crm_controller.rb
@@ -1,0 +1,10 @@
+module SuperAdmins
+  class AccountsForCrmController < SuperAdmins::ApplicationController
+    def index
+      @accounts_for_crm = policy_scope(Territory.where(category: ["", nil]), policy_scope_class: SuperAdmin::TerritoryPolicy::Scope)
+
+      # le module Administrate::Punditize oblige à faire un appel à #authorize même si on est sur l'index
+      authorize(@accounts_for_crm, policy_class: SuperAdmin::TerritoryPolicy)
+    end
+  end
+end

--- a/app/controllers/super_admins/accounts_for_crm_controller.rb
+++ b/app/controllers/super_admins/accounts_for_crm_controller.rb
@@ -11,5 +11,21 @@ module SuperAdmins
       @territory = Territory.find(params[:id])
       authorize(@territory, policy_class: SuperAdmin::TerritoryPolicy)
     end
+
+    def update
+      @territory = Territory.find(params[:id])
+      authorize(@territory, policy_class: SuperAdmin::TerritoryPolicy)
+
+      @territory.assign_attributes(params.require(:territory).permit(:category))
+
+      authorize(@territory, policy_class: SuperAdmin::TerritoryPolicy)
+
+      if @territory.save
+        flash[:success] = "Catégorie ajoutée à l'espace"
+        redirect_to super_admins_accounts_for_crm_index_path
+      else
+        render :edit
+      end
+    end
   end
 end

--- a/app/controllers/super_admins/accounts_for_crm_controller.rb
+++ b/app/controllers/super_admins/accounts_for_crm_controller.rb
@@ -6,5 +6,10 @@ module SuperAdmins
       # le module Administrate::Punditize oblige à faire un appel à #authorize même si on est sur l'index
       authorize(@accounts_for_crm, policy_class: SuperAdmin::TerritoryPolicy)
     end
+
+    def edit
+      @territory = Territory.find(params[:id])
+      authorize(@territory, policy_class: SuperAdmin::TerritoryPolicy)
+    end
   end
 end

--- a/app/views/super_admins/accounts_for_crm/edit.html.slim
+++ b/app/views/super_admins/accounts_for_crm/edit.html.slim
@@ -19,7 +19,7 @@ section.main-content__body
     dt.attribute-label.attribute-label--normal-case Lieux
     dd.attribute-data = Lieu.joins(:organisation).where(organisations: { territory_id: @territory.id }).pluck(:name).to_sentence
 
-    - siret = @territory.admin_agents.order("created_at desc").first.proconnect_siret
+    - siret = @territory.admin_agents.where.not(proconnect_siret: nil).order("created_at desc").first&.proconnect_siret
     - if siret
       dt.attribute-label SIRET
       dd.attribute-data
@@ -29,3 +29,16 @@ section.main-content__body
         - if annuaire_client.mairie?
           p ✅ Cette structure est une mairie
 
+section.main-content__body
+  p Ajoutez cet espace au CRM, puis remplissez sa catégorie ici.
+  = simple_form_for([namespace, @territory], url: super_admins_accounts_for_crm_path(@territory), html: { class: "form" }) do |f|
+    - if @territory.errors.any?
+      #error_explanation
+        h2
+          = t("administrate.form.errors", pluralized_errors: pluralize(@territory.errors.count, t("administrate.form.error")),
+            resource_name: display_resource_name(page.resource_name, singular: true))
+        ul
+          - @territory.errors.full_messages.each do |message|
+            li.flash-error= message
+    div[style="margin-bottom: 24px"]= f.input :category, as: :select, collection: Compte::CATEGORIES, label: "Catégorie de l'espace"
+    = f.submit

--- a/app/views/super_admins/accounts_for_crm/edit.html.slim
+++ b/app/views/super_admins/accounts_for_crm/edit.html.slim
@@ -1,0 +1,31 @@
+- content_for(:title) { "Espace à ajouter au CRM" }
+
+header.main-content__header
+  h1.main-content__page-title
+    = content_for(:title)
+
+section.main-content__body
+  dl
+    dt.attribute-label.attribute-label--normal-case Espace
+    dd.attribute-data = @territory.name_in_stats
+
+    dt.attribute-label.attribute-label--normal-case Administré par
+    dd.attribute-data
+      = @territory.admin_agents.map { |agent| "#{agent.full_name} (#{agent.email})" }.to_sentence
+
+    dt.attribute-label.attribute-label--normal-case Crée le
+    dd.attribute-data = "#{l(@territory.created_at, format: :human)} (il y a #{time_ago_in_words(@territory.created_at)})"
+
+    dt.attribute-label.attribute-label--normal-case Lieux
+    dd.attribute-data = Lieu.joins(:organisation).where(organisations: { territory_id: @territory.id }).pluck(:name).to_sentence
+
+    - siret = @territory.admin_agents.order("created_at desc").first.proconnect_siret
+    - if siret
+      dt.attribute-label SIRET
+      dd.attribute-data
+        = link_to(siret, "https://annuaire-entreprises.data.gouv.fr/etablissement/#{siret}", target: "_blank")
+        - annuaire_client = AnnuaireServicePublic.new(siret)
+        p= link_title = annuaire_client.nom
+        - if annuaire_client.mairie?
+          p ✅ Cette structure est une mairie
+

--- a/app/views/super_admins/accounts_for_crm/index.html.slim
+++ b/app/views/super_admins/accounts_for_crm/index.html.slim
@@ -1,0 +1,17 @@
+header.main-content__header
+  h1.main-content__page-title
+    | Espaces à ajouter au CRM
+
+section.main-content__body.main-content__body--flush
+  div[style="margin-bottom: 12px"]
+    p Le champs "Catégorie" n'a pas été renseigné pour ces espaces, généralement parce qu'ils ont été crées via des intégrations sans intervention manuelle de notre équipe.
+    p Il faut donc renseigner ce champs pour chaque espace, et l'ajouter au CRM.
+  div[style="margin: 12px"]
+    - if @accounts_for_crm.empty?
+      p Il n'y a aucune demande avec ce statut
+    - @accounts_for_crm.each do |territory|
+      h3
+        = link_to(edit_super_admins_territory_path(territory.id))
+          = territory.name_in_stats
+      p
+        = "créé le #{l(territory.created_at, format: :human)} (il y a #{time_ago_in_words(territory.created_at)})"

--- a/app/views/super_admins/accounts_for_crm/index.html.slim
+++ b/app/views/super_admins/accounts_for_crm/index.html.slim
@@ -10,8 +10,6 @@ section.main-content__body.main-content__body--flush
     - if @accounts_for_crm.empty?
       p Il n'y a aucune demande avec ce statut
     - @accounts_for_crm.each do |territory|
-      h3
-        = link_to(edit_super_admins_territory_path(territory.id))
-          = territory.name_in_stats
-      p
-        = "créé le #{l(territory.created_at, format: :human)} (il y a #{time_ago_in_words(territory.created_at)})"
+      h2 = link_to(territory.name_in_stats, edit_super_admins_accounts_for_crm_path(territory.id))
+
+      p = "créé le #{l(territory.created_at, format: :human)} (il y a #{time_ago_in_words(territory.created_at)})"

--- a/app/views/super_admins/accounts_for_crm/index.html.slim
+++ b/app/views/super_admins/accounts_for_crm/index.html.slim
@@ -3,10 +3,10 @@ header.main-content__header
     | Espaces à ajouter au CRM
 
 section.main-content__body.main-content__body--flush
-  div[style="margin-bottom: 12px"]
+  div[style="margin: 28px"]
     p Le champs "Catégorie" n'a pas été renseigné pour ces espaces, généralement parce qu'ils ont été crées via des intégrations sans intervention manuelle de notre équipe.
     p Il faut donc renseigner ce champs pour chaque espace, et l'ajouter au CRM.
-  div[style="margin: 12px"]
+  div[style="margin: 28px"]
     - if @accounts_for_crm.empty?
       p Il n'y a aucune demande avec ce statut
     - @accounts_for_crm.each do |territory|

--- a/app/views/super_admins/application/_navigation.html.erb
+++ b/app/views/super_admins/application/_navigation.html.erb
@@ -20,8 +20,10 @@ as defined by the routes in the `admin/` namespace
   <% end %>
   <hr />
   <%= link_to "Ouverture de compte", new_super_admins_compte_path, class: "navigation__link"%>
-  <%= link_to "Demandes d'ouverture d'espace", super_admins_territory_creation_requests_path, class: "navigation__link"%>
-  <%= link_to "Espaces à ajouter au CRM", super_admins_accounts_for_crm_index_path, class: "navigation__link"%>
+  <% if current_domain.allow_self_onboarding %>
+    <%= link_to "Demandes d'ouverture d'espace", super_admins_territory_creation_requests_path, class: "navigation__link"%>
+    <%= link_to "Espaces à ajouter au CRM", super_admins_accounts_for_crm_index_path, class: "navigation__link"%>
+  <% end %>
 
   <hr />
   <%= link_to "Good Job", super_admins_good_job_path, class: "navigation__link" if current_super_admin.legacy_admin_member?%>

--- a/app/views/super_admins/application/_navigation.html.erb
+++ b/app/views/super_admins/application/_navigation.html.erb
@@ -21,6 +21,7 @@ as defined by the routes in the `admin/` namespace
   <hr />
   <%= link_to "Ouverture de compte", new_super_admins_compte_path, class: "navigation__link"%>
   <%= link_to "Demandes d'ouverture d'espace", super_admins_territory_creation_requests_path, class: "navigation__link"%>
+  <%= link_to "Espaces à ajouter au CRM", super_admins_accounts_for_crm_path, class: "navigation__link"%>
 
   <hr />
   <%= link_to "Good Job", super_admins_good_job_path, class: "navigation__link" if current_super_admin.legacy_admin_member?%>

--- a/app/views/super_admins/application/_navigation.html.erb
+++ b/app/views/super_admins/application/_navigation.html.erb
@@ -11,7 +11,7 @@ as defined by the routes in the `admin/` namespace
   <%= link_to "Se déconnecter", super_admins_sign_out_path, method: :delete, class: "navigation__link" %>
 
   <hr />
-  <% Administrate::Namespace.new(namespace).resources_with_index_route.excluding("territory_creation_requests").each do |resource| %>
+  <% Administrate::Namespace.new(namespace).resources_with_index_route.excluding("territory_creation_requests", "accounts_for_crm").each do |resource| %>
     <%= link_to(
       display_resource_name(resource),
       resource_index_route(resource),
@@ -21,7 +21,7 @@ as defined by the routes in the `admin/` namespace
   <hr />
   <%= link_to "Ouverture de compte", new_super_admins_compte_path, class: "navigation__link"%>
   <%= link_to "Demandes d'ouverture d'espace", super_admins_territory_creation_requests_path, class: "navigation__link"%>
-  <%= link_to "Espaces à ajouter au CRM", super_admins_accounts_for_crm_path, class: "navigation__link"%>
+  <%= link_to "Espaces à ajouter au CRM", super_admins_accounts_for_crm_index_path, class: "navigation__link"%>
 
   <hr />
   <%= link_to "Good Job", super_admins_good_job_path, class: "navigation__link" if current_super_admin.legacy_admin_member?%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
     resources :lieux
     resources :territories, except: %i[new create]
     resources :territory_creation_requests, only: %i[index edit update]
-    resources :accounts_for_crm, only: %i[index]
+    resources :accounts_for_crm, only: %i[index edit update]
     resources :users
     resources :comptes, only: %i[new create]
     resources :rdvs, only: %i[show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
     resources :lieux
     resources :territories, except: %i[new create]
     resources :territory_creation_requests, only: %i[index edit update]
+    resources :accounts_for_crm, only: %i[index]
     resources :users
     resources :comptes, only: %i[new create]
     resources :rdvs, only: %i[show]

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
 
     context "et qu'il s'est connecté via une application externe" do
       let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
+      let(:super_admin) { create :super_admin }
 
-      it "permet de créer un territoire et une organisation" do
+      it "permet de créer un territoire et une organisation, puis d'être ajouté au CRM par un super admin" do
         visit "/admin/organisations/configuration" # Les pages de paramètres des applications externes mènent à cette url
 
         click_on "Ouvrir un espace"
@@ -31,6 +32,18 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
         )
         expect(agent.reload.organisations.last.name).to eq "CCAS de Montreuil"
         expect(agent.services).to be_empty
+
+        login_as(super_admin, scope: :super_admin)
+        visit super_admins_accounts_for_crm_index_path
+
+        expect(page).to have_content("Espaces à ajouter au CRM")
+        click_on("CCAS de Montreuil")
+
+        select("Commune", from: "Catégorie")
+        click_on "Enregistrer"
+
+        expect(page).to have_content("Catégorie ajoutée à l'espace")
+        expect(Territory.last.category).to eq "Commune"
       end
 
       context "et qu'il a un rdv plan qui a été créé par intégration" do


### PR DESCRIPTION
<img width="1420" height="752" alt="Screenshot 2025-11-04 at 14 51 39" src="https://github.com/user-attachments/assets/36ae6488-b07a-4b59-a283-a20c7cf96047" />
<img width="895" height="489" alt="Screenshot 2025-11-04 at 14 51 48" src="https://github.com/user-attachments/assets/544652ec-47d3-4998-926b-1c5fb1e684e6" />


Cette PR ajoute une page et un formulaire qui permettent de liste les espaces qui ont été ouverts mais qui n'ont pas été ajouté à notre CRM (ce qu'on détecte au fait que leur catégorie n'a pas été renseignée).

Actuellement, cette page correspond à tous les espaces qui ont été créés via des intégrations, mais quand on aura de la création de compte avec validation automatique, on y retrouvera tous les comptes qui ont été créés automatiquement.