### PR TITLE
Mise à jour de l'email de confirmation de l'ouverture d'un compte

### DIFF
--- a/app/views/mailers/agents/territory_creation_request_mailer/accepted.html.slim
+++ b/app/views/mailers/agents/territory_creation_request_mailer/accepted.html.slim
@@ -1,23 +1,32 @@
-- tutoriel_url = "https://scribehow.com/embed/Tutoriel__Configurer_son_Espace_RDV_Service_Public__WRoFB835RG-lulLQNrSTHQ?as=scrollable"
 p = t("mailers.common.hello")
 
 p
-  = "Nous avons le plaisir de vous confirmer l’ouverture de votre espace "
+  = "Bonne nouvelle ! Votre espace "
   b = domain.name
-  = ". Vous êtes l'"
-  b administrateur de votre espace
-  = ", à ce titre, vous pouvez dès maintenant :"
-  ul
-    li Paramétrer vos organisations, vos services, et inviter vos agents ;
-    li Configurer vos motifs de rendez-vous.
+  = " est désormais ouvert. 🎉"
 
-p Pour bien démarrer, #{link_to("consultez notre tutoriel", tutoriel_url)} pour configurer votre espace, et retrouvez toutes les ressources utiles dans notre #{link_to("centre d'aide", "https://aide.rdv-service-public.fr/")}.
+  br
+  | Vous pouvez dès maintenant commencer à configurer votre organisation :
+
+ul
+  li définir vos premiers motifs de rendez-vous,
+  li ouvrir vos plages de disponibilité,
+  li inviter vos collègues à rejoindre l’espace.
 
 .btn-wrapper
-  = link_to "Accéder à mon espace", configuration_admin_organisations_url(@organisation, @agent),  class: "btn btn-primary"
-.btn-wrapper
-  = link_to "Consulter le tutoriel", tutoriel_url,  class: "btn btn-secondary"
+  = link_to "Accéder à mon espace", configuration_admin_organisations_url,  class: "btn btn-primary"
 
-p Besoin d’aide ? Notre équipe est là pour vous accompagner, #{ link_to("planifiez un temps d'échange", "https://cal.com/team/rdv-service-public/accompagnement")}.
+hr
+br
+br
+
+p Pour aller plus loin dans la prise en main :
+
+.btn-wrapper
+  = link_to "Consulter les tutoriels", "https://aide.rdv-service-public.fr/", class: "btn btn-secondary", style: "padding-left: 86px; padding-right: 86px"
+.btn-wrapper
+  = link_to "Participer à un webinaire de présentation", "https://rdv.anct.gouv.fr/prendre_rdv?departement=SP&public_link_organisation_id=1628", class: "btn btn-primary"
+
+p Ces ressources vous aideront à prendre en main la solution pas à pas.
 
 = t("mailers.common.farewell_html", domain_name: domain.name)

--- a/spec/features/autodoc/creation_espace_spec.rb
+++ b/spec/features/autodoc/creation_espace_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   specify do
-    doc = Autodoc.start_scenario("Ouverture d'un espace", self, accessibility_checks: false)
+    doc = Autodoc.start_scenario("Ouverture d'un espace avec validation", self, accessibility_checks: false)
 
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="666" height="641" alt="Screenshot 2025-11-05 at 11 05 19" src="https://github.com/user-attachments/assets/8a79782c-d18c-4e8b-aade-b7f60e90b670" />|<img width="625" height="733" alt="Screenshot 2025-11-05 at 11 05 45" src="https://github.com/user-attachments/assets/60c0b15e-702a-4b78-82c3-5459e503023c" />

On met à jour le mail de confirmation d'ouverture de compte conformément à la nouvelle version demandée par Matis et Léa.

Je fais principalement une mise à jour du contenu, et je me lance pas dans une mise à jour de tous les templates de mails de l'appli pour le moment (ça risque de prendre un peu plus de temps et je voudrais pouvoir en discuter tranquillement avec Téo).


