### PR TITLE
Ouverture de compte en autonomie complète

### DIFF
--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -25,6 +25,11 @@ class Agents::PagesController < AgentAuthController
       redirect_to admin_organisation_planning_agenda_path(accessible_organisations.first)
     elsif accessible_organisations.count > 1
       redirect_to admin_organisations_path
+    else
+      policy = Agent::TerritoryPolicy.new(current_agent, Territory.new)
+      if current_agent.possible_duplicate_organisations.empty? && policy.new?
+        redirect_to new_agents_territory_path
+      end
     end
   end
 

--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -53,11 +53,13 @@ class Compte
         allow_to_invite_agents: true
       )
 
-      Agents::TerritoryCreationRequestMailer.accepted(
-        agent: agent,
-        organisation: organisation,
-        domain_id: @current_domain.id
-      ).deliver_later
+      if agent.invitation_created_at.nil? # On n'envoie pas ce mail si l'agent a déjà reçu un mail d'invitation
+        Agents::TerritoryCreationRequestMailer.accepted(
+          agent: agent,
+          organisation: organisation,
+          domain_id: @current_domain.id
+        ).deliver_later
+      end
       true
     end
   end

--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -53,13 +53,11 @@ class Compte
         allow_to_invite_agents: true
       )
 
-      if @territory_creation_request
-        Agents::TerritoryCreationRequestMailer.accepted(
-          agent: agent,
-          organisation: organisation,
-          domain_id: @current_domain.id
-        ).deliver_later
-      end
+      Agents::TerritoryCreationRequestMailer.accepted(
+        agent: agent,
+        organisation: organisation,
+        domain_id: @current_domain.id
+      ).deliver_later
       true
     end
   end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -313,4 +313,19 @@ class Agent < ApplicationRecord
       throw :abort
     end
   end
+
+  def possible_duplicate_organisations
+    possible_duplicate_organisations_by_email_domain + possible_duplicate_organisations_by_siret
+  end
+
+  def possible_duplicate_organisations_by_email_domain
+    email_domain = email.split("@").last
+    Organisation.joins(:agents).where("agents.email ilike ?", "%@#{email_domain}").distinct
+  end
+
+  def possible_duplicate_organisations_by_siret
+    return Organisation.none if proconnect_siret.blank?
+
+    Organisation.joins(:agents).where(agents: { proconnect_siret: proconnect_siret }).distinct
+  end
 end

--- a/app/models/territory_creation_request.rb
+++ b/app/models/territory_creation_request.rb
@@ -7,16 +7,7 @@ class TerritoryCreationRequest < ApplicationRecord
   validates :agent_id, uniqueness: true
   validate :can_only_have_one_response
 
-  def possible_duplicate_organisations_by_email_domain
-    email_domain = agent.email.split("@").last
-    Organisation.joins(:agents).where("agents.email ilike ?", "%@#{email_domain}").distinct
-  end
-
-  def possible_duplicate_organisations_by_siret
-    return Organisation.none if agent.proconnect_siret.blank?
-
-    Organisation.joins(:agents).where(agents: { proconnect_siret: agent.proconnect_siret }).distinct
-  end
+  delegate :possible_duplicate_organisations_by_email_domain, :possible_duplicate_organisations_by_siret, to: :agent
 
   private
 

--- a/app/models/territory_creation_request.rb
+++ b/app/models/territory_creation_request.rb
@@ -7,8 +7,6 @@ class TerritoryCreationRequest < ApplicationRecord
   validates :agent_id, uniqueness: true
   validate :can_only_have_one_response
 
-  delegate :possible_duplicate_organisations_by_email_domain, :possible_duplicate_organisations_by_siret, to: :agent
-
   private
 
   def can_only_have_one_response

--- a/app/policies/agent/territory_policy.rb
+++ b/app/policies/agent/territory_policy.rb
@@ -15,7 +15,7 @@ class Agent::TerritoryPolicy
   def new?
     return false if @current_agent.agent_territorial_access_rights.any?
 
-    OauthApplication.agent_is_verified_by_an_application?(@current_agent)
+    OauthApplication.agent_is_verified_by_an_application?(@current_agent) || @current_agent.email.end_with?(".gouv.fr")
   end
   alias create? new?
 

--- a/app/policies/agent/territory_policy.rb
+++ b/app/policies/agent/territory_policy.rb
@@ -15,7 +15,7 @@ class Agent::TerritoryPolicy
   def new?
     return false if @current_agent.agent_territorial_access_rights.any?
 
-    OauthApplication.agent_is_verified_by_an_application?(@current_agent) || @current_agent.email.end_with?(".gouv.fr")
+    OauthApplication.agent_is_verified_by_an_application?(@current_agent) || VerifiedServicePublicDomainNames.verified?(@current_agent.email)
   end
   alias create? new?
 

--- a/app/services/verified_service_public_domain_names.rb
+++ b/app/services/verified_service_public_domain_names.rb
@@ -1,0 +1,80 @@
+# Les domaines dans ce fichier viennent principalement de ce grist fourni par l'équipe ProConnect :
+# https://grist.numerique.gouv.fr/o/docs/3kQ829mp7bTy/ProConnect-Configuration-des-FI-et-FS/p/1
+class VerifiedServicePublicDomainNames
+  def self.verified?(email)
+    DOMAINS.any? do |domain|
+      email.ends_with?(domain)
+    end
+  end
+
+  DOMAINS = %w[
+    .gouv.fr
+
+    @ac-amiens.fr
+    @ac-besancon.fr
+    @ac-bordeaux.fr
+    @ac-caen.fr
+    @ac-clermont.fr
+    @ac-cned.fr
+    @ac-corse.fr
+    @ac-creteil.fr
+    @ac-dijon.fr
+    @ac-grenoble.fr
+    @ac-guadeloupe.fr
+    @ac-guyane.fr
+    @ac-lille.fr
+    @ac-limoges.fr
+    @ac-lyon.fr
+    @ac-martinique.fr
+    @ac-mayotte.fr
+    @ac-montpellier.fr
+    @ac-nancy-metz.fr
+    @ac-nantes.fr
+    @ac-nice.fr
+    @ac-normandie.fr
+    @ac-noumea.nc
+    @ac-orleans-tours.fr
+    @ac-paris.fr
+    @ac-poitiers.fr
+    @ac-polynesie.pf
+    @ac-reims.fr
+    @ac-rennes.fr
+    @ac-reunion.fr
+    @ac-rouen.fr
+    @ac-spm.fr
+    @ac-strasbourg.fr
+    @ac-toulouse.fr
+    @ac-versailles.fr
+    @ac-wf.wf
+    @cned.fr
+    @hceres.fr
+    @region-academique-auvergne-rhone-alpes.fr
+    @region-academique-bourgogne-franche-comte.fr
+    @region-academique-bretagne.fr
+    @region-academique-centre-val-de-loire.fr
+    @region-academique-corse.fr
+    @region-academique-grand-est.fr
+    @region-academique-guadeloupe.fr
+    @region-academique-guyane.fr
+    @region-academique-hauts-de-france.fr
+    @region-academique-ile-de-france.fr
+    @region-academique-martinique.fr
+    @region-academique-mayotte.fr
+    @region-academique-normandie.fr
+    @region-academique-nouvelle-aquitaine.fr
+    @region-academique-occitanie.fr
+    @region-academique-pays-de-la-loire.fr
+    @region-academique-provence-alpes-cote-dazur.fr
+    @region-academique-reunion.fr
+
+    @pole-emploi.fr
+    @france-travail.fr
+    @francetravail.fr
+
+    @ademe.fr
+    @assurance-maladie.fr
+    @cerema.fr
+
+    .senat.fr
+  ].freeze
+end

--- a/app/views/static_pages/nouvel_espace_rdv_service_public.html.slim
+++ b/app/views/static_pages/nouvel_espace_rdv_service_public.html.slim
@@ -4,7 +4,7 @@
 .rdv-background-color-alt-blue-ecume
   .fr-grid-row.fr-grid-row--center
     .fr-col-12.fr-col-md-10.fr-col-lg-8
-      = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: "Créer votre espace"
+      = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: "Ouvrir un espace"
       .card.fr-my-4w
         .card-body.fr-p-0
           .fr-grid-row

--- a/app/views/super_admins/territory_creation_requests/edit.html.slim
+++ b/app/views/super_admins/territory_creation_requests/edit.html.slim
@@ -48,12 +48,12 @@ section.main-content__body
 
       p Si vous pensez que ce nouvel espace serait un doublon, vous pouvez contacter un admin d'organisation pour lui proposer d'inviter #{@territory_creation_request.agent.full_name}.
 
-    - if @territory_creation_request.possible_duplicate_organisations_by_siret.none?
+    - if @territory_creation_request.agent.possible_duplicate_organisations_by_siret.none?
       p ✅ Aucun espace existant n'a d'agents avec des SIRET similaires.
     - else
       p ⚠️ Attention, ces organisations ont des agents avec le même SIRET :
       ul
-        - @territory_creation_request.possible_duplicate_organisations_by_siret.each do |organisation|
+        - @territory_creation_request.agent.possible_duplicate_organisations_by_siret.each do |organisation|
           li
             = link_to organisation.name, super_admins_organisation_path(organisation)
 

--- a/app/views/super_admins/territory_creation_requests/edit.html.slim
+++ b/app/views/super_admins/territory_creation_requests/edit.html.slim
@@ -37,12 +37,12 @@ section.main-content__body
       dd.attribute-data = @territory_creation_request.service_name
 
   section.main-content__body[style=""]
-    - if @territory_creation_request.possible_duplicate_organisations_by_email_domain.none?
+    - if @territory_creation_request.agent.possible_duplicate_organisations_by_email_domain.none?
       p ✅ Aucun espace existant n'a d'agents avec des adresses email similaires.
     - else
       p ⚠️ Attention, ces organisations ont des agents avec des adresses email similaires :
       ul
-        - @territory_creation_request.possible_duplicate_organisations_by_email_domain.each do |organisation|
+        - @territory_creation_request.agent.possible_duplicate_organisations_by_email_domain.each do |organisation|
           li
             = link_to organisation.name, super_admins_organisation_path(organisation)
 

--- a/spec/features/autodoc/creation_espace_spec.rb
+++ b/spec/features/autodoc/creation_espace_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   specify do
-    doc = Autodoc.start_scenario("Ouverture d'un espace avec validation", self, accessibility_checks: false, category: "Ouverture d'espace")
+    doc = Autodoc.start_scenario("Ouverture d'un espace avec validation", self, accessibility_checks: false, category: "1) Ouverture d'espace")
 
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")

--- a/spec/features/autodoc/creation_espace_spec.rb
+++ b/spec/features/autodoc/creation_espace_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   specify do
-    doc = Autodoc.start_scenario("Ouverture d'un espace avec validation", self, accessibility_checks: false, category: "1) Ouverture d'espace")
+    doc = Autodoc.start_scenario("2) Ouverture d'un espace avec validation", self, accessibility_checks: false, category: "1) Ouverture d'espace")
 
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")

--- a/spec/features/autodoc/creation_espace_spec.rb
+++ b/spec/features/autodoc/creation_espace_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   specify do
-    doc = Autodoc.start_scenario("Ouverture d'un espace avec validation", self, accessibility_checks: false)
+    doc = Autodoc.start_scenario("Ouverture d'un espace avec validation", self, accessibility_checks: false, category: "Ouverture d'espace")
 
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")

--- a/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe "Configuration de RDV Service Public par un administrateur de DS"
 
     Capybara.page.current_window.resize_to(1280, 600)
 
-    doc.add_screenshot(page,
-                       text: "Une première page me demande s'il existe déjà un espace dans RDV Service Public pour ma structure. Si ce n'est pas le cas, je clique sur Ouvrir un espace",
-                       wait_for: "Bienvenue")
-
-    click_on "Ouvrir un espace"
-
     fill_in("Nom de votre organisation", with: "Préfecture de Police de Paris")
 
     doc.add_screenshot(page,

--- a/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Configuration de RDV Service Public par un administrateur de DS"
   end
 
   specify do
-    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 2) Configuration de RDV Service Public par un admin", self, accessibility_checks: false)
+    doc = Autodoc.start_scenario("2) Configuration de RDV Service Public par un admin", self, accessibility_checks: false, category: "Intégration à Démarches Simplifiées")
 
     login_as(agent, scope: :agent)
     visit configuration_admin_organisations_url(host: "http://www.rdv-mairie-test.localhost")

--- a/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Configuration de RDV Service Public par un administrateur de DS"
   end
 
   specify do
-    doc = Autodoc.start_scenario("2) Configuration de RDV Service Public par un admin", self, accessibility_checks: false, category: "Intégration à Démarches Simplifiées")
+    doc = Autodoc.start_scenario("2) Configuration de RDV Service Public par un admin", self, accessibility_checks: false, category: "4) Intégration à Démarches Simplifiées")
 
     login_as(agent, scope: :agent)
     visit configuration_admin_organisations_url(host: "http://www.rdv-mairie-test.localhost")

--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
   stub_env_for_proconnect
 
   specify do
-    doc = Autodoc.start_scenario("1) Connexion de à RDV Service Public par un admin", self, category: "Intégration à Démarches Simplifiées")
+    doc = Autodoc.start_scenario("1) Connexion de à RDV Service Public par un admin", self, category: "4) Intégration à Démarches Simplifiées")
 
     visit oauth_authorization_path(
       client_id: oauth_application.uid,

--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
   stub_env_for_proconnect
 
   specify do
-    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 1) Connexion de à RDV Service Public par un admin", self)
+    doc = Autodoc.start_scenario("1) Connexion de à RDV Service Public par un admin", self, category: "Intégration à Démarches Simplifiées")
 
     visit oauth_authorization_path(
       client_id: oauth_application.uid,

--- a/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Prise de rendez-vous par un instructeur", js: true do
   end
 
   specify do
-    doc = Autodoc.start_scenario("3) Prise de RDV par un instructeur", self, accessibility_checks: false, category: "Intégration à Démarches Simplifiées")
+    doc = Autodoc.start_scenario("3) Prise de RDV par un instructeur", self, accessibility_checks: false, category: "4) Intégration à Démarches Simplifiées")
 
     doc.start_section("Première prise de rendez-vous")
 

--- a/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Prise de rendez-vous par un instructeur", js: true do
   end
 
   specify do
-    doc = Autodoc.start_scenario("Intégration à Démarches Simplifiées : 3) Prise de RDV par un instructeur", self, accessibility_checks: false)
+    doc = Autodoc.start_scenario("3) Prise de RDV par un instructeur", self, accessibility_checks: false, category: "Intégration à Démarches Simplifiées")
 
     doc.start_section("Première prise de rendez-vous")
 

--- a/spec/features/autodoc/liens_vers_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/liens_vers_rdv_aide_num_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   end
 
   specify do
-    doc = Autodoc.start_scenario("Liens vers RDV Aide Numérique après une migration", self, accessibility_checks: false)
+    doc = Autodoc.start_scenario("Liens vers RDV Aide Numérique après une migration", self, accessibility_checks: false, category: "RDV Aide Numérique")
 
     doc.start_section("Introduction")
     doc.add_text(<<~TEXT

--- a/spec/features/autodoc/liens_vers_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/liens_vers_rdv_aide_num_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   end
 
   specify do
-    doc = Autodoc.start_scenario("Liens vers RDV Aide Numérique après une migration", self, accessibility_checks: false, category: "RDV Aide Numérique")
+    doc = Autodoc.start_scenario("Liens vers RDV Aide Numérique après une migration", self, accessibility_checks: false, category: "5) RDV Aide Numérique")
 
     doc.start_section("Introduction")
     doc.add_text(<<~TEXT

--- a/spec/features/autodoc/managing_dead_ends_for_new_accounts_spec.rb
+++ b/spec/features/autodoc/managing_dead_ends_for_new_accounts_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Configuration initiale", js: true do
   end
 
   specify do
-    doc = Autodoc.start_scenario("Incitation à la création de motifs et de lieux", self)
+    doc = Autodoc.start_scenario("Incitation à la création de motifs et de lieux", self, category: "Embarquement")
 
     doc.start_section("Contexte")
 

--- a/spec/features/autodoc/managing_dead_ends_for_new_accounts_spec.rb
+++ b/spec/features/autodoc/managing_dead_ends_for_new_accounts_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Configuration initiale", js: true do
   end
 
   specify do
-    doc = Autodoc.start_scenario("Incitation à la création de motifs et de lieux", self, category: "Embarquement")
+    doc = Autodoc.start_scenario("Incitation à la création de motifs et de lieux", self, category: "2) Embarquement")
 
     doc.start_section("Contexte")
 

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   )
 
   specify do
-    doc = Autodoc.start_scenario("Migration depuis RDV Aide Numérique vers RDV Service Public", self, category: "RDV Aide Numérique")
+    doc = Autodoc.start_scenario("Migration depuis RDV Aide Numérique vers RDV Service Public", self, category: "5) RDV Aide Numérique")
 
     doc.start_section("Migration")
     doc.add_text(<<~TEXT

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   )
 
   specify do
-    doc = Autodoc.start_scenario("Migration depuis RDV Aide Numérique vers RDV Service Public", self)
+    doc = Autodoc.start_scenario("Migration depuis RDV Aide Numérique vers RDV Service Public", self, category: "RDV Aide Numérique")
 
     doc.start_section("Migration")
     doc.add_text(<<~TEXT

--- a/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
+++ b/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   specify do
-    doc = Autodoc.start_scenario("Ouverture d'un espace en complète autonomie", self, accessibility_checks: false)
+    doc = Autodoc.start_scenario("Ouverture d'un espace en complète autonomie", self, accessibility_checks: false, category: "Ouverture d'espace")
 
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")

--- a/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
+++ b/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
@@ -27,12 +27,6 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"
 
-    doc.add_screenshot(page,
-                       text: "Je clique sur Demander à ouvrir un espace",
-                       wait_for: "Pour commencer, aidez-nous à en savoir plus")
-
-    click_on "Ouvrir un espace"
-
     fill_in("Nom de votre organisation", with: "CCAS de Montreuil")
 
     doc.add_screenshot(page, text: "Je remplis le formulaire puis je valide", wait_for: "Nom de")

--- a/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
+++ b/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
 
     fill_in("Nom de votre organisation", with: "CCAS de Montreuil")
 
-    doc.add_screenshot(page, text: "Je remplis le formulaire puis je valide", wait_for: "Nom de")
+    doc.add_screenshot(page, text: "Il n'y a pas de doublon sur mon siret ni mon adresse mail donc je peux directement ouvrir mon compte. Je remplis le nom de l'orga et je valide.",
+                             wait_for: "Nom de")
 
     click_on "Enregistrer"
 

--- a/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
+++ b/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
@@ -1,0 +1,56 @@
+# Les captures d'écran des emails dans autodoc causent des erreurs JS à cause d'images qui ne chargent pas correctement
+# donc on désactive cette vérification pour ces specs
+RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
+  let!(:agent) { create(:agent, first_name: "Francis", last_name: "Factice", password: "c0rrecThorse!", email: "francis.factice@beta.gouv.fr") }
+
+  around { |example| perform_enqueued_jobs { example.run } }
+
+  specify do
+    doc = Autodoc.start_scenario("Ouverture d'un espace en complète autonomie", self, accessibility_checks: false)
+
+    doc.start_section("Côté agent")
+    doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")
+
+    visit "http://www.rdv-mairie-test.localhost/"
+    doc.add_screenshot(page,
+                       text: "Je clique sur 'Ouvrir un espace'",
+                       wait_for: "Ouvrir un espace")
+
+    click_on "Ouvrir un espace"
+    doc.add_screenshot(page,
+                       text: "Une page m'explique qu'il faut que je me ProConnecte.",
+                       wait_for: "Pour ouvrir votre espace, commencez par vous identifier avec ProConnect.")
+
+    # ProConnect ne marche pas en tests, donc on triche en faisant un login par email et mot de passe
+    visit new_agent_session_path
+    fill_in "Adresse email", with: agent.email
+    fill_in "Mot de passe", with: agent.password
+    click_on "Se connecter"
+
+    doc.add_screenshot(page,
+                       text: "Je clique sur Demander à ouvrir un espace",
+                       wait_for: "Pour commencer, aidez-nous à en savoir plus")
+
+    click_on "Ouvrir un espace"
+
+    fill_in("Nom de votre organisation", with: "CCAS de Montreuil")
+
+    doc.add_screenshot(page, text: "Je remplis le formulaire puis je valide", wait_for: "Nom de")
+
+    click_on "Enregistrer"
+
+    doc.add_screenshot(page,
+                       text: "J'arrive dans mon espace RDV Service Public",
+                       wait_for: "Pour commencer, vous pouvez créer votre premier motif de rendez-vous.")
+
+    open_email(agent.email)
+    expect(current_email.subject).to eq "Votre espace RDV Service Public est ouvert 🚀"
+
+    doc.add_screenshot(current_email, text: "J'ai un message de confirmation. Je clique sur le cta principal")
+
+    current_email.click_on "Accéder à mon espace"
+
+    doc.add_screenshot(page,
+                       text: "J'arrive dans mon espace")
+  end
+end

--- a/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
+++ b/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
                        wait_for: "Pour ouvrir votre espace, commencez par vous identifier avec ProConnect.")
 
     # ProConnect ne marche pas en tests, donc on triche en faisant un login par email et mot de passe
-    visit new_agent_session_path
+    visit new_agent_session_url(host:  "http://www.rdv-mairie-test.localhost")
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"
@@ -46,11 +46,6 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     open_email(agent.email)
     expect(current_email.subject).to eq "Votre espace RDV Service Public est ouvert 🚀"
 
-    doc.add_screenshot(current_email, text: "J'ai un message de confirmation. Je clique sur le cta principal")
-
-    current_email.click_on "Accéder à mon espace"
-
-    doc.add_screenshot(page,
-                       text: "J'arrive dans mon espace")
+    doc.add_screenshot(current_email, text: "J'ai aussi reçu un email de confirmation")
   end
 end

--- a/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
+++ b/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   specify do
-    doc = Autodoc.start_scenario("Ouverture d'un espace en complète autonomie", self, accessibility_checks: false, category: "Ouverture d'espace")
+    doc = Autodoc.start_scenario("Ouverture d'un espace en complète autonomie", self, accessibility_checks: false, category: "1) Ouverture d'espace")
 
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")

--- a/spec/features/autodoc/ouverture_espace_doublon_spec.rb
+++ b/spec/features/autodoc/ouverture_espace_doublon_spec.rb
@@ -2,11 +2,12 @@
 # donc on désactive cette vérification pour ces specs
 RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
   let!(:agent) { create(:agent, first_name: "Francis", last_name: "Factice", password: "c0rrecThorse!", email: "francis.factice@beta.gouv.fr") }
+  let!(:agent_with_similar_email) { create(:agent, email: "alex.emple@beta.gouv.fr", admin_role_in_organisations: [create(:organisation)]) }
 
   around { |example| perform_enqueued_jobs { example.run } }
 
   specify do
-    doc = Autodoc.start_scenario("1) Ouverture d'un espace en complète autonomie", self, accessibility_checks: false, category: "1) Ouverture d'espace")
+    doc = Autodoc.start_scenario("3) Détection de doublon lors des ouvertures d'espace", self, accessibility_checks: false, category: "1) Ouverture d'espace")
 
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")
@@ -27,30 +28,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"
 
-    fill_in("Nom de votre organisation", with: "CCAS de Montreuil")
-
-    doc.add_screenshot(page, text: "Il n'y a pas de doublon sur mon siret ni mon adresse mail donc je peux directement ouvrir mon compte. Je remplis le nom de l'orga et je valide.",
-                             wait_for: "Nom de")
-
-    click_on "Enregistrer"
-
-    doc.add_screenshot(page,
-                       text: "J'arrive dans mon espace RDV Service Public",
-                       wait_for: "Pour commencer, vous pouvez créer votre premier motif de rendez-vous.")
-
-    open_email(agent.email)
-    expect(current_email.subject).to eq "Votre espace RDV Service Public est ouvert 🚀"
-
-    doc.add_screenshot(current_email, text: "J'ai aussi reçu un email de confirmation")
-
-    doc.start_section("Côté super admin")
-    super_admin = create :super_admin
-    login_as(super_admin, scope: :super_admin)
-
-    visit super_admins_accounts_for_crm_index_url(host: "http://www.rdv-mairie-test.localhost")
-
-    doc.add_screenshot(page,
-                       text: "Le nouvel espace apparait dans la liste des comptes à ajouter au CRM.",
-                       wait_for: "CCAS de Montreuil")
+    doc.add_screenshot(page, text: "S'il existe déjà une autre organisation dont un admin a le même domaine d'adresse email ou siret que moi, je vois cette page de gestion des doublons.",
+                             wait_for: "Pour commencer")
   end
 end

--- a/spec/features/autodoc/planning_multi_agents_spec.rb
+++ b/spec/features/autodoc/planning_multi_agents_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Nouveau planning / planning multi-agents", js: true do
 
   specify do
     login_as(agent_basique, scope: :agent)
-    doc = Autodoc.start_scenario("Nouveau planning / planning multi-agents", self, accessibility_checks: false)
+    doc = Autodoc.start_scenario("Nouveau planning / planning multi-agents", self, accessibility_checks: false, category: "Produit")
 
     #
     # FEATURE FLAG DÉSACTIVÉ : on fait un tour du planning

--- a/spec/features/autodoc/planning_multi_agents_spec.rb
+++ b/spec/features/autodoc/planning_multi_agents_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Nouveau planning / planning multi-agents", js: true do
 
   specify do
     login_as(agent_basique, scope: :agent)
-    doc = Autodoc.start_scenario("Nouveau planning / planning multi-agents", self, accessibility_checks: false, category: "Produit")
+    doc = Autodoc.start_scenario("Nouveau planning / planning multi-agents", self, accessibility_checks: false, category: "3) Produit")
 
     #
     # FEATURE FLAG DÉSACTIVÉ : on fait un tour du planning

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     login_as(agent, scope: :agent)
 
-    doc = Autodoc.start_scenario("Prise de rendez-vous entre agents", self, accessibility_checks: false, category: "Produit")
+    doc = Autodoc.start_scenario("Prise de rendez-vous entre agents", self, accessibility_checks: false, category: "3) Produit")
 
     doc.start_section("Côté agent")
     doc.add_text(<<~TEXT

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     login_as(agent, scope: :agent)
 
-    doc = Autodoc.start_scenario("Prise de rendez-vous entre agents", self, accessibility_checks: false)
+    doc = Autodoc.start_scenario("Prise de rendez-vous entre agents", self, accessibility_checks: false, category: "Produit")
 
     doc.start_section("Côté agent")
     doc.add_text(<<~TEXT

--- a/spec/features/autodoc/self_onboarding_spec.rb
+++ b/spec/features/autodoc/self_onboarding_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Embarquement en autonomie pour les admins", js: true do
   before { login_as(agent, scope: :agent) }
 
   specify do
-    doc = Autodoc.start_scenario("Embarquement guidé", self, accessibility_checks: false, category: "Embarquement")
+    doc = Autodoc.start_scenario("Embarquement guidé", self, accessibility_checks: false, category: "2) Embarquement")
 
     doc.start_section("Pour un admin")
 

--- a/spec/features/autodoc/self_onboarding_spec.rb
+++ b/spec/features/autodoc/self_onboarding_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Embarquement en autonomie pour les admins", js: true do
   before { login_as(agent, scope: :agent) }
 
   specify do
-    doc = Autodoc.start_scenario("Embarquement en autonomie (self-onboarding)", self, accessibility_checks: false)
+    doc = Autodoc.start_scenario("Embarquement guidé", self, accessibility_checks: false, category: "Embarquement")
 
     doc.start_section("Pour un admin")
 

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
       it "permet de créer un territoire et une organisation, puis d'être ajouté au CRM par un super admin" do
         visit "/admin/organisations/configuration" # Les pages de paramètres des applications externes mènent à cette url
 
-        click_on "Ouvrir un espace"
-
         fill_in("Nom de votre organisation", with: "CCAS de Montreuil")
         click_on "Enregistrer"
 

--- a/spec/policies/agent/territory_policy_spec.rb
+++ b/spec/policies/agent/territory_policy_spec.rb
@@ -90,10 +90,19 @@ RSpec.describe Agent::TerritoryPolicy, type: :policy do
     end
 
     context "when the agent only logged in from the homepage with ProConnect" do
-      let(:agent) { create(:agent) }
+      context "when the agent's email is not recognized" do
+        it "doesn't authorize the creation" do
+          expect(described_class.new(create(:agent, email: "bob@gmail.com"), territory).create?).to be_falsey
+          expect(described_class.new(create(:agent, email: "bob@fakegouv.fr"), territory).create?).to be_falsey
+          expect(described_class.new(create(:agent, email: "bob@bac-grenoble.fr"), territory).create?).to be_falsey
+        end
+      end
 
-      it "doesn't authorize the creation" do
-        expect(subject.create?).to be_falsey
+      context "when the agent's email is verified as a public service email" do
+        it "authorizes the creation" do
+          expect(described_class.new(create(:agent, email: "bob@beta.gouv.fr"), territory).create?).to be_truthy
+          expect(described_class.new(create(:agent, email: "bob@ac-grenoble.fr"), territory).create?).to be_truthy
+        end
       end
     end
   end

--- a/spec/services/verified_service_public_domain_names_spec.rb
+++ b/spec/services/verified_service_public_domain_names_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe VerifiedServicePublicDomainNames do
+  it "only has domains names starting with . or @ to avoid fake domains ending with the correct domain name from being validated" do
+    described_class::DOMAINS.each do |domain|
+      expect(domain.start_with?(".") || domain.start_with?("@")).to be_truthy
+    end
+  end
+end

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -1,19 +1,20 @@
 # Autodoc, la doc automatique !
 class Autodoc
-  @scenarios = []
+  @categories = {}
 
-  def self.start_scenario(title, example, accessibility_checks: true)
+  def self.start_scenario(title, example, accessibility_checks: true, category: nil)
     scenario = Scenario.new(title, example, accessibility_checks)
-    @scenarios << scenario
+    @categories[category] ||= []
+    @categories[category] << scenario
     scenario
   end
 
   def self.render
-    return if @scenarios.empty?
+    return if @categories.empty?
 
     `mkdir -p tmp/capybara/autodoc`
 
-    @scenarios.each do |scenario|
+    @categories.values.flatten.each do |scenario|
       Rails.root.join("tmp/capybara/autodoc/scenario_#{scenario.index}.html").write(
         Slim::Template.new(Rails.root.join("spec/support/autodoc/layout.html.slim")).render(scenario) do
           Slim::Template.new(Rails.root.join("spec/support/autodoc/scenario.html.slim")).render(scenario).html_safe # rubocop:disable Rails/OutputSafety
@@ -27,9 +28,7 @@ class Autodoc
       end
     )
 
-    if @scenarios.any?
-      puts "La doc est accessible sur file://#{Rails.root.join('tmp/capybara/autodoc/index.html')}"
-    end
+    puts "La doc est accessible sur file://#{Rails.root.join('tmp/capybara/autodoc/index.html')}"
   end
 
   class Scenario

--- a/spec/support/autodoc/index.html.slim
+++ b/spec/support/autodoc/index.html.slim
@@ -5,7 +5,7 @@
     p Cette page documente différentes fonctionnalités de RDV Service Public
     p Elle est mise à jour automatiquement dès que l'application change.
 
-    - @categories.each do |title, scenarios|
+    - @categories.sort.each do |title, scenarios|
       - if title
         h2 = title
       ul.fr-mb-4w

--- a/spec/support/autodoc/index.html.slim
+++ b/spec/support/autodoc/index.html.slim
@@ -5,9 +5,12 @@
     p Cette page documente différentes fonctionnalités de RDV Service Public
     p Elle est mise à jour automatiquement dès que l'application change.
 
-    ul
-    - @scenarios.sort_by(&:title).each do |scenario|
-      li
-        a[href='scenario_#{scenario.index}.html'] #{scenario.title}
+    - @categories.each do |title, scenarios|
+      - if title
+        h2 = title
+      ul.fr-mb-4w
+        - scenarios.sort_by(&:title).each do |scenario|
+          li
+            a[href='scenario_#{scenario.index}.html'] #{scenario.title}
 
     p Dernière mise à jour le #{I18n.l(Time.zone.now)}


### PR DESCRIPTION
# Contexte

On est enfin prêts à permettre la création de compte en complète autonomie pour les agents du service public qu'on peut identifier de manière fiable grâce au domaine de leur adresse email.

Cette PR est l'aboutissement de https://github.com/betagouv/rdv-service-public/pull/5593, https://github.com/betagouv/rdv-service-public/pull/5794, https://github.com/betagouv/rdv-service-public/pull/5792, https://github.com/betagouv/rdv-service-public/pull/5787, https://github.com/betagouv/rdv-service-public/pull/5576

# Solution

On introduit principalement 3 changements :
- Les comptes ayant des adresse email avec des noms de domaine venant de [ce grist](https://grist.numerique.gouv.fr/o/docs/3kQ829mp7bTy/ProConnect-Configuration-des-FI-et-FS/p/1) sont autorisés à ouvrir un espace. Sur les 1k dernier comptes ouverts, au moins 50% auraient été autorisés automatiquement avec ce système.
- On saute l'étape de gestion des doublons si on n'en détecte pas via l'email ou le siret (et je pense qu'il faudra la revoir plus en détails, parce qu'elle est largement améliorable)
- L'autodoc est maintenant segmentée en plusieurs catégories de scénario pour que ça soit plus lisible.

<img width="871" height="964" alt="Screenshot 2025-11-05 at 17 00 13" src="https://github.com/user-attachments/assets/63be3800-c574-4741-89d6-54b73826421b" />
<img width="2316" height="7120" alt="_Users_victormours_dev_rdv-solidarites fr_tmp_capybara_autodoc_scenario_45c3644d1 html" src="https://github.com/user-attachments/assets/e3d7bc4b-bb01-405f-b7f6-31c78321183a" />

