### PR TITLE
Ajout des nouveaux comptes ouvert dans le CRM

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -106,6 +106,7 @@ SCALINGO_TIMEOUT_ERROR_URL=https://rawcdn.githack.com/betagouv/rdv-service-publi
 
 # Notion
 NOTION_API_SECRET=change_me
+NOTION_DATABASE_ID=28e2b05c-ed41-8048-8f5e-d34c80129504 # Base de données utilisée pour faire les tests. Pour trouver l’idée d’une base, voir : https://developers.notion.com/reference/retrieve-a-database
 
 # Zammad
 ZAMMAD_API_TOKEN="voir https://zammad10.ethibox.fr/#profile/token_access (clé rattachée à un compte individuel Agent Zammad)"

--- a/app/controllers/super_admins/accounts_for_crm_controller.rb
+++ b/app/controllers/super_admins/accounts_for_crm_controller.rb
@@ -21,6 +21,10 @@ module SuperAdmins
       authorize(@territory, policy_class: SuperAdmin::TerritoryPolicy)
 
       if @territory.save
+        if params[:add_to_crm]
+          CreateCrmPageJob.perform_later(@territory.id)
+        end
+
         flash[:success] = "Catégorie ajoutée à l'espace"
         redirect_to super_admins_accounts_for_crm_index_path
       else

--- a/app/controllers/super_admins/comptes_controller.rb
+++ b/app/controllers/super_admins/comptes_controller.rb
@@ -17,6 +17,10 @@ module SuperAdmins
       authorize_resource(compte)
 
       if compte.save!
+        if params[:add_to_crm]
+          CreateCrmPageJob.perform_later(compte.territory.id)
+        end
+
         redirect_to(
           super_admins_agent_path(compte.agent),
           notice: "Le nouvel espace a été créé, et une invitation a été envoyée à #{compte.agent.email}"

--- a/app/jobs/create_crm_page_job.rb
+++ b/app/jobs/create_crm_page_job.rb
@@ -1,0 +1,58 @@
+class CreateCrmPageJob < ApplicationJob
+  queue_as :default
+
+  # Base de données "Activation"
+  # ID récupéré dans l’URL de la page
+  # Cf: https://developers.notion.com/reference/retrieve-a-database
+  NOTION_DATABASE_ID = ENV["NOTION_DATABASE_ID"].freeze
+
+  def perform(territory_id)
+    return unless ENV["NOTION_API_SECRET"]
+
+    territory = Territory.find(territory_id)
+    client.create_page(
+      parent: {
+        type: "database_id",
+        database_id: NOTION_DATABASE_ID,
+      },
+      properties: {
+        "Project name": {
+          title: [
+            {
+              text: {
+                content: territory.name.presence || territory.organisations.first&.name,
+              },
+            },
+          ],
+        },
+        STATUS: {
+          status: {
+            name: "ACTIVATION",
+          },
+        },
+        CATEGORIE: {
+          multi_select: [
+            { name: territory.category },
+          ],
+        },
+        ENTREE: {
+          select: {
+            name: "Self-Onboarding", # TODO: gérer les ouvertures de compte par intégration
+          },
+        },
+        "COMPTE PROD": {
+          url: "#{ENV['HOST']}/super_admins/territories/#{territory.id}",
+        },
+        CONTACT: {
+          email: territory.agent_territorial_access_rights.count == 1 ? territory.agent_territorial_access_rights.first.agent.email : nil,
+        },
+      }
+    )
+  end
+
+  private
+
+  def client
+    @client ||= Notion::Client.new(token: ENV["NOTION_API_SECRET"])
+  end
+end

--- a/app/jobs/create_crm_page_job.rb
+++ b/app/jobs/create_crm_page_job.rb
@@ -20,7 +20,7 @@ class CreateCrmPageJob < ApplicationJob
           title: [
             {
               text: {
-                content: territory.name.presence || territory.organisations.first&.name,
+                content: territory.name_in_stats,
               },
             },
           ],

--- a/app/jobs/create_crm_page_job.rb
+++ b/app/jobs/create_crm_page_job.rb
@@ -37,14 +37,14 @@ class CreateCrmPageJob < ApplicationJob
         },
         ENTREE: {
           select: {
-            name: "Self-Onboarding", # TODO: gérer les ouvertures de compte par intégration
+            name: OauthApplication.agent_is_verified_by_an_application?(territory.admin_agents.first) ? "Intégration" : "Self-Onboarding",
           },
         },
         "COMPTE PROD": {
           url: "#{ENV['HOST']}/super_admins/territories/#{territory.id}",
         },
         CONTACT: {
-          email: territory.agent_territorial_access_rights.count == 1 ? territory.agent_territorial_access_rights.first.agent.email : nil,
+          email: territory.admin_agents.count == 1 ? territory.admin_agents.first.email : nil,
         },
       }
     )

--- a/app/views/super_admins/accounts_for_crm/edit.html.slim
+++ b/app/views/super_admins/accounts_for_crm/edit.html.slim
@@ -41,4 +41,7 @@ section.main-content__body
           - @territory.errors.full_messages.each do |message|
             li.flash-error= message
     div[style="margin-bottom: 24px"]= f.input :category, as: :select, collection: Compte::CATEGORIES, label: "Catégorie de l'espace"
+    div[style="margin-bottom: 16px"]
+      = label_tag "add_to_crm", "Créer la carte dans Notion"
+      = check_box_tag "add_to_crm", id: "add_to_crm", checked: true
     = f.submit

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -47,5 +47,8 @@ section.main-content__body
         .form-text.text-muted[style="margin-bottom: 12px"]
           = "L'agent a indiqué travailler pour le service "
           b #{@territory_creation_request.service_name}
+      div[style="margin-bottom: 16px"]
+        = label_tag "add_to_crm", "Créer la carte dans Notion"
+        = check_box_tag "add_to_crm", id: "add_to_crm", checked: true
 
     = f.submit

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -47,8 +47,10 @@ section.main-content__body
         .form-text.text-muted[style="margin-bottom: 12px"]
           = "L'agent a indiqué travailler pour le service "
           b #{@territory_creation_request.service_name}
-      div[style="margin-bottom: 16px"]
-        = label_tag "add_to_crm", "Créer la carte dans Notion"
-        = check_box_tag "add_to_crm", id: "add_to_crm", checked: true
+      / Lors d’une création qui n’est pas passé par le self-onboarding, la carte Notion est créée en amont, donc pas besoin de proposer cette option
+      - if @territory_creation_request
+        div[style="margin-bottom: 16px"]
+          = label_tag "add_to_crm", "Créer la carte dans Notion"
+          = check_box_tag "add_to_crm", id: "add_to_crm", checked: true
 
     = f.submit


### PR DESCRIPTION
# Contexte

Dans le cadre des ouvertures de comptes en autonomie, nous souhaitons faire en sorte que les cartes soient créées automatiquement dans le CRM afin d’éviter aux équipes de déploiements de refaire une saisie manuelle.

# Solution

- On propose de créer automatiquement la carte Notion lors de l’acceptation d’une demande de création de compte ou lors de la catégorisation d’un compte crée (soit par intégration avec un service externe, soit par ouverture de compte en complète autonomie #5796)


