### PR TITLE
Amélioration du layout du titre du calendrier

### DIFF
--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -118,6 +118,10 @@
   }
 }
 
+.rdv-min-width-200px {
+  min-width: 200px;
+}
+
 .rdv-max-height-12rem {
   max-height: 12rem;
 }

--- a/app/views/admin/planning/_planning_agents_select.html.slim
+++ b/app/views/admin/planning/_planning_agents_select.html.slim
@@ -1,36 +1,38 @@
 #planning_agents_select.container-fluid.py-1.px-3[style="background-color: white; border-bottom: 1px solid #EEE;"]
-  - unless @agents.size > 1 # Pas la place pour le toggle quand plusieurs agents sont sélectionnés
-    .float-right.mt-2.rdv-display-flex.flex-gap-1em.rdv-align-items-center.js-new-planning-toggle
-      = link_to "Revenir à l'ancienne vue", admin_organisation_planning_toggle_new_planning_path(current_organisation, set_to: "false"), method: :put, class: "fr-link fr-link--sm"
-      = link_to("Donnez votre avis", "https://tally.so/r/3jORDR", target: "_blank", class: "fr-link fr-link--sm")
-
-  h1.fr-h2.my-1.d-flex
-    | Planning de
-    .ml-2
-      = form_with(url: url_for({}), method: :get, class: "d-flex rdv-align-items-end") do |form|
-        div
-          ruby:
-            # Le select initial contient tous les agents sélectionnés, puis il sera alimenté en Ajax.
-            collection = @agents.map { |agent| [agent.reverse_full_name_or_email, agent.id] }
-            data = {
-              "select2-config": {
-                ajax: {
-                  url: search_agents_agents_path(organisation_id: current_organisation),
-                  dataType: "json",
-                  delay: 250,
+  .rdv-display-flex.rdv-gap-05rem.rdv-align-items-center.rdv-flex-wrap-wrap.rdv-justify-content-space-between.fr-my-2w
+    div.rdv-display-flex.rdv-gap-05rem.rdv-flex-wrap-wrap
+      h1.fr-h2.fr-mb-0
+        | Planning de
+      div
+        = form_with(url: url_for({}), method: :get, class: "d-flex rdv-align-items-end") do |form|
+          div
+            ruby:
+              # Le select initial contient tous les agents sélectionnés, puis il sera alimenté en Ajax.
+              collection = @agents.map { |agent| [agent.reverse_full_name_or_email, agent.id] }
+              data = {
+                "select2-config": {
+                  ajax: {
+                    url: search_agents_agents_path(organisation_id: current_organisation),
+                    dataType: "json",
+                    delay: 250,
+                  },
                 },
-              },
-            }
+              }
 
-          = form.select :agent_id, collection, { selected: @agents.map(&:id), multiple: @agents.size > 1 }, { name: "agent_id[]", class: ["select2-input"], data: }
+            = form.select :agent_id, collection, { selected: @agents.map(&:id), multiple: @agents.size > 1 }, { name: "agent_id[]", class: ["select2-input rdv-min-width-200px"], data:}
 
-        .ml-2.d-flex[style="gap: 0 0.5em"]
-          - if @agents.size == 1 && @multiple_agents_makes_sense && current_organisation.agents.count > 1
-            button#multi_agent_enable.fr-btn.fr-btn--tertiary Sélectionner plusieurs agents
-          #submit_agents[class=(@agents.size > 1 ? "" : "hidden")]
-            = form.submit "Appliquer", {class: "fr-btn  "}
-          #reset_agents[class=(@agents.size > 1 ? "" : "hidden")]
-            = link_to "Revenir à mon agenda", admin_organisation_planning_agenda_path(current_organisation, agent_id: current_agent), class: "fr-btn fr-btn--tertiary"
+          .ml-2.d-flex[style="gap: 0 0.5em"]
+            - if @agents.size == 1 && @multiple_agents_makes_sense && current_organisation.agents.count > 1
+              button#multi_agent_enable.fr-btn.fr-btn--tertiary Sélectionner plusieurs agents
+            #submit_agents[class=(@agents.size > 1 ? "" : "hidden")]
+              = form.submit "Appliquer", {class: "fr-btn  "}
+            #reset_agents[class=(@agents.size > 1 ? "" : "hidden")]
+              = link_to "Revenir à mon agenda", admin_organisation_planning_agenda_path(current_organisation, agent_id: current_agent), class: "fr-btn fr-btn--tertiary"
+
+    - unless @agents.size > 1 # Pas la place pour le toggle quand plusieurs agents sont sélectionnés
+      div.rdv-display-flex.rdv-gap-05rem.rdv-flex-wrap-wrap
+        div= link_to "Revenir à l'ancienne vue", admin_organisation_planning_toggle_new_planning_path(current_organisation, set_to: "false"), method: :put, class: "fr-link fr-link--sm js-new-planning-toggle"
+        div= link_to("Donnez votre avis", "https://tally.so/r/3jORDR", target: "_blank", class: "fr-link fr-link--sm js-new-planning-toggle")
 
 .container-fluid.px-2.d-flex[style="background-color: white; border-bottom: 1px solid #EEE;align-items: center;"]
   .flex-grow-1


### PR DESCRIPTION
## Contexte

Je sais qu’on vise quasi exclusivement le desktop côté agents mais là c’était cassé chez moi pour peu que le viewport width soit pas super grand

## Captures

| Avant | Après |
| - | - |
| <img width="2401" height="1339" alt="image" src="https://github.com/user-attachments/assets/3c2c9e93-2577-47f2-9422-c2bed61f427b" /> | <img width="2401" height="1339" alt="image" src="https://github.com/user-attachments/assets/f3f20070-11db-4247-9bb1-f64751b3f6c9" /> |
| <img width="1478" height="1067" alt="image" src="https://github.com/user-attachments/assets/25a251d2-48d4-412f-8150-703ebd37ab26" /> | <img width="1478" height="1067" alt="image" src="https://github.com/user-attachments/assets/2614e8a9-1f44-495d-8a88-e94ea0198dae" /> |

Petite amélioration sémantique : on sort le formulaire, le select et les liens de droite du `h1`

## Points technique

### Tailwind vs Y2K

à ce niveau de complexité d’imbrication de `div flex`, je me demande si je préfère l’approche tailwind avec plein de utility classes dans le dom (que j’ai faite dans cette PR) ou l’approche classique avec un composant `.rdv-calendar-title` et plein de règles CSS 🤷 

### Select width

Actuellement le select a une width assez importante, je me demandais pourquoi. C’est parce qu’étant imbriqué dans le `h1`, il a une police super grande, donc le select natif est énorme, et donc `select2` réserve toute cette place. 

Voilà ce qu’on voit si on désactive select2 sur ce select sur `production` :

<img width="961" height="499" alt="image" src="https://github.com/user-attachments/assets/6bb6642b-3883-4520-851d-90ff4df9c1e7" />

Comme on sort ici le `select` du `h1`, ce tweak ne fonctionne plus. Je propose ici de mettre un `min-width: 200px` tout à fait arbitraire.

## Review App

[Review app](https://rdv-service-public-review-app-pr5799.osc-secnum-fr1.scalingo.io/)
