### PR TITLE
Utiliser uniquement la gem "debug" native

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -214,7 +214,7 @@ group :development do
 end
 
 group :development, :test do
-  gem "pry" # CI 2
+  gem "debug" # CI 1
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -214,7 +214,7 @@ group :development do
 end
 
 group :development, :test do
-  gem "byebug" # CI 1
+  gem "byebug" # CI 2
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -214,7 +214,7 @@ group :development do
 end
 
 group :development, :test do
-  gem "debug" # CI 1
+  gem "debug" # CI 2
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -192,8 +192,6 @@ group :development do
 
   # help to kill N+1 queries and unused eager loading.
   gem "bullet"
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem "byebug"
   # Better error page for Rails and other Rack apps
   gem "better_errors"
   # Retrieve the binding of a method's caller, or further up the stack.
@@ -213,6 +211,10 @@ group :development do
   gem "letter_opener_web" # Saves sent emails and serves them on /letter_opener
   # Entity-relationship diagram for your Rails models.
   gem "rails-erd", require: false # Keeps docs/domain_model.svg up-to-date. See .erdconfig
+end
+
+group :development, :test do
+  gem "debug"
 end
 
 group :test do
@@ -266,6 +268,4 @@ group :test do
   gem "axiom-types", git: "https://github.com/rdv-solidarites/axiom-types.git", ref: "b9b204c"
 
   gem "sinatra"
-
-  gem "pry"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -214,7 +214,7 @@ group :development do
 end
 
 group :development, :test do
-  gem "debug" # CI 2
+  gem "debug"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -214,7 +214,7 @@ group :development do
 end
 
 group :development, :test do
-  gem "byebug" # CI 2
+  gem "pry" # CI 1
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -214,7 +214,7 @@ group :development do
 end
 
 group :development, :test do
-  gem "debug"
+  gem "byebug" # CI 1
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -214,7 +214,7 @@ group :development do
 end
 
 group :development, :test do
-  gem "pry" # CI 1
+  gem "pry" # CI 2
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -214,7 +214,7 @@ group :development do
 end
 
 group :development, :test do
-  gem "debug"
+  gem "debug", require: "debug/prelude"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,6 +377,7 @@ GEM
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2025.0924)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (5.26.1)
     montrose (0.16.0)
       activesupport (>= 5.2, < 8)
@@ -398,7 +399,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    nokogiri (1.18.10)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notion-ruby-client (1.2.2)
       faraday (>= 2.0)
@@ -755,7 +757,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   active_link_to

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,7 +449,7 @@ GEM
       activerecord (>= 6.1)
       request_store (~> 1.4)
     parallel (1.26.3)
-    parallel_tests (4.8.0)
+    parallel_tests (5.5.0)
       parallel
     parser (3.3.7.3)
       ast (~> 2.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,6 @@ GEM
       logger (~> 1.5)
     choice (0.2.0)
     climate_control (1.2.0)
-    coderay (1.1.3)
     common_french_passwords (0.0.1)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
@@ -199,6 +198,9 @@ GEM
       addressable
     csv (3.3.2)
     date (3.5.0)
+    debug (1.11.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     debug_inspector (1.2.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -470,9 +472,6 @@ GEM
       premailer (~> 1.7, >= 1.7.9)
     prettyprint (0.2.0)
     prism (1.4.0)
-    pry (0.15.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     psych (5.2.6)
       date
       stringio
@@ -782,6 +781,7 @@ DEPENDENCIES
   common_french_passwords
   connection_pool
   csv
+  debug
   devise!
   devise-async
   devise_invitable
@@ -819,7 +819,6 @@ DEPENDENCIES
   pg_search
   phonelib
   premailer-rails
-  pry
   puma
   pundit
   rack-attack

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,6 @@ GEM
     bullet (8.0.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (12.0.0)
     calendav (0.5.0)
       http
       icalendar
@@ -189,7 +188,6 @@ GEM
       logger (~> 1.5)
     choice (0.2.0)
     climate_control (1.2.0)
-    coderay (1.1.3)
     common_french_passwords (0.0.1)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
@@ -200,6 +198,9 @@ GEM
       addressable
     csv (3.3.2)
     date (3.5.0)
+    debug (1.11.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     debug_inspector (1.2.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -473,9 +474,6 @@ GEM
       premailer (~> 1.7, >= 1.7.9)
     prettyprint (0.2.0)
     prism (1.4.0)
-    pry (0.15.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     psych (5.2.6)
       date
       stringio
@@ -775,7 +773,6 @@ DEPENDENCIES
   bootsnap
   brakeman
   bullet
-  byebug
   calendav (~> 0.5)
   capybara
   capybara-email
@@ -786,6 +783,7 @@ DEPENDENCIES
   common_french_passwords
   connection_pool
   csv
+  debug
   devise!
   devise-async
   devise_invitable
@@ -823,7 +821,6 @@ DEPENDENCIES
   pg_search
   phonelib
   premailer-rails
-  pry
   puma
   pundit
   rack-attack

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,7 @@ GEM
     bullet (8.0.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    byebug (12.0.0)
     calendav (0.5.0)
       http
       icalendar
@@ -198,9 +199,6 @@ GEM
       addressable
     csv (3.3.2)
     date (3.5.0)
-    debug (1.11.0)
-      irb (~> 1.10)
-      reline (>= 0.3.8)
     debug_inspector (1.2.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -377,7 +375,6 @@ GEM
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2025.0924)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.26.1)
     montrose (0.16.0)
       activesupport (>= 5.2, < 8)
@@ -399,8 +396,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.18.10)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     notion-ruby-client (1.2.2)
       faraday (>= 2.0)
@@ -757,7 +753,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   active_link_to
@@ -773,6 +769,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   bullet
+  byebug
   calendav (~> 0.5)
   capybara
   capybara-email
@@ -783,7 +780,6 @@ DEPENDENCIES
   common_french_passwords
   connection_pool
   csv
-  debug
   devise!
   devise-async
   devise_invitable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,6 @@ GEM
     bullet (8.0.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (12.0.0)
     calendav (0.5.0)
       http
       icalendar
@@ -189,6 +188,7 @@ GEM
       logger (~> 1.5)
     choice (0.2.0)
     climate_control (1.2.0)
+    coderay (1.1.3)
     common_french_passwords (0.0.1)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
@@ -470,6 +470,9 @@ GEM
       premailer (~> 1.7, >= 1.7.9)
     prettyprint (0.2.0)
     prism (1.4.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     psych (5.2.6)
       date
       stringio
@@ -769,7 +772,6 @@ DEPENDENCIES
   bootsnap
   brakeman
   bullet
-  byebug
   calendav (~> 0.5)
   capybara
   capybara-email
@@ -817,6 +819,7 @@ DEPENDENCIES
   pg_search
   phonelib
   premailer-rails
+  pry
   puma
   pundit
   rack-attack

--- a/docs/4-notes-techniques.md
+++ b/docs/4-notes-techniques.md
@@ -186,7 +186,7 @@ scalingo --app rdv-service-public-metabase deploy https://github.com/Scalingo/me
 
 Une manière pratique et intéractive d’écrire ou de debugger des feature specs (end-to-end) est :
 
-- insérer un `binding.pry` dans la spec avant la ligne qui échoue
+- insérer un `debugger` dans la spec avant la ligne qui échoue
 - préfixer `HEADLESS=false` avant l’appel à `bundle exec rspec ...`
 - le test utilisera alors le driver capybara JS même si le flag `js: true` n’est pas présent
 - le navigateur Chrome orchestré par Capybara sera maintenant visible

--- a/scripts/blocked_contacts_stats.rb
+++ b/scripts/blocked_contacts_stats.rb
@@ -3,7 +3,7 @@
 
 require "csv"
 require "optparse"
-require "pry"
+require "debug"
 
 options = Struct.new(:path).new
 OptionParser.new do |opts|
@@ -57,7 +57,7 @@ IGNORED_DOMAINS = %w[
 ].freeze
 
 rows = CSV.read(options.path, col_sep: ";", headers: true)
-# binding.pry
+# debugger
 rows
   .select { _1["Reason"].include?("hard bounce") }
   .map { _1["Contact"].split("@").last }

--- a/scripts/webhook_debug_rack_app.ru
+++ b/scripts/webhook_debug_rack_app.ru
@@ -2,7 +2,7 @@
 # ngrok http 9292
 
 require "openssl"
-require "byebug"
+require "debug"
 
 class WebhookDebugRackApp
   def call(env)
@@ -13,7 +13,7 @@ class WebhookDebugRackApp
     received_signature = env["HTTP_X_LAPIN_SIGNATURE"]
     puts "computed_signature : #{computed_signature}"
     puts "received_signature : #{received_signature}"
-    [200, { "Content-Type" => "text/html" }, ["Hello World!"]]
+    [200, { "content-type" => "text/html" }, ["Hello World!"]]
   end
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -119,4 +119,11 @@ RSpec.configure do |config|
     Warden.test_reset!
     WebMock.reset!
   end
+
+  config.around do |example|
+    Timeout.timeout(10) do
+      example.run
+      ActiveRecord::Tasks::DatabaseTasks.truncate_all
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,7 +121,7 @@ RSpec.configure do |config|
   end
 
   config.around do |example|
-    Timeout.timeout(10) do
+    Timeout.timeout(30) do
       example.run
       ActiveRecord::Tasks::DatabaseTasks.truncate_all
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,7 +87,7 @@ RSpec.configure do |config|
     Faker::Config.random = Random.new(config.seed)
   end
 
-  # config.after(:suite) { Autodoc.render }
+  config.after(:suite) { Autodoc.render }
 
   config.around do |example|
     if example.metadata[:js] || ENV["HEADLESS"] == "false"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -119,11 +119,4 @@ RSpec.configure do |config|
     Warden.test_reset!
     WebMock.reset!
   end
-
-  config.around do |example|
-    Timeout.timeout(30) do
-      example.run
-      ActiveRecord::Tasks::DatabaseTasks.truncate_all
-    end
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,7 +87,7 @@ RSpec.configure do |config|
     Faker::Config.random = Random.new(config.seed)
   end
 
-  config.after(:suite) { Autodoc.render }
+  # config.after(:suite) { Autodoc.render }
 
   config.around do |example|
     if example.metadata[:js] || ENV["HEADLESS"] == "false"


### PR DESCRIPTION
Nous avons eu une [discussion entre devs sur les outils de debug](https://mattermost.incubateur.net/betagouv/pl/ikmgr3ih9pgduysx8xho891r9r) dans laquelle personne n'exprimait de préférence pour un outil de debug interactif spécifique. 

Je propose donc d'unifier nos pratiques autour de la gem `debug`. Cette gem semble la  plus moderne, beaucoup plus performante que `byebug`, et [suggérée par Rails](https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem). 

En homogénéisant nos pratiques au sein de l'équipe, on a une opportunité de construire une culture technique commune.

La doc de la gem : https://github.com/ruby/debug

Note : une feature me plait particulièrement : 

```
 - catch <Error>
   - Set breakpoint on raising <Error>.
```

# Dans cette PR

J'ai cherché et remplacé les exemples d'usages de `byebug` et `pry` dans notre codebase.

J'ai mis à jour la super doc d'Adrien sur comment on fait du debug pas-à-pas dans les specs JS, j'ai bien vérifié que la gem `debug` permettait d'appeler `click_button "Continuer"` en direct live. :ok_hand: 