### PR TITLE
Ajouter `agents.deleted_at` dans papertrail

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -13,7 +13,7 @@ class Agent < ApplicationRecord
       email unconfirmed_email
       first_name last_name
       pro_connect_openid_sub proconnect_siret
-      invitation_sent_at invitation_accepted_at
+      invitation_sent_at invitation_accepted_at deleted_at
     ]
   )
 


### PR DESCRIPTION
On a eu un ticket Zammad d'un agent dont le compte a été supprimé, mais on ne sait pas par qui.
En ajoutant cet attribut, ça rendra cette info dispo dans le super admin pour la prochaine fois.