### PR TITLE
Améliorer les ICS pour les plages d'ouverture et absences

### DIFF
--- a/app/models/concerns/ics_payloads/absence.rb
+++ b/app/models/concerns/ics_payloads/absence.rb
@@ -6,7 +6,8 @@ module IcsPayloads
         starts_at: starts_at,
         ends_at: first_occurrence_ends_at,
         ical_uid: ical_uid,
-        summary: "#{IcalFormatters::Ics::ICS_UID_SUFFIX} #{title}",
+        summary: title,
+        description: "Voir sur #{domain.name} : #{Rails.application.routes.url_helpers.edit_admin_organisation_planning_absence_url(agent.organisations.first, id, host: domain.host_name)}",
         rrule: IcalFormatters::Rrule.from_recurrence(recurrence),
         domain: domain,
       }

--- a/app/models/concerns/ics_payloads/plage_ouverture.rb
+++ b/app/models/concerns/ics_payloads/plage_ouverture.rb
@@ -6,7 +6,9 @@ module IcsPayloads
         starts_at: starts_at,
         ends_at: first_occurrence_ends_at,
         ical_uid: ical_uid,
-        summary: "#{IcalFormatters::Ics::ICS_UID_SUFFIX} #{title_with_default}",
+        summary: title_with_default,
+        description: "Voir sur #{domain.name} : #{Rails.application.routes.url_helpers.admin_organisation_planning_plage_ouverture_url(organisation, id, host: domain.host_name)}",
+        location: lieu_address,
         rrule: IcalFormatters::Rrule.from_recurrence(recurrence),
         domain: domain,
       }

--- a/spec/blueprint/absence_blueprint_spec.rb
+++ b/spec/blueprint/absence_blueprint_spec.rb
@@ -1,29 +1,32 @@
 RSpec.describe AbsenceBlueprint do
+  let(:organisation) { create(:organisation) }
+
   describe "#render" do
     it "contains an agent" do
-      absence = build(:absence, agent: build(:agent, email: "bob@example.com", first_name: "Bob", last_name: "Henri"))
+      agent = create(:agent, email: "bob@example.com", first_name: "Bob", last_name: "Henri", basic_role_in_organisations: [organisation])
+      absence = create(:absence, agent:)
       parsed_absence = JSON.parse(described_class.render(absence, root: :absence))
       expect(parsed_absence["absence"]["agent"]).to eq({
                                                          "email" => "bob@example.com",
                                                          "first_name" => "Bob",
                                                          "last_name" => "Henri",
-                                                         "id" => nil,
+                                                         "id" => agent.id,
                                                        })
     end
 
     it "contains rrules" do
-      now = Time.zone.parse("2020-12-23 14h00")
-      absence = build(:absence, recurrence: Montrose.every(:week, starts: now))
+      Time.zone.parse("2020-12-23 14h00")
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      absence = create(:absence, :weekly_on_monday, agent:)
       parsed_absence = JSON.parse(described_class.render(absence, root: :absence))
-      expect(parsed_absence["absence"]["rrule"]).to eq("FREQ=WEEKLY;")
+      expect(parsed_absence["absence"]["rrule"]).to eq("FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;")
     end
 
     # TODO: Supprimer quand la solution à ce problème est mise en place:
     #   https://github.com/betagouv/rdv-solidarites.fr/pull/3456
     it "contains an organisation" do
-      organisation = create(:organisation)
       agent = create(:agent, basic_role_in_organisations: [organisation])
-      absence = build(:absence, agent: agent)
+      absence = create(:absence, agent:)
       parsed_absence = JSON.parse(described_class.render(absence, root: :absence))
 
       expect(parsed_absence["absence"]["organisation"]["id"]).to eq(organisation.id)

--- a/spec/mailers/agents/absence_mailer_spec.rb
+++ b/spec/mailers/agents/absence_mailer_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe Agents::AbsenceMailer, type: :mailer do
   end
 
   describe "#absence_destroyed" do
-    let(:absence) { create :absence }
+    let(:agent) { create(:agent, basic_role_in_organisations: [create(:organisation)]) }
+    let(:absence) { create :absence, agent: agent }
 
     it "have a STATUS:CANCELLED in ICS file joined" do
       mail = described_class.with(absence: absence).absence_destroyed

--- a/spec/models/concerns/ics_payloads/absence_spec.rb
+++ b/spec/models/concerns/ics_payloads/absence_spec.rb
@@ -1,47 +1,51 @@
 RSpec.describe IcsPayloads::Absence do
+  let(:agent) { create(:agent, basic_role_in_organisations: [create(:organisation)]) }
+
   describe "#payload" do
     %i[name starts_at rrule ical_uid ends_at].each do |key|
       it "return an hash with key #{key}" do
-        absence = build(:absence)
+        absence = create(:absence, agent:)
         expect(absence.payload).to have_key(key)
       end
     end
 
     describe ":action" do
       it "return an hash with key action key and value" do
-        absence = build(:absence)
+        absence = create(:absence, agent:)
         expect(absence.payload(:create)[:action]).to eq(:create)
       end
     end
 
     describe ":name" do
-      let(:absence) { build(:absence, title: "something", start_time: Time.zone.parse("12h30"), first_day: Date.new(2020, 11, 13)) }
+      let(:absence) { create(:absence, agent:, title: "something", start_time: Time.zone.parse("12h30"), first_day: Date.new(2020, 11, 13)) }
 
       it { expect(absence.payload[:name]).to eq("absence-something-2020-11-13-12-30-00-0100.ics") }
     end
 
     describe ":starts_at" do
       let(:starts_at) { Time.zone.parse("20201009 11h45") }
-      let(:absence) { build(:absence, start_time: starts_at, first_day: starts_at.to_date) }
+      let(:absence) { create(:absence, agent:, start_time: starts_at, first_day: starts_at.to_date) }
 
       it { expect(absence.payload[:starts_at]).to eq(starts_at) }
     end
 
     describe ":rrule" do
-      let(:absence) { build(:absence, recurrence: Montrose.every(:week, starts: Date.new(2020, 11, 18), on: [:wednesday]).to_json) }
+      let(:absence) do
+        create(:absence, agent:, first_day: Date.new(2020, 11, 18), recurrence: Montrose.every(:week, starts: Date.new(2020, 11, 18), on: [:wednesday]).to_json)
+      end
 
       it { expect(absence.payload[:rrule]).to eq("FREQ=WEEKLY;BYDAY=WE;") }
     end
 
     describe ":ical_uid" do
-      let(:absence) { create(:absence) }
+      let(:absence) { create(:absence, agent:) }
 
       it { expect(absence.payload[:ical_uid]).to eq("absence_#{absence.id}@RDV Solidarités") }
     end
 
     describe ":ends_at" do
       let(:starts_at) { Time.zone.parse("20201009 11h45") }
-      let(:absence) { build(:absence, end_time: starts_at + 5.hours, first_day: starts_at.to_date) }
+      let(:absence) { create(:absence, agent:, end_time: starts_at + 5.hours, first_day: starts_at.to_date) }
 
       it { expect(absence.payload[:ends_at]).to eq(starts_at + 5.hours) }
     end

--- a/spec/models/concerns/ics_payloads/plage_ouverture_spec.rb
+++ b/spec/models/concerns/ics_payloads/plage_ouverture_spec.rb
@@ -2,20 +2,20 @@ RSpec.describe IcsPayloads::PlageOuverture do
   describe "#payload" do
     %i[name starts_at rrule ical_uid ends_at].each do |key|
       it "return an hash with key #{key}" do
-        plage_ouverture = build(:plage_ouverture)
+        plage_ouverture = create(:plage_ouverture)
         expect(plage_ouverture.payload).to have_key(key)
       end
     end
 
     describe ":action" do
       it "return an hash with key action key and value" do
-        plage_ouverture = build(:plage_ouverture)
+        plage_ouverture = create(:plage_ouverture)
         expect(plage_ouverture.payload(:create)[:action]).to eq(:create)
       end
     end
 
     describe ":name" do
-      let(:plage_ouverture) { build(:plage_ouverture, title: "Permanence mairie", start_time: Tod::TimeOfDay.new(9), first_day: Date.new(2020, 11, 13)) }
+      let(:plage_ouverture) { create(:plage_ouverture, title: "Permanence mairie", start_time: Tod::TimeOfDay.new(9), first_day: Date.new(2020, 11, 13)) }
 
       it { expect(plage_ouverture.payload[:name]).to eq("plage-ouverture-permanence-mairie-2020-11-13-09-00-00-0100.ics") }
 
@@ -27,26 +27,35 @@ RSpec.describe IcsPayloads::PlageOuverture do
     end
 
     describe ":summary" do
-      let(:plage_ouverture) { build(:plage_ouverture, title: "something") }
+      let(:plage_ouverture) { create(:plage_ouverture, title: "Permanence d'accueil") }
 
-      it { expect(plage_ouverture.payload[:summary]).to eq("RDV Solidarités something") }
+      it { expect(plage_ouverture.payload[:summary]).to eq("Permanence d'accueil") }
 
       context "when title is empty" do
         let(:plage_ouverture) { create(:plage_ouverture, title: nil) }
 
-        it { expect(plage_ouverture.payload[:summary]).to eq("RDV Solidarités Plage de 8h-12h") }
+        it { expect(plage_ouverture.payload[:summary]).to eq("Plage de 8h-12h") }
+      end
+    end
+
+    describe ":description" do
+      let(:plage_ouverture) { create(:plage_ouverture) }
+
+      it do
+        description = "Voir sur RDV Solidarités : http://www.rdv-solidarites-test.localhost/admin/organisations/#{plage_ouverture.organisation_id}/planning/plage_ouvertures/#{plage_ouverture.id}"
+        expect(plage_ouverture.payload[:description]).to eq(description)
       end
     end
 
     describe ":starts_at" do
       let(:starts_at) { Time.zone.parse("20201009 11h45") }
-      let(:plage_ouverture) { build(:plage_ouverture, start_time: starts_at, first_day: starts_at.to_date) }
+      let(:plage_ouverture) { create(:plage_ouverture, start_time: starts_at, first_day: starts_at.to_date) }
 
       it { expect(plage_ouverture.payload[:starts_at]).to eq(starts_at) }
     end
 
     describe ":rrule" do
-      let(:plage_ouverture) { build(:plage_ouverture, recurrence: Montrose.every(:week, starts: Date.new(2020, 11, 18), on: [:wednesday]).to_json) }
+      let(:plage_ouverture) { create(:plage_ouverture, first_day: Date.new(2025, 11, 5), recurrence: Montrose.every(:week, starts: Date.new(2025, 11, 5), on: [:wednesday])) }
 
       it { expect(plage_ouverture.payload[:rrule]).to eq("FREQ=WEEKLY;BYDAY=WE;") }
     end
@@ -59,7 +68,7 @@ RSpec.describe IcsPayloads::PlageOuverture do
 
     describe ":ends_at" do
       let(:starts_at) { Time.zone.parse("20201009 11h45") }
-      let(:plage_ouverture) { build(:plage_ouverture, end_time: starts_at + 5.hours, first_day: starts_at.to_date) }
+      let(:plage_ouverture) { create(:plage_ouverture, end_time: starts_at + 5.hours, first_day: starts_at.to_date) }
 
       it { expect(plage_ouverture.payload[:ends_at]).to eq(starts_at + 5.hours) }
     end


### PR DESCRIPTION
# Contexte

Un ticket Zammad nous indique que pour une plage d'ouverture crée dans RDV Service Public, la pièce jointe ICS crée un évènement intitulé "Rdv solidarités permanence" (voir https://zammad10.ethibox.fr/#ticket/zoom/30222), ce qui n'a effectivement pas de sens.


# Solution

Cette PR corrige donc ce comportement, en reprenant ce qu'on fait pour les rendez-vous.

Au passage, j'applique un correctif similaire aux absences.