### PR TITLE
Endpoint de mise à jour du statut d'un rendez-vous pour l'espace coop

### DIFF
--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -25,4 +25,19 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
 
     render_collection(rdvs)
   end
+
+  def update
+    @rdv = Rdv.find(params[:id])
+    authorize(@rdv, policy_class: Agent::RdvPolicy)
+
+    @rdv.update(params.permit(:status))
+
+    render_record @rdv
+  end
+
+  private
+
+  def pundit_user
+    current_agent
+  end
 end

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -30,9 +30,14 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
     @rdv = Rdv.find(params[:id])
     authorize(@rdv, policy_class: Agent::RdvPolicy)
 
-    @rdv.update(params.permit(:status))
+    @rdv.update!(params.permit(:status))
 
-    render_record @rdv
+    # Le blueprint complet du rendez-vous renvoie énormément d'information, qui ne sont pas pertinentes ici.
+    # On va sans doute devoir restreindre la quantité de données renvoyées par ce blueprint pour rendre
+    # l'index de ce controller plus rapide.
+    # Pour éviter de devoir investiguer quels clients de l'api dépendent des attributs de ce
+    # blueprint pour cet endpoint d'update, on ne renvoie que le statut (ce qui répond à notre besoin).
+    render json: @rdv.attributes.symbolize_keys.slice(:status)
   end
 
   private

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -26,9 +26,9 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
     render_collection(rdvs)
   end
 
-  def update
-    @rdv = Rdv.find(params[:id])
-    authorize(@rdv, policy_class: Agent::RdvPolicy)
+  def update_status
+    @rdv = Rdv.find(params[:rdv_id])
+    authorize(@rdv, :update?, policy_class: Agent::RdvPolicy)
 
     @rdv.update!(params.permit(:status))
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -62,7 +62,7 @@ class Rdv < ApplicationRecord
            :service_name, :service_short_name, to: :motif
 
   # Validations
-  validates :starts_at, :ends_at, :agents, presence: true
+  validates :starts_at, :ends_at, :agents, :status, presence: true
   validate :lieu_is_not_disabled_if_needed
   validates :starts_at, realistic_date: true
   validate :duration_is_plausible

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -19,7 +19,7 @@ namespace :api do
       resources :rdvs, only: %i[index]
     end
     resources :motifs, only: %i[create]
-    resources :rdvs, only: %i[index]
+    resources :rdvs, only: %i[index update]
     resources :participations, only: %i[update]
     resources :rdv_plans, only: %i[create show]
     resources :teams, only: %i[index]

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -19,7 +19,9 @@ namespace :api do
       resources :rdvs, only: %i[index]
     end
     resources :motifs, only: %i[create]
-    resources :rdvs, only: %i[index update]
+    resources :rdvs, only: %i[index] do
+      patch :update_status
+    end
     resources :participations, only: %i[update]
     resources :rdv_plans, only: %i[create show]
     resources :teams, only: %i[index]

--- a/spec/requests/api/v1/swagger_doc/lieux_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/lieux_request_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe "API des lieux", swagger_doc: "v1/api.json" do
 
       let!(:organisation) { create(:organisation) }
       let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-      let(:oauth_token) { create(:access_token, resource_owner_id: agent.id) }
-      let(:authorization) { "Bearer #{oauth_token.plaintext_token}" }
 
       response 200, "Renvoie une liste des lieux" do
         schema "$ref" => "#/components/schemas/lieux"
@@ -49,8 +47,6 @@ RSpec.describe "API des lieux", swagger_doc: "v1/api.json" do
 
       let!(:organisation) { create(:organisation) }
       let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-      let(:oauth_token) { create(:access_token, resource_owner_id: agent.id) }
-      let(:authorization) { "Bearer #{oauth_token.plaintext_token}" }
 
       response 200, "Crée et renvoie un lieu" do
         let(:organisation_id) { organisation.id }

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -208,13 +208,39 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
     patch "Mettre à jour le statut d'un rendez-vous" do
       with_oauth_token_authentication
 
+      let!(:agent) { create(:agent, admin_role_in_organisations: [rdv.organisation]) }
+      let(:oauth_token) { create(:access_token, resource_owner_id: agent.id) }
+      let(:authorization) { "Bearer #{oauth_token.plaintext_token}" }
+
       tags "RDV"
       produces "application/json"
       consumes "application/json"
       operationId "updateRdv"
       description "Met à jour le statut d'un rendez-vous passé, pour indiquer s'il a bien eu lieu comme prévu ou s'il a été annulé."
 
+      parameter name: :rdv_id, in: :path, type: :integer, description: "ID du rendez-vous", example: 123
+      parameter(
+        name: :params, # ce nom n'est pas utilisé, car tous les paramètres sont dans le body de la requête
+        in: :body,
+        schema: {
+          type: :object,
+          properties: {
+            status: { type: :string, example: "seen" },
+          },
+          required: %w[status],
+        },
+        example: { status: "seen" }
+      )
 
+      let(:rdv) { create(:rdv, status: :unknown) }
+      let(:rdv_id) { rdv.id }
 
+      response 200, "Met à jour et renvoie un rendez-vous" do
+        run_test!
+        let(:params) do
+          { status: "seen" }
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -214,7 +214,15 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
       produces "application/json"
       consumes "application/json"
       operationId "updateRdv"
-      description "Met à jour le statut d'un rendez-vous passé, pour indiquer s'il a bien eu lieu comme prévu ou s'il a été annulé."
+
+      humanized_status_values = Rdv.statuses.keys.map do |status|
+        "#{status} (#{Rdv.human_attribute_value(:status, status)})"
+      end.to_sentence
+
+      description <<~TEXT
+        Met à jour le statut d'un rendez-vous passé, pour indiquer s'il a bien eu lieu comme prévu ou s'il a été annulé.
+        Les valeurs autorisées pour le statut sont #{humanized_status_values}."
+      TEXT
 
       parameter name: :rdv_id, in: :path, type: :integer, description: "ID du rendez-vous", example: 123
       parameter(

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -237,8 +237,15 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
 
       response 200, "Met à jour et renvoie un rendez-vous" do
         run_test!
+
         let(:params) do
           { status: "seen" }
+        end
+      end
+
+      it_behaves_like "an endpoint that returns 422 - unprocessable_entity", "le statut envoyé n'est pas valide" do
+        let(:params) do
+          { status: nil }
         end
       end
     end

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -208,9 +208,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
     patch "Mettre à jour le statut d'un rendez-vous" do
       with_oauth_token_authentication
 
-      let!(:agent) { create(:agent, admin_role_in_organisations: [rdv.organisation]) }
-      let(:oauth_token) { create(:access_token, resource_owner_id: agent.id) }
-      let(:authorization) { "Bearer #{oauth_token.plaintext_token}" }
+      let!(:agent) { create(:agent, :francis_factice, admin_role_in_organisations: [rdv.organisation]) }
 
       tags "RDV"
       produces "application/json"

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -203,4 +203,18 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
       it_behaves_like "an endpoint that returns 401 - unauthorized"
     end
   end
+
+  path "/api/v1/rdvs/{rdv_id}" do
+    patch "Mettre à jour le statut d'un rendez-vous" do
+      with_oauth_token_authentication
+
+      tags "RDV"
+      produces "application/json"
+      consumes "application/json"
+      operationId "updateRdv"
+      description "Met à jour le statut d'un rendez-vous passé, pour indiquer s'il a bien eu lieu comme prévu ou s'il a été annulé."
+
+
+
+  end
 end

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
     end
   end
 
-  path "/api/v1/rdvs/{rdv_id}" do
+  path "/api/v1/rdvs/{rdv_id}/update_status" do
     patch "Mettre à jour le statut d'un rendez-vous" do
       with_oauth_token_authentication
 
@@ -213,7 +213,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
       tags "RDV"
       produces "application/json"
       consumes "application/json"
-      operationId "updateRdv"
+      operationId "updateRdvStatus"
 
       humanized_status_values = Rdv.statuses.keys.map do |status|
         "#{status} (#{Rdv.human_attribute_value(:status, status)})"

--- a/spec/support/api_spec_macros.rb
+++ b/spec/support/api_spec_macros.rb
@@ -29,6 +29,8 @@ module ApiSpecMacros
     parameter name: "content-type", in: :header, type: :string
     parameter name: "authorization", in: :header, type: :string, description: "Token d'accès (authentification)", example: "Bearer 123456"
     let(:"content-type") { "application/json" }
+    let(:oauth_token) { create(:access_token, resource_owner_id: agent.id) }
+    let(:authorization) { "Bearer #{oauth_token.plaintext_token}" }
   end
 
   def with_visioplainte_authentication

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -14,12 +14,6 @@ RSpec.configure do |config|
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
   config.openapi_specs = {
 
-    "conseillers_numeriques/api.json" => {
-      openapi: "3.0.1",
-      info: {
-        title: "API de création de comptes agents pour conseillers numériques",
-      },
-    },
     "visioplainte/api.json" => {
       openapi: "3.0.1",
       info: {

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -3622,6 +3622,110 @@
         }
       }
     },
+    "/api/v1/rdvs/{rdv_id}": {
+      "patch": {
+        "summary": "Mettre à jour le statut d'un rendez-vous",
+        "security": [
+          {
+            "content-type": [],
+            "autorization": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "content-type",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "description": "Token d'accès (authentification)",
+            "example": "Bearer 123456",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rdv_id",
+            "in": "path",
+            "description": "ID du rendez-vous",
+            "example": 123,
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "tags": [
+          "RDV"
+        ],
+        "operationId": "updateRdv",
+        "description": "Met à jour le statut d'un rendez-vous passé, pour indiquer s'il a bien eu lieu comme prévu ou s'il a été annulé.",
+        "responses": {
+          "200": {
+            "description": "Met à jour et renvoie un rendez-vous",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": {
+                      "status": "seen"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Renvoie 'unprocessable_entity' quand le statut envoyé n'est pas valide",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": {
+                      "errors": {
+                        "status": [
+                          {
+                            "error": "blank"
+                          }
+                        ]
+                      },
+                      "error_messages": [
+                        "status doit être rempli(e)"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/error_unprocessable_entity"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "example": "seen"
+                  }
+                },
+                "required": [
+                  "status"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/referent_assignations": {
       "post": {
         "summary": "Créer une assignation à un référent",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -3663,7 +3663,7 @@
           "RDV"
         ],
         "operationId": "updateRdv",
-        "description": "Met à jour le statut d'un rendez-vous passé, pour indiquer s'il a bien eu lieu comme prévu ou s'il a été annulé.",
+        "description": "Met à jour le statut d'un rendez-vous passé, pour indiquer s'il a bien eu lieu comme prévu ou s'il a été annulé.\nLes valeurs autorisées pour le statut sont unknown (État indéterminé), seen (Rendez-vous honoré), excused (Annulé (excusé)), revoked (Annulé (par le service)) et noshow (Absence non excusée).\"\n",
         "responses": {
           "200": {
             "description": "Met à jour et renvoie un rendez-vous",


### PR DESCRIPTION
On a besoin de cet endpoint pour l'intégration avec la Coop de la médiation numérique. Ils affichent une page avec la liste de tous les accompagnement passés, et les rendez-vous servent à pré-remplir un compte-rendu d'activité (CRA) pour un accompagnement.
Lorsqu'un CRA est rempli à partir du rendez-vous, on veut en profiter pour renseigner si le rdv a eu lieu ou non pour limiter les actions manuelles à faire pour chaque rendez-vous.

On propose donc un endpoint d'update de status dans l'api.