### PR TITLE
Afficher les liens de visio aux agents même s'ils ne participent pas au rdv

### DIFF
--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -22,14 +22,9 @@
     | RDV téléphonique
 - elsif rdv.motif.visio?
   p.card-text.mb-0
-    - should_display_link = current_agent.in?(rdv.agents) || current_agent.secretaire?
     = visio_icon(class: "text-primary-blue fr-mr-1w")
     |> Par visioconférence
-    - if should_display_link
-      = link_to("démarrer la visioconférence ", rdv.visio_url, target: :_blank)
-    - else
-      br
-      small.text-muted = "Le lien de visioconférence s'affiche uniquement pour l'agent qui assure le RDV et les secrétaires."
+    = link_to("démarrer la visioconférence ", rdv.visio_url, target: :_blank)
 
 - else
   .d-flex.mb-1

--- a/spec/features/agents/rdv_details_spec.rb
+++ b/spec/features/agents/rdv_details_spec.rb
@@ -150,24 +150,12 @@ RSpec.describe "Agent can see RDV details correctly" do
     let(:motif) { create(:motif, location_type: :visio, organisation:) }
     let(:user) { create(:user, organisations: [organisation]) }
 
-    context "when the agent participates in the rdv" do
-      let(:rdv) { create(:rdv, agents: [agent], users: [user], motif: motif, organisation: organisation, starts_at: starts_at) }
+    let(:rdv) { create(:rdv, agents: [agent], users: [user], motif: motif, organisation: organisation, starts_at: starts_at) }
 
-      it "shows the link to start the visio" do
-        visit admin_organisation_rdv_path(organisation, rdv)
-        expect(page).to have_content "démarrer la visioconférence"
-        expect(page).to have_content "Par visioconférence"
-      end
-    end
-
-    context "when the agent does not participates in the rdv" do
-      let(:rdv) { create(:rdv, agents: [create(:agent)], users: [user], motif: motif, organisation: organisation, starts_at: starts_at) }
-
-      it "does not show the link to start the visio" do
-        visit admin_organisation_rdv_path(organisation, rdv)
-        expect(page).not_to have_content "démarrer la visioconférence"
-        expect(page).to have_content "Par visioconférence"
-      end
+    it "shows the link to start the visio" do
+      visit admin_organisation_rdv_path(organisation, rdv)
+      expect(page).to have_content "démarrer la visioconférence"
+      expect(page).to have_content "Par visioconférence"
     end
   end
 end


### PR DESCRIPTION
Lors de la mise en place de la visio (https://github.com/betagouv/rdv-service-public/pull/4235 ), on avait décidé de ne pas afficher le lien de visio aux agents qui ne participent pas au rendez-vous.
On avait ensuite assez rapidement permis aux secrétaires d'afficher ce lien dans https://github.com/betagouv/rdv-service-public/pull/4302.

On a maintenant le cas d'un admin d'organisation (la fonctionnalité secrétaire n'est pas utilisée sur RDV SP) qui aurait besoin de voir le lien pour un rdv fait par un intervenant.

On en a rediscuté avec Nesserine, et on avait probablement été trop paranoïaque, et cette restriction semble causer plus de problème qu'elle n'en évite. On s'est mis d'accord pour afficher le lien pour tout le monde.

Si un agent se connecte à la visio, il sera visible pour les autres agents et usager qui participent à la visio, donc il n'y a pas vraiment de risque de toutes façons.