### PR TITLE
Harmoniser la liste de motifs proposée entre les intégrations et l'interface habituelle.

### DIFF
--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -108,15 +108,9 @@ class Agents::RdvPlansController < AgentAuthController
   private
 
   def available_motifs(rdv_plan)
-    motif_scope = Agent::MotifPolicy::Scope.new(
-      current_agent,
-      Motif.individuel.active
-    ).resolve
-
-    motif_scope.where(
-      service: rdv_plan.rdv_agent.services + [nil],
-      organisation_id: rdv_plan.rdv_agent.roles.select(:organisation_id)
-    )
+    rdv_plan.rdv_agent.organisations.map do |organisation|
+      Motif.available_motifs_for_organisation_and_agent(organisation, rdv_plan.rdv_agent)
+    end.compact
   end
 
   def find_rdv_plan

--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -110,7 +110,9 @@ class Agents::RdvPlansController < AgentAuthController
   def available_motifs(rdv_plan)
     rdv_plan.rdv_agent.organisations.map do |organisation|
       Motif.available_motifs_for_organisation_and_agent(organisation, rdv_plan.rdv_agent)
-    end.compact
+    end.reduce do |motifs, additional_motifs|
+      motifs.or(additional_motifs)
+    end
   end
 
   def find_rdv_plan


### PR DESCRIPTION
Pour la première implémentation de la prise de rendez-vous par intégration, j'avais filtré les motifs proposés en fonction des services de l'agent. Il y avait deux motivations à ce choix :
- je n'avais pas la motivation de faire une implémentation de `Motif.available_motifs_for_organisation_and_agent` qui soit indépendante de l'organisation mais qui ne fasse pas une requête par organisation.
- j'avais un peu l'espoir qu'on aille vers un fonctionnement où on sépare les rôles des admin font de la configuration, et des agents qui font des rendez-vous (en les rendant aussi cumulables).

C'est un fonctionnement différent de l'interface principale, où si un agent est admin d'orga, on lui proposer tous les motifs de l'orga.

Au final, cette approche pose plusieurs problèmes :
- c'est difficile de comprendre cette différence de permission entre les deux interfaces (et encore plus de l'expliquer de manière convaincante)
- pour des admins à qui on a oublié de mettre un service, ça empêche la prise de rdv par intégration. C'est un ticket zammad d'un agent dans ce cas qui motive cette PR

Du coup j'harmonise les deux règles, en faisant une implémentation très basique.
Dans la mesure où les agents qui utilisent les intégration sont très généralement dans une seule organisation, je pense que c'est complètement acceptable de faire la concaténation des motifs en ruby plutôt qu'avec une requête sql qui serait très compliquées.
