### PR TITLE
Afficher un message d'erreur si aucun motif n'est disponible lors de la prise de rdv par intégration.

### DIFF
--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -37,9 +37,10 @@ class Agents::RdvPlansController < AgentAuthController
   end
 
   def edit_modalites
-    @available_location_types = available_motifs(@rdv_plan).pluck(:location_type)
-
-    render locals: { event_sources: }
+    render locals: {
+      available_location_types: available_motifs(@rdv_plan).pluck(:location_type),
+      event_sources:,
+    }
   end
 
   def update_modalites

--- a/app/views/agents/rdv_plans/_modalites_field.html.slim
+++ b/app/views/agents/rdv_plans/_modalites_field.html.slim
@@ -1,10 +1,10 @@
-/# locals: (rdv_plan:)
+/# locals: (rdv_plan:, available_location_types:)
 
 fieldset[class="fr-fieldset" id="rdv_plan[modalite]" aria-labelledby="radio-rich-no-pictogram-inline-legend radio-rich-no-pictogram-inline-messages"]
   legend[class="fr-fieldset__legend--regular fr-fieldset__legend" id="radio-rich-no-pictogram-inline-legend"]
     | Comment souhaitez-vous faire le rendez-vous ?
 
-  - if @available_location_types.include?("public_office")
+  - if available_location_types.include?("public_office")
     - lieux = policy_scope(Lieu.enabled, policy_scope_class: Agent::LieuPolicy::Scope)
     - lieux.each do |lieu|
       .fr-fieldset__element
@@ -16,7 +16,7 @@ fieldset[class="fr-fieldset" id="rdv_plan[modalite]" aria-labelledby="radio-rich
               = " Sur place à #{lieu.name}"
             span.fr-hint-text = lieu.address
 
-  - if @available_location_types.include?("phone")
+  - if available_location_types.include?("phone")
     .fr-fieldset__element
       .fr-radio-group.fr-radio-rich
         input[value="phone" type="radio" id="rdv_plan_modalite_phone" name="rdv_plan[modalite]" required]
@@ -25,7 +25,7 @@ fieldset[class="fr-fieldset" id="rdv_plan[modalite]" aria-labelledby="radio-rich
             = phone_icon
             = " Par téléphone"
 
-  - if @available_location_types.include?("visio")
+  - if available_location_types.include?("visio")
     .fr-fieldset__element
       .fr-radio-group.fr-radio-rich
         input[value="visio" type="radio" id="rdv_plan_modalite_visio" name="rdv_plan[modalite]" required]
@@ -36,7 +36,7 @@ fieldset[class="fr-fieldset" id="rdv_plan[modalite]" aria-labelledby="radio-rich
           span.fr-hint-text
             | Nous vous fournirons un lien de visio
 
-  - if @available_location_types.include?("home")
+  - if available_location_types.include?("home")
     .fr-fieldset__element
       .fr-radio-group.fr-radio-rich
         input[value="home" type="radio" id="rdv_plan_modalite_home" name="rdv_plan[modalite]" required]

--- a/app/views/agents/rdv_plans/edit_modalites.html.slim
+++ b/app/views/agents/rdv_plans/edit_modalites.html.slim
@@ -6,7 +6,6 @@
 .fr-grid-row.fr-mb-16w[data-controller="rdv-plan"]
   - if available_location_types.none?
     .fr-col-12.fr-mt-2w
-      / TODO: afficher un bandeau d'erreur
       = dsfr_alert type: :error, size: :sm, close_button: false, html_attributes: { class: "fr-pb-1w fr-my-2w", role: "alert" } do
         - if @rdv_plan.rdv_agent.organisations.count == 1
           - organisation = @rdv_plan.rdv_agent.organisations.first

--- a/app/views/agents/rdv_plans/edit_modalites.html.slim
+++ b/app/views/agents/rdv_plans/edit_modalites.html.slim
@@ -43,4 +43,3 @@
         = render "agents/rdv_plans/modalites_field", { available_location_types:, rdv_plan: @rdv_plan }
 
         = f.submit "Continuer", class: "fr-btn float-right"
-

--- a/app/views/agents/rdv_plans/edit_modalites.html.slim
+++ b/app/views/agents/rdv_plans/edit_modalites.html.slim
@@ -1,24 +1,46 @@
-/# locals: (event_sources:)
+/# locals: (event_sources:, available_location_types:)
 
 .fr-row
   .fr-col-12
     = render "agents/rdv_plans/header", rdv_plan: @rdv_plan, current_step: 1, step_title: "Créneau", next_step_title: "Motif"
 .fr-grid-row.fr-mb-16w[data-controller="rdv-plan"]
-  .fr-col-12.fr-col-md-4.fr-mt-4w
-    = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, event_sources:, single_day: true
-    = link_to edit_starts_at_agents_rdv_plan_path(@rdv_plan) do
-      = back_icon(class: "fr-mr-1w")
-      = "retour"
+  - if available_location_types.none?
+    .fr-col-12.fr-mt-2w
+      / TODO: afficher un bandeau d'erreur
+      = dsfr_alert type: :error, size: :sm, close_button: false, html_attributes: { class: "fr-pb-1w fr-my-2w", role: "alert" } do
+        - if @rdv_plan.rdv_agent.organisations.count == 1
+          - organisation = @rdv_plan.rdv_agent.organisations.first
+          - if organisation.motifs.active.none?
+            p Vous devez d'abord créer un motif de rendez-vous pour l'organisation #{organisation.name}
+          - else
+            p #{@rdv_plan.rdv_agent.full_name_or_email} n'a accès à aucun des motifs de rendez-vous de #{organisation.name}. Vous devez soit créer un nouveau motif soit changer son niveau de permission.
+        - else
+          p Aucun motif de rendez-vous n'est disponible pour cet agent.
+          p Vous pouvez corriger cette erreur en ajoutant de nouveaux motifs de rendez-vous ou en donnant plus de permissions à cet agent.
+      - @rdv_plan.rdv_agent.organisations.each do |organisation|
+        = link_to("Voir les motifs de #{organisation.name}", admin_organisation_motifs_path(organisation), class: "fr-btn fr-btn--secondary", target: :_blank)
 
-  .fr-col-12.fr-col-md-8.fr-px-2w
-    = render "agents/rdv_plans/summary/agent", rdv_plan: @rdv_plan
-    hr.fr-mt-2w.fr-mb-4w
+      .fr-mt-3w
+        = link_to edit_starts_at_agents_rdv_plan_path(@rdv_plan) do
+          = back_icon(class: "fr-mr-1w")
+          = "retour"
+  - else
+    .fr-col-12.fr-col-md-4.fr-mt-4w
+      = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, event_sources:, single_day: true
+      = link_to edit_starts_at_agents_rdv_plan_path(@rdv_plan) do
+        = back_icon(class: "fr-mr-1w")
+        = "retour"
 
-    = simple_form_for @rdv_plan, url: update_modalites_agents_rdv_plan_path(@rdv_plan) do |f|
-      .fr-mb-4w
-        .input-group
-          = datetime_input(f, :starts_at, options: { label_html: { style: "flex-shrink: 0;", class: "fr-mr-2w" }, wrapper_html: { class: "d-flex", style: "align-items: baseline;" }})
+    .fr-col-12.fr-col-md-8.fr-px-2w
+      = render "agents/rdv_plans/summary/agent", rdv_plan: @rdv_plan
+      hr.fr-mt-2w.fr-mb-4w
 
-      = render "agents/rdv_plans/modalites_field", rdv_plan: @rdv_plan
+      = simple_form_for @rdv_plan, url: update_modalites_agents_rdv_plan_path(@rdv_plan) do |f|
+        .fr-mb-4w
+          .input-group
+            = datetime_input(f, :starts_at, options: { label_html: { style: "flex-shrink: 0;", class: "fr-mr-2w" }, wrapper_html: { class: "d-flex", style: "align-items: baseline;" }})
 
-      = f.submit "Continuer", class: "fr-btn float-right"
+        = render "agents/rdv_plans/modalites_field", { available_location_types:, rdv_plan: @rdv_plan }
+
+        = f.submit "Continuer", class: "fr-btn float-right"
+

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'interface de rdv_plan" do
-  let!(:organisation) { create(:organisation) }
+  let!(:organisation) { create(:organisation, name: "CCAS de Montreuil") }
   let(:application) do
     create(:oauth_application,
            name: "Démarches Simplifiées",
@@ -198,6 +198,18 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
       expect(page).to have_content "Motif du rendez-vous"
 
       expect(page).not_to have_content(other_motif.name)
+    end
+  end
+
+  context "quand aucun motif n'est disponible pour l'agent choisi" do
+    before { motif.archive }
+
+    it "affiche un message qui explique le blocage" do
+      visit edit_modalites_agents_rdv_plan_path(rdv_plan.id)
+
+      expect(page).not_to have_content("Continuer")
+
+      expect(page).to have_content "Vous devez d'abord créer un motif de rendez-vous pour l'organisation CCAS de Montreuil"
     end
   end
 end


### PR DESCRIPTION
Correctif pour https://sentry.incubateur.net/organizations/betagouv/issues/196586

Si aucun motif n'est disponible pour l'agent, on affiche un message d'erreur plutôt qu'une 500


<img width="1251" height="627" alt="Screenshot 2025-11-07 at 18 37 24" src="https://github.com/user-attachments/assets/b2b45bf7-3c5a-490c-a2b8-439ba0a7c382" />

