### PR TITLE
Import axe-core en environnement test

### DIFF
--- a/app/javascript/application_test.js
+++ b/app/javascript/application_test.js
@@ -1,1 +1,5 @@
+// Ce fichier est utilisé pour importer le module axe-core pour les tests d'accessibilité qui sont effectués dans :
+// - spec/features/accessibility
+// - spec/features/autodoc (nous intégrons maintenant les tests d'accessibilité dans les captures d'écran autodoc)
+
 import "axe-core/axe.min.js";

--- a/app/javascript/application_test.js
+++ b/app/javascript/application_test.js
@@ -1,0 +1,1 @@
+import "axe-core/axe.min.js";

--- a/app/views/common/_head_agent.html.slim
+++ b/app/views/common/_head_agent.html.slim
@@ -4,6 +4,7 @@
 = stylesheet_link_tag "application_agent", media: "all", "data-turbolinks-track": "reload"
 
 = javascript_include_tag "application_agent", "data-turbolinks-track": "reload"
+= javascript_include_tag "application_test" if Rails.env.test?
 = javascript_include_tag "#{dsfr_path}/dsfr.module.min.js", "data-turbo-track": "reload", type: "module", defer: true
 = javascript_include_tag "#{dsfr_path}/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true
 

--- a/app/views/layouts/application_agent_config.html.slim
+++ b/app/views/layouts/application_agent_config.html.slim
@@ -8,6 +8,7 @@ html lang="fr"
     = stylesheet_link_tag "#{dsfr_path}/utility/icons/icons.min.css", "data-turbo-track": "reload"
     = stylesheet_link_tag    "application_agent_config", media: "all", "data-turbolinks-track": "reload"
 
+    = javascript_include_tag "application_test" if Rails.env.test?
     = javascript_include_tag "application_agent_config", "data-turbolinks-track": "reload"
     = javascript_include_tag "#{dsfr_path}/dsfr.module.min.js", "data-turbo-track": "reload", type: "module", defer: true
     = javascript_include_tag "#{dsfr_path}/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -8,6 +8,7 @@ html lang="fr"
     = content_for(:additional_stylesheets)
 
     = javascript_include_tag "application", "data-turbolinks-track": "reload"
+    = javascript_include_tag "application_test" if Rails.env.test?
     = javascript_include_tag "#{dsfr_path}/dsfr.module.min.js", "data-turbo-track": "reload", type: "module", defer: true
     = javascript_include_tag "#{dsfr_path}/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true
     = content_for(:additional_scripts)

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -22,16 +22,6 @@ metabase = "rdv-service-public-metabase.osc-secnum-fr1.scalingo.io"
 # Utilisés par swagger pour la documentation de l'api
 swagger_shas = ["'sha256-j4Lx1FqFgvYDBEjW7NQaEY7/HhCi8WVsLWkqC4+wJ3w='", "'sha256-JHKToH7KbGJj6TloPeWnKnbImDel00Whl1rRnBiTYuQ='"]
 
-# Utilisé par Axios pour les tests d'accessibilité
-test_shas = []
-if Rails.env.test?
-  test_shas << if ENV["CI"].present?
-                 "'sha256-4UywW1I9VFu7o60u4zSiU9FmUjIhiIv4N1FflQjVse0='"
-               else
-                 "'sha256-MW9ENekiBxLmssEGlk+IVYZiQXOqQCOggVxAMOB1ePc='"
-               end
-end
-
 # Tant qu'on utilise les Turbolinks, c'est très difficile d'avoir des CSP différentes pour chaque pages,
 # puisque les CSP sont uniquement chargées lors de la première requête qui charle le premier document,
 # et pas lors des appels XHR fait par les turbolinks.
@@ -49,7 +39,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src :self, :unsafe_inline, bootstrap_cdn, unpkg_cdn
   policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv
 
-  policy.script_src :self, unpkg_cdn, *swagger_shas, *test_shas
+  policy.script_src :self, unpkg_cdn, *swagger_shas
 end
 
 # If you are using UJS then enable automatic nonce generation

--- a/spec/support/accessibility_spec_matchers.rb
+++ b/spec/support/accessibility_spec_matchers.rb
@@ -34,7 +34,6 @@ class AxeRunner
     @raw_results ||= JSON.parse(
       page.driver.with_playwright_page do |playwright_page|
         playwright_page.expect_console_message(predicate: method(:console_message_contains_axe_results?)) do
-          playwright_page.add_script_tag(path: Rails.root.join("node_modules/axe-core/axe.min.js"))
           page.evaluate_script("axe.run().then(results => console.log(JSON.stringify(results)));")
         end
       end.text

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
   entry: {
     administrate: "./app/javascript/administrate",
     application: "./app/javascript/application",
+    application_test: "./app/javascript/application_test",
     application_agent: "./app/javascript/application_agent",
     lieux_map: "./app/javascript/lieux_map",
     application_agent_config: "./app/javascript/application_agent_config",


### PR DESCRIPTION
# Contexte

Avec la manière que nous utilisons actuellement pour importer axe-core dans les tests d’accessiblité, nous sommes obligés d’ajouter le SHA du JS dans les CSP.
Cela est contraignant car : 
- dès que nous mettons à jour le package `axe-core` on doit mettre à jour le SHA
- on a des différences de SHA entre l’environnement local et la CI

# Solution

Je propose donc d’importer le javascript le package via un `application_test.js` qui est ajouté dans le `head` si on est en envrionnement de test.
