### PR TITLE
Ajout d'un feature flag pour l'intégration avec l'application mobile Justice.fr

### DIFF
--- a/app/controllers/api/justice/lieux_controller.rb
+++ b/app/controllers/api/justice/lieux_controller.rb
@@ -34,7 +34,7 @@ class Api::Justice::LieuxController < ActionController::Base # rubocop:disable R
       end
     end
 
-    render json: { lieux: }
+    render json: { lieux:, display_feature: ENV["ENABLE_JUSTICE_FR_FEATURE_FLAG"].present? }
   end
 
   private

--- a/spec/requests/api/justice/lieu_spec.rb
+++ b/spec/requests/api/justice/lieu_spec.rb
@@ -29,4 +29,22 @@ RSpec.describe "Api pour Justice.fr" do
       }
     )
   end
+
+  describe "feature flag pour indiquer si la prise de rendez-vous doit être mise en avant sur l'application" do
+    context "sans la variable d'env pour le feature flag" do
+      it "n'indique pas d'activer la feature" do
+        get "/api/justice/lieux"
+        expect(parsed_response_body["display_feature"]).to be false
+      end
+    end
+
+    context "avec la variable d'env" do
+      stub_env_with(ENABLE_JUSTICE_FR_FEATURE_FLAG: "true")
+
+      it "indique d'activer la feature" do
+        get "/api/justice/lieux"
+        expect(parsed_response_body["display_feature"]).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
La Dicom de la justice a demandé à l'équipe qui gère l'application mobile Justice.fr qu'il y ai un feature flag pour pouvoir mettre en avant ou non la prise de rendez-vous dans leur application, vraisemblablement pour attendre qu'on ai assez de lieux de justice connectés et à jour avant d'activer ce feature flag.

C'est notre api qui sert de back-office pour ce feature flag (c'était plus simple à organiser comme ça, et pas absurde vu que c'est nous qui gérons la liste des lieux ouverts).

J'ai validé ce format d'api avec l'équipe tech de l'appli mobile.