### PR TITLE
Ajout de la notion d’opérateur

### DIFF
--- a/app/controllers/super_admins/operators_controller.rb
+++ b/app/controllers/super_admins/operators_controller.rb
@@ -1,0 +1,2 @@
+class SuperAdmins::OperatorsController < SuperAdmins::ApplicationController
+end

--- a/app/dashboards/operator_dashboard.rb
+++ b/app/dashboards/operator_dashboard.rb
@@ -1,0 +1,28 @@
+require "administrate/base_dashboard"
+
+class OperatorDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    name: Field::String,
+    territories: Field::HasMany,
+  }.freeze
+
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    name
+  ].freeze
+
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    name
+    territories
+  ].freeze
+
+  FORM_ATTRIBUTES = %i[
+    name
+  ].freeze
+
+  def display_resource(operator)
+    operator.name
+  end
+end

--- a/app/dashboards/territory_dashboard.rb
+++ b/app/dashboards/territory_dashboard.rb
@@ -13,6 +13,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     name: Field::String,
     category: Field::Select.with_options(collection: Compte::CATEGORIES),
     organisations: Field::HasMany.with_options(sort_by: :name, direction: :asc),
+    operator: Field::BelongsTo,
     admin_agents: Field::HasMany,
     roles: Field::HasMany,
     created_at: Field::DateTime,
@@ -42,6 +43,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     work_on_sunday
     roles
     organisations
+    operator
     created_at
     updated_at
   ].freeze
@@ -55,6 +57,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     departement_number
     category
     work_on_sunday
+    operator
   ].freeze
 
   def display_resource(territory)

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -1,0 +1,3 @@
+class Operator < ApplicationRecord
+  has_many :territories, dependent: :nullify
+end

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -32,6 +32,7 @@ class Territory < ApplicationRecord
   has_many :agent_territorial_access_rights, dependent: :destroy
   has_many :territory_services, dependent: :destroy
   has_and_belongs_to_many :motif_categories
+  belongs_to :operator, optional: true
 
   # Through relations
   has_many :organisations_agents, -> { distinct }, through: :organisations, source: :agents

--- a/app/policies/super_admin/operator_policy.rb
+++ b/app/policies/super_admin/operator_policy.rb
@@ -1,0 +1,9 @@
+class SuperAdmin::OperatorPolicy < DefaultSuperAdminPolicy
+  alias index? team_member?
+  alias show? team_member?
+  alias create? team_member?
+  alias new? team_member?
+  alias edit? team_member?
+  alias update? team_member?
+  alias destroy? legacy_admin_member?
+end

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -500,3 +500,6 @@ tables:
       - good_job_batch_id
       - created_at
       - updated_at
+  - table_name: operators
+    anonymized_column_names:
+      - name

--- a/config/locales/models/operator.fr.yml
+++ b/config/locales/models/operator.fr.yml
@@ -1,0 +1,4 @@
+fr:
+  activerecord:
+    models:
+      operator: Opérateur

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     resources :user_profiles, only: %i[destroy]
     resources :super_admins, only: %i[index destroy]
     resources :organisations
+    resources :operators
     resources :services
     resources :motifs
     resources :lieux

--- a/db/migrate/20251110155850_add_operator.rb
+++ b/db/migrate/20251110155850_add_operator.rb
@@ -1,0 +1,12 @@
+class AddOperator < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    create_table :operators do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    add_reference :territories, :operator, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_06_170448) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_10_155850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -555,6 +555,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_06_170448) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
+  create_table "operators", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "organisations", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -799,7 +805,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_06_170448) do
     t.string "category", comment: "La catégorie permet classifier les différents territoires principalement pour faire des statistiques dans metabase,\net pour avoir un suivi approprié de chaque territoire pour notre équipe déploiement et support. Par exemple, les besoins d'une commune\nne seront pas les mêmes que ceux d'un service de l'état.\n"
     t.boolean "enable_address_field", default: false
     t.boolean "work_on_sunday", default: false
+    t.bigint "operator_id"
     t.index ["departement_number"], name: "index_territories_on_departement_number", where: "((departement_number)::text <> ''::text)"
+    t.index ["operator_id"], name: "index_territories_on_operator_id"
   end
 
   create_table "territory_creation_requests", force: :cascade do |t|


### PR DESCRIPTION
# Contexte

Dans le cadre de la mise en place du compte et des APIs opérateur, je propose une première PR pour créer l’entité `Operator`. Celle-ci est liée à des espaces.

Par la suite : 
- Un opérateur pourra ajouter ces agents
- Les « agents opérateur » pourront se ProConnect et faire le support de niveau 1 pour les espaces liés à l’opérateur
- Un opérateur pour préciser ses informations de contact que nous afficherons aux agents dans la page de support
- Un opérateur pour accéder à un point d’API pour inviter ses adhérents à créer des espaces. Cette API sera également utilisée pour l’Espace Opérateur de la suite territoriale.

# Solution

- Création du modèle `Operator`
- Liaison entre l’opérateur et l’espace
- Affichage des informations de l’opérateur dans le Super Admin
- Permettre d’assigner un espace à un opérateur dans le Super Admin