### PR TITLE
Amélioration de l’accessibilité de la partie planning agent

### DIFF
--- a/app/helpers/recurrence_helper.rb
+++ b/app/helpers/recurrence_helper.rb
@@ -73,7 +73,7 @@ module RecurrenceHelper
   end
 
   def exceptionnelle_tag(recurrent_record)
-    tag.span("Exceptionnelle", class: "badge badge-info") if recurrent_record.exceptionnelle?
+    tag.span("Exceptionnelle", class: "fr-badge fr-badge--sm fr-badge--green-archipel") if recurrent_record.exceptionnelle?
   end
 
   def filter_plage_ouvertures_in_departement_scope(plage_ouvertures)

--- a/app/views/admin/planning/_planning_agents_select.html.slim
+++ b/app/views/admin/planning/_planning_agents_select.html.slim
@@ -19,7 +19,8 @@
                 },
               }
 
-            = form.select :agent_id, collection, { selected: @agents.map(&:id), multiple: @agents.size > 1 }, { name: "agent_id[]", class: ["select2-input rdv-min-width-200px"], data:}
+            = form.label :agent_id, "Planning de", class: "fr-label sr-only", for: "agent_id"
+            = form.select :agent_id, collection, { selected: @agents.map(&:id), multiple: @agents.size > 1 }, { name: "agent_id[]", class: ["select2-input rdv-min-width-200px"], data: }
 
           .ml-2.d-flex[style="gap: 0 0.5em"]
             - if @agents.size == 1 && @multiple_agents_makes_sense && current_organisation.agents.count > 1

--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -1,7 +1,7 @@
 tr
   - organisation = plage_ouverture.organisation
   td
-    = link_to plage_ouverture.title_with_default, admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture)
+    = link_to plage_ouverture.title_with_default, admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture), class: "fr-link"
     = exceptionnelle_tag(plage_ouverture)
     br
     small

--- a/spec/features/autodoc/planning_multi_agents_spec.rb
+++ b/spec/features/autodoc/planning_multi_agents_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Nouveau planning / planning multi-agents", js: true do
 
   specify do
     login_as(agent_basique, scope: :agent)
+    # L’accessibilité a été améliorée, mais on laisse le paramètre désactivé pour cette doc, car nous utilisons select2 qu’il est difficile de corriger.
     doc = Autodoc.start_scenario("Nouveau planning / planning multi-agents", self, accessibility_checks: false, category: "3) Produit")
 
     #

--- a/spec/helpers/recurrence_helper_spec.rb
+++ b/spec/helpers/recurrence_helper_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RecurrenceHelper do
   describe "#exceptionnelle_tag" do
     it "return exceptionnelle badge without recurrence" do
       plage_ouverture = build(:plage_ouverture)
-      expect(exceptionnelle_tag(plage_ouverture)).to eq(%(<span class="badge badge-info">Exceptionnelle</span>))
+      expect(exceptionnelle_tag(plage_ouverture)).to eq(%(<span class="fr-badge fr-badge--sm fr-badge--green-archipel">Exceptionnelle</span>))
     end
 
     it "return nil with recurrence" do


### PR DESCRIPTION
# Contexte

J’ai essayé d’activer les tests automatiques de l’autodoc `planning_multi_agents_spec`.
J’ai corrigé les petites remontées, mais on doit pour le moment laisser `accessibility_checks` à `false` car nous utilisons `select2` pour la sélection multi-agents et que ce dernier n’est pas accessible.

Des pistes de solutions sont évoquées ici #4375 

# Solution

- Changement du tag « Exceptionnelle » pour les plages d’ouvertures au profit du tag DSFR
- Correction d’un label manquant 
- Passage des liens avec le soulignement dans la liste des plages d’ouvertures

## Captures d'écran

Avant | Après
:- | -:
<img width="1149" height="662" alt="image" src="https://github.com/user-attachments/assets/b1ca9d34-6a62-42b4-8e54-dac5e74fbb6e" /> | <img width="1154" height="716" alt="image" src="https://github.com/user-attachments/assets/dc7f4b5a-e109-4c69-93a7-d83d71a83fe1" />

