### PR TITLE
Suppression de la mention « nouveau » sur l’archivage des motifs

### DIFF
--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -38,12 +38,6 @@
             = label
             span.badge.badge-light.badge-pill.ml-1 = count
 
-    - if current_agent.admin_in_organisation?(current_organisation) && @current_tab == :archived
-      .row
-        .col-12
-          .alert.alert-info.d-flex.align-items-center.mt-2
-            = t("admin.motifs.archiving_explanation")
-
     table.table.table-centered
       - if current_organisation.motifs.any?
         thead

--- a/app/views/admin/territories/motifs/index.html.slim
+++ b/app/views/admin/territories/motifs/index.html.slim
@@ -70,12 +70,6 @@
 
 .row
   .col-12
-    - if @current_tab == :archived
-      .row
-        .col-12
-          .alert.alert-info.d-flex.align-items-center
-            = t("admin.motifs.archiving_explanation")
-
     - if @motifs_page.any?
       = paginate @motifs_page, theme: "dsfr"
       = render partial: "admin/territories/motifs/motifs_table", locals: { motifs: @motifs_page, display_actions: true, display_checkboxes: @current_tab != :archived }

--- a/config/locales/views/admin_motifs.fr.yml
+++ b/config/locales/views/admin_motifs.fr.yml
@@ -8,7 +8,6 @@ fr:
         agents_and_prescripteurs: Uniquement par les agents et prescripteurs
         agents_and_prescripteurs_and_invited_users: Par les agents, prescripteurs et les usagers sur invitation
         everyone: Par les agents, prescripteurs et les usagers
-      archiving_explanation: "Nouveau : vous pouvez désormais archiver les motifs que vous ne souhaitez plus utiliser. Un motif archivé ne sera plus proposé lors de la prise de RDV. Il peut être réactivé à tout moment ou supprimé définitivement si aucun RDV n'est rattaché."
       motif_without_service_explanation: "Ce motif n'est pas limité à un service en particulier, et peut donc être utilisé par n'importe quel agent de votre organisation."
       actions:
         new: Créer un motif


### PR DESCRIPTION
# Contexte

Lors de l’arrivée de l’archivage des motifs, nous avions mis une mention « Nouveau » avec une explication.
L’archivage des motifs ayant maintenant un an (joyeux anniversaire 🎂) nous pouvons supprimer la mention. 

#4717

Et au passage ça fait un élément Bootstrap en moins.
