### PR TITLE
Ne plus utiliser la gem `database_cleaner`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -247,6 +247,9 @@ group :test do
   # Playwright is an alternative to Selenium
   gem "capybara-playwright-driver"
 
+  # Strategies for cleaning databases. Can be used to ensure a clean slate for testing.
+  gem "database_cleaner"
+
   # Factories
 
   # factory_bot provides a framework and DSL for defining and using model instance factories.

--- a/Gemfile
+++ b/Gemfile
@@ -247,9 +247,6 @@ group :test do
   # Playwright is an alternative to Selenium
   gem "capybara-playwright-driver"
 
-  # Strategies for cleaning databases. Can be used to ensure a clean slate for testing.
-  gem "database_cleaner"
-
   # Factories
 
   # factory_bot provides a framework and DSL for defining and using model instance factories.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,12 @@ GEM
     css_parser (1.16.0)
       addressable
     csv (3.3.2)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.5.0)
     debug_inspector (1.2.0)
     descendants_tracker (0.0.4)
@@ -786,6 +792,7 @@ DEPENDENCIES
   common_french_passwords
   connection_pool
   csv
+  database_cleaner
   devise!
   devise-async
   devise_invitable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,12 +199,6 @@ GEM
     css_parser (1.16.0)
       addressable
     csv (3.3.2)
-    database_cleaner (2.1.0)
-      database_cleaner-active_record (>= 2, < 3)
-    database_cleaner-active_record (2.2.0)
-      activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
-    database_cleaner-core (2.0.1)
     date (3.5.0)
     debug_inspector (1.2.0)
     descendants_tracker (0.0.4)
@@ -792,7 +786,6 @@ DEPENDENCIES
   common_french_passwords
   connection_pool
   csv
-  database_cleaner
   devise!
   devise-async
   devise_invitable

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", disable_transaction: true, js: true do
+RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   # Pour simplifier les test, on crée deux agents sur la même instance

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", js: true do
+RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", disable_transaction: true, js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   # Pour simplifier les test, on crée deux agents sur la même instance

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -120,3 +120,5 @@ RSpec.configure do |config|
     WebMock.reset!
   end
 end
+
+# CI après 1

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,4 +129,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avant 5
+# CI avant 6

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # CI 9
+  # CI 10
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,4 +125,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avec JS en truncation (coucou Antoine) 5
+# CI avec JS en truncation (coucou Antoine) 6

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -86,24 +86,10 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
-
     Rack::Attack.enabled = false
 
     Faker::Config.locale = :fr
     Faker::Config.random = Random.new(config.seed)
-  end
-
-  config.around do |example|
-    DatabaseCleaner.strategy = if example.metadata[:js] || ENV["HEADLESS"] == "false"
-                                 :truncation
-                               else
-                                 :transaction
-                               end
-
-    DatabaseCleaner.cleaning do
-      example.run
-    end
   end
 
   config.after(:suite) { Autodoc.render }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,4 +125,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avec JS en truncation (coucou Antoine) 4
+# CI avec JS en truncation (coucou Antoine) 5

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,4 +121,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI après 6
+# CI après 7

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # CI 6
+  # CI 7
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,4 +129,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avant 8
+# CI avant 9

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -128,3 +128,5 @@ RSpec.configure do |config|
     WebMock.reset!
   end
 end
+
+# CI avant 1

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,4 +121,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI après 5
+# CI après 6

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -124,5 +124,3 @@ RSpec.configure do |config|
     WebMock.reset!
   end
 end
-
-# CI avec JS en truncation (coucou Antoine) 10

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,4 +125,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avec JS en truncation (coucou Antoine) 8
+# CI avec JS en truncation (coucou Antoine) 9

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -86,10 +86,24 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+
     Rack::Attack.enabled = false
 
     Faker::Config.locale = :fr
     Faker::Config.random = Random.new(config.seed)
+  end
+
+  config.around do |example|
+    DatabaseCleaner.strategy = if example.metadata[:js] || ENV["HEADLESS"] == "false"
+                                 :truncation
+                               else
+                                 :transaction
+                               end
+
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 
   config.after(:suite) { Autodoc.render }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,4 +125,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI après 10
+# CI avec JS en truncation (coucou Antoine) 1

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,4 +121,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI après 1
+# CI après 2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,4 +129,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avant 2
+# CI avant 3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # CI 2
+  # CI 3
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,8 +71,6 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # CI 10
-
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,4 +125,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avec JS en truncation (coucou Antoine) 9
+# CI avec JS en truncation (coucou Antoine) 10

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,4 +121,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI après 8
+# CI après 9

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # CI 4
+  # CI 5
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,4 +125,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avec JS en truncation (coucou Antoine) 3
+# CI avec JS en truncation (coucou Antoine) 4

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,4 +121,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI après 9
+# CI après 10

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # CI 5
+  # CI 6
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,4 +129,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avant 7
+# CI avant 8

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,4 +129,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avant 3
+# CI avant 4

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,4 +129,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avant 9
+# CI avant 10

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,4 +125,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avec JS en truncation (coucou Antoine) 2
+# CI avec JS en truncation (coucou Antoine) 3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,6 +65,12 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.around(:each, disable_transaction: true) do |example|
+    self.use_transactional_tests = false
+    example.run
+    ActiveRecord::Tasks::DatabaseTasks.truncate_all
+  end
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,4 +129,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avant 4
+# CI avant 5

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,4 +125,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avec JS en truncation (coucou Antoine) 6
+# CI avec JS en truncation (coucou Antoine) 7

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # CI 1
+  # CI 2
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,10 +65,14 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  config.around(:each, disable_transaction: true) do |example|
-    self.use_transactional_tests = false
-    example.run
-    ActiveRecord::Tasks::DatabaseTasks.truncate_all
+  config.around do |example|
+    if example.metadata[:js] || ENV["HEADLESS"] == "false"
+      self.use_transactional_tests = false
+      example.run
+      ActiveRecord::Tasks::DatabaseTasks.truncate_all
+    else
+      example.run
+    end
   end
 
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,4 +129,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avant 6
+# CI avant 7

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # CI 7
+  # CI 8
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,4 +125,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avec JS en truncation (coucou Antoine) 7
+# CI avec JS en truncation (coucou Antoine) 8

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -120,5 +120,3 @@ RSpec.configure do |config|
     WebMock.reset!
   end
 end
-
-# CI avant 10

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,4 +121,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI après 7
+# CI après 8

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,21 +60,6 @@ RSpec.configure do |config|
     Faker::Config.random = Random.new(ENV["FAKER_SEED"].to_i)
   end
 
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = true
-
-  config.around do |example|
-    if example.metadata[:js] || ENV["HEADLESS"] == "false"
-      self.use_transactional_tests = false
-      example.run
-      ActiveRecord::Tasks::DatabaseTasks.truncate_all
-    else
-      example.run
-    end
-  end
-
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.
@@ -103,6 +88,17 @@ RSpec.configure do |config|
   end
 
   config.after(:suite) { Autodoc.render }
+
+  config.around do |example|
+    if example.metadata[:js] || ENV["HEADLESS"] == "false"
+      self.use_transactional_tests = false
+      example.run
+      ActiveRecord::Tasks::DatabaseTasks.truncate_all
+    else
+      self.use_transactional_tests = true
+      example.run
+    end
+  end
 
   config.before do
     setup_sentry_test

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -125,4 +125,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avec JS en truncation (coucou Antoine) 1
+# CI avec JS en truncation (coucou Antoine) 2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # CI 3
+  # CI 4
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,8 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
+  # CI 1
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,4 +129,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI avant 1
+# CI avant 2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,4 +121,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI après 3
+# CI après 4

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,12 +65,6 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  config.around(:each, disable_transaction: true) do |example|
-    self.use_transactional_tests = false
-    example.run
-    ActiveRecord::Tasks::DatabaseTasks.truncate_all
-  end
-
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
     ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
-  # CI 8
+  # CI 9
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,4 +121,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI après 2
+# CI après 3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,4 +121,4 @@ RSpec.configure do |config|
   end
 end
 
-# CI après 4
+# CI après 5

--- a/spec/requests/agents/agents_controller_search_spec.rb
+++ b/spec/requests/agents/agents_controller_search_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Agents::AgentsController, "#search" do
     let!(:francis) { create(:agent, first_name: "Francis", last_name: "Factice", basic_role_in_organisations: [orga_1, orga_2]) }
 
     it "ne s'affiche qu'une seule fois dans la liste" do
-      get search_agents_agents_path(organisation_id: [orga_1, orga_2], term: "fra"), as: :json
+      get search_agents_agents_path(organisation_id: [orga_1, orga_2], term: "francis fac"), as: :json
       expect(parsed_response_body[:results].sole).to match({ "id" => francis.id, "text" => "FACTICE Francis" })
     end
   end


### PR DESCRIPTION
# Contexte

## Rails 8

J'ai été amené à explorer ce sujet lors d'une tentative de MAJ vers Rails 8.

Avec le code de Rails 8, la spec `calculator_spec.rb` s'est mis à échouer : on observe que les appels à `load_async` et `async_pluck` ne retournent aucune valeur.  Pourtant sous Rails 7, ces méthodes retournaient bien les valeurs créées dans les `let`, la spec était au vert. La raison pour cela, c'est que Rails 7 détectait que l'on était dans une transaction (Postgres) et faisait alors les appels en synchrone. Or, depuis ce changement inclus dans Rails 8 [^1], le système de tests est désormais capable de réutiliser la même connexion à la base pour les appels synchrones et asynchrones. C'est une bonne nouvelle : les tests vont pouvoir exécuter `load_async` pareil qu'en production ! 

Le problème, c'est que la gestion de cette connexion se fait au niveau du code Rails. Les hooks apportées par `database_cleaner` sont indépendants de ce code. D'ailleurs la gem est surtout conçue pour des projets non-rails : 

> One of my motivations for writing this library was to have an easy way to turn on what Rails calls "transactional_fixtures" in my non-rails ActiveRecord projects.
> https://github.com/DatabaseCleaner/database_cleaner?tab=readme-ov-file#why

## Best practices

Indépendamment de cette aventure avec Rails 8, il me semble que ça fait presque 10 ans qu'on entend que `database_cleaner` n'est plus nécessaire depuis ce fix dans Rails 5.1 : 

> Transactional tests now wrap all Active Record connections in database transactions.
> https://guides.rubyonrails.org/v6.1/5_1_release_notes.html?utm_source=chatgpt.com#transactional-tests-with-multiple-connections

Dans mon expérience, j'ai malgré tout rencontré des problèmes et j'ai toujours utilisé `database_cleaner`. Je nourris l'espoir que cette fois, Rails soit suffisamment mature pour qu'on puisse s'en passer. :crossed_fingers: 

# Qu'est-ce qui change concrètement ?

Toutes nos specs sont donc désormais lancées dans une transaction ! :tada: 

Toutes ? Non ! Une spec d'autodoc semble résister et partir en deadlock, j'ai donc dû introduire le flag `disable_transaction: true`.

[^1]: https://github.com/rails/rails/pull/52806