### PR TITLE
Extraire le code postal d'un lieu pour ne pas l'anonymiser

### DIFF
--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -32,6 +32,12 @@ class Lieu < ApplicationRecord
   validate :longitude_and_latitude_must_be_present
   validate :cant_change_availibility_single_use
 
+  # Hooks
+
+  # Nous souhaitons extraire le code postal afin de l'exploiter facilement,
+  # l'adresse précise étant anonymisée dans l'ETL.
+  before_save { self.code_postal = code_postal_from_address }
+
   # Scopes
   scope :for_motif, lambda { |motif|
     lieux_ids = PlageOuverture
@@ -104,5 +110,10 @@ class Lieu < ApplicationRecord
     return unless changes[:availability]&.include?("single_use")
 
     errors.add(:availability, :cant_change_from_or_to_single_use)
+  end
+
+  def code_postal_from_address
+    # Toutes nos adresses ont la forme : "7 rue de l'adresse, Ville, 12345".
+    address.to_s.match(/, (\d{5})\z/).to_a[1]
   end
 end

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -32,12 +32,6 @@ class Lieu < ApplicationRecord
   validate :longitude_and_latitude_must_be_present
   validate :cant_change_availibility_single_use
 
-  # Hooks
-
-  # Nous souhaitons extraire le code postal afin de l'exploiter facilement,
-  # l'adresse précise étant anonymisée dans l'ETL.
-  before_save { self.code_postal = code_postal_from_address }
-
   # Scopes
   scope :for_motif, lambda { |motif|
     lieux_ids = PlageOuverture
@@ -97,6 +91,13 @@ class Lieu < ApplicationRecord
     earth_radius * c
   end
 
+  # Nous souhaitons extraire le code postal afin de l'exploiter facilement,
+  # l'adresse précise étant anonymisée dans l'ETL.
+  def address=(value)
+    self.code_postal = code_postal_from_address(value)
+    super
+  end
+
   private
 
   def longitude_and_latitude_must_be_present
@@ -112,8 +113,10 @@ class Lieu < ApplicationRecord
     errors.add(:availability, :cant_change_from_or_to_single_use)
   end
 
-  def code_postal_from_address
-    # Toutes nos adresses ont la forme : "7 rue de l'adresse, Ville, 12345".
-    address.to_s.match(/, (\d{5})\z/).to_a[1]
+  def code_postal_from_address(address)
+    matches = address.to_s.scan(/\b\d{5}\b/)
+    if matches.size == 1
+      matches.first
+    end
   end
 end

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -94,8 +94,15 @@ class Lieu < ApplicationRecord
   # Nous souhaitons extraire le code postal afin de l'exploiter facilement,
   # l'adresse précise étant anonymisée dans l'ETL.
   def address=(value)
-    self.code_postal = code_postal_from_address(value)
+    self.code_postal = self.class.code_postal_from_address(value)
     super
+  end
+
+  def self.code_postal_from_address(address)
+    matches = address.to_s.scan(/\b\d{5}\b/)
+    if matches.size == 1
+      matches.first
+    end
   end
 
   private
@@ -111,12 +118,5 @@ class Lieu < ApplicationRecord
     return unless changes[:availability]&.include?("single_use")
 
     errors.add(:availability, :cant_change_from_or_to_single_use)
-  end
-
-  def code_postal_from_address(address)
-    matches = address.to_s.scan(/\b\d{5}\b/)
-    if matches.size == 1
-      matches.first
-    end
   end
 end

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -234,6 +234,7 @@ tables:
       - longitude
       - old_enabled
       - availability
+      - code_postal
 
   - table_name: participations
     anonymized_column_names:

--- a/db/migrate/20251106170448_add_lieux_code_postal.rb
+++ b/db/migrate/20251106170448_add_lieux_code_postal.rb
@@ -1,0 +1,5 @@
+class AddLieuxCodePostal < ActiveRecord::Migration[7.2]
+  def change
+    add_column :lieux, :code_postal, :string
+  end
+end

--- a/db/migrate/20251106170448_add_lieux_code_postal.rb
+++ b/db/migrate/20251106170448_add_lieux_code_postal.rb
@@ -1,5 +1,15 @@
 class AddLieuxCodePostal < ActiveRecord::Migration[7.2]
   def change
     add_column :lieux, :code_postal, :string
+
+    reversible do |direction|
+      direction.up do
+        Lieu.all.find_each do |lieu|
+          if lieu.address.present?
+            lieu.update_columns(code_postal: Lieu.code_postal_from_address(lieu.address))
+          end
+        end
+      end
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_22_160200) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_06_170448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -445,6 +445,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_22_160200) do
     t.string "phone_number_formatted"
     t.enum "availability", default: "enabled", null: false, comment: "Permet de savoir si le lieu est un lieu normal (enabled), un lieu ponctuel qui sera utilisé pour un seul rdv (single_use), ou un lieu supprimé par soft-delete (disabled). Dans la plupart des cas on s'intéresse uniquement aux lieux enabled\n", enum_type: "lieu_availability"
     t.string "address", null: false
+    t.string "code_postal"
     t.index ["availability"], name: "index_lieux_on_availability"
     t.index ["name"], name: "index_lieux_on_name"
     t.index ["organisation_id"], name: "index_lieux_on_organisation_id"

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -225,15 +225,20 @@ RSpec.describe Lieu, type: :model do
   end
 
   describe "code_postal" do
-    it "est extrait à la sauvegarde" do
-      lieu = build(:lieu, address: "7 rue de l'adresse, Ville, 12345")
-      expect { lieu.save! }.to change { lieu.code_postal }.from(nil).to("12345")
+    it "est extrait de l'adresse lorsque celle-ci est définie" do
+      # Formats classiques trouvés en base
+      expect(described_class.new(address: "7 rue de l'adresse, Ville, 12345").code_postal).to eq("12345")
+      expect(described_class.new(address: "430 AV JEAN JAURES  46000 CAHORS").code_postal).to eq("46000")
 
-      lieu.update!(address: "adresse sans code postal, Ville")
-      expect(lieu.code_postal).to be_nil
+      # Pas de code postal présent (ça arrrive)
+      expect(described_class.new(address: "53 avenue de Fontainebleau").code_postal).to be_nil
 
-      lieu.update!(address: "adresse avec nouveau code postal, Autreville, 99999")
-      expect(lieu.code_postal).to eq("99999")
+      # Ne pas matcher les suites de plus de 5 chiffres
+      expect(described_class.new(address: "1234567 AV JEAN JAURES  46000 CAHORS CEDEX 1234567").code_postal).to eq("46000")
+
+      # En cas d'ambigüité, on reste prudent et on retourne nil
+      expect(described_class.new(address: "67 AV JEAN JAURES, batiment 12345, 46000 CAHORS").code_postal).to be_nil
+
     end
   end
 end

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -223,4 +223,17 @@ RSpec.describe Lieu, type: :model do
       expect(lieu.availability).to eq "disabled"
     end
   end
+
+  describe "code_postal" do
+    it "est extrait à la sauvegarde" do
+      lieu = build(:lieu, address: "7 rue de l'adresse, Ville, 12345")
+      expect { lieu.save! }.to change { lieu.code_postal }.from(nil).to("12345")
+
+      lieu.update!(address: "adresse sans code postal, Ville")
+      expect(lieu.code_postal).to be_nil
+
+      lieu.update!(address: "adresse avec nouveau code postal, Autreville, 99999")
+      expect(lieu.code_postal).to eq("99999")
+    end
+  end
 end

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -238,7 +238,6 @@ RSpec.describe Lieu, type: :model do
 
       # En cas d'ambigüité, on reste prudent et on retourne nil
       expect(described_class.new(address: "67 AV JEAN JAURES, batiment 12345, 46000 CAHORS").code_postal).to be_nil
-
     end
   end
 end


### PR DESCRIPTION
# Contexte

Vous trouverez beaucoup de contexte dans la fiche Notion : https://www.notion.so/rdvs/S-int-grer-la-cartographie-de-d-ploiement-de-la-Suite-Territoriale-27e2b05ced41802a8551dbf5763ec06e

En synthèse : l'ANCT nous demande des données géographique pour alimenter leur cartographie de déploiement de la suite territoriale.

Je souhaite calculer ces données via Metabase, notamment afin de
- réunir les données des 2 instances
- faire la correspondance entre code postal et code insee grâce à un import dans Metabase de [cette source data.gouv](https://www.data.gouv.fr/datasets/correspondance-entre-les-codes-postaux-et-codes-insee-des-communes-francaises/)

Le problème, c'est qu'on anonymise les adresses des lieux dans Metabase (car les agents saisissent parfois les adresses d'usager comme une adresse de lieu à usage unique :grimacing: ).

# Solution

Le plus simple, et donc le moins cher pour répondre au besoin de l'ANCT, c'est de rajouter une colonne contenant uniquement le code postal, et de ne pas l'anonymiser.

Si vous avez d'autres idées, je suis preneur.
