### PR TITLE
Ajout d’un badge pour les motifs archivés

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -41,7 +41,7 @@ module MotifsHelper
     tag.span(motif_name_and_location_type(motif)) + motif_badges(motif)
   end
 
-  def motif_badges(motif, only: %i[bookable_by_invited_users bookable_by_everyone bookable_by_agents_and_prescripteurs for_secretariat follow_up collectif])
+  def motif_badges(motif, only: %i[bookable_by_invited_users bookable_by_everyone bookable_by_agents_and_prescripteurs for_secretariat follow_up collectif archived])
     safe_join(only.select { motif.send("#{_1}?") }.map { build_badge_tag_for(_1) })
   end
 

--- a/app/javascript/stylesheets/components/_motifs.scss
+++ b/app/javascript/stylesheets/components/_motifs.scss
@@ -36,6 +36,11 @@
   border: 1px solid $gray-900;
 }
 
+.badge-motif-archived {
+  background-color: $gray-600;
+  color: $white;
+}
+
 .motif-color-badge {
   display: inline-block;
   width: 20px;

--- a/config/locales/motifs.yml
+++ b/config/locales/motifs.yml
@@ -12,6 +12,7 @@ fr:
       sectorisation_level_agent: "Sectorisé à l'agent"
       sectorisation_level_organisation: "Sectorisé à l'organisation"
       sectorisation_level_departement: "Sectorisé au département"
+      archived: "Archivé"
     follow_up_need_signed_user: "Le RDV '%{motif_name}' est disponible uniquement pour les personnes déjà suivies. Veuillez vous connecter pour prendre ce type de RDV."
     form:
       title:


### PR DESCRIPTION
# Contexte

Dans ce [Ticket Zammad](https://zammad10.ethibox.fr/#ticket/zoom/30312), un agent nous signale que les créneaux n'apparaissent pas alors que la configuration a l'air correcte. J'ai mis un moment à comprendre d'où venait le problème. L'ensemble des motifs des plages d'ouvertures actives avaient été archivés.

Actuellement on ne voit pas du tout sur la vue des plages d'ouverture que les motifs sont archivés.

# Solution

Je propose dans cette première PR d’ajouter un badge Archivé.

Je proposerai probablement dans une PR successive de retirer les motifs des plages d'ouverture lors de leur archivage. Cette PR me semble tout de même nécessaire pour l’historique des PO existantes avec des motifs archivés.

Sinon une piste alternative serait d’ajouter une migraiton dans la PR successive pour corriger tout l’existant 🤔 peut-être que c’est mieux en fait, il me semble que ça n’a pas d’intérêt de conserver les motifs archivés dans des PO actives.

## Captures d'écran

Avant | Après
:- | -:
<img width="1121" height="802" alt="image" src="https://github.com/user-attachments/assets/c7caeb19-5529-4e5d-8bfd-d8d00d4ddc29" /> | <img width="1125" height="707" alt="image" src="https://github.com/user-attachments/assets/04a4f829-6cb2-4dab-98d8-59293b4784e4" />


