### PR TITLE
WIP à l’archivage d’un motif, le retirer des plages d’ouverture

### DIFF
--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -96,6 +96,18 @@
           @motif.custom_cancel_warning_message, \
           hint: Motif.human_attribute_name(:custom_cancel_warning_message_hint)
 
+      hr
+        .row.fr-mb-4w
+          .col-md-4.text-right Plages d’ouvertures
+          .col-md-8
+            - po_count = @motif.plage_ouvertures.not_expired.count
+            - if po_count == 0
+              | Aucune plage d’ouverture active pour ce motif
+            - elsif po_count == 1
+              | Une plage d’ouverture propose des créneaux pour ce motif
+            - else
+              | #{po_count} plages d’ouvertures proposent des créneaux pour ce motif
+
       - if @motif_policy.edit? || @motif_policy.destroy?
         .card-footer
           .d-flex.justify-content-end.flex-gap-1em

--- a/config/locales/views/admin_motifs.fr.yml
+++ b/config/locales/views/admin_motifs.fr.yml
@@ -15,7 +15,7 @@ fr:
         edit: Modifier
         duplicate: Dupliquer
         archive: Archiver
-        archive_confirm: En archivant ce motif, il ne sera plus possible de créer des RDV. Vous pouvez le réactiver à tout moment. Confirmer ?
+        archive_confirm: En archivant ce motif, il ne sera plus possible de créer des RDV. Le motif sera retiré des plages d’ouvertures qui le proposent. Vous pouvez le réactiver à tout moment. Confirmer ?
         unarchive: Réactiver
         destroy: Supprimer
         destroy_confirm: Confirmez-vous la suppression de ce motif ?


### PR DESCRIPTION
WIP

Suite de #5823 

# Contexte

cf la PR précédente

# doutes

Je me demande si c’est une bonne idée de retirer automatiquement le motif des PO actives

Je peux imaginer un cas d’usage de l’archivage des motifs : 
- je propose le motif « vaccination COVID »
- plusieurs agents ont des plages d’ouvertures un peu complexes, dont certaines avec ce motif 
- on n’a plus de places pour la vaccination / le gouvernement fait des annonces perturbantes
- je veux désactiver le motif temporairement
- qques jours après je veux réactiver le motif
- je n’ai pas envie de repasser sur chaque PO pour décider s’il faut la remettre ou non

🤔 est-ce capillotracté ou complètement minoritaire comme cas ?

# Solution

J’avais envie d’afficher dans le message de confirmation le nombre de PO qui vont être affectées mais on peut faire cette action depuis plusieurs endroits et j’ai peur que ça impacte les perfs si c’est dans des listes

# Captures

| Avant | Après |
| - | - | 
<img width="1123" height="763" alt="image" src="https://github.com/user-attachments/assets/1cc29a2f-895f-4ac7-8e75-d4de46777264" /> | <img width="1134" height="752" alt="image" src="https://github.com/user-attachments/assets/5e9173ee-b88f-4a10-bbfd-33f7f10cb220" />
<img width="460" height="279" alt="image" src="https://github.com/user-attachments/assets/bbd05a7c-5684-46c1-944d-900c7665fd8e" /> | <img width="434" height="232" alt="image" src="https://github.com/user-attachments/assets/814ed97a-c496-4b09-9c42-ded188b71d4a" />

