### PR TITLE
Ajout d’une alerte annulation prescripteur sans numéro

### DIFF
--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -18,7 +18,7 @@
             onclick="document.querySelector('.js-ignore-benign-errors').setAttribute('disabled', 'disabled');"
           ] Annuler et modifier
         div= f.submit "Confirmer en ignorant les avertissements", class: "fr-btn fr-btn--tertiary"
-      hr
+      hr.fr-mt-4v
 
 - elsif model.errors.any?
   .fr-alert.fr-alert--error.fr-mb-1w

--- a/app/views/prescripteur_rdv_wizard/_rdv.html.slim
+++ b/app/views/prescripteur_rdv_wizard/_rdv.html.slim
@@ -34,11 +34,13 @@ ul.list-group.list-group-flush.fr-mt-0
       .pl-3.pt-1
         = instruction_for_rdv_to_html(rdv.motif)
 .fr-mt-4v
-  ul.fr-btns-group.fr-btns-group--inline
-    li
-    - if prescripteur.rdv.cancellable_by_user?
+  - if prescripteur.rdv.cancellable_by_user?
+    - if prescripteur.user.phone_number.blank?
+      .fr-alert.fr-alert--warning.fr-mb-2w
+        | Si vous annulez ce rendez-vous, veuillez noter que le bénéficiaire ne recevra pas de notification par SMS en raison de l'absence de numéro de téléphone associé à son compte.
+    ul.fr-btns-group.fr-btns-group--inline
       li
-        = link_to "Annuler le rendez-vous", prescripteur_cancel_rdv_path, class: "fr-btn fr-btn--secondary", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ?", method: :delete }
+        = link_to "Annuler le rendez-vous", prescripteur_cancel_rdv_path, class: "fr-btn fr-btn--secondary", data: { confirm: prescripteur.user.phone_number.blank? ? "Attention ! L’usager ne recevera pas notification d’annulation. Êtes-vous sûr de vouloir annuler ce rendez-vous ?" : "Êtes-vous sûr de vouloir annuler ce rendez-vous ?", method: :delete }
 p
   |> Besoin de corriger un détail ?
   = link_to "Contactez-nous", new_aide_demande_support_path(role: :agent,

--- a/app/views/prescripteur_rdv_wizard/_rdv.html.slim
+++ b/app/views/prescripteur_rdv_wizard/_rdv.html.slim
@@ -36,8 +36,8 @@ ul.list-group.list-group-flush.fr-mt-0
 .fr-mt-4v
   - if prescripteur.rdv.cancellable_by_user?
     - if prescripteur.user.phone_number.blank?
-      .fr-alert.fr-alert--warning.fr-mb-2w
-        | Si vous annulez ce rendez-vous, veuillez noter que le bénéficiaire ne recevra pas de notification par SMS en raison de l'absence de numéro de téléphone associé à son compte.
+      .fr-callout.fr-icon-alert-line.fr-callout--yellow-moutarde
+        | Vous n’avez pas renseigné de numéro de téléphone pour l’usager. En cas d’annulation, il ne recevra pas de notification automatique.
     ul.fr-btns-group.fr-btns-group--inline
       li
         = link_to "Annuler le rendez-vous", prescripteur_cancel_rdv_path, class: "fr-btn fr-btn--secondary", data: { confirm: prescripteur.user.phone_number.blank? ? "Attention ! L’usager ne recevera pas notification d’annulation. Êtes-vous sûr de vouloir annuler ce rendez-vous ?" : "Êtes-vous sûr de vouloir annuler ce rendez-vous ?", method: :delete }

--- a/app/views/prescripteur_rdv_wizard/show.html.slim
+++ b/app/views/prescripteur_rdv_wizard/show.html.slim
@@ -1,6 +1,6 @@
 /# locals: (prescripteur:)
 
-.fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
+.fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1.fr-mt-4v
   .card
     .card-body
       h1.fr-h3 Détails du rendez-vous


### PR DESCRIPTION
# Contexte

Suite à l’arrivée de l’annulation prescripteur, @francois-ferrandis a fait une remarque très juste. Un prescripteur peut prendre rendez-vous pour un usager, mais ne pas mettre son numéro de téléphone lors de la prise de rendez-vous. Si tel est le cas, l’usager ne reçoit pas de SMS ni pour la confirmation, ni pour l’annulation.
Dans la très grande majorité des cas, les annulations se font directement après la prise de rendez-vous suite à une erreur ou à la demande de l’usager. Ce dernier est donc au courant de l’annulation. Pour être certain qu’un prescripteur ne fasse pas une annulation sans prévenir l’usager, on rajoute une alerte.

# Solution

- Ajout d’une alerte ET modification du wording dans le confirm si l’usager n’a pas de numéro de téléphone sur sa fiche.

<img width="1222" height="703" alt="image" src="https://github.com/user-attachments/assets/4c0d04d1-b29c-4acb-92a8-073f26fc6550" />

- J’en ai profité pour corriger un problème d’espacement 

## Avant

<img width="805" height="567" alt="image" src="https://github.com/user-attachments/assets/1aaac546-b9be-41b2-ac8c-0d5f5e73b0f2" />

## Après 

<img width="831" height="610" alt="image" src="https://github.com/user-attachments/assets/20bd297f-d870-40dd-b4aa-4c35c8d0acf9" />


