### PR TITLE
Ajout du site web aux webhooks des organisations

### DIFF
--- a/app/blueprints/organisation_blueprint.rb
+++ b/app/blueprints/organisation_blueprint.rb
@@ -1,5 +1,5 @@
 class OrganisationBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :phone_number, :email, :verticale
+  fields :name, :phone_number, :email, :website, :verticale
 end


### PR DESCRIPTION
# Contexte

On est en train de revoir les mails d'invitations des usagers côté rdv-insertion, et on veut afficher toutes les données de contacts de l'organisation en cas de problème, dont le site web. Cette info est la moins importante mais si ça ne pose pas de problème de la récupérer pourquoi pas l'afficher.

<img width="662" height="315" alt="image" src="https://github.com/user-attachments/assets/7c86303f-b6ea-4b74-8390-baa279e78179" />

# Solution

J'ajoute le champ `website` au blueprint des organisations.