### PR TITLE
Ajout de l'historique des rendez-vous à la migration inter-instance

### DIFF
--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -26,6 +26,50 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
     render_collection(rdvs)
   end
 
+  # Cet endpoint est utilisé seulement pour la copie des données d'une instance à l'autre, il n'est donc pas documenté.
+  def create
+    # On crée le rendez-vous via ActiveRecord sans lancer les Notifiers, ce qui évite de déclencher des callbacks de notifications pour les agents et les usager
+    rdv = Rdv.new(
+      params.permit(%w[starts_at status cancelled_at context ends_at name max_participants_count])
+    )
+
+    Rdv.transaction do
+      oauth_application = doorkeeper_token&.application
+
+      rdv.lieu_id = ExternalReference.find_by(item_type: "Lieu", external_id: params[:lieu_external_id], oauth_application:)&.item_id
+      rdv.motif_id = ExternalReference.find_by(item_type: "Motif", external_id: params[:motif_external_id], oauth_application:)&.item_id
+      rdv.organisation_id = rdv.motif.organisation_id
+
+      rdv.user_ids = ExternalReference.where(item_type: "User", external_id: params[:user_external_ids], oauth_application:).map(&:item_id)
+      rdv.agents = Agent.where(email: params[:agent_emails])
+
+      rdv.created_by_type = params[:created_by_type]
+      # Il faut un created_by sur le rendez-vous pour initialiser les created_by des participations
+      # Mais le champs n'est pas utilisé à part pour envoyer des notifications (ce qu'on ne fait pas ici)
+      # ou identifier un prescripteur, ce qui n'est pas très utile pour les rendez-vous passés.
+      # On peut donc se permettre de faire l'approximation que c'est l'usager ou l'agent du rendez-vous qui l'a créé.
+      rdv.created_by_id = if rdv.created_by_type == "User"
+                            rdv.user_ids.first
+                          else
+                            rdv.agent_ids.first
+                          end
+
+      authorize(rdv, :update?, policy_class: Agent::RdvPolicy)
+
+      rdv.save!
+      if params[:external_reference].present?
+        ExternalReference.create!(
+          params.require(:external_reference).permit(:external_id, :external_url).merge(
+            item: rdv,
+            oauth_application:
+          )
+        )
+      end
+    end
+
+    render json: RdvBlueprint.render(rdv)
+  end
+
   def update_status
     @rdv = Rdv.find(params[:rdv_id])
     authorize(@rdv, :update?, policy_class: Agent::RdvPolicy)

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -33,6 +33,10 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
       params.permit(%w[starts_at status cancelled_at context ends_at name max_participants_count])
     )
 
+    if rdv.starts_at > Time.zone.now
+      raise "Cet endpoint ne doit pas être utilisé pour créer des rendez-vous à venir"
+    end
+
     Rdv.transaction do
       oauth_application = doorkeeper_token&.application
 
@@ -40,7 +44,6 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
       rdv.motif_id = ExternalReference.find_by(item_type: "Motif", external_id: params[:motif_external_id], oauth_application:)&.item_id
       rdv.organisation_id = rdv.motif.organisation_id
 
-      rdv.user_ids = ExternalReference.where(item_type: "User", external_id: params[:user_external_ids], oauth_application:).map(&:item_id)
       rdv.agents = Agent.where(email: params[:agent_emails])
 
       rdv.created_by_type = params[:created_by_type]
@@ -56,7 +59,23 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
 
       authorize(rdv, :update?, policy_class: Agent::RdvPolicy)
 
-      rdv.save!
+      if rdv.collectif?
+        rdv.save!
+
+        params[:participations].each do |participation_params|
+          Participation.create(
+            rdv: rdv,
+            user_id: ExternalReference.find_by(item_type: "User", external_id: participation_params[:user_external_id], oauth_application:)&.item_id,
+            status: participation_params[:status],
+            created_by: rdv.created_by
+          )
+        end
+      else
+        user_external_ids = params[:participations].map { |p| p[:user_external_id] }
+        rdv.user_ids = ExternalReference.where(item_type: "User", external_id: user_external_ids, oauth_application:).map(&:item_id)
+        rdv.save!
+      end
+
       if params[:external_reference].present?
         ExternalReference.create!(
           params.require(:external_reference).permit(:external_id, :external_url).merge(

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
   end
 
   # Cet endpoint est utilisé seulement pour la copie des données d'une instance à l'autre, il n'est donc pas documenté.
-  def create
+  def create # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     # On crée le rendez-vous via ActiveRecord sans lancer les Notifiers, ce qui évite de déclencher des callbacks de notifications pour les agents et les usager
     rdv = Rdv.new(
       params.permit(%w[starts_at status cancelled_at context ends_at name max_participants_count])

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -30,6 +30,10 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
           CopyRdvAsAbsenceJob.perform_later(instance_export.id, rdv_id, current_domain_id)
         end
 
+        source_organisation.rdvs.past.pluck(:id).each do |rdv_id|
+          CopyRdvJob.perform_later(instance_export.id, rdv_id, current_domain_id)
+        end
+
         organisation_absences = Absence.where(agent_id: source_organisation.agents.select(:agent_id)).not_expired
 
         organisation_absences.pluck(:id).each do |absence_id|
@@ -78,6 +82,42 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
         api_client = instance_export.api_client
         api_client.post("absences", params)
       end
+    end
+  end
+
+  class CopyRdvJob < ApplicationJob
+    queue_as :latency_5m
+
+    def perform(instance_export_id, rdv_id, domain_id)
+      domain = Domain.find(domain_id)
+      instance_export = InstanceExport.find(instance_export_id)
+      rdv = Rdv.find(rdv_id)
+
+      instance_export.api_client.post(
+        "rdvs",
+        {
+          user_external_ids: rdv.users.pluck(:id),
+          agent_emails: rdv.agents.pluck(:email),
+          lieu_external_id: rdv.lieu_id,
+          motif_external_id: rdv.motif_id,
+
+          starts_at: rdv.starts_at,
+          status: rdv.status,
+          cancelled_at: rdv.cancelled_at,
+          context: rdv.context,
+          ends_at: rdv.ends_at,
+          name: rdv.name,
+          max_participants_count: rdv.max_participants_count,
+
+          created_by_type: rdv.created_by_type,
+          created_by_external_id: rdv.created_by_id,
+
+          external_reference: {
+            external_id: rdv_id,
+            external_url: Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: domain.host_name),
+          },
+        }
+      )
     end
   end
 

--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -96,7 +96,6 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
       instance_export.api_client.post(
         "rdvs",
         {
-          user_external_ids: rdv.users.pluck(:id),
           agent_emails: rdv.agents.pluck(:email),
           lieu_external_id: rdv.lieu_id,
           motif_external_id: rdv.motif_id,
@@ -111,6 +110,13 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
 
           created_by_type: rdv.created_by_type,
           created_by_external_id: rdv.created_by_id,
+
+          participations: rdv.participations.map do |participation|
+            {
+              status: participation.status,
+              user_external_id: participation.user_id,
+            }
+          end,
 
           external_reference: {
             external_id: rdv_id,

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -40,6 +40,7 @@ class Rdv < ApplicationRecord
   # https://github.com/rails/rails/issues/7618
   has_many :participations, validate: false, inverse_of: :rdv, dependent: :destroy, class_name: "Participation"
   has_many :receipts, dependent: :nullify
+  has_many :external_references, as: :item, dependent: :destroy
 
   accepts_nested_attributes_for :participations, allow_destroy: true
   accepts_nested_attributes_for :lieu

--- a/app/views/admin/instance_exports/edit.html.slim
+++ b/app/views/admin/instance_exports/edit.html.slim
@@ -19,7 +19,7 @@
 
             .fr-col-6
               h4.fr-h5 Planning
-              p #{source_org.rdvs.future.count} rendez-vous à venir
+              p #{source_org.rdvs.count} rendez-vous
               p #{source_org.plage_ouvertures.not_expired.count} plages d'ouverture
               p #{Absence.where(agent_id: source_org.agents.select(:id)).not_expired.count} absences
 

--- a/app/views/admin/instance_exports/index.html.slim
+++ b/app/views/admin/instance_exports/index.html.slim
@@ -37,9 +37,11 @@
     h3.fr-h4.fr-mt-6w Copie de vos données
     p Toute la configuration de #{current_organisation.name}, les fiches des usagers, et les planning des agents seront copiés automatiquement sur RDV Service Public.
 
-    p Les historiques de rendez-vous de vos usagers ne seront pas copiés, mais vous pourrez les retrouver facilement à l'aide de liens depuis RDV Service Public vers #{current_domain.name}.
+    p Les historiques de rendez-vous de vos usagers et vos statistiques seront copiés aussi.
 
     p Les agents de votre organisation actuelle seront aussi invités à se créer un compte sur RDV Service Public
+
+    p Les seules données qui ne seront pas copiées exactement sont vos rendez-vous à venir : ils apparaîtront comme des indisponibilités sur votre planning RDV Service Public, avec un lien pour les retrouver sur #{current_domain.name}
 
     h3.fr-h4.fr-mt-6w Bascule vers RDV Service Public
 

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -19,7 +19,7 @@ namespace :api do
       resources :rdvs, only: %i[index]
     end
     resources :motifs, only: %i[create]
-    resources :rdvs, only: %i[index] do
+    resources :rdvs, only: %i[index create] do
       patch :update_status
     end
     resources :participations, only: %i[update]

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -72,14 +72,15 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     doc = Autodoc.start_scenario("Migration depuis RDV Aide Numérique vers RDV Service Public", self, category: "5) RDV Aide Numérique")
 
     doc.start_section("Migration")
-    doc.add_text(<<~TEXT
-      Dans un premier temps, cette fonctionnalité n'est accessible que en ayant directement l'url.
-      On va la communiquer aux beta testeurs, et on pourra ensuite la rendre accessible depuis le menu des paramètres.
-    TEXT
-                )
 
     login_as(agent_rdv_aide_num, scope: :agent)
-    visit "http://www.rdv-aide-numerique-test.localhost/agents/instance_exports"
+    visit "http://www.rdv-aide-numerique-test.localhost/"
+
+    doc.add_screenshot(page,
+                       text: "Depuis toutes les pages de RDV Aide Numérique, j'ai un lien vers la migration dans le header. Je clique dessus.",
+                       wait_for: "Passer à RDV Service Public")
+
+    click_on "Passer à RDV Service Public"
 
     Capybara.page.current_window.resize_to(1280, 1200)
 
@@ -202,5 +203,15 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     doc.add_screenshot(page,
                        text: "En se connectant sur RDV Service Public, on constate que les agents ont bien été créés.",
                        wait_for: collegue.email)
+
+    click_on "Liste des RDV"
+
+    expect(page).to have_content("1 rendez-vous")
+    scroll_to(find("h4", text: "1 rendez-vous"))
+
+    doc.add_screenshot(page,
+                       text: "Je vois mon historique de rendez-vous",
+                       wait_for: "vous voyez les RDV de toute l'organisation",
+                       accessibility_checks: false)
   end
 end

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   let!(:future_rdv_collectif) do
     create(:rdv, agents: [collegue], users: [], starts_at: 2.weeks.from_now, motif: motif_collectif, lieu:, organisation: organisation_rdv_aide_num)
   end
+  let!(:old_rdv) do
+    create(:rdv, agents: [collegue], users: [users.last], starts_at: 2.weeks.ago, motif:, lieu:, organisation: organisation_rdv_aide_num)
+  end
 
   let!(:absence) { create(:absence, :no_recurrence, agent: agent_rdv_aide_num) }
   let!(:recurrent_absence) { create(:absence, :weekly_on_monday, agent: agent_rdv_aide_num) }
@@ -146,6 +149,21 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
 
     created_motif = created_organisation.motifs.individuel.sole
     expect(created_motif).to have_attributes(name: motif.name)
+
+    created_user = created_organisation.users.last
+
+    # On importe les anciens rendez-vous
+    created_rdv = created_organisation.rdvs.last
+    expect(created_rdv).to have_attributes(
+      users: [created_user],
+      lieu: created_lieu,
+      motif: created_motif,
+      agents: created_organisation.agents.where(email: collegue.email)
+    )
+    expect(created_rdv.external_references.last).to have_attributes(
+      external_id: old_rdv.id
+      external_url: "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{old_rdv.id}"
+    )
 
     # On crée des absences qui permettent de retrouver les rendez-vous sur l'ancienne instance
     absence_representing_rdv = collegue.absences.find_by(title: "RDV avec #{future_rdv.users.first.full_name} (sur RDV Aide Numérique)")

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -150,20 +150,21 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     created_motif = created_organisation.motifs.individuel.sole
     expect(created_motif).to have_attributes(name: motif.name)
 
-    created_user = created_organisation.users.last
+    created_organisation.users.last
 
     # On importe les anciens rendez-vous
     created_rdv = created_organisation.rdvs.last
     expect(created_rdv).to have_attributes(
-      users: [created_user],
       lieu: created_lieu,
       motif: created_motif,
       agents: created_organisation.agents.where(email: collegue.email)
     )
     expect(created_rdv.external_references.last).to have_attributes(
-      external_id: old_rdv.id
+      external_id: old_rdv.id.to_s,
       external_url: "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{old_rdv.id}"
     )
+
+    expect(created_rdv.users.first.full_name).to eq old_rdv.users.first.full_name
 
     # On crée des absences qui permettent de retrouver les rendez-vous sur l'ancienne instance
     absence_representing_rdv = collegue.absences.find_by(title: "RDV avec #{future_rdv.users.first.full_name} (sur RDV Aide Numérique)")

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -8,6 +8,30 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
                           website: "www.montreuil.fr/france-service",
                           email: "contact@exemple.montreuil.fr")
   end
+  let!(:absence) { create(:absence, :no_recurrence, agent: agent_rdv_aide_num) }
+  let!(:recurrent_absence) { create(:absence, :weekly_on_monday, agent: agent_rdv_aide_num) }
+  let!(:recurrent_absence_with_end_date) { create(:absence, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num) }
+  let!(:plage_ouverture) do
+    create(:plage_ouverture, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num, organisation: organisation_rdv_aide_num, lieu: lieu, motifs: [motif])
+  end
+  let!(:absence_du_collegue) { create(:absence, :no_recurrence, agent: collegue) }
+  let!(:agent_rdv_sp) do
+    create(:agent, first_name: "Camille", last_name: "Clavier", password: "c0rrecThorse!", admin_role_in_organisations: [])
+  end
+  let!(:oauth_application) do
+    application = OauthApplication.new(
+      name: "RDV Aide Numérique",
+      uid: "fake-app-id",
+      redirect_uri: "http://www.rdv-aide-numerique-test.localhost/omniauth/rdvservicepublic/callback",
+      logo_base64: "",
+      default_service: create(:service)
+    )
+
+    application.secret_strategy.store_secret(application, :secret, "fake-app-secret")
+    application.save!
+
+    application
+  end
   let!(:agent_rdv_aide_num) do
     create(:agent, first_name: "Camille", last_name: "Clavier", admin_role_in_organisations: [organisation_rdv_aide_num])
   end
@@ -32,33 +56,13 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
   let!(:old_rdv) do
     create(:rdv, agents: [collegue], users: [users.last], starts_at: 2.weeks.ago, motif:, lieu:, organisation: organisation_rdv_aide_num)
   end
-
-  let!(:absence) { create(:absence, :no_recurrence, agent: agent_rdv_aide_num) }
-  let!(:recurrent_absence) { create(:absence, :weekly_on_monday, agent: agent_rdv_aide_num) }
-  let!(:recurrent_absence_with_end_date) { create(:absence, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num) }
-  let!(:plage_ouverture) do
-    create(:plage_ouverture, :weekly_on_monday_until_next_month, agent: agent_rdv_aide_num, organisation: organisation_rdv_aide_num, lieu: lieu, motifs: [motif])
+  let!(:old_rdv_collectif) do
+    create(:rdv, :without_users, agents: [collegue], users: [], starts_at: 2.weeks.ago, motif: motif_collectif, lieu:, organisation: organisation_rdv_aide_num, status: :seen)
   end
 
-  let!(:absence_du_collegue) { create(:absence, :no_recurrence, agent: collegue) }
-
-  let!(:agent_rdv_sp) do
-    create(:agent, first_name: "Camille", last_name: "Clavier", password: "c0rrecThorse!", admin_role_in_organisations: [])
-  end
-
-  let!(:oauth_application) do
-    application = OauthApplication.new(
-      name: "RDV Aide Numérique",
-      uid: "fake-app-id",
-      redirect_uri: "http://www.rdv-aide-numerique-test.localhost/omniauth/rdvservicepublic/callback",
-      logo_base64: "",
-      default_service: create(:service)
-    )
-
-    application.secret_strategy.store_secret(application, :secret, "fake-app-secret")
-    application.save!
-
-    application
+  before do
+    create(:participation, rdv: old_rdv_collectif, status: :seen, user: users[0])
+    create(:participation, rdv: old_rdv_collectif, status: :noshow, user: users[1])
   end
 
   stub_env_for_proconnect
@@ -151,10 +155,12 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     created_motif = created_organisation.motifs.individuel.sole
     expect(created_motif).to have_attributes(name: motif.name)
 
-    created_organisation.users.last
+    # On ne crée que des rdvs dans le passé : les rendez-vous à venir sont matérialisés par des absences.
+    expect(created_organisation.rdvs.pluck(:starts_at).max < Time.zone.now).to be true
+    expect(created_organisation.rdvs.count).to eq 2
 
     # On importe les anciens rendez-vous
-    created_rdv = created_organisation.rdvs.last
+    created_rdv = created_organisation.rdvs.joins(:motif).merge(Motif.individuel).last
     expect(created_rdv).to have_attributes(
       lieu: created_lieu,
       motif: created_motif,
@@ -166,6 +172,10 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     )
 
     expect(created_rdv.users.first.full_name).to eq old_rdv.users.first.full_name
+
+    created_rdv_collectif = created_organisation.rdvs.collectif.last
+    expect(created_rdv_collectif.status).to eq "seen"
+    expect(created_rdv_collectif.participations.pluck(:status).sort).to eq(%w[noshow seen])
 
     # On crée des absences qui permettent de retrouver les rendez-vous sur l'ancienne instance
     absence_representing_rdv = collegue.absences.find_by(title: "RDV avec #{future_rdv.users.first.full_name} (sur RDV Aide Numérique)")
@@ -206,8 +216,8 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
 
     click_on "Liste des RDV"
 
-    expect(page).to have_content("1 rendez-vous")
-    scroll_to(find("h4", text: "1 rendez-vous"))
+    expect(page).to have_content("2 rendez-vous")
+    scroll_to(find("h4", text: "2 rendez-vous"))
 
     doc.add_screenshot(page,
                        text: "Je vois mon historique de rendez-vous",

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe "RDV API" do
   end
   let(:application) { create(:oauth_application) }
 
+  let(:motif) { create(:motif, organisation: organisation, service: service) }
+  let(:service) { create(:service) }
+  let(:organisation) { create(:organisation) }
+
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+  let(:other_agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
   describe "#index" do
-    let(:motif) { create(:motif, organisation: organisation, service: service) }
-    let(:service) { create(:service) }
-    let(:organisation) { create(:organisation) }
-
-    let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
-    let(:other_agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
-    let(:user) { create(:user) }
-    let(:other_user) { create(:user) }
-
     let!(:rdv_with_user_and_agent) { create(:rdv, organisation: organisation, motif: motif, users: [user], agents: [agent]) }
     let!(:rdv_with_user_and_other_agent) { create(:rdv, organisation: organisation, motif: motif, users: [user], agents: [other_agent]) }
 

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -52,7 +52,7 @@ class Autodoc
       @current_section.steps << { text: description }
     end
 
-    def add_screenshot(page_or_email, text: nil, wait_for: nil)
+    def add_screenshot(page_or_email, text: nil, wait_for: nil, accessibility_checks: true)
       if wait_for
         @example.expect(page_or_email).to(@example.have_content(wait_for))
       end
@@ -66,7 +66,7 @@ class Autodoc
         Capybara.current_session.driver.visit "file://#{page_or_email.save_page}"
         Capybara.current_session.driver.save_screenshot(path)
       else
-        if @accessibility_checks
+        if @accessibility_checks && accessibility_checks # On peut désactiver ces checks au niveau de tout le scénario ou juste pour ce screenshot
           @example.expect(page_or_email).to @example.be_axe_clean
         end
         page_or_email.driver.save_screenshot(path)

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -36,7 +36,7 @@ class Autodoc
       @title = title
       @index = Digest::SHA1.hexdigest(title)[0..8]
       @example = example
-      @accessibility_checks = accessibility_checks
+      @scenario_accessibility_checks = accessibility_checks
       @sections = []
       @current_section = nil
     end
@@ -66,7 +66,7 @@ class Autodoc
         Capybara.current_session.driver.visit "file://#{page_or_email.save_page}"
         Capybara.current_session.driver.save_screenshot(path)
       else
-        if @accessibility_checks && accessibility_checks # On peut désactiver ces checks au niveau de tout le scénario ou juste pour ce screenshot
+        if @scenario_accessibility_checks && accessibility_checks # On peut désactiver ces checks au niveau de tout le scénario ou juste pour ce screenshot
           @example.expect(page_or_email).to @example.be_axe_clean
         end
         page_or_email.driver.save_screenshot(path)


### PR DESCRIPTION
# Contexte

Suite de https://github.com/betagouv/rdv-service-public/pull/5647 et des autres PRs pour la migration des conums.

Certains conums ont refusé de faire la migration parce qu'ils perdaient leur historique de rendez-vous (historique des usagers et statistiques).

On était un peu hésitants à ajouter de la création de rendez-vous lors de la migration des conums, mais en créant des données de test ça s'est avéré assez faisable.

On peut faire de la création de rendez-vous par api qui n'envoie pas de notifications (et c'est là qu'on est très heureux que les Notifiers soient appelés par des services/form objects plutôt que par des callbacks AR).

Ça veut dire que ça va un tout petit peu gonfler nos stats de manière erronée, mais vu les volumes de rendez-vous dont il s'agit, ça devrait pas changer grand chose. On pourrait éventuellement même éviter ça en excluant les rdvs avec des external references dans les stats.

# Solution

On reprend les même principes que pour les autres copies de données pendant la migration.