### PR TITLE
Renommage de `RDV_MAIRIE` en `RDV_SERVICE_PUBLIC`

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -28,7 +28,7 @@ class SearchController < ApplicationController
     end
     # >> REMOVE AFTER 01/01/2026
 
-    if current_domain == Domain::RDV_MAIRIE
+    if current_domain == Domain::RDV_SERVICE_PUBLIC
       render "dsfr/rdv_mairie/homepage"
     else
       search_rdv

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -35,7 +35,7 @@ module Ants
       # on n’utilise pas de regex ci-dessous pour éviter un faux-positif de Brakeman
       protocol = Rails.env.production? ? "https" : "http"
       @ants_appointments = ants_status["appointments"].select do |appointment|
-        appointment["management_url"].start_with?("#{protocol}://#{Domain::RDV_MAIRIE.host_name}")
+        appointment["management_url"].start_with?("#{protocol}://#{Domain::RDV_SERVICE_PUBLIC.host_name}")
       end
 
       return true unless needs_synchronization?

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -301,7 +301,7 @@ class Agent < ApplicationRecord
     @domain ||= if organisations.where(verticale: :rdv_aide_numerique).any?
                   Domain::RDV_AIDE_NUMERIQUE
                 elsif organisations.where(verticale: :rdv_mairie).any?
-                  Domain::RDV_MAIRIE
+                  Domain::RDV_SERVICE_PUBLIC
                 else
                   Domain.default_domain_for_current_instance
                 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -140,7 +140,7 @@ class Domain
       {
         RDV_SOLIDARITES => "www.rdv-solidarites-test.localhost",
         RDV_AIDE_NUMERIQUE => "www.rdv-aide-numerique-test.localhost",
-        RDV_SERVICE_PUBLIC => "www.rdv-mairie-test.localhost",
+        RDV_SERVICE_PUBLIC => "www.rdv-service-public-test.localhost",
       }.fetch(self)
     else
       raise "Rails.env not recognized: #{Rails.env.inspect}"
@@ -180,7 +180,7 @@ class Domain
       {
         RDV_SOLIDARITES => "reply.rdv-solidarites-test.localhost",
         RDV_AIDE_NUMERIQUE => "reply.rdv-aide-numerique-test.localhost",
-        RDV_SERVICE_PUBLIC => "reply.rdv-mairie-test.localhost",
+        RDV_SERVICE_PUBLIC => "reply.rdv-service-public-test.localhost",
       }.fetch(self)
     else
       raise "Rails.env not recognized: #{Rails.env.inspect}"

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -61,8 +61,8 @@ class Domain
       secretariat_email: "secretariat-auto@rdv-solidarites.fr"
     ),
 
-    RDV_MAIRIE = new(
-      id: "RDV_MAIRIE",
+    RDV_SERVICE_PUBLIC = new(
+      id: "RDV_SERVICE_PUBLIC",
       logo_path: "logos/logo_rdv_service_public.svg",
       public_logo_path: "/logo_rdv_service_public.png",
       dark_logo_path: "logos/logo_sombre_rdv_service_public.svg",
@@ -92,7 +92,7 @@ class Domain
     {
       RDV_SOLIDARITES => ENV["AGENT_CONNECT_RDVS_CLIENT_ID"],
       RDV_AIDE_NUMERIQUE => ENV["AGENT_CONNECT_RDVAN_CLIENT_ID"],
-      RDV_MAIRIE => ENV["AGENT_CONNECT_RDVSP_CLIENT_ID"],
+      RDV_SERVICE_PUBLIC => ENV["AGENT_CONNECT_RDVSP_CLIENT_ID"],
     }.fetch(self)
   end
 
@@ -100,7 +100,7 @@ class Domain
     {
       RDV_SOLIDARITES => ENV["AGENT_CONNECT_RDVS_CLIENT_SECRET"],
       RDV_AIDE_NUMERIQUE => ENV["AGENT_CONNECT_RDVAN_CLIENT_SECRET"],
-      RDV_MAIRIE => ENV["AGENT_CONNECT_RDVSP_CLIENT_SECRET"],
+      RDV_SERVICE_PUBLIC => ENV["AGENT_CONNECT_RDVSP_CLIENT_SECRET"],
     }.fetch(self)
   end
 
@@ -115,32 +115,32 @@ class Domain
         {
           RDV_SOLIDARITES => "staging.rdv-solidarites.fr", # sous-domaine pas configuré
           RDV_AIDE_NUMERIQUE => "staging.rdv-aide-numerique.fr", # sous-domaine pas configuré
-          RDV_MAIRIE => "staging.rdv-service-public.fr",
+          RDV_SERVICE_PUBLIC => "staging.rdv-service-public.fr",
         }.fetch(self)
       elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
         {
           RDV_SOLIDARITES => "demo.rdv-solidarites.fr",
           RDV_AIDE_NUMERIQUE => "demo.rdv-aide-numerique.fr",
-          RDV_MAIRIE => "demo.rdv.anct.gouv.fr",
+          RDV_SERVICE_PUBLIC => "demo.rdv.anct.gouv.fr",
         }.fetch(self)
       else
         {
           RDV_SOLIDARITES => "www.rdv-solidarites.fr",
           RDV_AIDE_NUMERIQUE => "www.rdv-aide-numerique.fr",
-          RDV_MAIRIE => "rdv.anct.gouv.fr",
+          RDV_SERVICE_PUBLIC => "rdv.anct.gouv.fr",
         }.fetch(self)
       end
     when :development
       {
         RDV_SOLIDARITES => "www.rdv-solidarites.localhost",
         RDV_AIDE_NUMERIQUE => "www.rdv-aide-numerique.localhost",
-        RDV_MAIRIE => "www.rdv-mairie.localhost",
+        RDV_SERVICE_PUBLIC => "www.rdv-mairie.localhost",
       }.fetch(self)
     when :test
       {
         RDV_SOLIDARITES => "www.rdv-solidarites-test.localhost",
         RDV_AIDE_NUMERIQUE => "www.rdv-aide-numerique-test.localhost",
-        RDV_MAIRIE => "www.rdv-mairie-test.localhost",
+        RDV_SERVICE_PUBLIC => "www.rdv-mairie-test.localhost",
       }.fetch(self)
     else
       raise "Rails.env not recognized: #{Rails.env.inspect}"
@@ -154,33 +154,33 @@ class Domain
         nil
       elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "STAGING"
         {
-          RDV_MAIRIE => "reply.staging.rdv-service-public.fr",
+          RDV_SERVICE_PUBLIC => "reply.staging.rdv-service-public.fr",
           # c’est le seul staging réellement ouvert pour l’instant
         }.fetch(self, nil)
       elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
         {
           RDV_SOLIDARITES => "reply.demo.rdv-solidarites.fr",
           RDV_AIDE_NUMERIQUE => "reply.demo.rdv-aide-numerique.fr",
-          RDV_MAIRIE => "reply.demo.rdv-service-public.fr",
+          RDV_SERVICE_PUBLIC => "reply.demo.rdv-service-public.fr",
         }.fetch(self)
       else
         {
           RDV_SOLIDARITES => "reply.rdv-solidarites.fr",
           RDV_AIDE_NUMERIQUE => "reply.rdv-aide-numerique.fr",
-          RDV_MAIRIE => "reply.rdv-service-public.fr", # TODO: remplacer par anct.gouv.fr une fois les DNS déployés
+          RDV_SERVICE_PUBLIC => "reply.rdv-service-public.fr", # TODO: remplacer par anct.gouv.fr une fois les DNS déployés
         }.fetch(self)
       end
     when :development
       {
         RDV_SOLIDARITES => "reply.rdv-solidarites.localhost",
         RDV_AIDE_NUMERIQUE => "reply.rdv-aide-numerique.localhost",
-        RDV_MAIRIE => "reply.rdv-mairie.localhost",
+        RDV_SERVICE_PUBLIC => "reply.rdv-mairie.localhost",
       }.fetch(self)
     when :test
       {
         RDV_SOLIDARITES => "reply.rdv-solidarites-test.localhost",
         RDV_AIDE_NUMERIQUE => "reply.rdv-aide-numerique-test.localhost",
-        RDV_MAIRIE => "reply.rdv-mairie-test.localhost",
+        RDV_SERVICE_PUBLIC => "reply.rdv-mairie-test.localhost",
       }.fetch(self)
     else
       raise "Rails.env not recognized: #{Rails.env.inspect}"
@@ -188,7 +188,7 @@ class Domain
   end
 
   def default?
-    self == RDV_MAIRIE
+    self == RDV_SERVICE_PUBLIC
   end
   alias default default?
 
@@ -197,7 +197,7 @@ class Domain
   def self.find_matching(domain_name)
     return review_app_domain if ENV["IS_REVIEW_APP"] == "true"
 
-    ALL_BY_HOST_NAME.fetch(domain_name) { RDV_MAIRIE }
+    ALL_BY_HOST_NAME.fetch(domain_name) { RDV_SERVICE_PUBLIC }
   end
 
   # Les review apps utilisent un host de Scalingo, elles ne permettent
@@ -214,7 +214,7 @@ class Domain
     if ENV["DEFAULT_DOMAIN_IS_RDV_SOLIDARITES"] == "true"
       RDV_SOLIDARITES
     else
-      RDV_MAIRIE
+      RDV_SERVICE_PUBLIC
     end
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -84,7 +84,7 @@ class Organisation < ApplicationRecord
     when :rdv_aide_numerique
       Domain::RDV_AIDE_NUMERIQUE
     when :rdv_mairie
-      Domain::RDV_MAIRIE
+      Domain::RDV_SERVICE_PUBLIC
     else
       Domain::RDV_SOLIDARITES
     end

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -12,7 +12,7 @@
   .col-md-6= f.input :last_name, **input_opts
 
 .form-row
-  - if current_domain != Domain::RDV_MAIRIE
+  - if current_domain != Domain::RDV_SERVICE_PUBLIC
     .col-md-6= f.input :birth_name, **input_opts.deep_merge(frozen_fields_opts)
   - if current_territory.enable_birth_date_field?
     .col-md-6= date_input(f, :birth_date, **input_opts.deep_merge(frozen_fields_opts))

--- a/app/views/aide/pages/aiguillage_usager.html.slim
+++ b/app/views/aide/pages/aiguillage_usager.html.slim
@@ -23,7 +23,7 @@
       - content_for :subtitle, "Prendre un RDV"
       h6 Étapes pour prendre un RDV
       ol
-        - if current_domain == Domain::RDV_MAIRIE
+        - if current_domain == Domain::RDV_SERVICE_PUBLIC
           li Cliquez sur votre lien de prise de RDV : vous l’avez peut-être trouvé sur le site de l’organisation ou bien il vous a été communiqué par email.
         - else
           li Sur la page d’accueil, dans la barre de recherche, saisissez votre adresse et cliquez sur « Rechercher ».

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -31,7 +31,7 @@ html lang="fr"
         elsif current_agent
           header.with_tool_link title: "Espace Agent", path: root_path
           header.with_tool_link title: current_agent.full_name, path: edit_agent_registration_path
-        elsif current_domain == Domain::RDV_MAIRIE && request.path == "/"
+        elsif current_domain == Domain::RDV_SERVICE_PUBLIC && request.path == "/"
           header.with_tool_link title: "Centre d’aide", path: "https://aide.rdv-service-public.fr", html_attributes: { class: "fr-icon-questionnaire-line" }
           header.with_tool_link title: "Connexion Agent", path: new_agent_session_path, html_attributes: { class: "fr-icon-admin-line" }
           header.with_tool_link title: "Connexion Usager", path: new_user_session_path, html_attributes: { class: "fr-icon-account-line" }
@@ -40,7 +40,7 @@ html lang="fr"
           header.with_tool_link title: "Se connecter", path: new_user_session_path,html_attributes: { class: "fr-fi-account-fill" }
         end
 
-        if current_domain == Domain::RDV_MAIRIE
+        if current_domain == Domain::RDV_SERVICE_PUBLIC
           header.with_direct_link_simple title: "Accueil", path: root_path, html_attributes: current_page?(root_path) ? { "aria-current": "page" } : {}
           header.with_direct_link_simple title: "Statistiques", path: stats_path, html_attributes: current_page?(stats_path) ? { "aria-current": "page" } : {}
         end

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -5,5 +5,5 @@
   = f.dsfr_text_field :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
   = f.hidden_field :ants_pre_demande_number_required, value: "true"
   = f.hidden_field :ants_meeting_point_id
-- if current_domain != Domain::RDV_MAIRIE # TODO: trouver un moyen d'avoir le contexte du rdv_wizard, pour ensuite se baser sur current_territory.enable_birth_date_field?
+- if current_domain != Domain::RDV_SERVICE_PUBLIC # TODO: trouver un moyen d'avoir le contexte du rdv_wizard, pour ensuite se baser sur current_territory.enable_birth_date_field?
   = f.dsfr_text_field :birth_date, type: :date, input_html: { type: "date" }, autocomplete: "bday"

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -10,7 +10,7 @@ ruby:
     .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, disabled: user.connected_with_sso?, autocomplete: "given-name"
     .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, disabled: user.pro_connect_openid_sub, autocomplete: "family-name"
   .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
-    - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE || user.pro_connect_openid_sub
+    - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_SERVICE_PUBLIC || user.pro_connect_openid_sub
       .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_name, placeholder: "Nom de naissance", disabled: user.connected_with_sso?
     - if !current_user.signed_in_with_invitation_token? && rdv_wizard&.rdv&.territory&.enable_birth_date_field?
       .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_date, type: "date", disabled: user.logged_once_with_franceconnect?, autocomplete: "bday"

--- a/db/seeds/ccas.rb
+++ b/db/seeds/ccas.rb
@@ -20,7 +20,7 @@ Compte.new(
       email: "cecile.astier@demo-rdv-service-public.fr",
       service_ids: [service.id],
     },
-  }, current_domain: Domain::RDV_MAIRIE
+  }, current_domain: Domain::RDV_SERVICE_PUBLIC
 ).save!
 
 agent = Agent.find_by(email: "cecile.astier@demo-rdv-service-public.fr")

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe AgentConnectController do
 
       context "when no existing agent matches email nor sub" do
         it "displays an error if the domain does not allow self-onboarding" do
-          allow(Domain::RDV_MAIRIE).to receive(:allow_self_onboarding).and_return(false)
+          allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(false)
           expect do
             get :callback, params: { state:, code: }
           end.not_to change(Agent, :count)
@@ -144,7 +144,7 @@ RSpec.describe AgentConnectController do
         end
 
         it "creates the agent if the domain allows it" do
-          allow(Domain::RDV_MAIRIE).to receive(:allow_self_onboarding).and_return(true)
+          allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
           expect do
             get :callback, params: { state:, code: }
           end.to change(Agent, :count).by(1)

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "public pages", js: true do
   end
 
   it "home page for RDV Mairie is accessible" do
-    visit "http://www.rdv-mairie-test.localhost/"
+    visit "http://www.rdv-service-public-test.localhost/"
     expect(page).to have_current_path("/")
     expect(page).to be_axe_clean
   end

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
     expect(page).to have_content("Sélectionnez un créneau")
   end
 
-  it "works on the RDV_MAIRIE domain" do
+  it "works on the RDV_SERVICE_PUBLIC domain" do
     login_as(agent, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/#{public_link_to_org_path(organisation_id: organisation.id)}"
     expect(page).to have_content("Sélectionnez le motif de votre RDV :")

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
 
   it "works on the RDV_SERVICE_PUBLIC domain" do
     login_as(agent, scope: :agent)
-    visit "http://www.rdv-mairie-test.localhost/#{public_link_to_org_path(organisation_id: organisation.id)}"
+    visit "http://www.rdv-service-public-test.localhost/#{public_link_to_org_path(organisation_id: organisation.id)}"
     expect(page).to have_content("Sélectionnez le motif de votre RDV :")
   end
 end

--- a/spec/features/agents/list_organisations_spec.rb
+++ b/spec/features/agents/list_organisations_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Organisations" do
   before { login_as(agent, scope: :agent) }
 
   it "shows the list of organisations when an agent with multiple organisations logs in" do
-    visit "http://www.rdv-mairie-test.localhost/"
+    visit "http://www.rdv-service-public-test.localhost/"
     expect(page).to have_content("MDS de Paris Nord")
     expect(page).to have_content("MDS de Paris Sud")
   end

--- a/spec/features/agents/users/agent_can_create_user_for_rdv_mairie_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_for_rdv_mairie_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Agent can create user" do
 
   before do
     login_as(agent, scope: :agent)
-    visit "http://www.rdv-mairie-test.localhost/"
+    visit "http://www.rdv-service-public-test.localhost/"
     click_link "Usagers"
     click_on "Ajouter un usager", match: :first
     expect_page_title("Nouvel usager")

--- a/spec/features/autodoc/creation_espace_spec.rb
+++ b/spec/features/autodoc/creation_espace_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
                        wait_for: "Pour ouvrir votre espace, commencez par vous identifier avec ProConnect.")
 
     # ProConnect ne marche pas en tests, donc on triche en faisant un login par email et mot de passe
-    visit new_agent_session_path
+    visit new_agent_session_url(host: Domain::RDV_SERVICE_PUBLIC.host_name)
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"

--- a/spec/features/autodoc/creation_espace_spec.rb
+++ b/spec/features/autodoc/creation_espace_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     doc.start_section("Côté agent")
     doc.add_text("Contexte : Je suis un agent qui n'a jamais utilisé RDV Service Public")
 
-    visit "http://www.rdv-mairie-test.localhost/"
+    visit "http://www.rdv-service-public-test.localhost/"
     doc.add_screenshot(page,
                        text: "Je clique sur 'Ouvrir un espace'",
                        wait_for: "Ouvrir un espace")
@@ -54,7 +54,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
 
     login_as(super_admin, scope: :super_admin)
 
-    visit super_admins_territory_creation_requests_url(host: "http://www.rdv-mairie-test.localhost")
+    visit super_admins_territory_creation_requests_url(host: "http://www.rdv-service-public-test.localhost")
 
     doc.add_screenshot(page,
                        text: "Je consulte la liste des demandes d'ouverture d'espace",

--- a/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/configuration_par_administrateur_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Configuration de RDV Service Public par un administrateur de DS"
     doc = Autodoc.start_scenario("2) Configuration de RDV Service Public par un admin", self, accessibility_checks: false, category: "4) Intégration à Démarches Simplifiées")
 
     login_as(agent, scope: :agent)
-    visit configuration_admin_organisations_url(host: "http://www.rdv-mairie-test.localhost")
+    visit configuration_admin_organisations_url(host: "http://www.rdv-service-public-test.localhost")
 
     doc.start_section("Ouverture de l'espace")
 
@@ -66,7 +66,7 @@ RSpec.describe "Configuration de RDV Service Public par un administrateur de DS"
 
     doc.start_section("Personaliser les motifs de rendez-vous (facultatif)")
 
-    visit configuration_admin_organisations_url(host: "http://www.rdv-mairie-test.localhost")
+    visit configuration_admin_organisations_url(host: "http://www.rdv-service-public-test.localhost")
 
     Capybara.page.current_window.resize_to(1280, 720)
     doc.add_screenshot(page,
@@ -88,7 +88,7 @@ RSpec.describe "Configuration de RDV Service Public par un administrateur de DS"
       A partir de la page de configuration, je clique sur la tuile "Lieux".
     TEXT
 
-    visit admin_organisation_lieux_url(Organisation.last, host: "http://www.rdv-mairie-test.localhost")
+    visit admin_organisation_lieux_url(Organisation.last, host: "http://www.rdv-service-public-test.localhost")
 
     doc.add_screenshot(page,
                        text: "Je clique sur le bouton Ajouter un lieu",

--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
 
   around do |example|
     previous_host = Capybara.app_host
-    Capybara.app_host = "http://www.rdv-mairie-test.localhost:#{previous_host[/\d+/]}"
+    Capybara.app_host = "http://www.rdv-service-public-test.localhost:#{previous_host[/\d+/]}"
     example.run
     Capybara.app_host = previous_host
   end

--- a/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Prise de rendez-vous par un instructeur", js: true do
 
   around do |example|
     previous_host = Capybara.app_host
-    Capybara.app_host = "http://www.rdv-mairie-test.localhost:#{previous_host[/\d+/]}"
+    Capybara.app_host = "http://www.rdv-service-public-test.localhost:#{previous_host[/\d+/]}"
     example.run
     Capybara.app_host = previous_host
   end

--- a/spec/features/autodoc/managing_dead_ends_for_new_accounts_spec.rb
+++ b/spec/features/autodoc/managing_dead_ends_for_new_accounts_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Configuration initiale", js: true do
 
     doc.add_text("Voici ce qui s'affiche sur les différentes pages qui nécessitent un motif")
 
-    visit new_admin_organisation_rdv_wizard_step_url(organisation, host: "http://www.rdv-mairie-test.localhost", starts_at: Time.zone.now, agent_ids: [agent.id])
+    visit new_admin_organisation_rdv_wizard_step_url(organisation, host: "http://www.rdv-service-public-test.localhost", starts_at: Time.zone.now, agent_ids: [agent.id])
 
     doc.add_screenshot(page,
                        text: "Prise de rendez-vous depuis le calendrier",
@@ -38,7 +38,7 @@ RSpec.describe "Configuration initiale", js: true do
     expect(page).to have_content("Pour prendre un rendez-vous, vous devez d'abord créer un motif.")
     expect(page).not_to have_content("Vue calendrier")
 
-    visit admin_organisation_creneaux_search_url(organisation, host: "http://www.rdv-mairie-test.localhost")
+    visit admin_organisation_creneaux_search_url(organisation, host: "http://www.rdv-service-public-test.localhost")
 
     doc.add_screenshot(page,
                        text: "Recherche de créneaux",
@@ -46,13 +46,13 @@ RSpec.describe "Configuration initiale", js: true do
 
     expect(page).to have_content("Pour prendre un rendez-vous, vous devez d'abord créer un motif.")
 
-    visit admin_organisation_rdvs_collectifs_url(organisation, host: "http://www.rdv-mairie-test.localhost", agent_id: agent.id)
+    visit admin_organisation_rdvs_collectifs_url(organisation, host: "http://www.rdv-service-public-test.localhost", agent_id: agent.id)
 
     doc.add_screenshot(page,
                        text: "Liste des RDV collectifs",
                        wait_for: "Pour créer un RDV collectif")
 
-    visit admin_organisation_planning_plage_ouvertures_url(organisation, host: "http://www.rdv-mairie-test.localhost", agent_id: agent.id)
+    visit admin_organisation_planning_plage_ouvertures_url(organisation, host: "http://www.rdv-service-public-test.localhost", agent_id: agent.id)
 
     doc.add_screenshot(page,
                        text: "Liste des plages d'ouverture",
@@ -60,7 +60,7 @@ RSpec.describe "Configuration initiale", js: true do
 
     expect(page).to have_content("Pour créer une plage d'ouverture, vous devez d'abord créer un motif")
 
-    visit admin_organisation_online_booking_url(organisation, host: "http://www.rdv-mairie-test.localhost")
+    visit admin_organisation_online_booking_url(organisation, host: "http://www.rdv-service-public-test.localhost")
 
     scroll_to(find(".fr-callout"))
 

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     expect(copied_absence).to be_present
 
     login_as(agent_rdv_sp, scope: :agent)
-    visit "http://www.rdv-mairie-test.localhost/admin/organisations/#{created_organisation.id}/agents"
+    visit "http://www.rdv-service-public-test.localhost/admin/organisations/#{created_organisation.id}/agents"
 
     doc.add_screenshot(page,
                        text: "En se connectant sur RDV Service Public, on constate que les agents ont bien été créés.",

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
                        wait_for: "Pour commencer")
 
     # On triche un peu pour simuler la connexion à RDV SP
-    visit "http://#{Domain::RDV_MAIRIE.host_name}/agents/sign_in"
+    visit "http://#{Domain::RDV_SERVICE_PUBLIC.host_name}/agents/sign_in"
 
     doc.add_screenshot(page,
                        text: "Je me connecte sur RDV Service Public",

--- a/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
+++ b/spec/features/autodoc/ouverture_espace_autonomie_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")
 
-    visit "http://www.rdv-mairie-test.localhost/"
+    visit "http://www.rdv-service-public-test.localhost/"
     doc.add_screenshot(page,
                        text: "Je clique sur 'Ouvrir un espace'",
                        wait_for: "Ouvrir un espace")
@@ -22,7 +22,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
                        wait_for: "Pour ouvrir votre espace, commencez par vous identifier avec ProConnect.")
 
     # ProConnect ne marche pas en tests, donc on triche en faisant un login par email et mot de passe
-    visit new_agent_session_url(host:  "http://www.rdv-mairie-test.localhost")
+    visit new_agent_session_url(host:  "http://www.rdv-service-public-test.localhost")
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"
@@ -47,7 +47,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     super_admin = create :super_admin
     login_as(super_admin, scope: :super_admin)
 
-    visit super_admins_accounts_for_crm_index_url(host: "http://www.rdv-mairie-test.localhost")
+    visit super_admins_accounts_for_crm_index_url(host: "http://www.rdv-service-public-test.localhost")
 
     doc.add_screenshot(page,
                        text: "Le nouvel espace apparait dans la liste des comptes à ajouter au CRM.",

--- a/spec/features/autodoc/ouverture_espace_doublon_spec.rb
+++ b/spec/features/autodoc/ouverture_espace_doublon_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")
 
-    visit "http://www.rdv-mairie-test.localhost/"
+    visit "http://www.rdv-service-public-test.localhost/"
     doc.add_screenshot(page,
                        text: "Je clique sur 'Ouvrir un espace'",
                        wait_for: "Ouvrir un espace")
@@ -23,7 +23,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
                        wait_for: "Pour ouvrir votre espace, commencez par vous identifier avec ProConnect.")
 
     # ProConnect ne marche pas en tests, donc on triche en faisant un login par email et mot de passe
-    visit new_agent_session_url(host:  "http://www.rdv-mairie-test.localhost")
+    visit new_agent_session_url(host:  "http://www.rdv-service-public-test.localhost")
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
     TEXT
       .html_safe) # rubocop:disable Rails/OutputSafety
 
-    visit "http://www.rdv-mairie-test.localhost/agents/agenda"
+    visit "http://www.rdv-service-public-test.localhost/agents/agenda"
 
     doc.add_screenshot(page,
                        text: "J'ouvre mon espace RDV Service Public",
@@ -113,7 +113,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     doc.start_section("Côté usager")
 
-    visit public_link_to_org_url(organisation_id: Organisation.last.id, host: "http://www.rdv-mairie-test.localhost/")
+    visit public_link_to_org_url(organisation_id: Organisation.last.id, host: "http://www.rdv-service-public-test.localhost/")
 
     doc.add_screenshot(page,
                        text: "Je visite le lien de prise de rendez-vous que l'agent m'a transmis.",

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
           email: "francis.factice@demo-rdv-service-public.gouv.fr",
           service_ids: [service.id],
         },
-      }, current_domain: Domain::RDV_MAIRIE
+      }, current_domain: Domain::RDV_SERVICE_PUBLIC
     ).save!
 
     create(:motif, organisation: Organisation.last, location_type: :visio, name: "Suivi de dossier", bookable_by: :agents)

--- a/spec/features/autodoc/rendez_vous_prescripteur_externe_spec.rb
+++ b/spec/features/autodoc/rendez_vous_prescripteur_externe_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Prendre RDV pour un usager en tant que prescripteur externe", js
     doc.start_section("Côté agent prescripteur")
     doc.add_text("Contexte : Je suis un agent prescripteur qui ne dispose pas de compte sur RDV Service Public et je veux prendre un RDV pour un usager")
 
-    visit "http://www.rdv-mairie-test.localhost/org/#{organisation.id}/"
+    visit "http://www.rdv-service-public-test.localhost/org/#{organisation.id}/"
     doc.add_screenshot(page,
                        text: "Je choisis le motif de rendez-vous",
                        wait_for: "Formation emails")

--- a/spec/features/autodoc/self_onboarding_spec.rb
+++ b/spec/features/autodoc/self_onboarding_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Embarquement en autonomie pour les admins", js: true do
     TEXT
       .html_safe) # rubocop:disable Rails/OutputSafety
 
-    visit admin_organisation_configuration_url(organisation, host: "http://www.rdv-mairie-test.localhost")
+    visit admin_organisation_configuration_url(organisation, host: "http://www.rdv-service-public-test.localhost")
 
     doc.add_screenshot(page,
                        text: "On affiche une bannière qui indique que la première action à prendre est de créer un motif",

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_in_rdv_mairie_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_in_rdv_mairie_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
   end
 
   before do
-    default_url_options[:host] = "http://www.rdv-mairie-test.localhost"
+    default_url_options[:host] = "http://www.rdv-service-public-test.localhost"
     travel_to(now)
     create(:plage_ouverture, :no_recurrence, first_day: now, motifs: [passport_motif], lieu: lieu, organisation: organisation, start_time: Tod::TimeOfDay(9), end_time: Tod::TimeOfDay.new(10))
   end

--- a/spec/features/super_admin/creating_a_new_account_spec.rb
+++ b/spec/features/super_admin/creating_a_new_account_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
 
   it "creates a new organisation" do
     login_as(super_admin, scope: :super_admin)
-    visit super_admins_root_url(host: "http://www.rdv-mairie-test.localhost")
+    visit super_admins_root_url(host: "http://www.rdv-service-public-test.localhost")
 
     click_link "Ouverture de compte"
 
@@ -81,7 +81,7 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
 
     it "crée un espace avec une organisation qui a les catégories de motif pour se brancher à l'ANTS" do
       login_as(super_admin, scope: :super_admin)
-      visit super_admins_root_url(host: "http://www.rdv-mairie-test.localhost")
+      visit super_admins_root_url(host: "http://www.rdv-service-public-test.localhost")
 
       click_link "Ouverture de compte"
 

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
 
         login_as(super_admin, scope: :super_admin)
 
-        visit super_admins_territory_creation_requests_url(host: "http://www.rdv-mairie-test.localhost")
+        visit super_admins_territory_creation_requests_url(host: "http://www.rdv-service-public-test.localhost")
         click_on "CCAS de Montreuil"
 
         expect(page).to have_content("Demande d'ouverture d'espace")
@@ -102,7 +102,7 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
         open_email(agent.email)
         expect(current_email.subject).to eq "Votre espace RDV Service Public est ouvert 🚀"
 
-        visit super_admins_territory_creation_requests_url(host: "http://www.rdv-mairie-test.localhost")
+        visit super_admins_territory_creation_requests_url(host: "http://www.rdv-service-public-test.localhost")
 
         expect(page).to have_content "Il n'y a aucune demande avec ce statut"
 

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "User can search for rdvs" do
 
     describe "On RDV Service Public" do
       it "doesn't require an ANTS predemande number for a relative", js: true do
-        visit "http://www.rdv-mairie-test.localhost/#{path_for_creneau_choice}"
+        visit "http://www.rdv-service-public-test.localhost/#{path_for_creneau_choice}"
         choose_creneau
         sign_up
         click_button("Continuer")

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
   end
 
   before do
-    default_url_options[:host] = "http://www.rdv-mairie-test.localhost"
+    default_url_options[:host] = "http://www.rdv-service-public-test.localhost"
     travel_to(now)
     create(:plage_ouverture, :no_recurrence, first_day: now, motifs: [passport_motif], lieu: lieu, organisation: organisation, start_time: Tod::TimeOfDay(9), end_time: Tod::TimeOfDay.new(10))
   end
@@ -456,7 +456,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
 
     context "il n’y a pas de créneaux dispos" do
       it "incite à passer par le moteur de l’ANTS", js: true do
-        visit "http://www.rdv-mairie-test.localhost/org/#{organisation.id}"
+        visit "http://www.rdv-service-public-test.localhost/org/#{organisation.id}"
         click_on "Passeport"
         expect(page).to have_content("Nombre de pré-demandes ANTS")
         expect(find_field(find("label", text: /pré-demandes ANTS/)[:for])[:value]).to eq("1")
@@ -471,7 +471,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
     end
 
     it "permet de choisir le nombre de dossiers à déposer" do
-      visit "http://www.rdv-mairie-test.localhost/org/#{organisation.id}"
+      visit "http://www.rdv-service-public-test.localhost/org/#{organisation.id}"
       click_on "Passeport"
       expect(page).to have_content("Nombre de pré-demandes ANTS")
       fill_in(find("label", text: /pré-demandes ANTS/)[:for], with: "2", fill_options: { clear: :backspace }) # ici on fait sans JS en remplissant le champ directement
@@ -520,7 +520,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
 
     context "l’usager tente de passer un nombre invalide à l’étape de séléction du nombre de pré-demandes" do
       specify do
-        visit "http://www.rdv-mairie-test.localhost/org/#{organisation.id}"
+        visit "http://www.rdv-service-public-test.localhost/org/#{organisation.id}"
         click_on "Passeport"
         expect(page).to have_content("Nombre de pré-demandes ANTS")
         fill_in(find("label", text: /pré-demandes ANTS/)[:for], with: "notanumber", fill_options: { clear: :backspace }) # ici on fait sans JS en remplissant le champ directement

--- a/spec/features/users/online_booking/on_rdv_service_public_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_service_public_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe "User can search rdv on rdv service public" do
   end
 
   before do
-    default_url_options[:host] = "http://www.rdv-mairie-test.localhost"
+    default_url_options[:host] = "http://www.rdv-service-public-test.localhost"
     travel_to(now)
     create(:plage_ouverture, :no_recurrence, first_day: now, motifs: [demarches_simplifies_motif], lieu: lieu, organisation: organisation, start_time: Tod::TimeOfDay(9),
                                              end_time: Tod::TimeOfDay.new(10))
   end
 
   it "allows booking a rdv" do
-    visit "http://www.rdv-mairie-test.localhost/org/#{organisation.id}"
+    visit "http://www.rdv-service-public-test.localhost/org/#{organisation.id}"
     click_on("Clarification du dossier")
     click_on(lieu.name) # choix du lieu
 

--- a/spec/form_models/compte_spec.rb
+++ b/spec/form_models/compte_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Compte do
           lieu: { address: "1 rue de la république", latitude: 48.859, longitude: 2.347 },
           agent: { first_name: "Francis", last_name: "Factice", email: agent.email, service_ids: [service.id] },
         },
-        current_domain: Domain::RDV_MAIRIE
+        current_domain: Domain::RDV_SERVICE_PUBLIC
       ).save!
 
       expect(agent.reload.roles.last).to have_attributes(access_level: "admin")
@@ -34,7 +34,7 @@ RSpec.describe Compte do
             lieu: { address: "1 rue de la république", latitude: 48.859, longitude: 2.347 },
             agent: { first_name: "Francis", last_name: "Factice", email: agent.email, service_ids: [service.id] },
           },
-          current_domain: Domain::RDV_MAIRIE,
+          current_domain: Domain::RDV_SERVICE_PUBLIC,
           territory_creation_request:
         )
 

--- a/spec/form_models/demande_support_form_spec.rb
+++ b/spec/form_models/demande_support_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe DemandeSupportForm do
   context "tous les attributs présents" do
     let(:attributes) do
       {
-        current_domain: Domain::RDV_MAIRIE,
+        current_domain: Domain::RDV_SERVICE_PUBLIC,
         role: "usager",
         sujet: "Je suis perdue",
         first_name: "Jeanne",
@@ -26,7 +26,7 @@ RSpec.describe DemandeSupportForm do
   context "un attribut manquant" do
     let(:attributes) do
       {
-        current_domain: Domain::RDV_MAIRIE,
+        current_domain: Domain::RDV_SERVICE_PUBLIC,
         role: "usager",
         sujet: "Je suis perdue",
         first_name: "Jeanne",
@@ -48,7 +48,7 @@ RSpec.describe DemandeSupportForm do
   context "le message est trop long" do
     let(:attributes) do
       {
-        current_domain: Domain::RDV_MAIRIE,
+        current_domain: Domain::RDV_SERVICE_PUBLIC,
         role: "usager",
         sujet: "Je suis perdue",
         first_name: "Jeanne",
@@ -71,7 +71,7 @@ RSpec.describe DemandeSupportForm do
   context "le mail n'est pas valide" do
     let(:attributes) do
       {
-        current_domain: Domain::RDV_MAIRIE,
+        current_domain: Domain::RDV_SERVICE_PUBLIC,
         role: "usager",
         sujet: "Je suis perdue",
         first_name: "Jeanne",

--- a/spec/jobs/ants/sync_appointment_job_spec.rb
+++ b/spec/jobs/ants/sync_appointment_job_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Ants::SyncAppointmentJob do
             "status" => "validated",
             "appointments" => [
               {
-                "management_url" => "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                "management_url" => "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
                 "meeting_point" => "Mairie de Saumur",
                 "appointment_date" => "2020-04-20 08:00:00",
               },
@@ -101,7 +101,7 @@ RSpec.describe Ants::SyncAppointmentJob do
           {
             "status" => "validated",
             "appointments" => [{
-              "management_url" => "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+              "management_url" => "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
               "meeting_point" => "Mairie de Saumur",
               "appointment_date" => "2020-04-20 08:00:00",
             }],
@@ -129,7 +129,7 @@ RSpec.describe Ants::SyncAppointmentJob do
           {
             "status" => "validated",
             "appointments" => [{
-              "management_url" => "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+              "management_url" => "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
               "meeting_point" => "Mairie de Saumur",
               "appointment_date" => "2020-04-20 08:00:00", # c’est différent de l’heure du RDV !
             }],
@@ -150,7 +150,7 @@ RSpec.describe Ants::SyncAppointmentJob do
           meeting_point: "Mairie de Saumur",
           meeting_point_id: lieu.id.to_s,
           appointment_date: "2020-04-20 12:00:00",
-          management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+          management_url: "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
         }
       )
       described_class.perform_now(ants_pre_demande_number: "A123456789")

--- a/spec/mailers/agents/plage_ouverture_mailer_spec.rb
+++ b/spec/mailers/agents/plage_ouverture_mailer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Agents::PlageOuvertureMailer, type: :mailer do
             expect(mail.subject).to start_with("RDV Service Public - Plage d’ouverture")
             expect(mail.html_part.body.to_s).to include(%(src="/logo_rdv_service_public.png))
             expect(mail.html_part.body.to_s).to include("Voir sur RDV Service Public") unless action == :destroyed
-            expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-mairie-test.localhost/))
+            expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-service-public-test.localhost/))
           end
         end
 

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
         it "works" do
           expect(mail.html_part.body.to_s).to include(%(src="/logo_rdv_service_public.png))
           expect(mail.html_part.body.to_s).to include("Voir sur RDV Service Public")
-          expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-mairie-test.localhost))
+          expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-service-public-test.localhost))
         end
       end
 

--- a/spec/mailers/agents/webhook_mailer_spec.rb
+++ b/spec/mailers/agents/webhook_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Agents::WebhookMailer, type: :mailer do
       expect(mail.subject).to eq("Une nouvelle URL de webhook vient d'être ajoutée")
 
       expect(mail.body.encoded).to include("Une nouvelle URL de webhook vient d'être introduite")
-      expect(mail.body.encoded).to include(%(href="http://www.rdv-mairie-test.localhost/admin/territories/#{webhook.territory.id}/webhook_endpoints"))
+      expect(mail.body.encoded).to include(%(href="http://www.rdv-service-public-test.localhost/admin/territories/#{webhook.territory.id}/webhook_endpoints"))
       expect(mail.body.encoded).to include(webhook.target_url)
     end
 

--- a/spec/mailers/custom_devise_mailer_domain_spec.rb
+++ b/spec/mailers/custom_devise_mailer_domain_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CustomDeviseMailer, "#domain" do
       stub_env_with(DEFAULT_DOMAIN_IS_RDV_SOLIDARITES: nil)
 
       it "uses RDV Service Public" do
-        expect_to_use_domain(Domain::RDV_MAIRIE)
+        expect_to_use_domain(Domain::RDV_SERVICE_PUBLIC)
       end
     end
   end
@@ -59,8 +59,8 @@ RSpec.describe CustomDeviseMailer, "#domain" do
     context "in a RDV Mairie organisation" do
       let!(:organisation) { create(:organisation, verticale: :rdv_mairie) }
 
-      it "uses RDV_MAIRIE" do
-        expect_to_use_domain(Domain::RDV_MAIRIE)
+      it "uses RDV_SERVICE_PUBLIC" do
+        expect_to_use_domain(Domain::RDV_SERVICE_PUBLIC)
       end
     end
   end
@@ -124,7 +124,7 @@ RSpec.describe CustomDeviseMailer, "#domain" do
 
     it "doesn't override the reply-to address" do
       perform_enqueued_jobs
-      expect(sent_email.from).to eq [Domain::RDV_MAIRIE.support_email]
+      expect(sent_email.from).to eq [Domain::RDV_SERVICE_PUBLIC.support_email]
       expect(sent_email.reply_to).to be_blank
     end
 

--- a/spec/mailers/previews/agents/territory_creation_request_mailer_preview.rb
+++ b/spec/mailers/previews/agents/territory_creation_request_mailer_preview.rb
@@ -1,6 +1,6 @@
 class Agents::TerritoryCreationRequestMailerPreview < ActionMailer::Preview
   def accepted
     agent = Agent.joins(:organisations).last
-    Agents::TerritoryCreationRequestMailer.accepted(agent: agent, domain_id: Domain::RDV_MAIRIE.id, organisation: agent.organisations.last)
+    Agents::TerritoryCreationRequestMailer.accepted(agent: agent, domain_id: Domain::RDV_SERVICE_PUBLIC.id, organisation: agent.organisations.last)
   end
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -228,10 +228,10 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
-          expect(mail[:from].to_s).to match(/RDV Service Public <rdv\+[a-z0-9\-]+@reply\.rdv-mairie-test\.localhost>/)
+          expect(mail[:from].to_s).to match(/RDV Service Public <rdv\+[a-z0-9\-]+@reply\.rdv-service-public-test\.localhost>/)
           # les guillemets autour de "RDV Service Public" disparaissent probablement ici car il n’y a que des caractères ASCII
           expect(mail.html_part.body.to_s).to include(%(src="/logo_rdv_service_public.png))
-          expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-mairie-test.localhost))
+          expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-service-public-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Service Public))
         end
       end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Agent, type: :model do
 
       context "on the RDV Service Public instance" do
         stub_env_with(DEFAULT_DOMAIN_IS_RDV_SOLIDARITES: nil)
-        it { is_expected.to eq(Domain::RDV_MAIRIE) }
+        it { is_expected.to eq(Domain::RDV_SERVICE_PUBLIC) }
       end
     end
   end

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             appointment_date: "2020-04-20 08:00:00",
             meeting_point: "Mairie de Saumur",
             meeting_point_id: rdv.lieu.id.to_s,
-            management_url: %r{http://www\.rdv-mairie-test\.localhost/users/rdvs/\d+} # on ne connaît pas encore l’ID du RDV
+            management_url: %r{http://www\.rdv-service-public-test\.localhost/users/rdvs/\d+} # on ne connaît pas encore l’ID du RDV
           ),
           headers:
         )
@@ -108,7 +108,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             status: "validated",
             appointments: [
               {
-                management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                management_url: "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
                 meeting_point: "Mairie de Saumur",
                 appointment_date: "2020-04-20 08:00:00",
               },
@@ -157,7 +157,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             status: "validated",
             appointments: [
               {
-                management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                management_url: "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
                 meeting_point: "Mairie de Saumur",
                 appointment_date: "2020-04-20 08:00:00",
               },
@@ -242,7 +242,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           query: {
             application_id: "A123456789",
             appointment_date: "2020-04-20 08:00:00",
-            management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+            management_url: "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
             meeting_point: "Mairie de Saumur",
             meeting_point_id: rdv.lieu.id,
           },
@@ -282,7 +282,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           query: {
             application_id: "AABBCCDDEE",
             appointment_date: "2020-04-20 08:00:00",
-            management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+            management_url: "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
             meeting_point: "Mairie de Saumur",
             meeting_point_id: rdv.lieu.id,
           },
@@ -321,7 +321,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           query: {
             application_id: "A123456789",
             appointment_date: "2020-04-20 08:00:00",
-            management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+            management_url: "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
             meeting_point: "Nouveau Lieu",
             meeting_point_id: rdv.lieu.id,
           },
@@ -360,7 +360,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           query: {
             application_id: "A123456789",
             appointment_date: "2020-04-20 08:00:00",
-            management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+            management_url: "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
             meeting_point: "Nouveau Lieu",
             meeting_point_id: rdv.lieu.id,
           },
@@ -397,7 +397,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             status: "validated",
             appointments: [
               {
-                management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                management_url: "http://www.rdv-service-public-test.localhost/users/rdvs/#{rdv.id}",
                 meeting_point: "Mairie de Saumur",
                 appointment_date: "2020-04-20 08:00:00",
               },

--- a/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
+++ b/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Outlook::EventSerializerAndListener do
   end
   let(:expected_description) do
     <<~HTML
-      Plus d'infos sur <a href="http://www.rdv-mairie-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}">RDV Service Public</a>:
+      Plus d'infos sur <a href="http://www.rdv-service-public-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}">RDV Service Public</a>:
       <br />
 
       Attention: ne modifiez pas cet évènement directement dans Outlook, car il ne sera pas mis à jour sur RDV Service Public.
-      Pour modifier ce rendez-vous, allez sur <a href="http://www.rdv-mairie-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}/edit">RDV Service Public</a>
+      Pour modifier ce rendez-vous, allez sur <a href="http://www.rdv-service-public-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}/edit">RDV Service Public</a>
     HTML
   end
 

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Domain do
       it "renvoie les bons domaines" do
         expect(described_class.find("RDV_SOLIDARITES").reply_host_name).to eq("reply.rdv-solidarites.fr")
         expect(described_class.find("RDV_AIDE_NUMERIQUE").reply_host_name).to eq("reply.rdv-aide-numerique.fr")
-        expect(described_class.find("RDV_MAIRIE").reply_host_name).to eq("reply.rdv-service-public.fr")
+        expect(described_class.find("RDV_SERVICE_PUBLIC").reply_host_name).to eq("reply.rdv-service-public.fr")
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Domain do
       it "renvoie les bons domaines" do
         expect(described_class.find("RDV_SOLIDARITES").reply_host_name).to eq("reply.demo.rdv-solidarites.fr")
         expect(described_class.find("RDV_AIDE_NUMERIQUE").reply_host_name).to eq("reply.demo.rdv-aide-numerique.fr")
-        expect(described_class.find("RDV_MAIRIE").reply_host_name).to eq("reply.demo.rdv-service-public.fr")
+        expect(described_class.find("RDV_SERVICE_PUBLIC").reply_host_name).to eq("reply.demo.rdv-service-public.fr")
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Domain do
       it "renvoie les bons domaines" do
         expect(described_class.find("RDV_SOLIDARITES").reply_host_name).to be_nil
         expect(described_class.find("RDV_AIDE_NUMERIQUE").reply_host_name).to be_nil
-        expect(described_class.find("RDV_MAIRIE").reply_host_name).to eq("reply.staging.rdv-service-public.fr")
+        expect(described_class.find("RDV_SERVICE_PUBLIC").reply_host_name).to eq("reply.staging.rdv-service-public.fr")
       end
     end
   end

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe "RDV Plan API" do
         stub_env_with(DEFAULT_DOMAIN_IS_RDV_SOLIDARITES: nil)
         it "shows a url with the correct domain name" do
           post "/api/v1/rdv_plans", headers: headers, params: params, as: :json
-          expect(parsed_response_body.dig("rdv_plan", "url")).to include("www.rdv-mairie-test.localhost")
+          expect(parsed_response_body.dig("rdv_plan", "url")).to include("www.rdv-service-public-test.localhost")
         end
       end
     end

--- a/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
 
         specify do
           rdv_plan = RdvPlan.last
-          expect(parsed_response_body.dig("rdv_plan", "url")).to eq "http://www.rdv-mairie-test.localhost/agents/rdv_plans/#{rdv_plan.id}"
+          expect(parsed_response_body.dig("rdv_plan", "url")).to eq "http://www.rdv-service-public-test.localhost/agents/rdv_plans/#{rdv_plan.id}"
 
           expect(parsed_response_body["rdv_plan"]).to include(
             "user_id" => User.last.id,
@@ -118,7 +118,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
         let(:rdv) { create(:rdv) }
 
         specify do
-          expect(parsed_response_body.dig("rdv_plan", "url")).to eq "http://www.rdv-mairie-test.localhost/agents/rdv_plans/#{rdv_plan.id}"
+          expect(parsed_response_body.dig("rdv_plan", "url")).to eq "http://www.rdv-service-public-test.localhost/agents/rdv_plans/#{rdv_plan.id}"
           expect(parsed_response_body.dig("rdv_plan", "rdv").symbolize_keys).to include(
             id: rdv.id,
             status: rdv.status,

--- a/spec/requests/france_connect_sector_identifier_spec.rb
+++ b/spec/requests/france_connect_sector_identifier_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Secteur d'identification France Connect V2" do
     expect(response.parsed_body).to eq %w[
       http://www.rdv-solidarites-test.localhost/franceconnect_v2/callback
       http://www.rdv-aide-numerique-test.localhost/franceconnect_v2/callback
-      http://www.rdv-mairie-test.localhost/franceconnect_v2/callback
+      http://www.rdv-service-public-test.localhost/franceconnect_v2/callback
     ]
 
     expect(response.headers["content-type"]).to eq "application/json"

--- a/spec/services/ical_formatters/ics_spec.rb
+++ b/spec/services/ical_formatters/ics_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe IcalFormatters::Ics do
       end
     end
 
-    describe "fields for RDV_MAIRIE domain" do
-      let(:domain) { Domain::RDV_MAIRIE }
+    describe "fields for RDV_SERVICE_PUBLIC domain" do
+      let(:domain) { Domain::RDV_SERVICE_PUBLIC }
 
       it do
         expect(subject).to include("ORGANIZER:mailto:secretariat-auto@rdv-service-public.fr")

--- a/spec/services/zammad_customer_spec.rb
+++ b/spec/services/zammad_customer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ZammadCustomer do
           zammad_customer = ZammadCustomer.new(email: "soukalina@gmail.com", phone: nil)
           described_class.new(zammad_customer).run
           expect(zammad_customer.note).to eq "Usager trouvé avec l'email soukalina@gmail.com"
-          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-mairie-test.localhost/super_admins/users/#{user.id}"
+          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-service-public-test.localhost/super_admins/users/#{user.id}"
         end
       end
 
@@ -20,7 +20,7 @@ RSpec.describe ZammadCustomer do
           zammad_customer = ZammadCustomer.new(email: "agent@example.com", phone: nil)
           described_class.new(zammad_customer).run
           expect(zammad_customer.note).to eq "Agent trouvé avec l'email agent@example.com"
-          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-mairie-test.localhost/super_admins/agents/#{agent.id}"
+          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-service-public-test.localhost/super_admins/agents/#{agent.id}"
         end
       end
 
@@ -31,7 +31,7 @@ RSpec.describe ZammadCustomer do
           zammad_customer = ZammadCustomer.new(phone: "0612345678", email: nil)
           described_class.new(zammad_customer).run
           expect(zammad_customer.note).to eq "Usager trouvé avec le numéro de téléphone formatté +33612345678"
-          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-mairie-test.localhost/super_admins/users/#{user.id}"
+          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-service-public-test.localhost/super_admins/users/#{user.id}"
         end
       end
 
@@ -52,8 +52,8 @@ RSpec.describe ZammadCustomer do
           zammad_customer = ZammadCustomer.new(email: "test@example.com", phone: "0612345678")
           described_class.new(zammad_customer).run
           expect(zammad_customer.note).to eq "Usager trouvé avec l'email test@example.com"
-          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-mairie-test.localhost/super_admins/users/#{user_by_email.id}"
-          expect(zammad_customer.super_admin_url).not_to eq "http://www.rdv-mairie-test.localhost/super_admins/users/#{user_by_phone.id}"
+          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-service-public-test.localhost/super_admins/users/#{user_by_email.id}"
+          expect(zammad_customer.super_admin_url).not_to eq "http://www.rdv-service-public-test.localhost/super_admins/users/#{user_by_phone.id}"
         end
       end
 
@@ -64,7 +64,7 @@ RSpec.describe ZammadCustomer do
           zammad_customer = ZammadCustomer.new(phone: "06 12 34 56 78", email: nil)
           described_class.new(zammad_customer).run
           expect(zammad_customer.note).to eq "Usager trouvé avec le numéro de téléphone formatté +33612345678"
-          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-mairie-test.localhost/super_admins/users/#{user.id}"
+          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-service-public-test.localhost/super_admins/users/#{user.id}"
         end
       end
 
@@ -111,7 +111,7 @@ RSpec.describe ZammadCustomer do
         zammad_customer = ZammadCustomer.new(phone: "123", email: nil)
         described_class.new(zammad_customer).augment_with_agent(agent)
         expect(zammad_customer.note).to be_blank
-        expect(zammad_customer.super_admin_url).to eq "http://www.rdv-mairie-test.localhost/super_admins/agents/#{agent.id}"
+        expect(zammad_customer.super_admin_url).to eq "http://www.rdv-service-public-test.localhost/super_admins/agents/#{agent.id}"
       end
     end
 
@@ -122,7 +122,7 @@ RSpec.describe ZammadCustomer do
         zammad_customer = ZammadCustomer.new(phone: "123", email: nil)
         described_class.new(zammad_customer).augment_with_user(user)
         expect(zammad_customer.note).to be_blank
-        expect(zammad_customer.super_admin_url).to eq "http://www.rdv-mairie-test.localhost/super_admins/users/#{user.id}"
+        expect(zammad_customer.super_admin_url).to eq "http://www.rdv-service-public-test.localhost/super_admins/users/#{user.id}"
       end
     end
   end

--- a/spec/support/calendar.ics
+++ b/spec/support/calendar.ics
@@ -26,8 +26,8 @@ DTSTAMP:20220707T220000Z
 UID:abb701a5-381a-4fae-9157-129b5843834c
 DTSTART;TZID=Europe/Paris:20220711T000000
 DTEND;TZID=Europe/Paris:20220711T004500
-DESCRIPTION:plus d'infos dans RDV Service Public: http://www.rdv-mairie-tes
- t.localhost/admin/organisations/123000/rdvs/123123
+DESCRIPTION:plus d'infos dans RDV Service Public: http://www.rdv-service-pu
+ blic-test.localhost/admin/organisations/123000/rdvs/123123
 LOCATION:Lieu n°3 (3 rue de l'adresse\, Ville\, 12345)
 STATUS:CONFIRMED
 SUMMARY:Atelier collectif (1/5)
@@ -37,8 +37,8 @@ DTSTAMP:20220707T220000Z
 UID:749336ce-eaca-40a3-8c28-246ed8d18849
 DTSTART;TZID=Europe/Paris:20220710T000000
 DTEND;TZID=Europe/Paris:20220710T004500
-DESCRIPTION:plus d'infos dans RDV Service Public: http://www.rdv-mairie-tes
- t.localhost/admin/organisations/123000/rdvs/789000
+DESCRIPTION:plus d'infos dans RDV Service Public: http://www.rdv-service-pu
+ blic-test.localhost/admin/organisations/123000/rdvs/789000
 LOCATION:Lieu n°2 (2 rue de l'adresse\, Ville\, 12345)
 STATUS:CANCELLED
 SUMMARY:Accompagnement individuel
@@ -48,8 +48,8 @@ DTSTAMP:20220707T220000Z
 UID:e0a8dbac-d06c-4d18-98c6-a48f47fddd4c
 DTSTART;TZID=Europe/Paris:20220709T000000
 DTEND;TZID=Europe/Paris:20220709T004500
-DESCRIPTION:plus d'infos dans RDV Service Public: http://www.rdv-mairie-tes
- t.localhost/admin/organisations/123000/rdvs/456000
+DESCRIPTION:plus d'infos dans RDV Service Public: http://www.rdv-service-pu
+ blic-test.localhost/admin/organisations/123000/rdvs/456000
 LOCATION:Lieu n°1 (1 rue de l'adresse\, Ville\, 12345)
 STATUS:CONFIRMED
 SUMMARY:Accompagnement individuel

--- a/spec/support/calendar_guadeloupe.ics
+++ b/spec/support/calendar_guadeloupe.ics
@@ -35,8 +35,8 @@ DTSTAMP:20220707T220000Z
 UID:e0a8dbac-d06c-4d18-98c6-a48f47fddd4c
 DTSTART;TZID=America/Guadeloupe:20220709T000000
 DTEND;TZID=America/Guadeloupe:20220709T004500
-DESCRIPTION:plus d'infos dans RDV Service Public: http://www.rdv-mairie-tes
- t.localhost/admin/organisations/123000/rdvs/456000
+DESCRIPTION:plus d'infos dans RDV Service Public: http://www.rdv-service-pu
+ blic-test.localhost/admin/organisations/123000/rdvs/456000
 LOCATION:Lieu n°1 (1 rue de l'adresse\, Ville\, 12345)
 STATUS:CONFIRMED
 SUMMARY:Accompagnement individuel

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -2849,7 +2849,7 @@
                         "created_at": "2025-10-06 13:36:33 +0200",
                         "rdv": null,
                         "updated_at": "2025-10-06 13:36:33 +0200",
-                        "url": "http://www.rdv-mairie-test.localhost/agents/rdv_plans/2",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/2",
                         "user_id": 8
                       }
                     }
@@ -2968,7 +2968,7 @@
                           "location_type": "public_office"
                         },
                         "updated_at": "2025-10-06 13:36:34 +0200",
-                        "url": "http://www.rdv-mairie-test.localhost/agents/rdv_plans/4",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/4",
                         "user_id": 12
                       }
                     }


### PR DESCRIPTION
Cette PR renomme juste la constante dans `domain.rb` et le hostname en tests, donc aucun impact sur le fonctionnement de l'appli.

Le nom "RDV Mairie" est un reliquat de l'été 2023 avant qu'on adopte "RDV Service Public", j'ai perdu un peu de temps à ne pas utiliser le bon nom ce matin, donc je me suis dit qu'il était temps de le corriger.