### PR TITLE
Correction des breadcrumbs sur les pages de statistiques

### DIFF
--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -1,10 +1,5 @@
 - content_for :title, "Statistiques"
 
-- content_for :breadcrumbs do
-  = dsfr_breadcrumbs do |b|
-    = b.with_breadcrumb label: "Accueil", href: "/"
-    = b.with_breadcrumb label: yield(:title)
-
 - content_for :additional_stylesheets do
   link href="https://unpkg.com/maplibre-gl@5.0.1/dist/maplibre-gl.css" rel="stylesheet"
 

--- a/app/views/stats/territories.html.slim
+++ b/app/views/stats/territories.html.slim
@@ -1,9 +1,10 @@
 - content_for :title, "Statistiques par structure"
 
-= dsfr_breadcrumbs do |b|
-  = b.with_breadcrumb label: "Accueil", href: "/"
-  = b.with_breadcrumb label: "Statistiques globales", href: stats_path
-  = b.with_breadcrumb label: yield(:title)
+- content_for :breadcrumbs do
+  = dsfr_breadcrumbs do |b|
+    = b.with_breadcrumb label: "Accueil", href: "/"
+    = b.with_breadcrumb label: "Statistiques globales", href: stats_path
+    = b.with_breadcrumb label: yield(:title)
 
 .fr-grid-row
   .fr-col-md-8


### PR DESCRIPTION
# Contexte

Je propose ici de supprimer le fil d’ariane sur la page de statistiques de 1ᵉʳ niveau maintenant que nous avons le bandeau de liens directs (#5729). Cela fait également à un retour de @Teodora-Stanki 

J’en profite également pour corriger la position du fil d’ariane sur les pages de statistiques des territoires.

## Captures d'écran

Avant | Après
:- | -:
<img width="1256" height="436" alt="image" src="https://github.com/user-attachments/assets/ef4d2ca8-8ed1-42c0-94a6-b83abf7dea87" /> | <img width="1231" height="383" alt="image" src="https://github.com/user-attachments/assets/cb21f7ef-ff6a-4cd9-8bd3-cb36d8f5b668" />
<img width="1270" height="394" alt="image" src="https://github.com/user-attachments/assets/898761b8-e474-43e3-a4b8-cd9a10bb9cb1" /> | <img width="1214" height="417" alt="image" src="https://github.com/user-attachments/assets/f540aeab-c9fd-4799-af1b-144e06e6725a" />