### PR TITLE
Retrait de l’adresse email sur les pages 404

### DIFF
--- a/app/views/errors/not_found.html.slim
+++ b/app/views/errors/not_found.html.slim
@@ -11,9 +11,7 @@
     p Si vous avez tapé l’adresse web dans le navigateur, vérifiez qu’elle est correcte. La page n’est peut-être plus disponible.
 
     p
-      |> Vous pouvez retourner sur la page d’accueil, ou nous contacter pour que l’on puisse vous rediriger vers la bonne page, avec le bouton ci-dessous,
-      |>  ou en nous écrivant directement à l’adresse
-      = mail_to(current_domain.support_email, current_domain.support_email)
+      |> Vous pouvez retourner sur la page d’accueil, ou nous contacter pour que l’on puisse vous rediriger vers la bonne page, avec le bouton ci-dessous.
 
     .fr-btns-group.fr-btns-group--inline
       = link_to "Contactez-nous", new_aide_demande_support_path(sujet: "Erreur 404", message: "\n\n--- votre message au-dessus ---\n\nErreur rencontrée sur la page : #{request.original_url}"), class: "fr-btn"

--- a/app/views/errors/not_found.html.slim
+++ b/app/views/errors/not_found.html.slim
@@ -11,7 +11,7 @@
     p Si vous avez tapé l’adresse web dans le navigateur, vérifiez qu’elle est correcte. La page n’est peut-être plus disponible.
 
     p
-      |> Vous pouvez retourner sur la page d’accueil, ou nous contacter pour que l’on puisse vous rediriger vers la bonne page, avec le bouton ci-dessous.
+      |> Vous pouvez retourner sur la page d’accueil, ou nous contacter pour que l’on puisse vous rediriger vers la bonne page.
 
     .fr-btns-group.fr-btns-group--inline
       = link_to "Contactez-nous", new_aide_demande_support_path(sujet: "Erreur 404", message: "\n\n--- votre message au-dessus ---\n\nErreur rencontrée sur la page : #{request.original_url}"), class: "fr-btn"


### PR DESCRIPTION
# Contexte

Nous avons tendance à de plus en plus rediriger les usagers et les agents qui veulent nous contacter vers le formulaire de contact plutôt qu’en leur donnant notre mail. Cela nous permet notamment de mieux qualifier les demandes.

# Solution

Dans le cas présent, le passage par le formulaire de contact nous apporte des informations de contexte, je propose donc de supprimer la mention de l’adresse email.
