### PR TITLE
Mieux traiter les cas d’expiration de session pour les prescripteurs

### DIFF
--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -4,6 +4,7 @@ class PrescripteurRdvWizardController < ApplicationController
   before_action :log_session_to_sentry
   before_action :check_rdv_wizard_attributes, except: %i[start confirmation cancel_rdv show]
   before_action :set_rdv_wizard, only: %i[new_prescripteur new_beneficiaire create_rdv]
+  before_action :set_prescripteur_from_session, only: %i[confirmation cancel_rdv]
   before_action :redirect_if_creneau_unavailable, only: %i[new_prescripteur new_beneficiaire create_rdv]
   before_action :set_paper_trail_whodunnit
 
@@ -69,31 +70,27 @@ class PrescripteurRdvWizardController < ApplicationController
   end
 
   def cancel_rdv
-    if session[:prescripteur_id].blank?
-      flash.now[:error] = "Votre session a expiré. Si vous souhaitez annuler le rendez-vous d’un bénéficiaire, veuillez utiliser le bouton présent dans l’email de confirmation."
-      redirect_to root_path
-    else
-      prescripteur = Prescripteur.find(session[:prescripteur_id])
-
-      if prescripteur.rdv.cancellable_by_user?
-        prescripteur.rdv.update_and_notify(prescripteur, status: "excused")
+    if @prescripteur
+      if @prescripteur.rdv.cancellable_by_user?
+        @prescripteur.rdv.update_and_notify(@prescripteur, status: "excused")
         flash[:success] = "Le rendez-vous a bien été annulé."
       else
         flash[:error] = "Le rendez-vous ne peut plus être annulé."
       end
 
       redirect_to prescripteur_show_path
+    else
+      flash[:error] = "Votre session a expiré. Si vous souhaitez annuler le rendez-vous d’un bénéficiaire, veuillez utiliser le bouton présent dans l’email de confirmation."
+      redirect_to root_path
     end
   end
 
   def confirmation
-    if session[:prescripteur_id].blank?
+    if @prescripteur
+      render locals: { prescripteur: @prescripteur }
+    else
       flash[:error] = "Votre session a expiré. Si vous souhaitez consulter ou annuler le rendez-vous d’un bénéficiaire, veuillez regarder l’email de confirmation que nous vous avons fait parvenir."
       redirect_to root_path
-    else
-      prescripteur = Prescripteur.find(session[:prescripteur_id])
-
-      render locals: { prescripteur: }
     end
   end
 
@@ -131,6 +128,12 @@ class PrescripteurRdvWizardController < ApplicationController
       flash[:error] = "Ce créneau n'est plus disponible. Veuillez en choisir un autre."
       redirect_to path_to_creneau_selection(@rdv_wizard.params_to_selections)
     end
+  end
+
+  def set_prescripteur_from_session
+    return if session[:prescripteur_id].blank?
+
+    @prescripteur = Prescripteur.find(session[:prescripteur_id])
   end
 
   def user_for_paper_trail

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -4,7 +4,6 @@ class PrescripteurRdvWizardController < ApplicationController
   before_action :log_session_to_sentry
   before_action :check_rdv_wizard_attributes, except: %i[start confirmation cancel_rdv show]
   before_action :set_rdv_wizard, only: %i[new_prescripteur new_beneficiaire create_rdv]
-  before_action :set_prescripteur_from_session, only: %i[confirmation cancel_rdv]
   before_action :redirect_if_creneau_unavailable, only: %i[new_prescripteur new_beneficiaire create_rdv]
   before_action :set_paper_trail_whodunnit
 
@@ -70,18 +69,32 @@ class PrescripteurRdvWizardController < ApplicationController
   end
 
   def cancel_rdv
-    if @prescripteur.rdv.cancellable_by_user?
-      @prescripteur.rdv.update_and_notify(@prescripteur, status: "excused")
-      flash[:success] = "Le rendez-vous a bien été annulé."
+    if session[:prescripteur_id].blank?
+      flash.now[:error] = "Votre session a expiré. Si vous souhaitez annuler le rendez-vous d’un bénéficiaire, veuillez utiliser le bouton présent dans l’email de confirmation."
+      redirect_to root_path
     else
-      flash[:error] = "Le rendez-vous ne peut plus être annulé."
-    end
+      prescripteur = Prescripteur.find(session[:prescripteur_id])
 
-    redirect_to prescripteur_show_path
+      if prescripteur.rdv.cancellable_by_user?
+        prescripteur.rdv.update_and_notify(prescripteur, status: "excused")
+        flash[:success] = "Le rendez-vous a bien été annulé."
+      else
+        flash[:error] = "Le rendez-vous ne peut plus être annulé."
+      end
+
+      redirect_to prescripteur_show_path
+    end
   end
 
   def confirmation
-    render locals: { prescripteur: @prescripteur }
+    if session[:prescripteur_id].blank?
+      flash[:error] = "Votre session a expiré. Si vous souhaitez consulter ou annuler le rendez-vous d’un bénéficiaire, veuillez regarder l’email de confirmation que nous vous avons fait parvenir."
+      redirect_to root_path
+    else
+      prescripteur = Prescripteur.find(session[:prescripteur_id])
+
+      render locals: { prescripteur: }
+    end
   end
 
   def show
@@ -118,10 +131,6 @@ class PrescripteurRdvWizardController < ApplicationController
       flash[:error] = "Ce créneau n'est plus disponible. Veuillez en choisir un autre."
       redirect_to path_to_creneau_selection(@rdv_wizard.params_to_selections)
     end
-  end
-
-  def set_prescripteur_from_session
-    @prescripteur = Prescripteur.find(session[:prescripteur_id])
   end
 
   def user_for_paper_trail


### PR DESCRIPTION
Lié a : [LAPINS-529](https://sentry.incubateur.net/organizations/betagouv/issues/217726/)

# Contexte

En regardant la Sentry précédente, il semblerait qu’il s’agisse d’un prescripteur qui a laissé son navigateur trop longtemps ouvert et qui a rafraichi la page de confirmation.

Dans le cadre d’un usager ou d’un agent connecté, on gère correctement l’expiration de la session. Dans le cadre de la prescription externe, on renvoie juste vers une 404.

# Solution


- ~J’ai fait le choix de retirer le before action, car je trouve que ça réduit la lisibilité, d’autant plus que c’est seulement une ligne pour 2 méthodes.~
- ~On vérifie la présence de l’id en session avant de faire le find pour mettre une alerte plus parlante pour l’agent.~


EDIT: J’avais oublié la méthode qui set le prescripteur pour Papertrail. J’ai donc fait le choix d’éditer `set_prescripteur_from_session` pour lui faire retourner `nil` si l’id n’est pas présent en session et générer des alertes en fonction de ça.