### PR TITLE
Suppression d’une ancienne route courte pour accéder à son RDV

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -387,12 +387,6 @@ Rails.application.routes.draw do
   ## Shorten urls for SMS
   get "r", to: redirect("users/rdvs", status: 301), as: "rdvs_short"
 
-  # We keep this deprecated route because some users have received sms or emails with this kind of link
-  get "r/:id", to: (redirect do |path_params, req|
-    query_params = format_redirect_params(req.params)
-    "users/rdvs/#{path_params[:id]}#{query_params}"
-  end), as: "rdv_short_deprecated"
-
   # tkn est obligatoire pour s'assurer qu'il est possible de se connecter
   get "r/:id/:tkn", to: (redirect do |path_params, req|
     query_params = format_redirect_params(req.params)


### PR DESCRIPTION
# Contexte

En relisant des issues, je suis retombé sur #5292 et je me suis demandé si on ne pouvait pas avancer rapidement sur le sujet.
Je suis alors tombé sur cette ancienne route qui semble dépréciée depuis bien longtemps. Le commentaire de dépréciation a été posé depuis bien longtemps (voir ici : #3183).

# Solution

Je propose donc qu’on supprime cette route dès maintenant pour qu’on puisse réutiliser cette route pour faire un `/r/:tkn`.

En plus de la lecture du code, j’ai également vérifié dans les logs si on n'avait pas des gens qui arrivent encore par là, mais je n’ai rien trouvé.

Pour être 100% safe, je supprime donc simplement la route avant de créer la nouvelle dans une prochaine PR.
