### PR TITLE
Corrige une flaky spec qui casse le dimanche

### DIFF
--- a/spec/features/agents/planning/keeping_agent_context_spec.rb
+++ b/spec/features/agents/planning/keeping_agent_context_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "permettre de revenir à l'agenda d'un collègue après avoir cliqué sur un RDV pour le modifier" do
   let(:territory) { create(:territory, work_on_sunday: true) } # nécessaire pour lancer cette spec un dimanche
-  let(:organisation) { create(:organisation) }
+  let(:organisation) { create(:organisation, territory:) }
   let!(:current_agent) { create(:agent, first_name: "Agent", last_name: "COURANT", admin_role_in_organisations: [organisation], display_saturdays: true) }
   let!(:collegue) { create(:agent, first_name: "Mon", last_name: "COLLEGUE", admin_role_in_organisations: [organisation]) }
   let!(:usager_du_rdv) { create(:user, first_name: "Usager", last_name: "DU RDV") }


### PR DESCRIPTION
Le dimanche n'était pas affiché dans le calendrier car on était pas sur le bon territory.