### PR TITLE
Flaky spec : clic sur l'agenda bloqué par le now indicator

### DIFF
--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       click_link "Vue calendrier"
       expect(page).to have_content "Semaine" # necessary to make sure the calendar page has loaded
       expect(page).to have_content "Permanence"
-      first("a:not(.fc-event-today)", text: "Permanence").click
+      first("a.fc-event:not(.fc-event-today)", text: "Permanence").click
       expect_page_title("Permanence")
       click_link "Modifier"
 

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       click_link "Vue calendrier"
       expect(page).to have_content "Semaine" # necessary to make sure the calendar page has loaded
       expect(page).to have_content "Permanence"
-      first("a", text: "Permanence").click
+      first("a:not(.fc-event-today)", text: "Permanence").click
       expect_page_title("Permanence")
       click_link "Modifier"
 


### PR DESCRIPTION
On a eu une flaky spec avec l'erreur suivante :

```
<div class="fc-timegrid-now-indicator-line"></div> from <div class="fc-timegrid-now-indicator-container">…</div>
subtree intercepts pointer events
```

Nous sommes donc dans le cas improbable (une chance sur 200 puisque la plage mesure environ 200px de haut) où le clic sur la plage tombe sur le `.fc-timegrid-now-indicator-line`.

<img width="1280" height="1096" alt="image" src="https://github.com/user-attachments/assets/c02edf30-47db-48ca-9ed1-ba738aaa820f" />


Pour éviter ça, on clique sur une plage qui n'a pas la classe `.fc-event-today` (merci FullCalendar d'ajouter plein de classes utiles).
