### PR TITLE
Ne pas griser la dernière heure du calendrier

### DIFF
--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -10,7 +10,7 @@ const defaultFullCalendarConfig = () => ({
     // days of week. an array of zero-based day of week integers (0=Sunday)
     daysOfWeek: [1, 2, 3, 4, 5, 6, 0],
       startTime: '07:00',
-      endTime: '19:00',
+      endTime: '20:00',
   },
   slotMinTime: '07:00:00',
   slotMaxTime: '20:00:00',


### PR DESCRIPTION
Inspiré par les améliorations du calendrier faites par François, j'ai vu qu'on pouvait éviter de griser la dernière heure du calendrier pour éviter d'ajouter du bruit visuel sur cette page qui est déjà bien remplie

Avant | Après
:- | -:
<img width="1141" height="848" alt="Screenshot 2025-11-18 at 12 27 21" src="https://github.com/user-attachments/assets/9149174c-53a4-4991-893f-f6f4ea37569d" />|<img width="1134" height="846" alt="Screenshot 2025-11-18 at 12 26 57" src="https://github.com/user-attachments/assets/207ad710-cf00-498c-8833-210f684b7fe2" />
