### PR TITLE
Autoriser le HTML dans le bandeau d'information "service dégradé"

### DIFF
--- a/app/views/layouts/_degraded_service.html.slim
+++ b/app/views/layouts/_degraded_service.html.slim
@@ -1,2 +1,2 @@
 - if message.present?
-  = dsfr_notice title: "Information", description: message, type: "warning"
+  = dsfr_notice title: "Information", description: sanitize(message), type: "warning"


### PR DESCRIPTION
# Avant

<img width="1181" height="74" alt="image" src="https://github.com/user-attachments/assets/3a0a07f0-afaf-4fd3-8a1f-3534379168c2" />

# Après

<img width="1181" height="74" alt="image" src="https://github.com/user-attachments/assets/a45dd907-fbfc-46da-a8a3-6d0c077e696d" />
