### PR TITLE
Suppression du numéro de version dans le footer

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,7 +7,7 @@ SECRET_KEY_BASE=rdv-sp-key-rd123
 # Feature flags and App configuration
 DEGRADED_SERVICE_MESSAGE_USERS=
 DEGRADED_SERVICE_MESSAGE_AGENTS=
-# RDV_SOLIDARITES_VERSION is set automatically in bin/start_web_server
+
 SIGN_IN_AS_ALLOWED=true
 SAFE_DOMAIN_LIST=
 

--- a/app/views/layouts/_agent_footer.html.slim
+++ b/app/views/layouts/_agent_footer.html.slim
@@ -4,8 +4,7 @@ footer.footer#footer[role="contentinfo"]
       .col-md-12
         .d-none.d-md-flex.flex-wrap.flex-gap-1em.justify-content-end.mb-2
           = link_to "Accessibilité : partiellement conforme", accessibilite_path, class: "fr-link"
-          = link_to "https://github.com/betagouv/rdv-service-public/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}", target: "_blank", class: "fr-link" do
-            = ENV["RDV_SOLIDARITES_VERSION"]
+          = external_link_to "Code source", "https://github.com/betagouv/rdv-service-public", title: "Code source de #{current_domain.name} sur Github - nouvel onglet", class: "fr-link"
           = link_to mentions_legales_path, class: "fr-link" do
             | Mentions Légales
           = link_to cgu_agent_path, class: "fr-link", title: "Conditions générales d’utilisation" do

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -110,8 +110,6 @@ html lang="fr"
             li.fr-footer__bottom-item
               = link_to "CGU - Agents", cgu_agent_path, class: "fr-footer__bottom-link", title: "Conditions générales d’utilisation des agents"
             li.fr-footer__bottom-item
-              = link_to "Code Source sur GitHub", "https://github.com/betagouv/rdv-service-public", class: "fr-footer__bottom-link", target: "_blank", rel: "noopener"
+              = external_link_to "Code source", "https://github.com/betagouv/rdv-service-public", class: "fr-footer__bottom-link", title: "Code source de #{current_domain.name} sur Github - nouvel onglet"
             li.fr-footer__bottom-item
-              = link_to ENV["RDV_SOLIDARITES_VERSION"], "https://github.com/betagouv/rdv-service-public/commit/#{ENV['CONTAINER_VERSION']}", class: "fr-footer__bottom-link", title: "#{ENV['RDV_SOLIDARITES_VERSION']} - Aller au code source de #{current_domain.name}", target: "_blank", rel: "noopener"
-            li.fr-footer__bottom-item
-              = link_to "Budget", budget_path, class: "fr-footer__bottom-link", target: "_blank", rel: "noopener"
+              = external_link_to "Budget", budget_path, class: "fr-footer__bottom-link"

--- a/bin/start_web_server
+++ b/bin/start_web_server
@@ -1,5 +1,1 @@
-export RDV_SOLIDARITES_VERSION=v1.`date +"%y%m%d%H%M"`
-if [[ -z "${CONTAINER_VERSION}" ]]; then
-  export CONTAINER_VERSION=`git rev-parse HEAD`
-fi
 bundle exec puma


### PR DESCRIPTION
# Contexte

Nous affichons actuellement 2 fois le lien vers notre repos GitHub côté usagers/site public (un avec numéro de version et l’autre non).
Côté agent, nous affichons seulement le lien avec le numéro de version.

Le footer étant déjà très chargé côté usagers/site public et le numéro de version étant très peu utile pour des utilisateurs, je propose donc de supprimer cette notion et de garder simplement le lien vers le Github.
