### PR TITLE
Retrait du niveau 1 de fil d’ariane côté agent

### DIFF
--- a/app/views/admin/agents/_fil_ariane.html.slim
+++ b/app/views/admin/agents/_fil_ariane.html.slim
@@ -2,7 +2,6 @@
 
 ruby:
   titles_and_paths = [
-    ["Accueil", root_path],
     (["Configuration", admin_organisation_configuration_path(current_organisation)] if current_agent_role.admin?),
     (["Agents", admin_organisation_agents_path(current_organisation)] if current_page_title),
   ].compact

--- a/app/views/admin/lieux/_fil_ariane.html.slim
+++ b/app/views/admin/lieux/_fil_ariane.html.slim
@@ -2,7 +2,6 @@
 
 ruby:
   titles_and_paths = [
-    ["Accueil", root_path],
     (["Configuration", admin_organisation_configuration_path(current_organisation)] if current_agent_role.admin?),
     (["Lieux", admin_organisation_lieux_path(current_organisation)] if current_page_title),
   ].compact

--- a/app/views/admin/merge_users/new.html.slim
+++ b/app/views/admin/merge_users/new.html.slim
@@ -4,7 +4,7 @@
   | Fusionner deux usagers
 
 - content_for :fil_ariane do
-  - render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Usagers", admin_organisation_users_path(current_organisation)]], current_page_title: yield(:title)
+  - render "common/fil_ariane", titles_and_paths: [["Usagers", admin_organisation_users_path(current_organisation)]], current_page_title: yield(:title)
 
 = simple_form_for [:admin, @merge_users_form], url: admin_organisation_merge_users_path(current_organisation), method: "POST" do |f|
   = render "model_errors", model: @merge_users_form

--- a/app/views/admin/motifs/_fil_ariane.html.slim
+++ b/app/views/admin/motifs/_fil_ariane.html.slim
@@ -2,7 +2,6 @@
 
 ruby:
   titles_and_paths = [
-    ["Accueil", root_path],
     (["Configuration", admin_organisation_configuration_path(current_organisation)] if current_agent_role.admin?),
     (["Motifs de rendez-vous", admin_organisation_motifs_path(current_organisation)] if current_page_title),
   ].compact

--- a/app/views/admin/organisations/configurations/_fil_ariane.html.slim
+++ b/app/views/admin/organisations/configurations/_fil_ariane.html.slim
@@ -1,5 +1,5 @@
 /# locals: (current_page_title:)
-- titles_and_paths = [["Accueil", root_path], ["Configuration", admin_organisation_configuration_path(current_organisation)]]
+- titles_and_paths = [["Configuration", admin_organisation_configuration_path(current_organisation)]]
 
 - content_for :fil_ariane do
   = render "common/fil_ariane", titles_and_paths: titles_and_paths, current_page_title: current_page_title

--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -1,6 +1,3 @@
-- content_for :fil_ariane do
-  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: "Configuration"
-
 - content_for(:menu_item) { "menu-settings" }
 
 - content_for :title do

--- a/app/views/admin/organisations/online_booking/motifs/edit.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/edit.html.slim
@@ -1,5 +1,5 @@
 - content_for :fil_ariane do
-  - titles_and_paths = [["Accueil", root_path], ["Configuration", admin_organisation_configuration_path(current_organisation)], ["Réservation en ligne", admin_organisation_online_booking_path(current_organisation)], [@motif.name, admin_organisation_online_booking_motif_path(current_organisation, @motif)]]
+  - titles_and_paths = [["Configuration", admin_organisation_configuration_path(current_organisation)], ["Réservation en ligne", admin_organisation_online_booking_path(current_organisation)], [@motif.name, admin_organisation_online_booking_motif_path(current_organisation, @motif)]]
   = render "common/fil_ariane", titles_and_paths: titles_and_paths, current_page_title: "Options de réservation en ligne"
 
 - content_for :title do

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -1,4 +1,4 @@
-- titles_and_paths = [["Accueil", root_path], ["Configuration", admin_organisation_configuration_path(current_organisation)], ["Réservation en ligne", admin_organisation_online_booking_path(current_organisation)]]
+- titles_and_paths = [["Configuration", admin_organisation_configuration_path(current_organisation)], ["Réservation en ligne", admin_organisation_online_booking_path(current_organisation)]]
 
 - content_for :fil_ariane do
   = render "common/fil_ariane", titles_and_paths: titles_and_paths, current_page_title: @motif.name

--- a/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
+++ b/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
@@ -1,4 +1,4 @@
-- titles_and_paths = [["Accueil", root_path], ["Configuration", admin_organisation_configuration_path(current_organisation)], ["Réservation en ligne", admin_organisation_online_booking_path(current_organisation)]]
+- titles_and_paths = [["Configuration", admin_organisation_configuration_path(current_organisation)], ["Réservation en ligne", admin_organisation_online_booking_path(current_organisation)]]
 
 - content_for :fil_ariane do
   = render "common/fil_ariane", titles_and_paths: titles_and_paths, current_page_title: "Profil des usagers"

--- a/app/views/admin/organisations/stats/index.html.slim
+++ b/app/views/admin/organisations/stats/index.html.slim
@@ -6,9 +6,6 @@
 - content_for :title do
   div.mb-0.pb-0 Statistiques de #{current_organisation.name}
 
-- content_for :fil_ariane do
-    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: "Statistiques de #{current_organisation.name}"
-
 .card.fr-mb-5v
   .card-body
     = render "stats/rdv_counters_with_links", rdvs: @stats.rdvs, breadcrumb_page: "organisation_stats"

--- a/app/views/admin/planning/absences/edit.html.slim
+++ b/app/views/admin/planning/absences/edit.html.slim
@@ -9,11 +9,11 @@
 - content_for :fil_ariane do
   - if @absence.agent == current_agent
     = render "common/fil_ariane",
-            titles_and_paths: [["Accueil", root_path], ["Vos indisponibilités", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
+            titles_and_paths: [["Vos indisponibilités", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
             current_page_title: yield(:title)
   - else
     = render "common/fil_ariane",
-            titles_and_paths: [["Accueil", root_path], ["Indisponibilités de #{@absence.agent.full_name_and_service}", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
+            titles_and_paths: [["Indisponibilités de #{@absence.agent.full_name_and_service}", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
             current_page_title: yield(:title)
 
 - content_for :right_of_page_title do

--- a/app/views/admin/planning/absences/index.html.slim
+++ b/app/views/admin/planning/absences/index.html.slim
@@ -7,9 +7,6 @@
   - else
     = "Indisponibilités de #{@agent.full_name_and_service}"
 
-- content_for :fil_ariane do
-  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)
-
 - content_for :right_of_page_title do
   = link_to "Créer une indisponibilité",
           new_admin_organisation_planning_absence_path(current_organisation, agent_id: @agent.id),

--- a/app/views/admin/planning/absences/new.html.slim
+++ b/app/views/admin/planning/absences/new.html.slim
@@ -10,11 +10,11 @@
 - content_for :fil_ariane do
     - if @absence.agent == current_agent
       = render "common/fil_ariane",
-              titles_and_paths: [["Accueil", root_path], ["Vos indisponibilités", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
+              titles_and_paths: [["Vos indisponibilités", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
               current_page_title: yield(:title)
     - else
       = render "common/fil_ariane",
-              titles_and_paths: [["Accueil", root_path], ["Indisponibilités de #{@absence.agent.full_name_and_service}", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
+              titles_and_paths: [["Indisponibilités de #{@absence.agent.full_name_and_service}", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
               current_page_title: yield(:title)
 
 .row.justify-content-center

--- a/app/views/admin/planning/plage_ouvertures/calendar.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/calendar.html.slim
@@ -7,9 +7,6 @@
   - else
     | Plages d’ouverture de #{@agent.full_name_and_service}
 
-- content_for :fil_ariane do
-  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)
-
 - content_for :right_of_page_title do
   .fr-btns-group.fr-btns-group--inline.fr-btns-group--icon-left
     = link_to t("admin.planning.plage_ouvertures.index.list_view"), admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: @agent.id, search: params[:search], current_tab: params[:current_tab]), class: "fr-btn fr-btn--secondary fr-icon-list-unordered"

--- a/app/views/admin/planning/plage_ouvertures/edit.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/edit.html.slim
@@ -8,8 +8,8 @@
 
 - content_for :fil_ariane do
   - if current_agent == @plage_ouverture.agent
-    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
+    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
   - else
-    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
+    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 = render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -7,9 +7,6 @@
   - else
     | Plages d’ouverture de #{@agent.full_name_and_service}
 
-- content_for :fil_ariane do
-  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)
-
 - content_for :right_of_page_title do
   - if current_organisation.motifs.active.any?
     .fr-btns-group.fr-btns-group--inline.fr-btns-group--icon-left

--- a/app/views/admin/planning/plage_ouvertures/new.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/new.html.slim
@@ -9,8 +9,8 @@
 
 - content_for :fil_ariane do
   - if current_agent == @plage_ouverture.agent
-    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
+    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
   - else
-    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
+    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 = render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/planning/plage_ouvertures/show.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/show.html.slim
@@ -5,9 +5,9 @@
 
 - content_for :fil_ariane do
   - if current_agent == @plage_ouverture.agent
-    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
+    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
   - else
-    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
+    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 .row.justify-content-center
   .col-md-6.mb-3

--- a/app/views/admin/rdvs/_fil_ariane_rdv.html.slim
+++ b/app/views/admin/rdvs/_fil_ariane_rdv.html.slim
@@ -1,6 +1,5 @@
 /# locals: (rdv:, b:, contextual_agents:)
 
-= b.with_breadcrumb label: "Accueil", href: root_path
 - if contextual_agents.blank?
   - if rdv.collectif?
     = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -6,11 +6,11 @@
 
   - content_for :fil_ariane do
     - if @breadcrumb_page == "agenda" && @form.agent.present?
-      = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Agenda de #{@form.agent.full_name}", admin_organisation_planning_agenda_path(current_organisation, agent_id: @form.agent.id, date: @form.start)]], current_page_title: "Liste des RDV"
+      = render "common/fil_ariane", titles_and_paths: [["Agenda de #{@form.agent.full_name}", admin_organisation_planning_agenda_path(current_organisation, agent_id: @form.agent.id, date: @form.start)]], current_page_title: "Liste des RDV"
     - if @breadcrumb_page == "user" && @form.user.present?
-      = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Usagers", admin_organisation_users_path(current_organisation)], [@form.user.full_name, admin_organisation_user_path(current_organisation, @form.user)]], current_page_title: "RDVs #{Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase}"
+      = render "common/fil_ariane", titles_and_paths: [["Usagers", admin_organisation_users_path(current_organisation)], [@form.user.full_name, admin_organisation_user_path(current_organisation, @form.user)]], current_page_title: "RDVs #{Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase}"
     - if @breadcrumb_page == "organisation_stats"
-      = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Statistiques de l'organisation", admin_organisation_stats_path(current_organisation)]], current_page_title: "RDVs #{Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase}"
+      = render "common/fil_ariane", titles_and_paths: [["Statistiques de l'organisation", admin_organisation_stats_path(current_organisation)]], current_page_title: "RDVs #{Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase}"
 
   .card
     .card-body

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -1,12 +1,7 @@
 - content_for(:title) { "Ajouter un participant" }
 
 - content_for :fil_ariane do
-  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
-    = b.with_breadcrumb label: "Accueil", href: root_path
-    = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)
-    = b.with_breadcrumb label: @rdv.motif_name, href: admin_organisation_rdv_path(current_organisation, @rdv)
-    = b.with_breadcrumb label: "Ajouter un participant"
-  end
+  = render "common/fil_ariane", titles_and_paths: [["RDV collectifs", admin_organisation_rdvs_collectifs_path(current_organisation)], [@rdv.motif_name, admin_organisation_rdv_path(current_organisation, @rdv)]], current_page_title: "Ajouter un participant"
 
 .row.justify-content-md-center
   .col-md-12.col-lg-8

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -3,11 +3,6 @@
 
 - content_for(:menu_item) { "menu-rdvs-collectifs-list" }
 
-- content_for :fil_ariane do
-  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
-    = b.with_breadcrumb label: "Accueil", href: root_path
-    = b.with_breadcrumb label: "RDV collectifs"
-
 - needs_collectif_motif = current_organisation.motifs.collectif.active.none?
 - content_for :right_of_page_title do
   - unless needs_collectif_motif

--- a/app/views/admin/rdvs_collectifs/motifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/motifs/index.html.slim
@@ -1,10 +1,7 @@
 - content_for(:title) { "Nouveau RDV collectif" }
 
 - content_for :fil_ariane do
-  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
-    = b.with_breadcrumb label: "Accueil", href: root_path
-    = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)
-    = b.with_breadcrumb label: "Choisir un motif"
+  = render "common/fil_ariane", titles_and_paths: [["RDV collectifs", admin_organisation_rdvs_collectifs_path(current_organisation)]], current_page_title: "Choisir un motif"
 
 .row.justify-content-md-center
   .col-md-12.col-lg-8

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -1,10 +1,7 @@
 - content_for(:title) { "Nouveau RDV collectif" }
 
 - content_for :fil_ariane do
-  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
-    = b.with_breadcrumb label: "Accueil", href: root_path
-    = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)
-    = b.with_breadcrumb label: "Nouveau RDV collectif"
+  = render "common/fil_ariane", titles_and_paths: [["RDV collectifs", admin_organisation_rdvs_collectifs_path(current_organisation)]], current_page_title: "Nouveau RDV collectif"
 
 .row.justify-content-md-center
   .col-md-12.col-lg-8

--- a/app/views/admin/referent_assignations/index.html.slim
+++ b/app/views/admin/referent_assignations/index.html.slim
@@ -3,7 +3,7 @@
 - content_for(:title, "Modifier les référents de #{@user.full_name}")
 
 - content_for :fil_ariane do
-    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Usagers", admin_organisation_users_path(current_organisation)], [@user.full_name, admin_organisation_user_path(current_organisation, @user)]], current_page_title: yield(:title)
+    = render "common/fil_ariane", titles_and_paths: [["Usagers", admin_organisation_users_path(current_organisation)], [@user.full_name, admin_organisation_user_path(current_organisation, @user)]], current_page_title: yield(:title)
 
 - if @referents.any?
   .container-fluid.bg-white.rounded.col-lg-10.mb-3

--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -1,7 +1,5 @@
 - content_for(:title) { "Support" }
 - content_for(:menu_item) { "menu-support" }
-- content_for :fil_ariane do
-  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: "Support"
 
 .fr-grid-row.fr-grid-row--gutters
   .fr-col.fr-col-md-6

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,6 +1,6 @@
 - content_for(:menu_item) { "menu-users" }
 
-- titles_and_paths = [["Accueil", root_path], ["Usagers", admin_organisation_users_path(current_organisation)]]
+- titles_and_paths = [["Usagers", admin_organisation_users_path(current_organisation)]]
 
 - if @user.relative?
   - content_for :title do

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -3,9 +3,6 @@
 - content_for :title do
   | Usagers
 
-- content_for :fil_ariane do
-    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: "Usagers"
-
 - content_for :right_of_page_title do
   .btn-group
     = link_to "Fusionner deux usagers", new_admin_organisation_merge_users_path(current_organisation), class: "fr-btn fr-btn--secondary mr-1"

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,6 +1,6 @@
 - content_for(:menu_item) { "menu-users" }
 
-- titles_and_paths = [["Accueil", root_path], ["Usagers", admin_organisation_users_path(current_organisation)]]
+- titles_and_paths = [["Usagers", admin_organisation_users_path(current_organisation)]]
 
 - if @user.relative? && @user.responsible.persisted?
   - content_for :title do

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -4,7 +4,7 @@
   | #{@user.full_name}
 
 ruby:
-  titles_and_paths = [["Accueil", root_path], ["Usagers", admin_organisation_users_path(current_organisation)]]
+  titles_and_paths = [["Usagers", admin_organisation_users_path(current_organisation)]]
   if @user.relative?
     titles_and_paths << [@user.responsible.full_name, admin_organisation_user_path(current_organisation, @user.responsible)]
   end

--- a/spec/features/agents/planning/keeping_agent_context_spec.rb
+++ b/spec/features/agents/planning/keeping_agent_context_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "permettre de revenir à l'agenda d'un collègue après avoir cli
     expect(page).to have_content("Agenda de Mon COLLEGUE")
     click_on "Usager DU RDV" # on clique sur le RDV dans l'agenda
 
-    expected_fil_ariane = "Accueil  Agenda de Mon COLLEGUE  RDV Usager DU RDV"
+    expected_fil_ariane = "Agenda de Mon COLLEGUE  RDV Usager DU RDV"
     expect(page).to have_content(expected_fil_ariane)
     click_on "Modifier"
     expect(page).to have_content(expected_fil_ariane)
@@ -48,7 +48,7 @@ RSpec.describe "permettre de revenir à l'agenda d'un collègue après avoir cli
     find("#submit_agents").click
     click_on "Usager DU RDV" # on clique sur le RDV dans l'agenda
 
-    expected_fil_ariane = "Accueil  Agendas de M. COLLEGUE, A. COURANT  RDV Usager DU RDV"
+    expected_fil_ariane = "Agendas de M. COLLEGUE, A. COURANT  RDV Usager DU RDV"
     expect(page).to have_content(expected_fil_ariane)
     click_on "Modifier"
     expect(page).to have_content(expected_fil_ariane)


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr5859.osc-secnum-fr1.scalingo.io/)

`martine@demo.rdv-solidarites.fr` / `Rdvservicepublictest1!`

# Contexte

Suite aux retours de Teo, nous nous sommes rendu compte que nous avions des fils d’ariane tout beaux au DSFR, mais : 
- La notion d’Accueil n’existe pas vraiment côté agent, nous ça n’a pas beaucoup de sens d’avoir « Accueil » sur tous les écrans
- Le premier niveau de fil d’ariane n’a pas vraiment d’intérêt, car nous savons toujours où nous sommes grâce au menu de gauche toujours présent

# Solution

- On retire la notion d’accueil du fil d’ariane
- On retire le fil sur toutes les pages de premier niveau
- J’en ai profité pour utiliser la partial que nous avons pour les fils d’ariane aux derniers endroits où ce n’était pas encore le cas
