### PR TITLE
Envoyer les alertes d’URL incorrectes à l’équipe déploiement

### DIFF
--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -20,7 +20,7 @@ class CronJob::SynchronizeCrm < CronJob
 
     client.database_query(database_id: NOTION_DATABASE_ID, filter:) do |page|
       page.results.each do |notion_page|
-        ids = organisations_ids(notion_page.properties["COMPTE PROD"].url)
+        ids = organisations_ids(notion_page)
         rdv_count = ids.blank? ? nil : Rdv.where(organisation: ids).count
         last_rdv = Rdv.where(organisation: ids).order(created_at: :desc).first
         if last_rdv
@@ -36,7 +36,8 @@ class CronJob::SynchronizeCrm < CronJob
 
   # Prend une URL de compte au format '/organisations/1' ou '/territories/1' et retourne les IDs des organisations correspondantes
   # On ne retourne les IDs que si les organisations existent dans la base de données
-  def organisations_ids(account_url)
+  def organisations_ids(notion_page)
+    account_url = notion_page.properties["COMPTE PROD"].url
     if account_url.match('territories/(\d+)')
       territory_id = account_url.match('territories/(\d+)')[1]
       territory = Territory.find_by(id: territory_id)
@@ -44,7 +45,12 @@ class CronJob::SynchronizeCrm < CronJob
     elsif account_url.match('organisations/(\d+)')
       Organisation.where(id: account_url.match('organisations/(\d+)')[1]).pluck(:id)
     else
-      Sentry.capture_message("Unrecognized account URL: #{account_url}", fingerprint: ["CronJob::SynchronizeCrm"])
+      MattermostApiClient.send_message(
+        channel: "startup-rdv-alertes-crm",
+        text: "L’URL du compte PROD de la carte Notion [#{notion_page.properties['Project name']['title'][0]['plain_text']}](#{notion_page.url}), est incorrecte.",
+        username: "CRM",
+        icon_url: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Notion-logo.svg/100px-Notion-logo.svg.png"
+      )
       []
     end
   end


### PR DESCRIPTION
# Contexte

Nous envoyons actuellement une Sentry quand une URL dans une carte du CRM est incorrecte.
Cela implique alors qu’un dev envoie un message Mattermost à l’équipe de déploiement pour corriger.

# Solution

Vu avec Léa et Matis, on envoie l’info directement dans un canal Mattermost.