### PR TITLE
Update `pg` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,7 +451,7 @@ GEM
     parser (3.3.7.3)
       ast (~> 2.4.1)
       racc
-    pg (1.4.6)
+    pg (1.6.2)
     pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)


### PR DESCRIPTION
En explorant #5865 j'ai encore une fois réalisé que notre version de `pg` était assez ancienne (`v1.4.6 [2023-02-26]`).

Je propose de passer à la dernière version (`v1.6.2 [2025-09-02]`) pour profiter des bugfixes passés depuis 2 ans et demi ! :sparkles: 

Cette dernière version est sortie début septembre, on peut considérer qu'elle a été bien testée.

CHANGELOG.md : https://github.com/ged/ruby-pg/blob/master/CHANGELOG.md