### PR TITLE
ne plus ajouter de commentaire dans les PR sur les résultats des tests CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,6 @@ jobs:
     if: (!cancelled())
     permissions:
       checks: write
-      pull-requests: write
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,7 @@ jobs:
         with:
           files: |
             tests-results/**/rspec-*.xml
+          comment_mode: off
   test_features_autodoc:
     name: Feature Tests using Autodoc
     runs-on: ubuntu-latest


### PR DESCRIPTION
je propose d’arrêter d’écrire ce commentaire dans les PR ça ne me paraît pas très utile : 

<img width="847" height="446" alt="image" src="https://github.com/user-attachments/assets/f6e4a337-431d-4944-af82-9c6f94ccd511" />

(il affiche tout le temps +600 -600 car on a mis des ID dans les titres de tests donc ils ne sont pas reconnaissables entre runs)

cf https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#configuration

En revanche je propose de garder cette GH action step qui rajoute du descriptif sur le run de l’action : 

<img width="1189" height="791" alt="image" src="https://github.com/user-attachments/assets/6bd9ccd6-ea30-4935-a83c-bd117c6f58c3" />

je ne suis pas encore convaincu à 100% par cette vue mais je pense qu’il y a du potentiel :) 