### PR TITLE
Limiter le nombre de jobs parallèles pour les appels d'api lors de la migration inter-instance

### DIFF
--- a/app/jobs/copy_planning_to_new_instance_job.rb
+++ b/app/jobs/copy_planning_to_new_instance_job.rb
@@ -86,6 +86,13 @@ class CopyPlanningToNewInstanceJob < ApplicationJob
   end
 
   class CopyRdvJob < ApplicationJob
+    include GoodJob::ActiveJobExtensions::Concurrency
+    good_job_control_concurrency_with(
+      perform_limit: 3,
+      # Pour éviter de spammer notre API, on limite le nombre de jobs
+      key: -> { "CopyPlanningToNewInstanceJob::CopyRdvJob" }
+    )
+
     queue_as :latency_5m
 
     def perform(instance_export_id, rdv_id, domain_id)

--- a/app/views/admin/instance_exports/show.html.slim
+++ b/app/views/admin/instance_exports/show.html.slim
@@ -28,5 +28,6 @@
               p Copie de votre configuration en cours. Rechargez cette page dans quelques instants.
             - elsif @instance_export.status == "copying_planning"
               p Votre configuration a été copiée sur RDV Service Public
-              p Votre planning est en cours de copie. Rechargez cette page dans quelques instants.
+              p Votre planning est en cours de copie. Si vous avez beaucoup de rendez-vous à copier, cette étape peut prendre quelques minutes.
+              p Rechargez cette page dans quelques instants.
             = link_to  "Ouvrir RDV Service Public", ENV["RDV_SERVICE_PUBLIC_OAUTH_BASE_URL"], target: "_blank", class: "fr-btn fr-btn--secondary"


### PR DESCRIPTION
Il semble que la création de rendez-vous pour la migration inter-instances cause des ralentissements sur la nouvelle instance parce qu'on envoie trop de requêtes à la fois.

Pour mitiger ce problème, on limite le nombre de jobs de création de rendez-vous qui s'exécute en parallèle.