### PR TITLE
Ajout de la durée d'exécution sur les api_calls

### DIFF
--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -136,7 +136,7 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
     yield
     end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-    api_call.update_columns(duration_in_ms: (end_time - start_time).in_milliseconds) # rubocop:disable Rails/SkipsModelValidations
+    api_call.update!(duration_in_ms: (end_time - start_time).in_milliseconds)
   rescue StandardError => e
     Sentry.capture_exception(e, extra: {
                                raw_http: raw_http,

--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -4,8 +4,8 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
 
   skip_before_action :verify_authenticity_token
   before_action :authenticate_agent
-  before_action :log_api_call_in_database
   before_action :set_paper_trail_whodunnit
+  around_action :log_api_call_in_database
 
   def pundit_user
     AgentOrganisationContext.new(current_agent, current_organisation)
@@ -124,13 +124,19 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       host: request.host,
     }
 
-    ApiCall.create!(
+    api_call = ApiCall.create!(
       raw_http: raw_http,
       controller_name: controller_name,
       action_name: action_name,
       agent_id: current_agent.id,
       authentication_type: @authentication_type
     )
+
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    api_call.update_columns(duration_in_ms: (end_time - start_time).in_milliseconds) # rubocop:disable Rails/SkipsModelValidations
   rescue StandardError => e
     Sentry.capture_exception(e, extra: {
                                raw_http: raw_http,

--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -4,8 +4,9 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
 
   skip_before_action :verify_authenticity_token
   before_action :authenticate_agent
+  before_action :log_api_call_in_database
   before_action :set_paper_trail_whodunnit
-  around_action :log_api_call_in_database
+  around_action :measure_execution_time
 
   def pundit_user
     AgentOrganisationContext.new(current_agent, current_organisation)
@@ -124,19 +125,13 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       host: request.host,
     }
 
-    api_call = ApiCall.create!(
+    @_api_call = ApiCall.create!(
       raw_http: raw_http,
       controller_name: controller_name,
       action_name: action_name,
       agent_id: current_agent.id,
       authentication_type: @authentication_type
     )
-
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    yield
-    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-    api_call.update!(duration_in_ms: (end_time - start_time).in_milliseconds)
   rescue StandardError => e
     Sentry.capture_exception(e, extra: {
                                raw_http: raw_http,
@@ -144,5 +139,14 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
                                action_name: action_name,
                                agent_id: current_agent&.id,
                              })
+  end
+
+  def measure_execution_time
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    duration = end_time - start_time
+    @_api_call.update(duration_in_ms: duration.in_milliseconds)
   end
 end

--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::AgentAuthBaseController < Api::V1::BaseController
   include ExplicitPunditConcern
   include DeviseTokenAuth::Concerns::SetUserByToken
+  include Api::V1::ApiCallLoggable
 
   skip_before_action :verify_authenticity_token
   before_action :authenticate_agent
@@ -116,37 +117,5 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
 
   def user_for_paper_trail
     "#{current_agent.name_for_paper_trail} (via API)"
-  end
-
-  def log_api_call_in_database
-    raw_http = {
-      method: request.method,
-      path: request.fullpath,
-      host: request.host,
-    }
-
-    @_api_call = ApiCall.create!(
-      raw_http: raw_http,
-      controller_name: controller_name,
-      action_name: action_name,
-      agent_id: current_agent.id,
-      authentication_type: @authentication_type
-    )
-  rescue StandardError => e
-    Sentry.capture_exception(e, extra: {
-                               raw_http: raw_http,
-                               controller_name: controller_name,
-                               action_name: action_name,
-                               agent_id: current_agent&.id,
-                             })
-  end
-
-  def measure_execution_time
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    yield
-    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-    duration = end_time - start_time
-    @_api_call.update(duration_in_ms: duration.in_milliseconds)
   end
 end

--- a/app/controllers/concerns/api/v1/api_call_loggable.rb
+++ b/app/controllers/concerns/api/v1/api_call_loggable.rb
@@ -1,0 +1,41 @@
+module Api::V1::ApiCallLoggable
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :api_call
+  end
+
+  private
+
+  def log_api_call_in_database
+    raw_http = {
+      method: request.method,
+      path: request.fullpath,
+      host: request.host,
+    }
+
+    self.api_call = ApiCall.create!(
+      raw_http: raw_http,
+      controller_name: controller_name,
+      action_name: action_name,
+      agent_id: current_agent.id,
+      authentication_type: @authentication_type
+    )
+  rescue StandardError => e
+    Sentry.capture_exception(e, extra: {
+                               raw_http: raw_http,
+                               controller_name: controller_name,
+                               action_name: action_name,
+                               agent_id: current_agent&.id,
+                             })
+  end
+
+  def measure_execution_time
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    duration = end_time - start_time
+    api_call.update(duration_in_ms: duration.in_milliseconds)
+  end
+end

--- a/db/migrate/20251124091704_add_api_call_duration.rb
+++ b/db/migrate/20251124091704_add_api_call_duration.rb
@@ -1,0 +1,5 @@
+class AddApiCallDuration < ActiveRecord::Migration[8.0]
+  def change
+    add_column :api_calls, :duration_in_ms, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_17_105536) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_24_134240) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -195,6 +195,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_17_105536) do
     t.string "action_name", null: false
     t.bigint "agent_id", null: false
     t.string "authentication_type"
+    t.integer "duration_in_ms"
   end
 
   create_table "blog_posts", force: :cascade do |t|

--- a/spec/requests/api/v1/api_call_logging_spec.rb
+++ b/spec/requests/api/v1/api_call_logging_spec.rb
@@ -9,5 +9,10 @@ RSpec.describe "On enregistre les appels à l'api pour mieux comprendre qui s'en
       get "/api/v1/absences", headers: oauth_client_headers(oauth_token), as: :json
       expect(ApiCall.last.authentication_type).to eq "OAuth"
     end
+
+    it "records the request's duration in ms" do
+      get "/api/v1/absences", headers: oauth_client_headers(oauth_token), as: :json
+      expect(ApiCall.last.duration_in_ms).to be_within(1000).of(50)
+    end
   end
 end


### PR DESCRIPTION
# Contexte

Nous avons subis de gros ralentissements la semaine dernière, et la liste des ApiCall a été utile pour débugger : on a pu voir des pics d'appels API pendants les ralentissements.

Dans un contexte où nous sommes attentifs aux performances, nous allons avoir besoin d'informations précises, je crois qu'il est pertinent d'ajouter la durée des requêtes API.

Note : on a déjà Skylight qui nous donne l'info mais seulement sur les derniers jours, ce qui est un peu limitant et ajoute un sentiment d'urgence au process d'analyse des ralentissements.