### PR TITLE
Set `to_time_preserves_timezone = :zone`

### DIFF
--- a/config/initializers/new_framework_defaults_8_0.rb
+++ b/config/initializers/new_framework_defaults_8_0.rb
@@ -15,7 +15,7 @@
 # If set to `:offset`, `to_time` methods will use the UTC offset.
 # If `false`, `to_time` methods will convert to the local system UTC offset instead.
 #++
-# Rails.application.config.active_support.to_time_preserves_timezone = :zone
+Rails.application.config.active_support.to_time_preserves_timezone = :zone
 
 ###
 # When both `If-Modified-Since` and `If-None-Match` are provided by the client


### PR DESCRIPTION
# Contexte 

Suite à la MAJ Rails 8.0 dans #5838, on migre vers les nouvelles configs par défaut.

# `to_time_preserves_timezone`

Rails 8.0 introduit un nouveau comportement par défaut: l'appel à `#to_time` préserve la timezone plutôt que de convertir en un `Time` sans timezone et qui porte l'offset de l'heure système.

Cet article explique assez bien les choses : 
https://dev.to/lightflight/rails-8-new-activesupport-timezone-defaults-321c

Voir aussi l'implémentation de `#to_time` ici :
https://github.com/rails/rails/blob/v8.0.4/activesupport/lib/active_support/time_with_zone.rb#L493

# Impact sur notre projet

On n'utilise pas `#to_time` directement dans ce projet, mais des gems semblent l'utilisent si on en croit les logs. 

Je ne vois pas trop comment valider que rien ne casse, les tests sont au vert, je propose d'activer la valeur par défaut `to_time_preserves_timezone = :zone`.