### PR TITLE
Fixup: `to_time_preserves_timezone`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,9 @@ module Lapin
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
+    # À supprimer quand on passera à load_defaults 8.0
+    config.active_support.to_time_preserves_timezone = :zone
+
     # À partir de Rails 7.2, YJIT est activé par défaut avec Ruby 3.3
     # Compte tenu de notre environnement mémoire contraint sur Scalingo, on le désactive pour l'instant.
     # Au besoin, nous pourrons le réactiver plus tard si nous avons + de mémoire ou en modifiant la mémoire allouée à YJIT.


### PR DESCRIPTION
Merci @AntoineGirard pour la vigilance. :pray: 

Dans #5877 j'ai tenté d'activer cette config mais en réalité elle n'a pas été activée parce que `ActiveSupport` est chargé avant que le fichier `config/initializers/new_framework_defaults_8_0.rb` ne soit lu. Pour preuve, on voit toujours les warnings : 

> DEPRECATION WARNING: `to_time` will always preserve the full timezone rather than offset of the receiver in Rails 8.1. To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`. (called from <main> at /home/francois/rdv-service-public/config/environment.rb:5)

Ce problème est documenté ici : 
https://github.com/rails/rails/pull/54449

Note : il y a déjà eu un premier fix mais il ne semble pas suffisant :
https://github.com/rails/rails/issues/54015

Solution : on copie la ligne dans l'initializer `config/application.rb`, on la supprimera quand on passera à `load_defaults 8.0`. On constate que le warning disparaît.
