### PR TITLE
Mise à jour de calendav et retrait de l’utilisation d’une méthode privée

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,8 +122,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
     administrate (0.19.0)
       actionpack (>= 5.0)
       actionview (>= 5.0)
@@ -157,7 +157,7 @@ GEM
     bullet (8.0.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    calendav (0.5.0)
+    calendav (0.5.1)
       http
       icalendar
       nokogiri
@@ -249,7 +249,7 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.1.0)
       net-http
-    ffi (1.16.3)
+    ffi (1.17.2)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -289,9 +289,12 @@ GEM
       mutex_m
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    icalendar (2.8.0)
+    icalendar (2.12.1)
+      base64
       ice_cube (~> 0.16)
-    ice_cube (0.16.4)
+      logger
+      ostruct
+    ice_cube (0.17.0)
     ice_nine (0.11.2)
     io-console (0.8.1)
     irb (1.15.3)
@@ -471,7 +474,7 @@ GEM
     psych (5.2.6)
       date
       stringio
-    public_suffix (6.0.2)
+    public_suffix (7.0.0)
     puma (6.4.3)
       nio4r (~> 2.0)
     pundit (2.2.0)

--- a/app/jobs/caldav/import_absences_from_caldav_job.rb
+++ b/app/jobs/caldav/import_absences_from_caldav_job.rb
@@ -51,9 +51,7 @@ module Caldav
       # Si l’événement existe et que l’agent s’est marqué comme disponible, on supprime l’absence
       # Sinon on ignore l’événement
       # Voir https://www.ietf.org/rfc/rfc2445.txt (4.8.2.7 Time Transparency).
-      # On utilise la méthode privée `inner_event` car Calendav n’expose pas cette information directement
-      # On pourra changer ça quand cette diff sera embarquée dans calendav (probablement en 0.6) : https://github.com/pat/calendav/pull/14
-      if event.send(:inner_event).transp == "TRANSPARENT"
+      if event.transp == "TRANSPARENT"
         absence.destroy if absence.persisted?
         return
       end


### PR DESCRIPTION
# Contexte

L’attribut `transp` d’un événement n’était pas exposée par la Gem calendav. J’avais donc dû faire appel à une méthode privée pour récupérer cet attribut.
Suite à cette PR : https://github.com/pat/calendav/pull/14
Et à la release de celle-ci : https://github.com/pat/calendav/commit/399d2bcc64c6e82814616e13d538974202f7daf2

Nous pouvons mettre à jour la Gem et retirer l’appel à la méthode privée.


