### PR TITLE
Corrections + garde fou sur les stats mises en cache

### DIFF
--- a/app/jobs/cron_job/refresh_cached_stats_job.rb
+++ b/app/jobs/cron_job/refresh_cached_stats_job.rb
@@ -4,7 +4,9 @@ class CronJob::RefreshCachedStatsJob < CronJob
 
     queries_by_key.each do |key, query|
       Rails.logger.debug { "querying Metabase for #{key}…" }
-      count = MetabaseApi.sql_query(query)[0]["c"].gsub(",", "").to_i
+      count = MetabaseApi.sql_query(query)[0]["c"]
+        .gsub(/[, ]/, "") # Metabase sometimes splits thousands with spaces or commas 🤷
+        .to_i
       Rails.logger.info "got #{key} = #{count}. writing to cache…"
       Rails.cache.write(key, count, expires_at: 30.days.from_now)
       Rails.logger.debug "✅ wrote to cache"

--- a/app/jobs/cron_job/refresh_cached_stats_job.rb
+++ b/app/jobs/cron_job/refresh_cached_stats_job.rb
@@ -1,16 +1,31 @@
 class CronJob::RefreshCachedStatsJob < CronJob
-  def perform
+  class SuspiciousFigureError < StandardError; end
+
+  def perform(force: false)
     return unless MetabaseApi.authentication_present?
 
     queries_by_key.each do |key, query|
+      previous_value = Rails.cache.fetch(key)
+
       Rails.logger.debug { "querying Metabase for #{key}…" }
-      count = MetabaseApi.sql_query(query)[0]["c"]
+      new_value = MetabaseApi.sql_query(query)[0]["c"]
         .gsub(/[, ]/, "") # Metabase sometimes splits thousands with spaces or commas 🤷
         .to_i
-      Rails.logger.info "got #{key} = #{count}. writing to cache…"
-      Rails.cache.write(key, count, expires_at: 30.days.from_now)
-      Rails.logger.debug "✅ wrote to cache"
+      Rails.logger.info "got #{key} = #{new_value}"
+
+      if previous_value.nil? ||
+         force ||
+         (new_value.to_f / previous_value).between?(0.1, 10) # des valeurs 10x plus hautes ou plus petites sont suspectes
+        Rails.cache.write(key, new_value, expires_at: 30.days.from_now)
+        Rails.logger.debug "✅ wrote to cache"
+      else
+        @suspicious_value = { key:, new_value:, previous_value: }
+      end
     end
+
+    # on lève l’exception hors de la boucle pour permettre de remplir les autres valeurs
+    raise SuspiciousFigureError, @suspicious_value.to_s if @suspicious_value
+
     Rails.logger.debug "🏁 done"
   end
 

--- a/spec/jobs/cron_job/refresh_cached_stats_job_spec.rb
+++ b/spec/jobs/cron_job/refresh_cached_stats_job_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe CronJob::RefreshCachedStatsJob do
+  before do
+    allow(MetabaseApi).to receive(:authentication_present?).and_return(true)
+  end
+
+  context "chiffres reçus correctement" do
+    specify do
+      expect(MetabaseApi).to receive(:sql_query).twice.and_return(
+        [{ "c" => "3 706 950" }],
+        [{ "c" => "2,482" }]
+      )
+      described_class.new.perform
+      expect(Rails.cache.fetch("stats.both_instances.2_years.rdvs_count")).to eq(3_706_950)
+      expect(Rails.cache.fetch("stats.both_instances.2_years.active_organisations_count")).to eq(2_482)
+    end
+  end
+end

--- a/spec/jobs/cron_job/refresh_cached_stats_job_spec.rb
+++ b/spec/jobs/cron_job/refresh_cached_stats_job_spec.rb
@@ -14,4 +14,46 @@ RSpec.describe CronJob::RefreshCachedStatsJob do
       expect(Rails.cache.fetch("stats.both_instances.2_years.active_organisations_count")).to eq(2_482)
     end
   end
+
+  context "chiffres similaires dans le cache avant" do
+    it "met à jour le cache" do
+      Rails.cache.write("stats.both_instances.2_years.rdvs_count", 3_500_000)
+      Rails.cache.write("stats.both_instances.2_years.active_organisations_count", 2_000)
+      expect(MetabaseApi).to receive(:sql_query).twice.and_return(
+        [{ "c" => "3 706 950" }],
+        [{ "c" => "2,482" }]
+      )
+      described_class.new.perform
+      expect(Rails.cache.fetch("stats.both_instances.2_years.rdvs_count")).to eq(3_706_950)
+      expect(Rails.cache.fetch("stats.both_instances.2_years.active_organisations_count")).to eq(2_482)
+    end
+  end
+
+  context "chiffres qui paraissent aberrants" do
+    it "ne remplace pas les valeurs dans le cache, valeurs aberrantes ignorées" do
+      Rails.cache.write("stats.both_instances.2_years.rdvs_count", 3_500_000)
+      Rails.cache.write("stats.both_instances.2_years.active_organisations_count", 2_000)
+      expect(MetabaseApi).to receive(:sql_query).twice.and_return(
+        [{ "c" => "3000" }],
+        [{ "c" => "20" }]
+      )
+      expect { described_class.new.perform }.to raise_error(CronJob::RefreshCachedStatsJob::SuspiciousFigureError)
+      expect(Rails.cache.fetch("stats.both_instances.2_years.rdvs_count")).to eq(3_500_000)
+      expect(Rails.cache.fetch("stats.both_instances.2_years.active_organisations_count")).to eq(2_000)
+    end
+  end
+
+  context "chiffres qui paraissent aberrants mais on force le rafraîchissement" do
+    it "ne remplace pas les valeurs dans le cache, valeurs aberrantes ignorées" do
+      Rails.cache.write("stats.both_instances.2_years.rdvs_count", 3_500_000)
+      Rails.cache.write("stats.both_instances.2_years.active_organisations_count", 2_000)
+      expect(MetabaseApi).to receive(:sql_query).twice.and_return(
+        [{ "c" => "3000" }],
+        [{ "c" => "20" }]
+      )
+      expect { described_class.new.perform(force: true) }.not_to raise_error
+      expect(Rails.cache.fetch("stats.both_instances.2_years.rdvs_count")).to eq(3_000)
+      expect(Rails.cache.fetch("stats.both_instances.2_years.active_organisations_count")).to eq(20)
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

Ce matin le chiffre sur rdv.anct.gouv.fr était cassé 😱

<img width="974" height="281" alt="image" src="https://github.com/user-attachments/assets/79b8e1cc-419a-48d6-a6a0-44990b3e963e" />

# Solution

C’était du à un problème de parsing : Metabase s’est mis à retourner les chiffres avec un séparateur de milliers en espaces plutôt qu’en virgules auparavant 🤷 peut-être un changement de config fait à l’échelle de Metabase global.

J’ai corrigé le parsing dans le premier commit

En bonus j’ai : 
- rajouté des specs pour ce job
- rajouté un garde-fou : ne pas écraser la valeur précédente si elle est 10x plus haute ou 10x plus basse que l’existante (avec des specs)