### PR TITLE
Correction de l’affichage « participants dont » dans la recherche de créneaux

### DIFF
--- a/app/views/admin/rdvs_collectifs/_participants_info.html.slim
+++ b/app/views/admin/rdvs_collectifs/_participants_info.html.slim
@@ -6,7 +6,7 @@
   - if selected_users
     - selected_users_already_participating = selected_users.to_set.intersection(rdv.users)
     - if selected_users_already_participating.count > 0
-    =< "dont #{selected_users_already_participating.to_a.to_sentence}"
+      =< "dont #{selected_users_already_participating.to_a.to_sentence}"
 
 .d-flex.card-text.mb-3
   - if rdv.remaining_seats? && rdv.not_cancelled?


### PR DESCRIPTION
Corrige ce petit bug du à une faute d’indentation

<img width="976" height="469" alt="image" src="https://github.com/user-attachments/assets/a61b533e-c9dd-4e34-89d3-a4ee986a1c80" />
