### PR TITLE
Stats publiques : correction du parsing des coordonnées pour la carte

### DIFF
--- a/app/javascript/lieux_map.js
+++ b/app/javascript/lieux_map.js
@@ -25,7 +25,8 @@ const initMap = (mapElt, lieux) => {
           "properties": lieu,
           "geometry": {
             "type": "Point",
-            "coordinates": [lieu.longitude, lieu.latitude]
+            "coordinates": [lieu.longitude.replace(",", "."), lieu.latitude.replace(",", ".")]
+            // selon la config de Metabase, les latitudes longitudes peuvent arriver avec des virgules
           }
         }))
       }


### PR DESCRIPTION
Review app : https://rdv-service-public-review-app-pr5886.osc-secnum-fr1.scalingo.io/stats

# Contexte

La carte est cassée depuis ce matin sur la page stats publiques 

<img width="1215" height="841" alt="image" src="https://github.com/user-attachments/assets/3f946648-ad04-4711-9f48-e5eb62b04603" />


# Solution

Les données se chargent bien depuis metabase mais il semble que le formatting ait changé : il peut maintenant y avoir des `,` qui ne sont pas bien interprétées par maplibre.

Je propose ici une solution un peu brutale mais qui a le mérite de marcher et devrait continuer à marcher en cas de basculement retour vers la config précédente de Metabase qui n’envoyait pas de virgules.