### PR TITLE
Permettre aux agents d’accéder à la bêta sync caldav en autonomie

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -1,10 +1,9 @@
 class Agents::CaldavSyncController < AgentAuthController
   layout "application_agent_config"
 
-  before_action :feature_flag_verification!
-
   def show
     skip_authorization
+    current_agent.enable_feature!(Agent::FeatureFlags::CALDAV_SYNC)
   end
 
   def update
@@ -44,11 +43,5 @@ class Agents::CaldavSyncController < AgentAuthController
 
   def pundit_user
     AgentContext.new(current_agent)
-  end
-
-  def feature_flag_verification!
-    return if current_agent.feature_enabled?(Agent::FeatureFlags::CALDAV_SYNC)
-
-    redirect_to agents_calendar_sync_path, alert: "Vous n’avez pas accès à cette fonctionnalité. Si vous pensez que c’est une erreur, contactez un administrateur."
   end
 end


### PR DESCRIPTION
# Contexte

On commence à ouvrir un peu plus la bêta de la synchro Caldav. On souhaite qu’il n’y ait pas besoin de l’intervention d’un super admin pour accéder à celle-ci.

# Solution

- On permet aux gens d’accéder à la configuration par le lien direct. 
- Quand l’agent accède à ce lien pour la première fois, ça lui active automatiquement le flag pour qu’il puisse revenir plus tard via le menu.

Vu avec Mehdi, on va ouvrir plus largement rapidement, mais on attend juste de peaufiner un peu la doc et de clarifier les textes.