### PR TITLE
Utiliser `--frozen-lockfile` dans tous nos appels Yarn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn run prettier --check .
   brakeman:
     name: Security Checker
@@ -154,7 +154,7 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
       - name: Install JS dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Cache precompiled assets
         id: cache-precompiled-assets
         uses: actions/cache@v4
@@ -247,7 +247,7 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
       - name: Install JS dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - uses: ./.github/actions/setup-playwright
       - name: Precompile assets
         run: yarn run build
@@ -303,7 +303,7 @@ jobs:
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: bin/test_boot
         env:
           HOST: http://www.rdv-test.fr

--- a/bin/setup
+++ b/bin/setup
@@ -16,7 +16,7 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
-  system! "yarn install"
+  system! "yarn install --frozen-lockfile"
   system! "yarn run playwright install chromium --with-deps"
 
   # puts "\n== Copying sample files =="

--- a/bin/update
+++ b/bin/update
@@ -18,7 +18,7 @@ chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies if using Yarn
-  system('bin/yarn install --check-files')
+  system('bin/yarn install --frozen-lockfile')
 
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'


### PR DESCRIPTION
D'après [la doc yarn](https://classic.yarnpkg.com/lang/en/docs/cli/install/) flag a l'effet suivant :

> Don’t generate a yarn.lock lockfile and fail if an update is needed.

Cela empêche donc l'installation de tout paquet qui n'est pas dans `yarn.lock`. Combiné à un `yarn.lock` sain, ça contribue à nous protéger des attaques par supply chain.

En complément, nous avons activé `ignore-scripts true` sur tout le projet dans 5b8f064.