### PR TITLE
Shai Hulud - Ajoute les configs recommandées dans le guide de la DINUM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn run prettier --check .
   brakeman:
     name: Security Checker
@@ -154,7 +154,7 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
       - name: Cache precompiled assets
         id: cache-precompiled-assets
         uses: actions/cache@v4
@@ -247,7 +247,7 @@ jobs:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
       - name: Install JS dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
       - uses: ./.github/actions/setup-playwright
       - name: Precompile assets
         run: yarn run build
@@ -303,7 +303,7 @@ jobs:
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --ignore-scripts
       - run: bin/test_boot
         env:
           HOST: http://www.rdv-test.fr

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
Voir ici le guide de la DINUM : https://pad.numerique.gouv.fr/p17z6y_pRJa6oiRhxjA3OQ

Nous utilisons Yarn dans notre projet, mais rien n'empêche d'appeler `npm`. Ici je rajoute donc un fichier `.npmrc` pour ignorer les scripts.

**Les devs sont aussi invités à lancer** 

```
npm config set ignore-scripts true
```

Aussi le guide recommande d'ajouter le flag `--ignore-scripts` de façon explicite dans les commandes de la CI, même si c'est redondant avec `.yarnrc`. 