### PR TITLE
Réactivation des tests d’accessiblité autodoc doublon ouverture espace

### DIFF
--- a/app/views/static_pages/nouvel_espace_rdv_service_public.html.slim
+++ b/app/views/static_pages/nouvel_espace_rdv_service_public.html.slim
@@ -9,7 +9,7 @@
         .card-body.fr-p-0
           .fr-grid-row
             .fr-col-12.fr-col-md-4.fr-p-2w.d-flex.rdv-align-items-center.rdv-justify-content-center[style="background-color: #F9F9FE; border-right: 1px solid rgb(227, 234, 239)"]
-                = image_tag("logos/logo_calendrier.svg")
+              = image_tag("logos/logo_calendrier.svg", alt: "")
             .fr-col-12.fr-col-md-8.fr-p-9w
               h1.fr-h2 Ouvrir un espace #{current_domain.name}
 

--- a/spec/features/autodoc/ouverture_espace_doublon_spec.rb
+++ b/spec/features/autodoc/ouverture_espace_doublon_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
   around { |example| perform_enqueued_jobs { example.run } }
 
   specify do
-    doc = Autodoc.start_scenario("3) Détection de doublon lors des ouvertures d'espace", self, accessibility_checks: false, category: "1) Ouverture d'espace")
+    doc = Autodoc.start_scenario("3) Détection de doublon lors des ouvertures d'espace", self, category: "1) Ouverture d'espace")
 
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")


### PR DESCRIPTION
# Contexte

Je continue dans ma lancée de réactiver petit à petit les tests d’accessibilité sur les autodocs.
Ici il y avait seulement un problème avec un `alt` sur une image.

# Solution

L’image étant là simplement dans un but décoratif, on met un alt vide.
