### PR TITLE
ne plus autocompléter avec la BAN le champ user.address_details

### DIFF
--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -55,7 +55,7 @@
   = f.input :city_name, as: :hidden, **input_opts
 
 - if current_territory.enable_address_details
-  = f.input :address_details, **(input_opts.deep_merge(input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }))
+  = f.input :address_details
 
 - if current_territory.enable_case_number
   = f.input :case_number, **input_opts

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -41,7 +41,7 @@ ruby:
     = f.dsfr_text_field :address, value: address_value, required: rdv_wizard&.motif&.home?, data: { "address-autocomplete": "on" }, autocomplete: "street-address", dir: "ltr"
 
   - if territories.map(&:enable_address_details).any?
-    = f.dsfr_text_field :address_details, data: { "address-autocomplete": "on" }, autocomplete: "street-address", dir: "ltr"
+    = f.dsfr_text_field :address_details
 
   = f.hidden_field :city_code
   = f.hidden_field :post_code


### PR DESCRIPTION
# Contexte

Je suis surpris que le champ « Complément d’adresse » ait un autocomplete sur la Base d’Adresses Nationale. 

On peut quand même soumettre sans sélectionner une valeur suggérée mais ça me paraît un peu perturbant. Quand je regarde en prod sur RDVS il y a plutôt des « Chez sa mère » , « Appt 4 » , « Quartier Chassagne »…

Ça a l’air d’être le cas depuis longtemps, ce n’est pas une nouveauté. 

<img width="1078" height="516" alt="image" src="https://github.com/user-attachments/assets/fbe9cf87-04df-40e4-b9ce-0b0e668826c0" />

remonté dans ce ticket https://zammad10.ethibox.fr/#ticket/zoom/30804


# Solution

ne plus autocompléter le champ partout où on peut l’éditer