### PR TITLE
Utiliser Redis comme cache_store par défaut en développement

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,8 +28,6 @@ Rails.application.configure do
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
 
   config.hosts << ".ngrok.io"


### PR DESCRIPTION
En voulant tester une PR qui utilise le cache (https://github.com/betagouv/rdv-service-public/pull/5885), j'ai mis un peu de temps à trouver pourquoi le cache était vide alors qu'il avait été rempli explicitement : c'est parce que par défaut j'étais dans le mode qui utilise le null_store localement.

Cette PR propose donc qu'on utilise systématiquement Redis comme cache store en local (redis est déjà listé parmi nos dépendances explicites dans les instructions d'installation). Ça n'active pas pour autant le caching de certains mécanismes de rails (page caching, action caching, ou fragment caching), pour éviter les problèmes en passant d'une branche à l'autre.