### PR TITLE
Revert "ne plus autocompléter avec la BAN le champ user.address_details (#5898)

### DIFF
--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -55,7 +55,7 @@
   = f.input :city_name, as: :hidden, **input_opts
 
 - if current_territory.enable_address_details
-  = f.input :address_details
+  = f.input :address_details, **(input_opts.deep_merge(input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }))
 
 - if current_territory.enable_case_number
   = f.input :case_number, **input_opts

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -41,7 +41,7 @@ ruby:
     = f.dsfr_text_field :address, value: address_value, required: rdv_wizard&.motif&.home?, data: { "address-autocomplete": "on" }, autocomplete: "street-address", dir: "ltr"
 
   - if territories.map(&:enable_address_details).any?
-    = f.dsfr_text_field :address_details
+    = f.dsfr_text_field :address_details, data: { "address-autocomplete": "on" }, autocomplete: "street-address", dir: "ltr"
 
   = f.hidden_field :city_code
   = f.hidden_field :post_code


### PR DESCRIPTION
corrige un bug sur le formulaire de creation dusager qui empeche la sauvegarde 😨 

on voit ça alors qu’on essaie de creer un responsable 
<img width="872" height="497" alt="image" src="https://github.com/user-attachments/assets/00e89fbb-d531-4eec-884a-4a3c65e44531" />




This reverts commit e2de3c43c039ce7fb0acbe27adec195dd4b08fe6.

