### PR TITLE
Création d’un lien court de RDV contenant uniquement le token

### DIFF
--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -1,5 +1,5 @@
 class RedirectController < ApplicationController
-  def rdv_short_without_id
+  def rdv_short_from_token
     @participation = Participation.find_by!(restricted_auth_token: params[:tkn])
 
     redirect_to users_rdv_path(@participation.rdv, invitation_token: params[:tkn])

--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -1,0 +1,7 @@
+class RedirectController < ApplicationController
+  def short_rdv_without_id
+    @participation = Participation.find_by!(restricted_auth_token: params[:tkn])
+
+    redirect_to users_rdv_path(@participation.rdv, invitation_token: params[:tkn])
+  end
+end

--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -5,7 +5,9 @@ class RedirectController < ApplicationController
     redirect_to users_rdv_path(@participation.rdv, invitation_token: params[:tkn])
   end
 
+  # << REMOVE AFTER 01/01/2027
   def rdv_short
     redirect_to users_rdv_path(params[:id], invitation_token: params[:tkn])
   end
+  # >> REMOVE AFTER 01/01/2027
 end

--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -1,7 +1,11 @@
 class RedirectController < ApplicationController
-  def short_rdv_without_id
+  def rdv_short_without_id
     @participation = Participation.find_by!(restricted_auth_token: params[:tkn])
 
     redirect_to users_rdv_path(@participation.rdv, invitation_token: params[:tkn])
+  end
+
+  def rdv_short
+    redirect_to users_rdv_path(params[:id], invitation_token: params[:tkn])
   end
 end

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -76,7 +76,7 @@ class Users::RdvSms < Users::BaseSms
 
     details += "\n\n"
 
-    url = rdv_short_url(rdv, host: domain_host, tkn: token).sub(%r{https?://}, "")
+    url = rdv_short_no_id_url(token, host: domain_host).sub(%r{https?://}, "")
     links = "Infos/annulation: #{url}"
 
     links += "\n#{rdv.phone_number}" if rdv.phone_number.present?

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -76,7 +76,7 @@ class Users::RdvSms < Users::BaseSms
 
     details += "\n\n"
 
-    url = rdv_short_no_id_url(token, host: domain_host).sub(%r{https?://}, "")
+    url = rdv_short_from_token_url(token, host: domain_host).sub(%r{https?://}, "")
     links = "Infos/annulation: #{url}"
 
     links += "\n#{rdv.phone_number}" if rdv.phone_number.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -389,13 +389,10 @@ Rails.application.routes.draw do
   get "r", to: redirect("users/rdvs", status: 301), as: "rdvs_short"
 
   # tkn est obligatoire pour s'assurer qu'il est possible de se connecter
-  get "r/:tkn" => "redirect#short_rdv_without_id", as: "rdv_short_no_id"
+  get "r/:tkn" => "redirect#rdv_short_without_id", as: "rdv_short_no_id"
 
   # On préserve la route courte avec id pour la rétrocompatibilité des anciens SMS
-  get "r/:id/:tkn", to: (redirect do |path_params, req|
-    query_params = format_redirect_params(req.params)
-    "users/rdvs/#{path_params[:id]}#{query_params}"
-  end), as: "rdv_short"
+  get "r/:id/:tkn" => "redirect#rdv_short", as: "rdv_short"
 
   get "prdv", to: (redirect do |_path_params, req|
     query_params = format_redirect_params(req.params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -389,7 +389,7 @@ Rails.application.routes.draw do
   get "r", to: redirect("users/rdvs", status: 301), as: "rdvs_short"
 
   # tkn est obligatoire pour s'assurer qu'il est possible de se connecter
-  get "r/:tkn" => "redirect#rdv_short_without_id", as: "rdv_short_no_id"
+  get "r/:tkn" => "redirect#rdv_short_from_token", as: "rdv_short_from_token"
 
   # On préserve la route courte avec id pour la rétrocompatibilité des anciens SMS
   get "r/:id/:tkn" => "redirect#rdv_short", as: "rdv_short"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -389,6 +389,9 @@ Rails.application.routes.draw do
   get "r", to: redirect("users/rdvs", status: 301), as: "rdvs_short"
 
   # tkn est obligatoire pour s'assurer qu'il est possible de se connecter
+  get "r/:tkn" => "redirect#short_rdv_without_id", as: "rdv_short_no_id"
+
+  # On préserve la route courte avec id pour la rétrocompatibilité des anciens SMS
   get "r/:id/:tkn", to: (redirect do |path_params, req|
     query_params = format_redirect_params(req.params)
     "users/rdvs/#{path_params[:id]}#{query_params}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -391,8 +391,10 @@ Rails.application.routes.draw do
   # tkn est obligatoire pour s'assurer qu'il est possible de se connecter
   get "r/:tkn" => "redirect#rdv_short_from_token", as: "rdv_short_from_token"
 
+  # << REMOVE AFTER 01/01/2027
   # On préserve la route courte avec id pour la rétrocompatibilité des anciens SMS
   get "r/:id/:tkn" => "redirect#rdv_short", as: "rdv_short"
+  # >> REMOVE AFTER 01/01/2027
 
   get "prdv", to: (redirect do |_path_params, req|
     query_params = format_redirect_params(req.params)

--- a/spec/features/agents/rdv_wizard/step4_spec.rb
+++ b/spec/features/agents/rdv_wizard/step4_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Step 4 of the rdv wizard" do
       visit new_admin_organisation_rdv_wizard_step_path(params)
       click_button "Confirmer le RDV"
       expect(page).to have_content("Le rendez-vous a été créé.")
-      rdv_url = rdv_short_no_id_url(Participation.last.restricted_auth_token, host: Domain::RDV_SOLIDARITES.host_name).sub(%r{https?://}, "")
+      rdv_url = rdv_short_from_token_url(Participation.last.restricted_auth_token, host: Domain::RDV_SOLIDARITES.host_name).sub(%r{https?://}, "")
       expect_sms_enqueued(content: /#{rdv_url}/)
     end
   end

--- a/spec/features/agents/rdv_wizard/step4_spec.rb
+++ b/spec/features/agents/rdv_wizard/step4_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Step 4 of the rdv wizard" do
       visit new_admin_organisation_rdv_wizard_step_path(params)
       click_button "Confirmer le RDV"
       expect(page).to have_content("Le rendez-vous a été créé.")
-      rdv_url = rdv_short_url(Rdv.last, host: Domain::RDV_SOLIDARITES.host_name, tkn: Participation.last.restricted_auth_token).sub(%r{https?://}, "")
+      rdv_url = rdv_short_no_id_url(Participation.last.restricted_auth_token, host: Domain::RDV_SOLIDARITES.host_name).sub(%r{https?://}, "")
       expect_sms_enqueued(content: /#{rdv_url}/)
     end
   end

--- a/spec/features/users/online_booking/with_short_rdv_link_spec.rb
+++ b/spec/features/users/online_booking/with_short_rdv_link_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "Les usagers peuvent accéder à leur RDV via des liens court" do
+  let(:rdv) { create(:rdv) }
+
+  context "lorsqu’ils utilisent le lien court avec le token uniquement" do
+    it "ils sont redirigés vers la page d’authentification avec le nom de famille puis vers la page du rendez-vous" do
+      visit rdv_short_from_token_path(rdv.participations.first.restricted_auth_token)
+      expect(page).to have_current_path(new_users_user_name_initials_verification_path)
+      fill_in(:letters, with: rdv.participations.first.user.last_name[0..2].upcase)
+      click_on "Valider"
+      expect(page).to have_current_path(users_rdv_path(rdv))
+    end
+  end
+
+  context "lorsqu’ils utilisent le lien court avec l’id et le token" do
+    it "ils sont redirigés vers la page d’authentification avec le nom de famille puis vers la page du rendez-vous" do
+      visit rdv_short_path(rdv.id, tkn: rdv.participations.first.restricted_auth_token)
+      expect(page).to have_current_path(new_users_user_name_initials_verification_path)
+      fill_in(:letters, with: rdv.participations.first.user.last_name[0..2].upcase)
+      click_on "Valider"
+      expect(page).to have_current_path(users_rdv_path(rdv))
+    end
+  end
+end

--- a/spec/features/users/online_booking/with_short_rdv_link_spec.rb
+++ b/spec/features/users/online_booking/with_short_rdv_link_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Les usagers peuvent accéder à leur RDV via des liens court" do
     end
   end
 
+  # << REMOVE AFTER 01/01/2027
   context "lorsqu’ils utilisent le lien court avec l’id et le token" do
     it "ils sont redirigés vers la page d’authentification avec le nom de famille puis vers la page du rendez-vous" do
       visit rdv_short_path(rdv.id, tkn: rdv.participations.first.restricted_auth_token)
@@ -20,4 +21,5 @@ RSpec.describe "Les usagers peuvent accéder à leur RDV via des liens court" do
       expect(page).to have_current_path(users_rdv_path(rdv))
     end
   end
+  # >> REMOVE AFTER 01/01/2027
 end

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Users::RdvSms, type: :service do
         expect(subject).to include("RDV PMI vendredi 10/12 13h10")
         expect(subject).to include("10 rue d'ici, Paris, 75016")
         expect(subject).to include("Infos/annulation")
-        expect(subject).to include("www.rdv-solidarites-test.localhost/r/123/12345")
+        expect(subject).to include("www.rdv-solidarites-test.localhost/r/12345")
         expect(subject).not_to include("Ne Doit pas s'afficher")
       end
 
@@ -108,7 +108,7 @@ RSpec.describe Users::RdvSms, type: :service do
       expect(subject).to include("RDV modifié: PMI vendredi 10/12 13h10")
       expect(subject).to include("10 rue d'ici, Paris, 75016")
       expect(subject).to include("Infos/annulation")
-      expect(subject).to include("www.rdv-solidarites-test.localhost/r/124/2345")
+      expect(subject).to include("www.rdv-solidarites-test.localhost/r/2345")
     end
 
     context "when rdv is in the following 2 days" do
@@ -201,7 +201,7 @@ RSpec.describe Users::RdvSms, type: :service do
       expect(subject).to include("MDS Centre")
       expect(subject).to include("10 rue d'ici, Paris, 75016")
       expect(subject).to include("Infos/annulation")
-      expect(subject).to include("www.rdv-solidarites-test.localhost/r/140/7777")
+      expect(subject).to include("www.rdv-solidarites-test.localhost/r/7777")
     end
   end
 


### PR DESCRIPTION
Closes #5292 

# Contexte

On veut toujours + réduire le nombre de caractères dans les SMS.
Comme indiqué dans l’issue ci-dessus, l’id n’a que très peu d’intérêt dans les liens courts que nous envoyons par SMS, car nous pouvons déjà retrouver le RDV à partir du token.

# Solution

Je propose de créer un contrôleur pour les redirections, parce que je trouve cela plus lisible que de mettre des redirect dans le fichier de routes.
