### PR TITLE
Informer l'agent que la connexion au serveur a été perdue

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -13,6 +13,11 @@ module ApplicationCable
       session = cookies.encrypted[Rails.application.config.session_options[:key]]
       agent_id_from_session = session["warden.user.agent.key"]&.first&.first if session
 
+      # Débugging temporaire
+      if session && !agent_id_from_session
+        Sentry.capture_message("Warn: Cookie de session trouvé mais sans ID", extra: { session: })
+      end
+
       if agent_id_from_session
         Agent.find_by(id: agent_id_from_session) || reject_unauthorized_connection
       else

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -9,28 +9,24 @@ module ApplicationCable
 
     private
 
-    # rubocop:disable Metrics/PerceivedComplexity
     def find_verified_agent
       session = cookies.encrypted[Rails.application.config.session_options[:key]]
       reject_unauthorized_connection and return unless session
 
       agent_id_from_session = session["warden.user.agent.key"]&.first&.first
 
-      # Débugging temporaire : on a un cookie de session, mais pas d'agent_id
-      unless agent_id_from_session
-        Redis.with_connection do |redis|
-          redis.lpush("actioncable_connection_debug", session.to_json)
-        end
-      end
-
       if agent_id_from_session
         Agent.find_by(id: agent_id_from_session) || reject_unauthorized_connection
       else
+        # Débugging temporaire : on a un cookie de session, mais pas d'agent_id
+        Redis.with_connection do |redis|
+          redis.lpush("actioncable_connection_debug", session.to_json)
+        end
+
         # On est par exemple dans ce cas lorsqu'un agent laisse son navigateur
         # ouvert toute la nuit et que le cookie a expiré le lendemain.
         reject_unauthorized_connection
       end
     end
-    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -16,9 +16,11 @@ module ApplicationCable
 
       agent_id_from_session = session["warden.user.agent.key"]&.first&.first
 
-      # Débugging temporaire
+      # Débugging temporaire : on a un cookie de session, mais pas d'agent_id
       unless agent_id_from_session
-        Rails.logger.debug { "Warn: Cookie de session trouvé mais sans ID. Session: #{session.inspect}" }
+        Redis.with_connection do |redis|
+          redis.lpush("actioncable_connection_debug", session.to_json)
+        end
       end
 
       if agent_id_from_session

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -11,8 +11,15 @@ module ApplicationCable
 
     def find_verified_agent
       session = cookies.encrypted[Rails.application.config.session_options[:key]]
-      agent_id_from_session = session["warden.user.agent.key"].first.first
-      Agent.find_by(id: agent_id_from_session) || reject_unauthorized_connection
+
+      if session
+        agent_id_from_session = session["warden.user.agent.key"].first.first
+        Agent.find_by(id: agent_id_from_session) || reject_unauthorized_connection
+      else
+        # On est dans ce cas lorsqu'un agent laisse son navigateur ouvert
+        # toute la nuit et que le cookie a expiré le lendemain.
+        reject_unauthorized_connection
+      end
     end
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -15,7 +15,7 @@ module ApplicationCable
 
       # NOTE : Le cookie de session peut être manquant ici, notamment si l'agent laisse son
       # navigateur ouvert toute la nuit et que le cookie de session a expiré le lendemain.
-      agent_id_from_session = session["warden.user.agent.key"]&.first&.first.presence
+      agent_id_from_session = session["warden.user.agent.key"]&.first&.first.presence if session
 
       if session && agent_id_from_session.nil?
         # Débugging temporaire : on a un cookie de session, mais pas d'agent_id, on veut en savoir plus !

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -10,23 +10,24 @@ module ApplicationCable
     private
 
     def find_verified_agent
+      # La valeur de `session_options` est définie via `config.session_store`
       session = cookies.encrypted[Rails.application.config.session_options[:key]]
 
-      # On est par exemple dans ce cas lorsqu'un agent laisse son navigateur
-      # ouvert toute la nuit et que le cookie de session a expiré le lendemain.
-      reject_unauthorized_connection and return unless session
+      # NOTE : Le cookie de session peut être manquant ici, notamment si l'agent laisse son
+      # navigateur ouvert toute la nuit et que le cookie de session a expiré le lendemain.
+      agent_id_from_session = session["warden.user.agent.key"]&.first&.first.presence
 
-      agent_id_from_session = session["warden.user.agent.key"]&.first&.first
+      if session && agent_id_from_session.nil?
+        # Débugging temporaire : on a un cookie de session, mais pas d'agent_id, on veut en savoir plus !
+        Redis.with_connection { |redis| redis.lpush("action_cable_connection_debug", session.to_json) }
+      end
 
       if agent_id_from_session
-        Agent.find_by(id: agent_id_from_session) || reject_unauthorized_connection
-      else
-        # Débugging temporaire : on a un cookie de session, mais pas d'agent_id
-        Redis.with_connection do |redis|
-          redis.lpush("actioncable_connection_debug", session.to_json)
-        end
-        reject_unauthorized_connection
+        agent = Agent.find_by(id: agent_id_from_session)
+        return agent if agent.present?
       end
+
+      reject_unauthorized_connection
     end
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -16,8 +16,8 @@ module ApplicationCable
         agent_id_from_session = session["warden.user.agent.key"].first.first
         Agent.find_by(id: agent_id_from_session) || reject_unauthorized_connection
       else
-        # On est dans ce cas lorsqu'un agent laisse son navigateur ouvert
-        # toute la nuit et que le cookie a expiré le lendemain.
+        # On est par exemple dans ce cas lorsqu'un agent laisse son navigateur
+        # ouvert toute la nuit et que le cookie a expiré le lendemain.
         reject_unauthorized_connection
       end
     end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -9,13 +9,16 @@ module ApplicationCable
 
     private
 
+    # rubocop:disable Metrics/PerceivedComplexity
     def find_verified_agent
       session = cookies.encrypted[Rails.application.config.session_options[:key]]
-      agent_id_from_session = session["warden.user.agent.key"]&.first&.first if session
+      reject_unauthorized_connection and return unless session
+
+      agent_id_from_session = session["warden.user.agent.key"]&.first&.first
 
       # Débugging temporaire
-      if session && !agent_id_from_session
-        Sentry.capture_message("Warn: Cookie de session trouvé mais sans ID", extra: { session: })
+      unless agent_id_from_session
+        Rails.logger.debug { "Warn: Cookie de session trouvé mais sans ID. Session: #{session.inspect}" }
       end
 
       if agent_id_from_session
@@ -26,5 +29,6 @@ module ApplicationCable
         reject_unauthorized_connection
       end
     end
+    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -11,6 +11,9 @@ module ApplicationCable
 
     def find_verified_agent
       session = cookies.encrypted[Rails.application.config.session_options[:key]]
+
+      # On est par exemple dans ce cas lorsqu'un agent laisse son navigateur
+      # ouvert toute la nuit et que le cookie de session a expiré le lendemain.
       reject_unauthorized_connection and return unless session
 
       agent_id_from_session = session["warden.user.agent.key"]&.first&.first
@@ -22,9 +25,6 @@ module ApplicationCable
         Redis.with_connection do |redis|
           redis.lpush("actioncable_connection_debug", session.to_json)
         end
-
-        # On est par exemple dans ce cas lorsqu'un agent laisse son navigateur
-        # ouvert toute la nuit et que le cookie a expiré le lendemain.
         reject_unauthorized_connection
       end
     end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -11,9 +11,9 @@ module ApplicationCable
 
     def find_verified_agent
       session = cookies.encrypted[Rails.application.config.session_options[:key]]
+      agent_id_from_session = session["warden.user.agent.key"]&.first&.first if session
 
-      if session
-        agent_id_from_session = session["warden.user.agent.key"].first.first
+      if agent_id_from_session
         Agent.find_by(id: agent_id_from_session) || reject_unauthorized_connection
       else
         # On est par exemple dans ce cas lorsqu'un agent laisse son navigateur

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -200,7 +200,7 @@ const setupRealtimeRefresh = (fullCalendarInstance, agentIds) => {
   const disconnectCallback = () => {
     clearTimeout(window.disconnectWarningTimeoutId);
     window.disconnectWarningTimeoutId = setTimeout(() => {
-      document.querySelector("#agenda_disconnecter_warning")?.classList?.remove("hidden");
+      document.querySelector("#js-agenda-disconnected-warning")?.classList?.remove("hidden");
     }, 5000);
   };
 
@@ -210,7 +210,7 @@ const setupRealtimeRefresh = (fullCalendarInstance, agentIds) => {
     // nous voulons cacher l'avertissement affiché lors de la perte de connexion.
     if (reconnected) {
       clearTimeout(window.disconnectWarningTimeoutId);
-      document.querySelector("#agenda_disconnecter_warning")?.classList?.add("hidden");
+      document.querySelector("#js-agenda-disconnected-warning")?.classList?.add("hidden");
       fullCalendarInstance.refetchEvents();
     }
   };

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -198,8 +198,8 @@ const setupRealtimeRefresh = (fullCalendarInstance, agentIds) => {
   };
 
   const disconnectCallback = () => {
-    clearTimeout(fullCalendarInstance.timeoutId);
-    fullCalendarInstance.timeoutId = setTimeout(() => {
+    clearTimeout(window.disconnectWarningTimeoutId);
+    window.disconnectWarningTimeoutId = setTimeout(() => {
       document.querySelector("#agenda_disconnecter_warning")?.classList?.remove("hidden");
     }, 5000);
   };
@@ -209,7 +209,7 @@ const setupRealtimeRefresh = (fullCalendarInstance, agentIds) => {
     // préalable déconnexion. C'est bien ce qui nous intéresse puisque
     // nous voulons cacher l'avertissement affiché lors de la perte de connexion.
     if (reconnected) {
-      clearTimeout(fullCalendarInstance.timeoutId);
+      clearTimeout(window.disconnectWarningTimeoutId);
       document.querySelector("#agenda_disconnecter_warning")?.classList?.add("hidden");
       fullCalendarInstance.refetchEvents();
     }

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -201,7 +201,7 @@ const setupRealtimeRefresh = (fullCalendarInstance, agentIds) => {
     clearTimeout(fullCalendarInstance.timeoutId);
     fullCalendarInstance.timeoutId = setTimeout(() => {
       document.querySelector("#agenda_disconnecter_warning")?.classList?.remove("hidden");
-    }, 2000);
+    }, 5000);
   };
 
   const connectCallback = ({reconnected}) => {

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -204,7 +204,10 @@ const setupRealtimeRefresh = (fullCalendarInstance, agentIds) => {
     }, 5000);
   };
 
-  const connectCallback = ({reconnected}) => {
+  const connectCallback = ({ reconnected }) => {
+    // `reconnected` nous indique que cette connexion fait suite à une
+    // préalable déconnexion. C'est bien ce qui nous intéresse puisque
+    // nous voulons cacher l'avertissement affiché lors de la perte de connexion.
     if (reconnected) {
       clearTimeout(fullCalendarInstance.timeoutId);
       document.querySelector("#agenda_disconnecter_warning")?.classList?.add("hidden");

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -197,8 +197,27 @@ const setupRealtimeRefresh = (fullCalendarInstance, agentIds) => {
     }
   };
 
+  const disconnectCallback = () => {
+    clearTimeout(fullCalendarInstance.timeoutId);
+    fullCalendarInstance.timeoutId = setTimeout(() => {
+      document.querySelector("#agenda_disconnecter_warning")?.classList?.remove("hidden");
+    }, 2000);
+  };
+
+  const connectCallback = ({reconnected}) => {
+    if (reconnected) {
+      clearTimeout(fullCalendarInstance.timeoutId);
+      document.querySelector("#agenda_disconnecter_warning")?.classList?.add("hidden");
+      fullCalendarInstance.refetchEvents();
+    }
+  };
+
   agentIds.forEach(agentId => {
-    getConsumer().subscriptions.create({channel: "AgendaChannel", agent_id: agentId}, { received: messageReceivedCallback });
+    getConsumer().subscriptions.create({channel: "AgendaChannel", agent_id: agentId}, {
+      received: messageReceivedCallback,
+      connected: connectCallback,
+      disconnected: disconnectCallback,
+    });
   });
 };
 

--- a/app/views/admin/planning/agendas/_disconnected_warning.html.slim
+++ b/app/views/admin/planning/agendas/_disconnected_warning.html.slim
@@ -1,5 +1,5 @@
 / Cet avertissement est affiché en JS lorsque l'on perd la connexion ActionCable
-#agenda_disconnecter_warning.hidden
+#js-agenda-disconnected-warning.hidden
   = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mb-2v" } do
     | La connexion avec le serveur a été perdue. Veuillez
     =< link_to("recharger la page", request.fullpath)

--- a/app/views/admin/planning/agendas/_disconnected_warning.html.slim
+++ b/app/views/admin/planning/agendas/_disconnected_warning.html.slim
@@ -1,0 +1,5 @@
+#agenda_disconnecter_warning.hidden
+  = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mb-2v" } do
+    | La connexion avec le serveur a été perdue. Veuillez
+    =< link_to("recharger la page", request.fullpath)
+    |.

--- a/app/views/admin/planning/agendas/_disconnected_warning.html.slim
+++ b/app/views/admin/planning/agendas/_disconnected_warning.html.slim
@@ -1,3 +1,4 @@
+/ Cet avertissement est affiché en JS lorsque l'on perd la connexion ActionCable
 #agenda_disconnecter_warning.hidden
   = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mb-2v" } do
     | La connexion avec le serveur a été perdue. Veuillez

--- a/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
+++ b/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
@@ -11,6 +11,8 @@ ruby:
   event_sources.push(OffDays.to_full_calendar_array) unless current_territory.work_on_sunday?
   resources = @agents.map { { id: _1.id, title: _1.full_name_or_email } }
 
+= render partial: "admin/planning/agendas/disconnected_warning"
+
 #agenda-multi-agent.mt-2[
   data-event-sources-json="#{event_sources.to_json}"
   data-resources-json="#{resources.to_json}"

--- a/app/views/admin/planning/agendas/show.html.slim
+++ b/app/views/admin/planning/agendas/show.html.slim
@@ -23,6 +23,8 @@ ruby:
   ]
   event_sources.push(OffDays.to_full_calendar_array) unless current_territory.work_on_sunday?
 
+= render partial: "admin/planning/agendas/disconnected_warning"
+
 #calendar[
   data-default-date-json="#{@date&.to_json}"
   data-agent-id="#{@agent.id}"

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe ApplicationCable::Connection, type: :channel do
+  it "successfully connects when agent provides Devise session in cookie" do
+    agent = create(:agent)
+    valid_session_cookie = {
+      "session_id" => "des_chiffres_et_des_lettres",
+      "warden.user.agent.key" => [[agent.id], "des_chiffres_et_des_lettres"],
+      "warden.user.agent.session" => { "last_request_at" => 2.minutes.ago.to_i },
+      "_csrf_token" => "des_chiffres_et_des_lettres",
+    }
+    cookies.encrypted["_rdv_sp_session"] = { value: valid_session_cookie }
+    connect "/cable"
+    expect(connection.current_agent).to eq(agent)
+  end
+
+  it "rejects connection when no cookie is provided" do
+    expect { connect "/cable" }.to have_rejected_connection
+  end
+
+  it "logs to Redis if session is there but without agent id" do
+    weird_session_cookie = { "session_id" => "des_chiffres_et_des_lettres" }
+    cookies.encrypted["_rdv_sp_session"] = { value: weird_session_cookie }
+    expect { connect "/cable" }.to have_rejected_connection
+    expect(JSON.parse(Redis.with_connection { _1.rpop "action_cable_connection_debug" })).to eq(weird_session_cookie)
+  end
+end

--- a/spec/features/agents/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/agent_has_a_calendar_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       francis = create(:user, first_name: "Francis", last_name: "Factice")
 
       visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
-      sleep 0.2 # on attend 200ms que la connexion Websocket se fasse
+      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
 
       rdv = create(:rdv, agents: [agent], motif:, organisation:, users: [francis], starts_at:)
       expect(page).to have_selector(".fc-event", text: "14:00 - 14:45\nFrancis FACTICE")
@@ -103,7 +103,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
 
     it "refreshes plages", js: true do
       visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
-      sleep 0.2 # on attend 200ms que la connexion Websocket se fasse
+      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
 
       plage = create(:plage_ouverture, organisation:, agent:, title: "Ma plage", first_day: Time.zone.now.beginning_of_week.to_date)
       expect(page).to have_selector(".fc-event.fc-bg-event", text: "Ma plage")
@@ -117,7 +117,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
 
     it "refreshes absence", js: true do
       visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
-      sleep 0.2 # on attend 200ms que la connexion Websocket se fasse
+      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
 
       absence = create(:absence, agent:, title: "Mon indispo", first_day: Time.zone.now.beginning_of_week.to_date)
       expect(page).to have_selector(".fc-event", text: "Mon indispo")
@@ -140,7 +140,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
 
       click_on "Planning"
       expect(page).to have_content("Planning de") # on vérifie que Turbolinks nous a bien changé la page
-      sleep 0.2 # on attend 200ms que la connexion Websocket se fasse
+      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
 
       create(:absence, agent:, title: "Mon indispo", first_day: Time.zone.now.beginning_of_week.to_date)
       expect(page).to have_selector(".fc-event", text: "Mon indispo")

--- a/spec/features/agents/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/agent_has_a_calendar_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       francis = create(:user, first_name: "Francis", last_name: "Factice")
 
       visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
-      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
+      sleep 0.2 # on attend 200ms que la connexion Websocket se fasse
 
       rdv = create(:rdv, agents: [agent], motif:, organisation:, users: [francis], starts_at:)
       expect(page).to have_selector(".fc-event", text: "14:00 - 14:45\nFrancis FACTICE")
@@ -103,7 +103,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
 
     it "refreshes plages", js: true do
       visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
-      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
+      sleep 0.2 # on attend 200ms que la connexion Websocket se fasse
 
       plage = create(:plage_ouverture, organisation:, agent:, title: "Ma plage", first_day: Time.zone.now.beginning_of_week.to_date)
       expect(page).to have_selector(".fc-event.fc-bg-event", text: "Ma plage")
@@ -117,7 +117,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
 
     it "refreshes absence", js: true do
       visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
-      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
+      sleep 0.2 # on attend 200ms que la connexion Websocket se fasse
 
       absence = create(:absence, agent:, title: "Mon indispo", first_day: Time.zone.now.beginning_of_week.to_date)
       expect(page).to have_selector(".fc-event", text: "Mon indispo")
@@ -140,7 +140,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
 
       click_on "Planning"
       expect(page).to have_content("Planning de") # on vérifie que Turbolinks nous a bien changé la page
-      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
+      sleep 0.2 # on attend 200ms que la connexion Websocket se fasse
 
       create(:absence, agent:, title: "Mon indispo", first_day: Time.zone.now.beginning_of_week.to_date)
       expect(page).to have_selector(".fc-event", text: "Mon indispo")


### PR DESCRIPTION
Issue Sentry : [LAPINS-61Q](https://sentry.incubateur.net/organizations/betagouv/issues/225282)

# Contexte

Nous avons déployé hier #5873 et activé la feature pour les agents qui ont activé le nouveau planning (1 423 agents sur RDV-S, 592 sur RDV-SP).

Ce matin nous avons commencé à voir apparaître cette erreur : 

```
undefined method '[]' for nil (NoMethodError)

      agent_id_from_session = session["warden.user.agent.key"].first.first
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
```

Il semble donc que certains agents tentent une connexion sans envoyer de cookie de session. **Notre supposition c'est qu'ils ont laissé leur navigateur ouvert toute la nuit et que le cookie avait expiré ce matin**. Dans ce cas, le client JS continue de ré-essayer d'établir une connexion, ce qui explique le volume observé (environ 10 appels en erreur par minute ce matin).

Il faut donc gérer le cas où le cookie de l'agent a expiré et qu'il tente une connexion. Nous avions déjà géré ce cas de figure pour le polling dans #4845 (merci @AntoineGirard :heart: ).

## Comment reproduire

1. Ouvrir un agenda en temps réel
2. Supprimer le cookie de session
3. Redémarrer le serveur local pour fermer les websockets ouverts et inviter le client JS à déclencher une reconnexion
4. Constater que `cookies["_rdv_sp_session"]` est vide quand on essaye de le récupérer dans `app/channels/application_cable/connection.rb`

### Astuces de dev

On peut observer les connexions WebSocket en filtrant les appels réseaux sur "WS" : 

<img width="1081" height="322" alt="image" src="https://github.com/user-attachments/assets/e2e2f4f5-909a-4657-939e-879856dc11f0" />

Puis en cliquant sur une connexion WebSocket, on voit les messages envoyés par le serveur dans l'onglet "Response" : 

<img width="1085" height="316" alt="image" src="https://github.com/user-attachments/assets/9d618712-c60d-40f9-ade9-48603812cdf3" />


# Solution

Côté JS :
- on détecte une déconnexion, et on affiche un message d'avertissement si la reconnexion n'a pas eu lieu dans les 5 secondes
- dans un cas de reconnexion automatique (après retry), on cache le message d'avertissement et on refetch l'agenda en Ajax

Côté serveur, dans le cas d'une tentative de connexion sans cookie de session, on rejette la tentative `(reject_unauthorized_connection`). Cela a pour effet d'ajouter un log `An unauthorized connection attempt was rejected` et de [tenter d'envoyer un message disant "pas la peine de retry" via le websocket ouvert si il y en a un](https://github.com/rails/rails/blob/0f3585ee229f1b3ee700a3e11a1527ff7ad364b8/actioncable/lib/action_cable/connection/base.rb) (malheureusement il n'y en a pas).

Note : L'appel à `reject_unauthorized_connection` a donc pour effet d'informer le client JS que la connexion n'a pas pu être faite, mais ne lui donne pas l'instruction d'arrêter les retry. Le client continue alors à retry. Ça ne paraît pas problématique vu le volume et la charge serveur (aucun appel en base, requête traitée en 2ms sur ma machine). On pourrait réfléchir à implémenter un abandon après un certain nombre de retries, mais ça paraît prématuré.


## Captures d'écran

<img width="1039" height="733" alt="image" src="https://github.com/user-attachments/assets/e7a4038c-b657-44be-9769-48c44c32e5ec" />
