### PR TITLE
Ajout des liens d’évitement dans la config côté agent

### DIFF
--- a/app/views/layouts/application_agent_config.html.slim
+++ b/app/views/layouts/application_agent_config.html.slim
@@ -14,10 +14,12 @@ html lang="fr"
     = javascript_include_tag "#{dsfr_path}/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true
   main
     body.pb-0
+      - links = [dsfr_link_to("Contenu", "#content"), dsfr_link_to("Menu", "#sidemenu")]
+      = dsfr_skiplink label: "Accès rapide", links: links, html_attributes: { "data-turbolinks": "false" }
       = render "layouts/super_admin_sign_in_as_warning"
       = render "layouts/rdv_solidarites_instance_name"
       .auth-fluid.row
-        .auth-fluid-left.text-center.col-xs-12.col-md-4 class="#{"auth-fluid-left--agent-preferences" if current_agent}"
+        .auth-fluid-left.text-center.col-xs-12.col-md-4#sidemenu class="#{"auth-fluid-left--agent-preferences" if current_agent}"
           .p-2
             = link_logo
           - if current_agent.present?
@@ -44,7 +46,7 @@ html lang="fr"
                     / on utilise un non-breaking hyphen dans rendez-vous pour éviter le retour à la ligne
                   | dans votre administration
 
-        .auth-fluid-form-box.col-xs-12.col-md-8
+        .auth-fluid-form-box.col-xs-12.col-md-8#content
           = content_for :breadcrumbs
           / Permet de centrer les formulaire de login, et d'aligner en haut de l'écran les formulaires de préférences
           div class="#{"align-items-center d-flex h-100" if current_agent.blank?}"

--- a/app/views/layouts/application_agent_config.html.slim
+++ b/app/views/layouts/application_agent_config.html.slim
@@ -14,7 +14,9 @@ html lang="fr"
     = javascript_include_tag "#{dsfr_path}/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true
   main
     body.pb-0
-      - links = [dsfr_link_to("Contenu", "#content"), dsfr_link_to("Menu", "#sidemenu")]
+      - links = [dsfr_link_to("Contenu", "#content")]
+      - if current_agent
+        - links << dsfr_link_to("Menu", "#sidemenu")
       = dsfr_skiplink label: "Accès rapide", links: links, html_attributes: { "data-turbolinks": "false" }
       = render "layouts/super_admin_sign_in_as_warning"
       = render "layouts/rdv_solidarites_instance_name"


### PR DESCRIPTION
# Contexte

Lors que j’ai ajouté les liens d’évitement dans l’interface agent, j’ai oublié le layout de config.

# Solution

J’ajoute donc les liens d’évitement manquant.

<img width="952" height="802" alt="image" src="https://github.com/user-attachments/assets/d672730f-457a-4870-bf17-363054d450e6" />
