### PR TITLE
Ne pas notifier de chaque retry pour le refresh des stats

### DIFF
--- a/app/jobs/cron_job/refresh_cached_stats.rb
+++ b/app/jobs/cron_job/refresh_cached_stats.rb
@@ -20,6 +20,12 @@ class CronJob::RefreshCachedStats
   end
 
   class RefreshKeyJob < CronJob
+    def capture_sentry_warning_for_retry?(_exception)
+      # on ne souhaite pas être avertis avec un warning dès le premier retry,
+      # un seul avertissement au 4è retry (arbitraire) suffit
+      executions == 4
+    end
+
     def perform(key:, force: false)
       filename = KEYS_TO_FILENAME[key]
       raise ArgumentError, "#{key} is not a valid stat key" if filename.nil?


### PR DESCRIPTION
cf https://sentry.incubateur.net/organizations/betagouv/issues/226474

Le job est passé au premier retry. J’aurais préféré qu’on ne soit pas avertis.

Le comportement par défaut est d’avertir avec un `warning` pour les 4 premiers retries, puis rien, puis une `error` à l’échec final. 

Je propose ici de n’avertir qu’au 4è retry pour ce job de refresh des stats. On fait la même chose pour le job de webhook et des choses similaires pour d’autres jobs. 

On pourrait aussi rediscuter de changer le comportement par défaut et ne pas avertir trop tôt mais on a déjà eu cette discussion par le passé.