### PR TITLE
Amélioration de performances de la recherche de créneaux

### DIFF
--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -5,7 +5,14 @@ module CreneauxSearch::Calculator
       datetime_range = CreneauxSearch::Range.ensure_date_range_with_time(date_range)
       plage_ouvertures = plage_ouvertures_for(motif, lieu, datetime_range, agents)
       import_absences_from_caldav(plage_ouvertures.map(&:agent).uniq)
-      free_times_po = free_times_from(plage_ouvertures, datetime_range) # dépendances implicite à Rdv, Absence et OffDays
+
+      # Cette méthode découpe les plages d'ouverture en fonction des absences, rdvs, et jours fériés
+      free_times_po = free_times_from(
+        plage_ouvertures,
+        datetime_range,
+        work_on_off_days: motif.organisation.territory.work_on_sunday? # La colonne `work_on_sunday` indique aussi que les agents travaillent les jours fériés
+      )
+
       slots_for(free_times_po, motif, duration_in_min:).select do |slot|
         slot.starts_at >= datetime_range.begin
       end
@@ -17,26 +24,26 @@ module CreneauxSearch::Calculator
         .in_range(datetime_range)
         .includes(:agent)
         .where(agent: Agent.excluding_pending_invitation)
-      scope = scope.includes(:organisation, organisation: :territory) if motif.organisation.territory.work_on_sunday?
+
       scope = scope.where(agent: agents) if agents&.any?
       scope = scope.where(lieu: lieu) if lieu.present?
       scope
     end
 
-    def free_times_from(plage_ouvertures, datetime_range)
+    def free_times_from(plage_ouvertures, datetime_range, work_on_off_days:)
       free_times = {}
       plage_ouvertures.each do |plage_ouverture|
-        free_times[plage_ouverture] = calculate_free_times(plage_ouverture, datetime_range)
+        free_times[plage_ouverture] = calculate_free_times(plage_ouverture, datetime_range, work_on_off_days:)
       end
       free_times.select { |_, v| v&.any? }
     end
 
-    def calculate_free_times(plage_ouverture, datetime_range)
+    def calculate_free_times(plage_ouverture, datetime_range, work_on_off_days:)
       ranges = ranges_for(plage_ouverture, datetime_range)
       return [] if ranges.empty?
 
       ranges.map do |range|
-        [range, BusyTimePreloader.start_loading_busy_times_for(range, plage_ouverture)]
+        [range, BusyTimePreloader.start_loading_busy_times_for(range, plage_ouverture, work_on_off_days:)]
       end.flat_map do |range, busy_times_preloader|
         busy_times = busy_times_preloader.busy_times
         split_range_recursively(range, busy_times)
@@ -130,20 +137,21 @@ module CreneauxSearch::Calculator
   end
 
   class BusyTimePreloader
-    def initialize(range, plage_ouverture)
+    def initialize(range, plage_ouverture, work_on_off_days)
       @range = range
       @plage_ouverture = plage_ouverture
+      @work_on_off_days = work_on_off_days
       start_loading!
     end
 
     attr_reader :range, :plage_ouverture
 
-    def self.start_loading_busy_times_for(range, plage_ouverture)
-      new(range, plage_ouverture)
+    def self.start_loading_busy_times_for(range, plage_ouverture, work_on_off_days:)
+      new(range, plage_ouverture, work_on_off_days)
     end
 
     def busy_times
-      busy_times = busy_times_from_off_days
+      busy_times = @work_on_off_days ? [] : busy_times_from_off_days
 
       # On calcule les occurrences des absences en premier pour laisser aux rdvs le temps de finir de charger
       busy_times += busy_times_from_absences
@@ -197,8 +205,6 @@ module CreneauxSearch::Calculator
     end
 
     def busy_times_from_off_days
-      return [] if @plage_ouverture.organisation.territory.work_on_sunday?
-
       OffDays.all_in_date_range(range).map do |off_day|
         BusyTime.new(off_day.beginning_of_day, off_day.end_of_day)
       end

--- a/spec/services/creneaux_search/calculator/busy_time_preloader_spec.rb
+++ b/spec/services/creneaux_search/calculator/busy_time_preloader_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
   subject(:busy_times) do
-    described_class.start_loading_busy_times_for(range, plage_ouverture).busy_times
+    described_class.start_loading_busy_times_for(range, plage_ouverture, work_on_off_days: false).busy_times
   end
 
   let(:monday) { Time.zone.parse("20211025 10:00") }
@@ -93,28 +93,28 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
     context "with a range on a single day" do
       it "returns off_day from beginning of day to end of day" do
         christmas_morning = Time.zone.parse("2024-12-25 8:00")..Time.zone.parse("2024-12-25 12:00")
-        busy_time = described_class.start_loading_busy_times_for(christmas_morning, plage_ouverture).busy_times.first
+        busy_time = described_class.start_loading_busy_times_for(christmas_morning, plage_ouverture, work_on_off_days: false).busy_times.first
         expect(busy_time.starts_at).to eq(Time.zone.parse("2024-12-25 0:00"))
         expect(busy_time.ends_at).to be_within(1.second).of(Time.zone.parse("2024-12-25 23:59:59"))
       end
 
       it "returns off_day that in given range only" do
         regular_monday_morning =  Time.zone.parse("2021-12-13 8:00")..Time.zone.parse("2021-12-13 12:00")
-        expect(described_class.start_loading_busy_times_for(regular_monday_morning, plage_ouverture).busy_times).to be_empty
+        expect(described_class.start_loading_busy_times_for(regular_monday_morning, plage_ouverture, work_on_off_days: false).busy_times).to be_empty
       end
     end
 
     context "with a range spanning several days" do
       it "returns off_day from beginning of day to end of day" do
         christmas_week = Time.zone.parse("2024-12-20 8:00")..Time.zone.parse("2024-12-26 12:00")
-        busy_time = described_class.start_loading_busy_times_for(christmas_week, plage_ouverture).busy_times.first
+        busy_time = described_class.start_loading_busy_times_for(christmas_week, plage_ouverture, work_on_off_days: false).busy_times.first
         expect(busy_time.starts_at).to eq(Time.zone.parse("2024-12-25 0:00"))
         expect(busy_time.ends_at).to be_within(1.second).of(Time.zone.parse("2024-12-25 23:59:59"))
       end
 
       it "returns off_day that in given range only" do
         all_work_week = Time.zone.parse("2021-12-13 8:00")..Time.zone.parse("2021-12-19 12:00")
-        expect(described_class.start_loading_busy_times_for(all_work_week, plage_ouverture).busy_times).to be_empty
+        expect(described_class.start_loading_busy_times_for(all_work_week, plage_ouverture, work_on_off_days: false).busy_times).to be_empty
       end
     end
   end
@@ -122,7 +122,7 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
   describe "request to fetch rdvs" do
     it "est optimisée pour utiliser l'index 'calculator_index'. Décommentez le test suivant si celui-ci échoue." do
       # Voir https://www.postgresql.org/docs/current/indexes-index-only-scans.html
-      request = described_class.new(range, plage_ouverture).send(:optimized_rdv_request)
+      request = described_class.new(range, plage_ouverture, work_on_off_days: false).send(:optimized_rdv_request)
       expect(request.select(:calculator_rdv_starts_at, :calculator_rdv_ends_at).to_sql.squish).to eq <<~SQL.squish
         SELECT "agents_rdvs"."calculator_rdv_starts_at",
                "agents_rdvs"."calculator_rdv_ends_at"

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -269,14 +269,14 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
     describe "#free_times_from" do
       it "return an empty hash without plage_ouvertures" do
         range = Date.new(2021, 10, 26)..Date.new(2021, 10, 29)
-        expect(described_class.free_times_from([], range)).to eq({})
+        expect(described_class.free_times_from([], range, work_on_off_days: false)).to eq({})
       end
 
       it "calls calculate_free_times for given plage_ouvertures" do
         plage_ouverture = build(:plage_ouverture)
         range = Date.new(2021, 10, 26)..Date.new(2021, 10, 29)
-        expect(described_class).to receive(:calculate_free_times).with(plage_ouverture, range)
-        described_class.free_times_from([plage_ouverture], range)
+        expect(described_class).to receive(:calculate_free_times).with(plage_ouverture, range, work_on_off_days: false)
+        described_class.free_times_from([plage_ouverture], range, work_on_off_days: false)
       end
     end
 
@@ -287,7 +287,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
       it "return one free time from plage ouverture date range" do
         plage_ouverture = build(:plage_ouverture, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
         range = Date.new(2021, 10, 26)..Date.new(2021, 10, 29)
-        expect(described_class.calculate_free_times(plage_ouverture, range)).to eq([Time.zone.parse("20211027 9:00")..Time.zone.parse("20211027 11:00")])
+        expect(described_class.calculate_free_times(plage_ouverture, range, work_on_off_days: false)).to eq([Time.zone.parse("20211027 9:00")..Time.zone.parse("20211027 11:00")])
       end
 
       it "return plage ouverture slot minus rdv duration" do
@@ -298,7 +298,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
         range = Date.new(2021, 10, 26)..Date.new(2021, 10, 29)
 
         expected_ranges = [rdv.ends_at..ends_at]
-        expect(described_class.calculate_free_times(plage_ouverture, range)).to eq(expected_ranges)
+        expect(described_class.calculate_free_times(plage_ouverture, range, work_on_off_days: false)).to eq(expected_ranges)
       end
 
       it "return plage ouverture slot minus RDV duration that overlap po when RDV starts before PO" do
@@ -309,7 +309,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
         range = Date.new(2021, 10, 26)..Date.new(2021, 10, 29)
 
         expected_ranges = [rdv.ends_at..ends_at]
-        expect(described_class.calculate_free_times(plage_ouverture, range)).to eq(expected_ranges)
+        expect(described_class.calculate_free_times(plage_ouverture, range, work_on_off_days: false)).to eq(expected_ranges)
       end
 
       it "return plage ouverture slots minus 2 RDV duration that overlap po" do
@@ -321,7 +321,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
         range = Date.new(2021, 10, 26)..Date.new(2021, 10, 29)
 
         expected_ranges = [rdv.ends_at..other_rdv.starts_at, other_rdv.ends_at..ends_at]
-        expect(described_class.calculate_free_times(plage_ouverture, range)).to eq(expected_ranges)
+        expect(described_class.calculate_free_times(plage_ouverture, range, work_on_off_days: false)).to eq(expected_ranges)
       end
 
       it "return plage ouverture slots minus 2 Absences duration that overlap po" do
@@ -339,7 +339,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
         range = Date.new(2021, 10, 25)..Date.new(2021, 10, 30)
 
         expected_ranges = [e9h30..s9h45, e10h45..ends_at]
-        expect(described_class.calculate_free_times(plage_ouverture, range)).to eq(expected_ranges)
+        expect(described_class.calculate_free_times(plage_ouverture, range, work_on_off_days: false)).to eq(expected_ranges)
       end
 
       it "returns plage ouverture's 3 occurrences of range" do
@@ -353,7 +353,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
           (Time.zone.parse("2021-10-28 9:00")..Time.zone.parse("2021-10-28 11:00")),
           (Time.zone.parse("2021-10-29 9:00")..Time.zone.parse("2021-10-29 11:00")),
         ]
-        expect(described_class.calculate_free_times(plage_ouverture, range)).to eq(expected_ranges)
+        expect(described_class.calculate_free_times(plage_ouverture, range, work_on_off_days: false)).to eq(expected_ranges)
       end
 
       it "don't returns past time" do
@@ -365,7 +365,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
         range = Date.new(2021, 11, 12)..Date.new(2021, 11, 19)
 
         expected_ranges = [(Time.zone.parse("2021-11-19 9:00")..Time.zone.parse("2021-11-19 11:00"))]
-        expect(described_class.calculate_free_times(plage_ouverture, range)).to eq(expected_ranges)
+        expect(described_class.calculate_free_times(plage_ouverture, range, work_on_off_days: false)).to eq(expected_ranges)
       end
 
       it "don't look at cancelled RDV" do
@@ -378,7 +378,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
         range = Date.new(2021, 11, 12)..Date.new(2021, 11, 19)
 
         expected_ranges = [(Time.zone.parse("2021-11-19 9:00")..Time.zone.parse("2021-11-19 11:00"))]
-        expect(described_class.calculate_free_times(plage_ouverture, range)).to eq(expected_ranges)
+        expect(described_class.calculate_free_times(plage_ouverture, range, work_on_off_days: false)).to eq(expected_ranges)
       end
 
       it "return range without only range of multi RDV on same range with same duration" do
@@ -391,7 +391,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
         range = Date.new(2021, 10, 26)..Date.new(2021, 10, 29)
 
         expected_ranges = [prev_rdv.ends_at..rdv.starts_at, rdv.ends_at..ends_at]
-        expect(described_class.calculate_free_times(plage_ouverture, range)).to eq(expected_ranges)
+        expect(described_class.calculate_free_times(plage_ouverture, range, work_on_off_days: false)).to eq(expected_ranges)
       end
 
       it "return range without only range of longer overlapped RDV on same range with same duration" do
@@ -404,20 +404,20 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
         range = Date.new(2021, 10, 26)..Date.new(2021, 10, 29)
 
         expected_ranges = [prev_rdv.ends_at..rdv.starts_at, rdv.ends_at..ends_at]
-        expect(described_class.calculate_free_times(plage_ouverture, range)).to eq(expected_ranges)
+        expect(described_class.calculate_free_times(plage_ouverture, range, work_on_off_days: false)).to eq(expected_ranges)
       end
 
       it "truncates off days (jours féries) from the ranges" do
         xmas_week = Date.new(2024, 12, 23)..Date.new(2024, 12, 27)
         plage_ouverture = create(:plage_ouverture, :weekdays, first_day: Date.new(2024, 12, 23), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
-        computed_dates = proc { described_class.calculate_free_times(plage_ouverture, xmas_week).map(&:begin).map(&:to_date) }
 
         # Par défaut les jours fériés ne sont pas travaillés
-        expect(computed_dates.call).to eq(xmas_week.to_a - [Date.new(2024, 12, 25)])
+        computed_dates = described_class.calculate_free_times(plage_ouverture, xmas_week, work_on_off_days: false).map(&:begin).map(&:to_date)
+        expect(computed_dates).to eq(xmas_week.to_a - [Date.new(2024, 12, 25)])
 
-        # Les agents de visioplainte travaillent les jours fériés
-        plage_ouverture.organisation.territory.update_columns(work_on_sunday: true) # rubocop:disable Rails/SkipsModelValidations
-        expect(computed_dates.call).to eq(xmas_week.to_a)
+        # Mais ils peuvent être activés avec un flag
+        computed_dates = described_class.calculate_free_times(plage_ouverture, xmas_week, work_on_off_days: true).map(&:begin).map(&:to_date)
+        expect(computed_dates).to eq(xmas_week.to_a)
       end
     end
 


### PR DESCRIPTION
# Contexte

En vérifiant les perfs pour la nouvelle logique de recherche de créneaux, je me suis rendu compte qu'on chargeait aussi les organisations et les territoires parmis toutes les requêtes qu'on fait.

C'est pour savoir si le territoire est configuré pour travailler les jours fériés, mais on peut éviter de faire cette requête.

# Solution

On profite du fait qu'on est en train de faire une requête pour un motif donné, donc pour n'importe laquelle des plages d'ouvertures correspondantes, on aura `motif.organisation_id == plage_ouverture.organisation_id`.

On peut donc faire la vérification sur le travail les jours fériés depuis l'orga et le territoire du motif en début de la recheche, plutôt que de faire cette vérification pour chaque plage d'ouverture.

On fait donc moins de requêtes et on initialise moins d'objets active record.

Au passage, on remarque que `territories.work_on_sunday` devrait plutôt s'appeler `work_on_sunday_and_off_days`, mais ce correctif sera pour plus tard.