### PR TITLE
Amélioration des performances sur la recherche de créneaux côté agent

### DIFF
--- a/app/form_models/agent_creneaux_search_form.rb
+++ b/app/form_models/agent_creneaux_search_form.rb
@@ -7,23 +7,23 @@ class AgentCreneauxSearchForm
   validates :organisation_id, :motif, presence: true
 
   def organisation
-    Organisation.find_by(id: organisation_id) if organisation_id.present?
+    @organisation ||= Organisation.find_by(id: organisation_id) if organisation_id.present?
   end
 
   def service
-    Service.find_by(id: service_id) if service_id.present?
+    @service ||= Service.find_by(id: service_id) if service_id.present?
   end
 
   def motif
-    organisation.motifs.find_by(id: motif_id) if motif_id.present?
+    @motif ||= organisation.motifs.find_by(id: motif_id) if motif_id.present?
   end
 
   def users
-    organisation.users.where(id: user_ids)
+    @users ||= organisation.users.where(id: user_ids)
   end
 
   def teams
-    organisation.territory.teams.where(id: team_ids)
+    @teams ||= organisation.territory.teams.where(id: team_ids)
   end
 
   def date_range


### PR DESCRIPTION
Similaire à https://github.com/betagouv/rdv-service-public/pull/5925 : en observant les requêtes depuis skylight, je me rends compte qu'on pourrait en éviter beaucoup avec un mémoize (même si le cache activerecord peut aider pour certaines de ces requêtes, on a eu des cas où un memoize est beaucou plus rapide, comme par exemple dans la sérialisation des créneaux pour l'ants)

