### PR TITLE
Supprime la gem rubyzip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,6 @@ gem "premailer-rails" # Mail formatting
 gem "spreadsheet" # Excel export
 # If string, numeric, symbol and nil values wanna be a boolean value, they can with the new #to_b method (and more).
 gem "wannabe_bool" # imports to_b method
-gem "rubyzip" # zip export files
 
 ## Time Management
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -646,7 +646,7 @@ GEM
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.2)
+    rubyzip (3.2.2)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -1095,7 +1095,7 @@ CHECKSUMS
   ruby-ole (1.2.12.2) sha256=7d67f050498aedc4e9b32cacdde10e1a6853e4c0962932b87c3636cd8cc10a7e
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
-  rubyzip (2.3.2) sha256=3f57e3935dc2255c414484fbf8d673b4909d8a6a57007ed754dde39342d2373f
+  rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   sassc (2.4.0) sha256=4c60a2b0a3b36685c83b80d5789401c2f678c1652e3288315a1551d811d9f83e
   sassc-rails (2.1.2) sha256=5f4fdf3881fc9bdc8e856ffbd9850d70a2878866feae8114aa45996179952db5
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -646,7 +646,6 @@ GEM
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (3.2.2)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -844,7 +843,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   rubocop-rspec
-  rubyzip
   sentry-rails
   sentry-ruby
   simple_form (~> 5.0)
@@ -1095,7 +1093,6 @@ CHECKSUMS
   ruby-ole (1.2.12.2) sha256=7d67f050498aedc4e9b32cacdde10e1a6853e4c0962932b87c3636cd8cc10a7e
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
-  rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   sassc (2.4.0) sha256=4c60a2b0a3b36685c83b80d5789401c2f678c1652e3288315a1551d811d9f83e
   sassc-rails (2.1.2) sha256=5f4fdf3881fc9bdc8e856ffbd9850d70a2878866feae8114aa45996179952db5
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1

--- a/app/mailers/agents/export_mailer.rb
+++ b/app/mailers/agents/export_mailer.rb
@@ -1,5 +1,3 @@
-require "zip"
-
 class Agents::ExportMailer < ApplicationMailer
   def rdv_export(export_id)
     @export = Export.find(export_id)


### PR DESCRIPTION
Nous avons le warning suivant lorsque nous installons la gem (en local ou sur le premier deploy d'une review app) : 

```
       Post-install message from rubyzip:
       RubyZip 3.0 is coming!
       **********************
       
       The public API of some Rubyzip classes has been modernized to use named
       parameters for optional arguments. Please check your usage of the
       following classes:
         * `Zip::File`
         * `Zip::Entry`
         * `Zip::InputStream`
         * `Zip::OutputStream`
       
       Please ensure that your Gemfiles and .gemspecs are suitably restrictive
       to avoid an unexpected breakage when 3.0 is released (e.g. ~> 2.3.0).
       See https://github.com/rubyzip/rubyzip for details. The Changelog also
       lists other enhancements and bugfixes that have been implemented since
       version 2.3.0.
```

En creusant un peu, j'ai réalisé que nous n'utilisions plus cette gem.

Je l'avais ajouté dans #3499 pour créer des archives ZIP des exports qui étaient alors envoyés par mail (:fearful: ).

Dorénavant nous stockons les exports dans Redis, sous forme compressée (avec la lib standard Zlib). Nous n'envoyons plus d'export par mail, et ils sont téléchargeables direct en XLS car c'est plus simple et que nous n'avons pas de contrainte de bande passante.