### PR TITLE
supprimer la step publish-test-results de la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,25 +190,6 @@ jobs:
             tmp/capybara
             tmp/rspec-*
           if-no-files-found: ignore
-  publish_test_results:
-    name: "Publish Test Results to GitHub"
-    needs: tests
-    runs-on: ubuntu-latest
-    if: (!cancelled())
-    permissions:
-      checks: write
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: tests-results-*
-          path: tests-results
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          files: |
-            tests-results/**/rspec-*.xml
-          comment_mode: off
   test_features_autodoc:
     name: Feature Tests using Autodoc
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Contexte

Dans #5511 j’avais rajouté une step  CI de GH Action qui rajoutait ces commentaires à partir des tests results XML

<img width="2484" height="1576" alt="image" src="https://github.com/user-attachments/assets/4eb9a78f-f051-468d-9623-ae9e5207ab75" />

Inconvénients : 
- On ne l’utilise pas beaucoup / jamais
- je crois que j’ai toujours du aller voir l’output brut pour comprendre l’erreur
- il y a un souci du calcul de nombre de tests supprimés et ajoutés 

# Solution

Je supprime la step

