### PR TITLE
Désactivation du submit sur le formulaire d’ajout de participant à un RDV collectif

### DIFF
--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -68,4 +68,4 @@
           .fr-grid-row.fr-grid-row--gutters
             .fr-col.rdv-justify-content-space-between.d-flex
               = link_to t("helpers.back"), admin_organisation_rdvs_collectifs_path(current_organisation), class: "fr-icon-arrow-left-line fr-btn--icon-left fr-btn fr-btn--tertiary-no-outline"
-              = f.submit t("helpers.submit.submit"), class: "fr-btn"
+              = f.submit t("helpers.submit.submit"), class: "fr-btn", disabled: @participations_to_add.empty?

--- a/spec/features/agents/rdvs_collectifs/agent_can_add_users_to_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_add_users_to_rdv_collectif_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe "Un agent peut ajouter des usagers à un RDV Collectif", js: true
       expect(page).to have_content("Atelier Collectif")
       click_on "Ajouter un participant"
       expect(page).to have_title("Ajouter un participant")
+      expect(find("input[type=submit]")).to be_disabled
       add_user(user_celeste)
+      expect(find("input[type=submit]")).not_to be_disabled
       click_on "Enregistrer"
 
       # aucun email n’est envoyé en cas de modification des usagers car on ne partage pas l’info sur les usagers

--- a/spec/features/agents/rdvs_collectifs/agent_can_add_users_to_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_add_users_to_rdv_collectif_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "Un agent peut ajouter des usagers à un RDV Collectif", js: true
       expect(page).to have_title("Ajouter un participant")
       expect(find("input[type=submit]")).to be_disabled
       add_user(user_celeste)
+      expect(page).to have_content("Céleste KHO")
       expect(find("input[type=submit]")).not_to be_disabled
       click_on "Enregistrer"
 


### PR DESCRIPTION
# Contexte

Un agent nous a prévenus que si on clique sur « ajouter un particpant » sur un RDV collectif, le bouton enregistrer est cliquable avant d’avoir sélectionné un usager à ajouter. Si on clique dessus, on reçoit une 404 :/ 

https://zammad10.ethibox.fr/#ticket/zoom/31270

# Solution

Je propose ici simplement de désactiver le bouton tant qu’un usager à ajouter n’a pas été sélectionné

<img width="940" height="681" alt="image" src="https://github.com/user-attachments/assets/f08afb2e-65ac-4778-b243-1a96f667c8b0" />


> [!NOTE]
> je le fais incrémentalement mais il y a mille choses à corriger sur l’UX de cette page, les tournures sont super ambigues
