### PR TITLE
Utilisation de groupes de boutons DSFR liste des RDV

### DIFF
--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -77,7 +77,7 @@
       = date_input(f, :start, label = "Période - Début", wrapper: "horizontal_form")
       = date_input(f, :end, label = "Période - Fin", wrapper: "horizontal_form")
   .fr-btns-group.fr-btns-group--inline.fr-btns-group--right.fr-btns-group--icon-left.fr-mb-n4v
-    = link_to "Afficher les RDVs du jour", admin_organisation_rdvs_path(current_organisation, start: Time.zone.today, end: Time.zone.today), class: "fr-btn fr-btn--tertiary-no-outline"
+    = link_to "Afficher les RDV du jour", admin_organisation_rdvs_path(current_organisation, start: Time.zone.today, end: Time.zone.today), class: "fr-btn fr-btn--tertiary-no-outline"
     = link_to "Réinitialiser", admin_organisation_rdvs_path(current_organisation), class: "fr-btn fr-btn--tertiary-no-outline"
     = f.hidden_field :per
     input.fr-btn type="submit" value="Rafraîchir la liste"

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -76,8 +76,8 @@
               input_html: { class: "select2-input" }
       = date_input(f, :start, label = "Période - Début", wrapper: "horizontal_form")
       = date_input(f, :end, label = "Période - Fin", wrapper: "horizontal_form")
-  .d-flex.justify-content-end
-    = link_to "Afficher les RDVs du jour", admin_organisation_rdvs_path(current_organisation, start: Time.zone.today, end: Time.zone.today), class: "btn btn-link"
-    = link_to "Réinitialiser", admin_organisation_rdvs_path(current_organisation), class: "btn btn-link"
+  .fr-btns-group.fr-btns-group--inline.fr-btns-group--right.fr-btns-group--icon-left.fr-mb-n4v
+    = link_to "Afficher les RDVs du jour", admin_organisation_rdvs_path(current_organisation, start: Time.zone.today, end: Time.zone.today), class: "fr-btn fr-btn--tertiary-no-outline"
+    = link_to "Réinitialiser", admin_organisation_rdvs_path(current_organisation), class: "fr-btn fr-btn--tertiary-no-outline"
     = f.hidden_field :per
-    input.btn.btn-primary.d-print-none type="submit" value="Rafraîchir la liste"
+    input.fr-btn type="submit" value="Rafraîchir la liste"

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -8,9 +8,9 @@
     - if @breadcrumb_page == "agenda" && @form.agent.present?
       = render "common/fil_ariane", titles_and_paths: [["Agenda de #{@form.agent.full_name}", admin_organisation_planning_agenda_path(current_organisation, agent_id: @form.agent.id, date: @form.start)]], current_page_title: "Liste des RDV"
     - if @breadcrumb_page == "user" && @form.user.present?
-      = render "common/fil_ariane", titles_and_paths: [["Usagers", admin_organisation_users_path(current_organisation)], [@form.user.full_name, admin_organisation_user_path(current_organisation, @form.user)]], current_page_title: "RDVs #{Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase}"
+      = render "common/fil_ariane", titles_and_paths: [["Usagers", admin_organisation_users_path(current_organisation)], [@form.user.full_name, admin_organisation_user_path(current_organisation, @form.user)]], current_page_title: "RDV #{Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase}"
     - if @breadcrumb_page == "organisation_stats"
-      = render "common/fil_ariane", titles_and_paths: [["Statistiques de l'organisation", admin_organisation_stats_path(current_organisation)]], current_page_title: "RDVs #{Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase}"
+      = render "common/fil_ariane", titles_and_paths: [["Statistiques de l'organisation", admin_organisation_stats_path(current_organisation)]], current_page_title: "RDV #{Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase}"
 
   .card
     .card-body
@@ -20,7 +20,7 @@
       .card-footer
         .fr-btns-group.fr-btns-group--inline.fr-btns-group--sm.fr-btns-group--right.fr-btns-group--icon-left.d-print-none
           = button_to participations_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "fr-btn fr-btn--tertiary fr-icon-download-line", disable_with: "Veuillez patienter…" do
-            | Exporter les RDVs par usager en XLS
+            | Exporter les RDV par usager en XLS
           = button_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "fr-btn fr-btn--tertiary fr-icon-download-line", disable_with: "Veuillez patienter…" do
             - if @rdvs.total_count == 1
               | Exporter le RDV en XLS

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -18,22 +18,17 @@
 
     - if @rdvs.total_count > 0
       .card-footer
-        div.d-flex.justify-content-end.align-items-center
-          = button_to participations_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "Veuillez patienter…" do
-            span> Exporter les RDVs par usager en XLS
-            i.fa.fa-download>
-          = button_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "Veuillez patienter…" do
-            span
-              - if @rdvs.total_count == 1
-                |> Exporter le RDV en XLS
-              - else
-                |> Exporter les #{@rdvs.total_count} RDV en XLS
+        .fr-btns-group.fr-btns-group--inline.fr-btns-group--sm.fr-btns-group--right.fr-btns-group--icon-left.d-print-none
+          = button_to participations_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "fr-btn fr-btn--tertiary fr-icon-download-line", disable_with: "Veuillez patienter…" do
+            | Exporter les RDVs par usager en XLS
+          = button_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "fr-btn fr-btn--tertiary fr-icon-download-line", disable_with: "Veuillez patienter…" do
+            - if @rdvs.total_count == 1
+              | Exporter le RDV en XLS
+            - else
+              | Exporter les #{@rdvs.total_count} RDV en XLS
 
-            i.fa.fa-download>
-
-          .btn.btn-sm.btn-link.d-print-none role="button" data-controller="print" data-action="click->print#print"
-            span> Imprimer
-            i.fa.fa-print>
+          .fr-btn.fr-btn--tertiary.fr-icon-printer-line role="button" data-controller="print" data-action="click->print#print"
+            | Imprimer
 
   = render "admin/rdvs/rdv_visibility"
   - if CopyPlanningToNewInstanceJob.agent_might_have_rdvs_on_old_instance?(current_agent, @form.start || Time.zone.today)

--- a/spec/features/agents/agent_can_export_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_export_rdvs_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "agent can export RDVs" do
   it "exports by participation" do
     visit admin_organisation_rdvs_url(organisation, agent)
     perform_enqueued_jobs do
-      click_on "Exporter les RDVs par usager en XLS"
+      click_on "Exporter les RDV par usager en XLS"
     end
 
     open_email(agent.email)


### PR DESCRIPTION
# Contexte

Dans le cadre de la suppression des font awesome, que je mène en parallèle ici : #5916 
Je me suis aperçu que les boutons qui sont sur la page de liste de RDV, ne sont pas au DSFR.

# Solution

J’ai donc choisi de passer ces boutons au DSFR dans des groupes de boutons (et d’utiliser au passage des icônes DSFR).

Suite au retour de Téo et à l’atelier Tone & Voice on passe également de RDVs à RDV. 
Dans ce cas on garde RDV et non rendez-vous pour éviter les boutons de 10km de long.

## Captures d'écran

Avant | Après
:- | -:
<img width="1248" height="297" alt="image" src="https://github.com/user-attachments/assets/fb83e23f-2726-4791-b87b-e9798157c9da" /> | <img width="1248" height="324" alt="image" src="https://github.com/user-attachments/assets/a28b95fd-a073-4928-9b3d-482cd0b887da" />
