### PR TITLE
Associations conditionnelles dans l'api pour améliorer les performances

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -20,11 +20,19 @@ class RdvBlueprint < Blueprinter::Base
     Rails.application.routes.url_helpers.agents_rdv_url(rdv, host: rdv.domain.host_name)
   end
 
-  association :organisation, blueprint: OrganisationBlueprint
-  association :motif, blueprint: MotifBlueprint
+  # On permet des associations optionnelles, mais on les charge toutes si le paramètre `include` n'est pas utilisé
+  def self.conditional_association(association_name, blueprint_class)
+    field(association_name, if: ->(_field_name, _rdv, options) { !options["include"].is_a?(Array) || association_name.to_s.in?(options["include"]) }) do |rdv, _options|
+      blueprint_class.render_as_hash(rdv.public_send(association_name))
+    end
+  end
+
+  conditional_association(:organisation, OrganisationBlueprint)
+  conditional_association(:motif, MotifBlueprint)
+
   # DEPRECATED : Nous laissons l'association `:users` le temps que le 92, 26, 62, 64, et data-insertion mettent à jours leur système.
-  association :users, blueprint: UserBlueprint
-  association :participations, blueprint: ParticipationBlueprint
-  association :agents, blueprint: AgentBlueprint
-  association :lieu, blueprint: LieuBlueprint
+  conditional_association(:users, UserBlueprint)
+  conditional_association(:participations, ParticipationBlueprint)
+  conditional_association(:agents, AgentBlueprint)
+  conditional_association(:lieu, LieuBlueprint)
 end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::BaseController < ActionController::Base
     render json: blueprint_klass.render(record, root: root, **options)
   end
 
-  def render_collection(objects, root: nil, blueprint_klass: nil)
+  def render_collection(objects, root: nil, blueprint_klass: nil, options: nil)
     objects = objects.page(page_number).per(PAGINATE_PER)
     meta = {
       current_page: objects.current_page,
@@ -34,7 +34,7 @@ class Api::V1::BaseController < ActionController::Base
     objects_klass = objects.klass
     blueprint_klass = "#{objects_klass.name}Blueprint".constantize if blueprint_klass.blank?
     root = objects_klass.model_name.collection if root.blank?
-    render json: blueprint_klass.render(objects, root: root, meta: meta)
+    render json: blueprint_klass.render(objects, root: root, meta: meta, **options)
   end
 
   def page_number

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
+  before_action :normalize_array_params, only: %i[index]
+
   def index # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).where(params.permit(:organisation_id))
 
@@ -121,6 +123,14 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
   end
 
   private
+
+  def normalize_array_params
+    %i[id status include].each do |param_name|
+      if params[param_name].is_a?(String)
+        params[param_name] = params[param_name].split(",")
+      end
+    end
+  end
 
   def pundit_user
     current_agent

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -5,14 +5,35 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
     rdvs = rdvs.starts_after(Time.zone.parse(params[:starts_after])) if params[:starts_after].present?
     rdvs = rdvs.starts_before(Time.zone.parse(params[:starts_before])) if params[:starts_before].present?
 
-    rdvs = rdvs.includes(:organisation, :motif, :lieu, :agents, :users, participations: [:user], motif: [:motif_category])
+    if params[:include].nil?
+      rdvs = rdvs.includes(:organisation, :lieu, :agents, :users, participations: [:user], motif: [:motif_category])
+    else
+      if params[:include].is_a?(Array) && "organisation".in?(params[:include])
+        rdvs.includes(:organisation)
+      end
+      if params[:include].is_a?(Array) && "lieu".in?(params[:include])
+        rdvs.includes(:lieu)
+      end
+      if params[:include].is_a?(Array) && "agents".in?(params[:include])
+        rdvs.includes(:agents)
+      end
+      if params[:include].is_a?(Array) && "users".in?(params[:include])
+        rdvs.includes(:users)
+      end
+      if params[:include].is_a?(Array) && "participations".in?(params[:include])
+        rdvs.includes(participations: [:user])
+      end
+      if params[:include].is_a?(Array) && "motif".in?(params[:include])
+        rdvs.includes(motif: [:motif_category])
+      end
+    end
 
     if params[:id].present?
       rdvs = rdvs.where(id: params[:id])
     end
 
     if params[:user_id].present?
-      rdvs = rdvs.where(participations: { user_id: params[:user_id] })
+      rdvs = rdvs.includes(participations: [:user]).where(participations: { user_id: params[:user_id] })
     end
 
     if params[:agent_id].present?

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
-  def index
+  def index # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).where(params.permit(:organisation_id))
 
     rdvs = rdvs.starts_after(Time.zone.parse(params[:starts_after])) if params[:starts_after].present?
@@ -7,25 +7,18 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
 
     if params[:include].nil?
       rdvs = rdvs.includes(:organisation, :lieu, :agents, :users, participations: [:user], motif: [:motif_category])
-    else
-      if params[:include].is_a?(Array) && "organisation".in?(params[:include])
-        rdvs.includes(:organisation)
-      end
-      if params[:include].is_a?(Array) && "lieu".in?(params[:include])
-        rdvs.includes(:lieu)
-      end
-      if params[:include].is_a?(Array) && "agents".in?(params[:include])
-        rdvs.includes(:agents)
-      end
-      if params[:include].is_a?(Array) && "users".in?(params[:include])
-        rdvs.includes(:users)
-      end
-      if params[:include].is_a?(Array) && "participations".in?(params[:include])
-        rdvs.includes(participations: [:user])
-      end
-      if params[:include].is_a?(Array) && "motif".in?(params[:include])
-        rdvs.includes(motif: [:motif_category])
-      end
+    elsif params[:include].is_a?(Array)
+      rdvs.includes(:organisation) if "organisation".in?(params[:include])
+
+      rdvs.includes(:lieu) if "lieu".in?(params[:include])
+
+      rdvs.includes(:agents) if "agents".in?(params[:include])
+
+      rdvs.includes(:users) if "users".in?(params[:include])
+
+      rdvs.includes(participations: [:user]) if "participations".in?(params[:include])
+
+      rdvs.includes(motif: [:motif_category]) if "motif".in?(params[:include])
     end
 
     if params[:id].present?

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
       rdvs = rdvs.where(status: params[:status])
     end
 
-    render_collection(rdvs)
+    render_collection(rdvs, options: params.permit(include: []))
   end
 
   # Cet endpoint est utilisé seulement pour la copie des données d'une instance à l'autre, il n'est donc pas documenté.

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -73,6 +73,19 @@ RSpec.describe "RDV API" do
         expect(rdv).not_to have_key("participations")
       end
 
+      it "supports a comma separated string syntax" do
+        get "/api/v1/rdvs", headers: headers, params: { include: "lieu,motif,agents" }
+        rdv = parsed_response_body["rdvs"].first
+
+        expect(rdv["agents"]).to be_present
+        expect(rdv["lieu"]).to be_present
+        expect(rdv["motif"]).to be_present
+
+        expect(rdv).not_to have_key("organisation")
+        expect(rdv).not_to have_key("users")
+        expect(rdv).not_to have_key("participations")
+      end
+
       it "also works when filtering by user_id" do
         get "/api/v1/rdvs", headers: headers, params: { include: %w[lieu motif agents], user_id: user.id }
 

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -58,6 +58,29 @@ RSpec.describe "RDV API" do
       expect(parsed_response_body["rdvs"].count).to eq 1
       expect(parsed_response_body["rdvs"].first["id"]).to eq cancelled_rdv.id
     end
+
+    describe "selecting which associations are loaded" do
+      it "makes the api response smaller" do
+        get "/api/v1/rdvs", headers: headers, params: { include: %w[lieu motif agents] }
+        rdv = parsed_response_body["rdvs"].first
+
+        expect(rdv["agents"]).to be_present
+        expect(rdv["lieu"]).to be_present
+        expect(rdv["motif"]).to be_present
+
+        expect(rdv).not_to have_key("organisation")
+        expect(rdv).not_to have_key("users")
+        expect(rdv).not_to have_key("participations")
+      end
+
+      it "also works when filtering by user_id" do
+        get "/api/v1/rdvs", headers: headers, params: { include: %w[lieu motif agents], user_id: user.id }
+
+        rdv = parsed_response_body["rdvs"].first
+        expect(rdv["agents"]).to be_present
+        expect(rdv).not_to have_key("organisation")
+      end
+    end
   end
 
   describe "#create" do

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
           <li>participations</li>
         </ul>
 
-        Par exemple, vous pouvez passer `include[]=agents&include[]=users` en query params.
+        Par exemple, vous pouvez passer `include[]=agents&include[]=users` ou `include=agents,users` en query params.
       DESCRIPTION
 
       parameter name: :organisation_id, in: :query, type: :string, description: "Identifiant de l'organisation", example: "20", required: false
@@ -48,17 +48,18 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
                   Filtre les rendez-vous par statut.
                   Vous pouvez passer soit une seule chaine de caractères, soit un tableau de chaines de caractères.
                   Les différentes valeurs possibles sont #{Rdv.statuses.keys}.
-                  Si vous passez un tableau, le format attendu est status[]=excused&status[]=revoked
+                  Si vous passez un tableau, vous pouvez utiliser le format `status[]=excused&status[]=revoked` ou `status=excused,revoked`.
                 DOC
-                example: "seen ou status[]=excused&status[]=revoked", required: false
+                example: "seen ou status[]=excused&status[]=revoked ou status=excused,revoked", required: false
 
       parameter name: :id, in: :query,
                 description: <<~DOC,
                   Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.
                   Vous pouvez passer soit un tableau d'entier pour obtenir plusieurs rdvs, soit un seul entier pour obtenir un seul rdv.
-                  Si vous passez un tableau d'entier, le format attendu est id[]=1234&id[]=5678
+                  Si vous passez un tableau d'entier, le format attendu est
+                  Si vous passez un tableau, vous pouvez utiliser le format id[]=1234&id[]=5678 ou id=1234,5678.
                 DOC
-                example: "789 ou id[]=1234&id[]=5678", required: false
+                example: "789 ou id[]=1234&id[]=5678 id=1234,5678", required: false
 
       parameter name: :starts_after, in: :query, type: :string,
                 description: "Filtre les rendez-vous avec un starts_at aprés cette date. Accepte des formats date ou time (iso8601).",

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -10,9 +10,32 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
       tags "RDV"
       produces "application/json"
       operationId "getRdvs"
-      description "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres facultatifs passés en paramètre"
 
-      parameter name: :organisation_id, in: :query, type: :string, description: "Identifiant de l'organisation", example: "20", required: false
+      # L'usage du paramètre `include` est expliqué dans la description plutôt qu'en tant qu'un paramètre séparé, parce que la
+      # meta-programmation utilisée par le matcher rspec et rswag-spec entrent en conflit.
+      # En décommentant la ligne suivant on a cette erreur : ArgumentError: include() is not supported, please supply an argument
+      # parameter name: :include, in: :query, description: "Indique quelles associations charger dans la réponse", example: "include[]=&status[]=revoked", required: false
+
+      description <<~DESCRIPTION.squish
+        Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres facultatifs passés en paramètre.
+        <br />
+        Par défaut, toutes les associations disponibles sont renvoyées (participants, agents, motif, etc...), ce qui peut
+        considérablement ralentir le temps de réponse.
+        Vous pouvez passer le paramètre `include` pour choisir quelles associations inclure dans la réponse.
+        Il prend un tableau de chaines de caractères, et les valeurs possibles sont :
+        <ul>
+          <li>organisation</li>
+          <li>lieu</li>
+          <li>motifs</li>
+          <li>agents</li>
+          <li>users</li>
+          <li>participations</li>
+        </ul>
+
+        Par exemple, vous pouvez passer `include[]=agents&include[]=users` en query params.
+      DESCRIPTION
+
+      parameter name: :organisation_id, in: :query, type: :string, description: "neIdentifiant de l'organisation", example: "20", required: false
 
       parameter name: :user_id, in: :query, type: :integer,
                 description: "Filtre pour obtenir uniquement les rendez-vous de l'usager qui a cet id",

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
         Par exemple, vous pouvez passer `include[]=agents&include[]=users` en query params.
       DESCRIPTION
 
-      parameter name: :organisation_id, in: :query, type: :string, description: "neIdentifiant de l'organisation", example: "20", required: false
+      parameter name: :organisation_id, in: :query, type: :string, description: "Identifiant de l'organisation", example: "20", required: false
 
       parameter name: :user_id, in: :query, type: :integer,
                 description: "Filtre pour obtenir uniquement les rendez-vous de l'usager qui a cet id",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -1291,24 +1291,25 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 12,
+                        "id": 62,
                         "agent": {
                           "id": 12,
                           "email": "agent@example.com",
-                          "first_name": "Barbe",
-                          "last_name": "Colin"
+                          "first_name": "Delphin",
+                          "last_name": "Arnaud"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113628Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_12@RDV Solidarités",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T132923Z\r\nUID:absence_62@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/442/planning/absences/62/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Super absence\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_62@RDV Solidarités",
                         "organisation": {
-                          "id": 12,
+                          "id": 442,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "rrule": null,
                         "start_time": "08:00:00",
@@ -1475,24 +1476,25 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 21,
+                        "id": 71,
                         "agent": {
-                          "id": 23,
+                          "id": 907,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Adeline",
-                          "last_name": "Paul"
+                          "first_name": "Marine",
+                          "last_name": "Gautier"
                         },
-                        "end_day": "2025-10-07",
+                        "end_day": "2026-01-07",
                         "end_time": "15:30:00",
-                        "first_day": "2025-10-07",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113629Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20251007T100000\r\nDTEND;TZID=Europe/Paris:20251007T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_21@RDV Solidarités",
+                        "first_day": "2026-01-07",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T132923Z\r\nUID:absence_71@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/456/planning/absences/71/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Indisponibilité 1\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_71@RDV Solidarités",
                         "organisation": {
-                          "id": 26,
+                          "id": 456,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "rrule": null,
                         "start_time": "10:00:00",
@@ -1681,24 +1683,25 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 33,
+                        "id": 83,
                         "agent": {
-                          "id": 35,
+                          "id": 919,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Gérard",
-                          "last_name": "Fabre"
+                          "first_name": "Athalie",
+                          "last_name": "Weber"
                         },
-                        "end_day": "2025-10-07",
+                        "end_day": "2026-01-07",
                         "end_time": "15:30:00",
-                        "first_day": "2025-10-07",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113629Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20251007T100000\r\nDTEND;TZID=Europe/Paris:20251007T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_33@RDV Solidarités",
+                        "first_day": "2026-01-07",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T132924Z\r\nUID:absence_83@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/468/planning/absences/83/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Nouveau titre\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_83@RDV Solidarités",
                         "organisation": {
-                          "id": 38,
+                          "id": 468,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "rrule": null,
                         "start_time": "10:00:00",
@@ -1978,10 +1981,10 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 59,
+                          "id": 943,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Suzanne",
-                          "last_name": "Pasquier"
+                          "first_name": "Pie",
+                          "last_name": "Besson"
                         }
                       ],
                       "meta": {
@@ -2200,12 +2203,12 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 2,
+                      "id": 639,
                       "address": "77 avenue de Ségur, 75015 Paris",
                       "latitude": 44.5569244,
                       "longitude": 4.7521632,
                       "name": "Maison France Service de Montreuil",
-                      "organisation_id": 76,
+                      "organisation_id": 506,
                       "phone_number": "01 22 33 44 55",
                       "single_use": false
                     }
@@ -2322,7 +2325,7 @@
                     "value": {
                       "motifs": [
                         {
-                          "id": 7,
+                          "id": 626,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
@@ -2331,16 +2334,16 @@
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 7,
+                            "id": 626,
                             "name": "Catégorie de motif n°1",
                             "short_name": "1_motif_cat"
                           },
                           "name": "Motif 1",
-                          "organisation_id": 82,
-                          "service_id": 19
+                          "organisation_id": 512,
+                          "service_id": 292
                         },
                         {
-                          "id": 8,
+                          "id": 627,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
@@ -2349,13 +2352,13 @@
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 8,
+                            "id": 627,
                             "name": "Catégorie de motif n°2",
                             "short_name": "2_motif_cat"
                           },
                           "name": "Motif 2",
-                          "organisation_id": 82,
-                          "service_id": 19
+                          "organisation_id": 512,
+                          "service_id": 292
                         }
                       ],
                       "meta": {
@@ -2480,39 +2483,44 @@
                     "value": {
                       "organisations": [
                         {
-                          "id": 117,
+                          "id": 547,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
-                          "id": 118,
+                          "id": 548,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
-                          "id": 119,
+                          "id": 549,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
-                          "id": 120,
+                          "id": 550,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
-                          "id": 121,
+                          "id": 551,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         }
                       ],
                       "meta": {
@@ -2626,11 +2634,12 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 128,
+                        "id": 558,
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
-                        "verticale": "rdv_solidarites"
+                        "verticale": "rdv_solidarites",
+                        "website": null
                       }
                     }
                   }
@@ -2735,11 +2744,12 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 132,
+                        "id": 562,
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
-                        "verticale": "rdv_solidarites"
+                        "verticale": "rdv_solidarites",
+                        "website": null
                       }
                     }
                   }
@@ -2845,12 +2855,12 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 2,
-                        "created_at": "2025-10-06 13:36:33 +0200",
+                        "id": 6,
+                        "created_at": "2026-01-06 14:29:28 +0100",
                         "rdv": null,
-                        "updated_at": "2025-10-06 13:36:33 +0200",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/2",
-                        "user_id": 8
+                        "updated_at": "2026-01-06 14:29:28 +0100",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/6",
+                        "user_id": 639
                       }
                     }
                   }
@@ -2959,17 +2969,17 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 4,
-                        "created_at": "2025-10-06 13:36:34 +0200",
+                        "id": 8,
+                        "created_at": "2026-01-06 14:29:28 +0100",
                         "rdv": {
-                          "id": 5,
+                          "id": 640,
                           "status": "unknown",
-                          "starts_at": "2025-10-09 13:36:00 +0200",
+                          "starts_at": "2026-01-09 14:29:00 +0100",
                           "location_type": "public_office"
                         },
-                        "updated_at": "2025-10-06 13:36:34 +0200",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/4",
-                        "user_id": 12
+                        "updated_at": "2026-01-06 14:29:28 +0100",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/8",
+                        "user_id": 643
                       }
                     }
                   }
@@ -3021,7 +3031,7 @@
           {
             "name": "organisation_id",
             "in": "query",
-            "description": "Identifiant de l'organisation",
+            "description": "neIdentifiant de l'organisation",
             "example": "20",
             "required": false,
             "schema": {
@@ -3087,7 +3097,7 @@
           "RDV"
         ],
         "operationId": "getRdvs",
-        "description": "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres facultatifs passés en paramètre",
+        "description": "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres facultatifs passés en paramètre. <br /> Par défaut, toutes les associations disponibles sont renvoyées (participants, agents, motif, etc...), ce qui peut considérablement ralentir le temps de réponse. Vous pouvez passer le paramètre `include` pour choisir quelles associations inclure dans la réponse. Il prend un tableau de chaines de caractères, et les valeurs possibles sont : <ul> <li>organisation</li> <li>lieu</li> <li>motifs</li> <li>agents</li> <li>users</li> <li>participations</li> </ul> Par exemple, vous pouvez passer `include[]=agents&include[]=users` en query params.",
         "responses": {
           "200": {
             "description": "Appel API réussi",
@@ -3098,38 +3108,38 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 6,
+                          "id": 641,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 127,
+                              "id": 1011,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Clodion",
-                              "last_name": "Leclercq"
+                              "first_name": "Jeanne",
+                              "last_name": "Noël"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-10-06 13:36:34 +0200",
+                          "created_at": "2026-01-06 14:29:28 +0100",
                           "created_by": "agent",
-                          "created_by_id": 127,
+                          "created_by_id": 1011,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 8,
+                            "id": 645,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 170,
+                            "organisation_id": 600,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 50,
+                            "id": 669,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3138,50 +3148,51 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 50,
+                              "id": 669,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 170,
-                            "service_id": 40
+                            "organisation_id": 600,
+                            "service_id": 313
                           },
                           "name": null,
                           "organisation": {
-                            "id": 170,
+                            "id": 600,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites"
+                            "verticale": "rdv_solidarites",
+                            "website": null
                           },
                           "participations": [
                             {
-                              "id": 9,
+                              "id": 647,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 127,
+                              "created_by_id": 1011,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 13,
+                                "id": 644,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2025-10-06 13:36:34 +0200",
+                                "created_at": "2026-01-06 14:29:28 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Florian",
+                                "first_name": "Gaud",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "PICHON",
+                                "last_name": "CARLIER",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "6 19 21 39 36",
-                                "phone_number_formatted": "+33619213936",
+                                "phone_number": "07 88 18 63 30",
+                                "phone_number_formatted": "+33788186330",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3190,33 +3201,33 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/6",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/641",
                           "users": [
                             {
-                              "id": 13,
+                              "id": 644,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2025-10-06 13:36:34 +0200",
+                              "created_at": "2026-01-06 14:29:28 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Florian",
+                              "first_name": "Gaud",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "PICHON",
+                              "last_name": "CARLIER",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "6 19 21 39 36",
-                              "phone_number_formatted": "+33619213936",
+                              "phone_number": "07 88 18 63 30",
+                              "phone_number_formatted": "+33788186330",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "c72fa749-69a2-49b6-a28a-4bbae50df1d8"
+                          "uuid": "5659a295-7582-4537-87ce-34cb728e3b14"
                         }
                       ],
                       "meta": {
@@ -3342,38 +3353,38 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 11,
+                          "id": 646,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 134,
+                              "id": 1018,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Annibal",
-                              "last_name": "Meyer"
+                              "first_name": "Adegrine",
+                              "last_name": "Lacroix"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-10-06 13:36:34 +0200",
+                          "created_at": "2026-01-06 14:29:29 +0100",
                           "created_by": "agent",
-                          "created_by_id": 134,
+                          "created_by_id": 1018,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 13,
+                            "id": 650,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 173,
+                            "organisation_id": 603,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 56,
+                            "id": 675,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3382,50 +3393,51 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 56,
+                              "id": 675,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 173,
-                            "service_id": 43
+                            "organisation_id": 603,
+                            "service_id": 316
                           },
                           "name": null,
                           "organisation": {
-                            "id": 173,
+                            "id": 603,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites"
+                            "verticale": "rdv_solidarites",
+                            "website": null
                           },
                           "participations": [
                             {
-                              "id": 14,
+                              "id": 652,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 134,
+                              "created_by_id": 1018,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 18,
+                                "id": 649,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2025-10-06 13:36:34 +0200",
+                                "created_at": "2026-01-06 14:29:29 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Julien",
+                                "first_name": "Lucie",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "DUPUY",
+                                "last_name": "LACROIX",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "0686864704",
-                                "phone_number_formatted": "+33686864704",
+                                "phone_number": "732539857",
+                                "phone_number_formatted": "+33732539857",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3434,67 +3446,67 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/11",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/646",
                           "users": [
                             {
-                              "id": 18,
+                              "id": 649,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2025-10-06 13:36:34 +0200",
+                              "created_at": "2026-01-06 14:29:29 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Julien",
+                              "first_name": "Lucie",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "DUPUY",
+                              "last_name": "LACROIX",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "0686864704",
-                              "phone_number_formatted": "+33686864704",
+                              "phone_number": "732539857",
+                              "phone_number_formatted": "+33732539857",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "cd32d504-532f-428a-b4fb-163e87de7dbc"
+                          "uuid": "580f20d0-054f-46ed-a0b0-b6a967e840a5"
                         },
                         {
-                          "id": 14,
+                          "id": 649,
                           "address": "4 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 137,
+                              "id": 1021,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Romain",
-                              "last_name": "Pichon"
+                              "first_name": "Jeanne",
+                              "last_name": "Roger"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-10-06 13:36:34 +0200",
+                          "created_at": "2026-01-06 14:29:29 +0100",
                           "created_by": "agent",
-                          "created_by_id": 137,
+                          "created_by_id": 1021,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2024-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 16,
+                            "id": 653,
                             "address": "4 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°4",
-                            "organisation_id": 173,
+                            "organisation_id": 603,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 60,
+                            "id": 679,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3503,50 +3515,51 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 60,
+                              "id": 679,
                               "name": "Catégorie de motif n°5",
                               "short_name": "5_motif_cat"
                             },
                             "name": "Motif 5",
-                            "organisation_id": 173,
+                            "organisation_id": 603,
                             "service_id": null
                           },
                           "name": null,
                           "organisation": {
-                            "id": 173,
+                            "id": 603,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites"
+                            "verticale": "rdv_solidarites",
+                            "website": null
                           },
                           "participations": [
                             {
-                              "id": 17,
+                              "id": 655,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 137,
+                              "created_by_id": 1021,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 21,
+                                "id": 652,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2025-10-06 13:36:34 +0200",
+                                "created_at": "2026-01-06 14:29:29 +0100",
                                 "email": "usager_4@lapin.fr",
-                                "first_name": "Édouard",
+                                "first_name": "Réjeanne",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "DUMONT",
+                                "last_name": "DENIS",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "0622502309",
-                                "phone_number_formatted": "+33622502309",
+                                "phone_number": "06 30 59 58 52",
+                                "phone_number_formatted": "+33630595852",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3555,33 +3568,33 @@
                           ],
                           "starts_at": "2024-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/14",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/649",
                           "users": [
                             {
-                              "id": 21,
+                              "id": 652,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2025-10-06 13:36:34 +0200",
+                              "created_at": "2026-01-06 14:29:29 +0100",
                               "email": "usager_4@lapin.fr",
-                              "first_name": "Édouard",
+                              "first_name": "Réjeanne",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "DUMONT",
+                              "last_name": "DENIS",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "0622502309",
-                              "phone_number_formatted": "+33622502309",
+                              "phone_number": "06 30 59 58 52",
+                              "phone_number_formatted": "+33630595852",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "59021b59-15f5-4ec5-b0da-c81987f1270e"
+                          "uuid": "4d3840fd-4075-473e-af50-64ec7970a675"
                         }
                       ],
                       "meta": {
@@ -3694,7 +3707,7 @@
                         ]
                       },
                       "error_messages": [
-                        "status doit être rempli(e)"
+                        "status doit être rempli·e"
                       ]
                     }
                   }
@@ -3798,29 +3811,29 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 252,
+                          "id": 1140,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Aurélie",
-                          "last_name": "Perez"
+                          "first_name": "Yolande",
+                          "last_name": "Muller"
                         },
                         "user": {
-                          "id": 111,
+                          "id": 744,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:39 +0200",
+                          "created_at": "2026-01-06 14:29:34 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Aimable",
+                          "first_name": "Brice",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "ARNAUD",
+                          "last_name": "CLÉMENT",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0642890191",
-                          "phone_number_formatted": "+33642890191",
+                          "phone_number": "07 67 40 81 31",
+                          "phone_number_formatted": "+33767408131",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4073,27 +4086,27 @@
                           "id": 5,
                           "agents": [
                             {
-                              "id": 284,
+                              "id": 1172,
                               "email": "agent_2@lapin.fr",
-                              "first_name": "Arian",
-                              "last_name": "Le Goff"
+                              "first_name": "Émérencie",
+                              "last_name": "Vasseur"
                             },
                             {
-                              "id": 285,
+                              "id": 1173,
                               "email": "agent_3@lapin.fr",
-                              "first_name": "Arielle",
-                              "last_name": "Morel"
+                              "first_name": "Anaëlle",
+                              "last_name": "Gilbert"
                             },
                             {
-                              "id": 286,
+                              "id": 1174,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Armelle",
-                              "last_name": "Guérin"
+                              "first_name": "Anthelme",
+                              "last_name": "Rolland"
                             }
                           ],
-                          "name": "Aquitaine ghosts 799285ed",
+                          "name": "Mayotte cats bda82927",
                           "territory": {
-                            "id": 232,
+                            "id": 664,
                             "departement_number": "01",
                             "motif_categories": [],
                             "name": "Espace n°1"
@@ -4210,30 +4223,31 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 236,
+                          "id": 668,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "user": {
-                          "id": 127,
+                          "id": 760,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:41 +0200",
+                          "created_at": "2026-01-06 14:29:36 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Agilberte",
+                          "first_name": "Alcyone",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "DENIS",
+                          "last_name": "DA SILVA",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0631339353",
-                          "phone_number_formatted": "+33631339353",
+                          "phone_number": "6 40 89 05 66",
+                          "phone_number_formatted": "+33640890566",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4292,7 +4306,7 @@
             }
           },
           "422": {
-            "description": "Renvoie 'unprocessable_entity' quand l'utilisateur ou l'organisation est inconnu(e) ou ce profil existe déjà",
+            "description": "Renvoie 'unprocessable_entity' quand l'utilisateur ou l'organisation est inconnu·e ou ce profil existe déjà",
             "content": {
               "application/json": {
                 "examples": {
@@ -4518,13 +4532,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 144,
+                        "id": 777,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2025-10-06 13:36:42 +0200",
+                        "created_at": "2026-01-06 14:29:37 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -4533,18 +4547,19 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "666609679",
-                        "phone_number_formatted": "+33666609679",
+                        "phone_number": "0648638119",
+                        "phone_number_formatted": "+33648638119",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 257,
+                              "id": 689,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
-                              "verticale": "rdv_solidarites"
+                              "verticale": "rdv_solidarites",
+                              "website": null
                             }
                           }
                         ]
@@ -4828,13 +4843,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 151,
+                        "id": 784,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2025-10-06 13:36:42 +0200",
+                        "created_at": "2026-01-06 14:29:37 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Alain",
                         "invitation_accepted_at": null,
@@ -4846,28 +4861,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 150,
+                          "id": 783,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:42 +0200",
+                          "created_at": "2026-01-06 14:29:37 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Huguette",
+                          "first_name": "Jude",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MARCHAND",
+                          "last_name": "DAVID",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "07 73 48 85 78",
-                          "phone_number_formatted": "+33773488578",
+                          "phone_number": "790340246",
+                          "phone_number_formatted": "+33790340246",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 150,
+                        "responsible_id": 783,
                         "user_profiles": null
                       }
                     }
@@ -4899,8 +4914,8 @@
                         ]
                       },
                       "error_messages": [
-                        "last_name doit être rempli(e)",
-                        "first_name doit être rempli(e)"
+                        "last_name doit être rempli·e",
+                        "first_name doit être rempli·e"
                       ]
                     }
                   }
@@ -4996,7 +5011,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "793HRDC6"
+                      "invitation_token": "FDC8U875"
                     }
                   }
                 },
@@ -5129,23 +5144,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 178,
+                          "id": 811,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:43 +0200",
+                          "created_at": "2026-01-06 14:29:38 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Maxime",
+                          "first_name": "Roland",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "GRONDIN",
+                          "last_name": "BOUCHER",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "7 39 50 85 46",
-                          "phone_number_formatted": "+33739508546",
+                          "phone_number": "06 70 74 59 63",
+                          "phone_number_formatted": "+33670745963",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5402,13 +5417,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 189,
+                        "id": 822,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2025-10-06 13:36:43 +0200",
+                        "created_at": "2026-01-06 14:29:39 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Johnny",
                         "invitation_accepted_at": null,
@@ -5420,28 +5435,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 188,
+                          "id": 821,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:43 +0200",
+                          "created_at": "2026-01-06 14:29:39 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Argine",
+                          "first_name": "Gilberte",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LE GOFF",
+                          "last_name": "SCHMITT",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "06 86 16 99 55",
-                          "phone_number_formatted": "+33686169955",
+                          "phone_number": "06 20 14 48 55",
+                          "phone_number_formatted": "+33620144855",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 188,
+                        "responsible_id": 821,
                         "user_profiles": null
                       }
                     }
@@ -5492,8 +5507,8 @@
                         ]
                       },
                       "error_messages": [
-                        "last_name doit être rempli(e)",
-                        "first_name doit être rempli(e)"
+                        "last_name doit être rempli·e",
+                        "first_name doit être rempli·e"
                       ]
                     }
                   }
@@ -5581,23 +5596,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 198,
+                          "id": 831,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:44 +0200",
+                          "created_at": "2026-01-06 14:29:39 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Eusèbe",
+                          "first_name": "Florie",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "PERRIER",
+                          "last_name": "GAUTIER",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "736258265",
-                          "phone_number_formatted": "+33736258265",
+                          "phone_number": "665269344",
+                          "phone_number_formatted": "+33665269344",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5714,13 +5729,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 203,
+                        "id": 836,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2025-10-06 13:36:44 +0200",
+                        "created_at": "2026-01-06 14:29:40 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -5729,18 +5744,19 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "06 33 09 76 25",
-                        "phone_number_formatted": "+33633097625",
+                        "phone_number": "0613501853",
+                        "phone_number_formatted": "+33613501853",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 322,
+                              "id": 754,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
-                              "verticale": "rdv_solidarites"
+                              "verticale": "rdv_solidarites",
+                              "website": null
                             }
                           }
                         ]
@@ -6043,7 +6059,7 @@
                     "value": {
                       "webhook_endpoint": {
                         "id": 26,
-                        "organisation_id": 342,
+                        "organisation_id": 774,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -6240,7 +6256,7 @@
                     "value": {
                       "webhook_endpoint": {
                         "id": 28,
-                        "organisation_id": 349,
+                        "organisation_id": 781,
                         "subscriptions": [
                           "rdv",
                           "user",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -1291,25 +1291,24 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 62,
+                        "id": 12,
                         "agent": {
                           "id": 12,
                           "email": "agent@example.com",
-                          "first_name": "Delphin",
-                          "last_name": "Arnaud"
+                          "first_name": "Barbe",
+                          "last_name": "Colin"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T132923Z\r\nUID:absence_62@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/442/planning/absences/62/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Super absence\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_62@RDV Solidarités",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113628Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_12@RDV Solidarités",
                         "organisation": {
-                          "id": 442,
+                          "id": 12,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites",
-                          "website": null
+                          "verticale": "rdv_solidarites"
                         },
                         "rrule": null,
                         "start_time": "08:00:00",
@@ -1476,25 +1475,24 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 71,
+                        "id": 21,
                         "agent": {
-                          "id": 907,
+                          "id": 23,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Marine",
-                          "last_name": "Gautier"
+                          "first_name": "Adeline",
+                          "last_name": "Paul"
                         },
-                        "end_day": "2026-01-07",
+                        "end_day": "2025-10-07",
                         "end_time": "15:30:00",
-                        "first_day": "2026-01-07",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T132923Z\r\nUID:absence_71@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/456/planning/absences/71/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Indisponibilité 1\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_71@RDV Solidarités",
+                        "first_day": "2025-10-07",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113629Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20251007T100000\r\nDTEND;TZID=Europe/Paris:20251007T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_21@RDV Solidarités",
                         "organisation": {
-                          "id": 456,
+                          "id": 26,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites",
-                          "website": null
+                          "verticale": "rdv_solidarites"
                         },
                         "rrule": null,
                         "start_time": "10:00:00",
@@ -1683,25 +1681,24 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 83,
+                        "id": 33,
                         "agent": {
-                          "id": 919,
+                          "id": 35,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Athalie",
-                          "last_name": "Weber"
+                          "first_name": "Gérard",
+                          "last_name": "Fabre"
                         },
-                        "end_day": "2026-01-07",
+                        "end_day": "2025-10-07",
                         "end_time": "15:30:00",
-                        "first_day": "2026-01-07",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T132924Z\r\nUID:absence_83@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/468/planning/absences/83/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Nouveau titre\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_83@RDV Solidarités",
+                        "first_day": "2025-10-07",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113629Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20251007T100000\r\nDTEND;TZID=Europe/Paris:20251007T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_33@RDV Solidarités",
                         "organisation": {
-                          "id": 468,
+                          "id": 38,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites",
-                          "website": null
+                          "verticale": "rdv_solidarites"
                         },
                         "rrule": null,
                         "start_time": "10:00:00",
@@ -1981,10 +1978,10 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 943,
+                          "id": 59,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Pie",
-                          "last_name": "Besson"
+                          "first_name": "Suzanne",
+                          "last_name": "Pasquier"
                         }
                       ],
                       "meta": {
@@ -2203,12 +2200,12 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 639,
+                      "id": 2,
                       "address": "77 avenue de Ségur, 75015 Paris",
                       "latitude": 44.5569244,
                       "longitude": 4.7521632,
                       "name": "Maison France Service de Montreuil",
-                      "organisation_id": 506,
+                      "organisation_id": 76,
                       "phone_number": "01 22 33 44 55",
                       "single_use": false
                     }
@@ -2325,7 +2322,7 @@
                     "value": {
                       "motifs": [
                         {
-                          "id": 626,
+                          "id": 7,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
@@ -2334,16 +2331,16 @@
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 626,
+                            "id": 7,
                             "name": "Catégorie de motif n°1",
                             "short_name": "1_motif_cat"
                           },
                           "name": "Motif 1",
-                          "organisation_id": 512,
-                          "service_id": 292
+                          "organisation_id": 82,
+                          "service_id": 19
                         },
                         {
-                          "id": 627,
+                          "id": 8,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
@@ -2352,13 +2349,13 @@
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 627,
+                            "id": 8,
                             "name": "Catégorie de motif n°2",
                             "short_name": "2_motif_cat"
                           },
                           "name": "Motif 2",
-                          "organisation_id": 512,
-                          "service_id": 292
+                          "organisation_id": 82,
+                          "service_id": 19
                         }
                       ],
                       "meta": {
@@ -2483,44 +2480,39 @@
                     "value": {
                       "organisations": [
                         {
-                          "id": 547,
+                          "id": 117,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites",
-                          "website": null
+                          "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 548,
+                          "id": 118,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites",
-                          "website": null
+                          "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 549,
+                          "id": 119,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites",
-                          "website": null
+                          "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 550,
+                          "id": 120,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites",
-                          "website": null
+                          "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 551,
+                          "id": 121,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites",
-                          "website": null
+                          "verticale": "rdv_solidarites"
                         }
                       ],
                       "meta": {
@@ -2634,12 +2626,11 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 558,
+                        "id": 128,
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
-                        "verticale": "rdv_solidarites",
-                        "website": null
+                        "verticale": "rdv_solidarites"
                       }
                     }
                   }
@@ -2744,12 +2735,11 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 562,
+                        "id": 132,
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
-                        "verticale": "rdv_solidarites",
-                        "website": null
+                        "verticale": "rdv_solidarites"
                       }
                     }
                   }
@@ -2855,12 +2845,12 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 6,
-                        "created_at": "2026-01-06 14:29:28 +0100",
+                        "id": 2,
+                        "created_at": "2025-10-06 13:36:33 +0200",
                         "rdv": null,
-                        "updated_at": "2026-01-06 14:29:28 +0100",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/6",
-                        "user_id": 639
+                        "updated_at": "2025-10-06 13:36:33 +0200",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/2",
+                        "user_id": 8
                       }
                     }
                   }
@@ -2969,17 +2959,17 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 8,
-                        "created_at": "2026-01-06 14:29:28 +0100",
+                        "id": 4,
+                        "created_at": "2025-10-06 13:36:34 +0200",
                         "rdv": {
-                          "id": 640,
+                          "id": 5,
                           "status": "unknown",
-                          "starts_at": "2026-01-09 14:29:00 +0100",
+                          "starts_at": "2025-10-09 13:36:00 +0200",
                           "location_type": "public_office"
                         },
-                        "updated_at": "2026-01-06 14:29:28 +0100",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/8",
-                        "user_id": 643
+                        "updated_at": "2025-10-06 13:36:34 +0200",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/4",
+                        "user_id": 12
                       }
                     }
                   }
@@ -3031,7 +3021,7 @@
           {
             "name": "organisation_id",
             "in": "query",
-            "description": "neIdentifiant de l'organisation",
+            "description": "Identifiant de l'organisation",
             "example": "20",
             "required": false,
             "schema": {
@@ -3108,38 +3098,38 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 641,
+                          "id": 6,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 1011,
+                              "id": 127,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Jeanne",
-                              "last_name": "Noël"
+                              "first_name": "Clodion",
+                              "last_name": "Leclercq"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-06 14:29:28 +0100",
+                          "created_at": "2025-10-06 13:36:34 +0200",
                           "created_by": "agent",
-                          "created_by_id": 1011,
+                          "created_by_id": 127,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 645,
+                            "id": 8,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 600,
+                            "organisation_id": 170,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 669,
+                            "id": 50,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3148,51 +3138,50 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 669,
+                              "id": 50,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 600,
-                            "service_id": 313
+                            "organisation_id": 170,
+                            "service_id": 40
                           },
                           "name": null,
                           "organisation": {
-                            "id": 600,
+                            "id": 170,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites",
-                            "website": null
+                            "verticale": "rdv_solidarites"
                           },
                           "participations": [
                             {
-                              "id": 647,
+                              "id": 9,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 1011,
+                              "created_by_id": 127,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 644,
+                                "id": 13,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-06 14:29:28 +0100",
+                                "created_at": "2025-10-06 13:36:34 +0200",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Gaud",
+                                "first_name": "Florian",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "CARLIER",
+                                "last_name": "PICHON",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "07 88 18 63 30",
-                                "phone_number_formatted": "+33788186330",
+                                "phone_number": "6 19 21 39 36",
+                                "phone_number_formatted": "+33619213936",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3201,33 +3190,33 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/641",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/6",
                           "users": [
                             {
-                              "id": 644,
+                              "id": 13,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-06 14:29:28 +0100",
+                              "created_at": "2025-10-06 13:36:34 +0200",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Gaud",
+                              "first_name": "Florian",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "CARLIER",
+                              "last_name": "PICHON",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "07 88 18 63 30",
-                              "phone_number_formatted": "+33788186330",
+                              "phone_number": "6 19 21 39 36",
+                              "phone_number_formatted": "+33619213936",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "5659a295-7582-4537-87ce-34cb728e3b14"
+                          "uuid": "c72fa749-69a2-49b6-a28a-4bbae50df1d8"
                         }
                       ],
                       "meta": {
@@ -3353,38 +3342,38 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 646,
+                          "id": 11,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 1018,
+                              "id": 134,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Adegrine",
-                              "last_name": "Lacroix"
+                              "first_name": "Annibal",
+                              "last_name": "Meyer"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-06 14:29:29 +0100",
+                          "created_at": "2025-10-06 13:36:34 +0200",
                           "created_by": "agent",
-                          "created_by_id": 1018,
+                          "created_by_id": 134,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 650,
+                            "id": 13,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 603,
+                            "organisation_id": 173,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 675,
+                            "id": 56,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3393,51 +3382,50 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 675,
+                              "id": 56,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 603,
-                            "service_id": 316
+                            "organisation_id": 173,
+                            "service_id": 43
                           },
                           "name": null,
                           "organisation": {
-                            "id": 603,
+                            "id": 173,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites",
-                            "website": null
+                            "verticale": "rdv_solidarites"
                           },
                           "participations": [
                             {
-                              "id": 652,
+                              "id": 14,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 1018,
+                              "created_by_id": 134,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 649,
+                                "id": 18,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-06 14:29:29 +0100",
+                                "created_at": "2025-10-06 13:36:34 +0200",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Lucie",
+                                "first_name": "Julien",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "LACROIX",
+                                "last_name": "DUPUY",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "732539857",
-                                "phone_number_formatted": "+33732539857",
+                                "phone_number": "0686864704",
+                                "phone_number_formatted": "+33686864704",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3446,67 +3434,67 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/646",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/11",
                           "users": [
                             {
-                              "id": 649,
+                              "id": 18,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-06 14:29:29 +0100",
+                              "created_at": "2025-10-06 13:36:34 +0200",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Lucie",
+                              "first_name": "Julien",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "LACROIX",
+                              "last_name": "DUPUY",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "732539857",
-                              "phone_number_formatted": "+33732539857",
+                              "phone_number": "0686864704",
+                              "phone_number_formatted": "+33686864704",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "580f20d0-054f-46ed-a0b0-b6a967e840a5"
+                          "uuid": "cd32d504-532f-428a-b4fb-163e87de7dbc"
                         },
                         {
-                          "id": 649,
+                          "id": 14,
                           "address": "4 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 1021,
+                              "id": 137,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Jeanne",
-                              "last_name": "Roger"
+                              "first_name": "Romain",
+                              "last_name": "Pichon"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-06 14:29:29 +0100",
+                          "created_at": "2025-10-06 13:36:34 +0200",
                           "created_by": "agent",
-                          "created_by_id": 1021,
+                          "created_by_id": 137,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2024-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 653,
+                            "id": 16,
                             "address": "4 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°4",
-                            "organisation_id": 603,
+                            "organisation_id": 173,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 679,
+                            "id": 60,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3515,51 +3503,50 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 679,
+                              "id": 60,
                               "name": "Catégorie de motif n°5",
                               "short_name": "5_motif_cat"
                             },
                             "name": "Motif 5",
-                            "organisation_id": 603,
+                            "organisation_id": 173,
                             "service_id": null
                           },
                           "name": null,
                           "organisation": {
-                            "id": 603,
+                            "id": 173,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites",
-                            "website": null
+                            "verticale": "rdv_solidarites"
                           },
                           "participations": [
                             {
-                              "id": 655,
+                              "id": 17,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 1021,
+                              "created_by_id": 137,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 652,
+                                "id": 21,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-06 14:29:29 +0100",
+                                "created_at": "2025-10-06 13:36:34 +0200",
                                 "email": "usager_4@lapin.fr",
-                                "first_name": "Réjeanne",
+                                "first_name": "Édouard",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "DENIS",
+                                "last_name": "DUMONT",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "06 30 59 58 52",
-                                "phone_number_formatted": "+33630595852",
+                                "phone_number": "0622502309",
+                                "phone_number_formatted": "+33622502309",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3568,33 +3555,33 @@
                           ],
                           "starts_at": "2024-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/649",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/14",
                           "users": [
                             {
-                              "id": 652,
+                              "id": 21,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-06 14:29:29 +0100",
+                              "created_at": "2025-10-06 13:36:34 +0200",
                               "email": "usager_4@lapin.fr",
-                              "first_name": "Réjeanne",
+                              "first_name": "Édouard",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "DENIS",
+                              "last_name": "DUMONT",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "06 30 59 58 52",
-                              "phone_number_formatted": "+33630595852",
+                              "phone_number": "0622502309",
+                              "phone_number_formatted": "+33622502309",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "4d3840fd-4075-473e-af50-64ec7970a675"
+                          "uuid": "59021b59-15f5-4ec5-b0da-c81987f1270e"
                         }
                       ],
                       "meta": {
@@ -3707,7 +3694,7 @@
                         ]
                       },
                       "error_messages": [
-                        "status doit être rempli·e"
+                        "status doit être rempli(e)"
                       ]
                     }
                   }
@@ -3811,29 +3798,29 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 1140,
+                          "id": 252,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Yolande",
-                          "last_name": "Muller"
+                          "first_name": "Aurélie",
+                          "last_name": "Perez"
                         },
                         "user": {
-                          "id": 744,
+                          "id": 111,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 14:29:34 +0100",
+                          "created_at": "2025-10-06 13:36:39 +0200",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Brice",
+                          "first_name": "Aimable",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "CLÉMENT",
+                          "last_name": "ARNAUD",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "07 67 40 81 31",
-                          "phone_number_formatted": "+33767408131",
+                          "phone_number": "0642890191",
+                          "phone_number_formatted": "+33642890191",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4086,27 +4073,27 @@
                           "id": 5,
                           "agents": [
                             {
-                              "id": 1172,
+                              "id": 284,
                               "email": "agent_2@lapin.fr",
-                              "first_name": "Émérencie",
-                              "last_name": "Vasseur"
+                              "first_name": "Arian",
+                              "last_name": "Le Goff"
                             },
                             {
-                              "id": 1173,
+                              "id": 285,
                               "email": "agent_3@lapin.fr",
-                              "first_name": "Anaëlle",
-                              "last_name": "Gilbert"
+                              "first_name": "Arielle",
+                              "last_name": "Morel"
                             },
                             {
-                              "id": 1174,
+                              "id": 286,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Anthelme",
-                              "last_name": "Rolland"
+                              "first_name": "Armelle",
+                              "last_name": "Guérin"
                             }
                           ],
-                          "name": "Mayotte cats bda82927",
+                          "name": "Aquitaine ghosts 799285ed",
                           "territory": {
-                            "id": 664,
+                            "id": 232,
                             "departement_number": "01",
                             "motif_categories": [],
                             "name": "Espace n°1"
@@ -4223,31 +4210,30 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 668,
+                          "id": 236,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites",
-                          "website": null
+                          "verticale": "rdv_solidarites"
                         },
                         "user": {
-                          "id": 760,
+                          "id": 127,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 14:29:36 +0100",
+                          "created_at": "2025-10-06 13:36:41 +0200",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Alcyone",
+                          "first_name": "Agilberte",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "DA SILVA",
+                          "last_name": "DENIS",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "6 40 89 05 66",
-                          "phone_number_formatted": "+33640890566",
+                          "phone_number": "0631339353",
+                          "phone_number_formatted": "+33631339353",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4306,7 +4292,7 @@
             }
           },
           "422": {
-            "description": "Renvoie 'unprocessable_entity' quand l'utilisateur ou l'organisation est inconnu·e ou ce profil existe déjà",
+            "description": "Renvoie 'unprocessable_entity' quand l'utilisateur ou l'organisation est inconnu(e) ou ce profil existe déjà",
             "content": {
               "application/json": {
                 "examples": {
@@ -4532,13 +4518,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 777,
+                        "id": 144,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2026-01-06 14:29:37 +0100",
+                        "created_at": "2025-10-06 13:36:42 +0200",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -4547,19 +4533,18 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "0648638119",
-                        "phone_number_formatted": "+33648638119",
+                        "phone_number": "666609679",
+                        "phone_number_formatted": "+33666609679",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 689,
+                              "id": 257,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
-                              "verticale": "rdv_solidarites",
-                              "website": null
+                              "verticale": "rdv_solidarites"
                             }
                           }
                         ]
@@ -4843,13 +4828,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 784,
+                        "id": 151,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2026-01-06 14:29:37 +0100",
+                        "created_at": "2025-10-06 13:36:42 +0200",
                         "email": "jean@jacques.fr",
                         "first_name": "Alain",
                         "invitation_accepted_at": null,
@@ -4861,28 +4846,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 783,
+                          "id": 150,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 14:29:37 +0100",
+                          "created_at": "2025-10-06 13:36:42 +0200",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Jude",
+                          "first_name": "Huguette",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "DAVID",
+                          "last_name": "MARCHAND",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "790340246",
-                          "phone_number_formatted": "+33790340246",
+                          "phone_number": "07 73 48 85 78",
+                          "phone_number_formatted": "+33773488578",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 783,
+                        "responsible_id": 150,
                         "user_profiles": null
                       }
                     }
@@ -4914,8 +4899,8 @@
                         ]
                       },
                       "error_messages": [
-                        "last_name doit être rempli·e",
-                        "first_name doit être rempli·e"
+                        "last_name doit être rempli(e)",
+                        "first_name doit être rempli(e)"
                       ]
                     }
                   }
@@ -5011,7 +4996,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "FDC8U875"
+                      "invitation_token": "793HRDC6"
                     }
                   }
                 },
@@ -5144,23 +5129,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 811,
+                          "id": 178,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 14:29:38 +0100",
+                          "created_at": "2025-10-06 13:36:43 +0200",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Roland",
+                          "first_name": "Maxime",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "BOUCHER",
+                          "last_name": "GRONDIN",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "06 70 74 59 63",
-                          "phone_number_formatted": "+33670745963",
+                          "phone_number": "7 39 50 85 46",
+                          "phone_number_formatted": "+33739508546",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5417,13 +5402,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 822,
+                        "id": 189,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2026-01-06 14:29:39 +0100",
+                        "created_at": "2025-10-06 13:36:43 +0200",
                         "email": "jean@jacques.fr",
                         "first_name": "Johnny",
                         "invitation_accepted_at": null,
@@ -5435,28 +5420,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 821,
+                          "id": 188,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 14:29:39 +0100",
+                          "created_at": "2025-10-06 13:36:43 +0200",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Gilberte",
+                          "first_name": "Argine",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "SCHMITT",
+                          "last_name": "LE GOFF",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "06 20 14 48 55",
-                          "phone_number_formatted": "+33620144855",
+                          "phone_number": "06 86 16 99 55",
+                          "phone_number_formatted": "+33686169955",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 821,
+                        "responsible_id": 188,
                         "user_profiles": null
                       }
                     }
@@ -5507,8 +5492,8 @@
                         ]
                       },
                       "error_messages": [
-                        "last_name doit être rempli·e",
-                        "first_name doit être rempli·e"
+                        "last_name doit être rempli(e)",
+                        "first_name doit être rempli(e)"
                       ]
                     }
                   }
@@ -5596,23 +5581,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 831,
+                          "id": 198,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 14:29:39 +0100",
+                          "created_at": "2025-10-06 13:36:44 +0200",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Florie",
+                          "first_name": "Eusèbe",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "GAUTIER",
+                          "last_name": "PERRIER",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "665269344",
-                          "phone_number_formatted": "+33665269344",
+                          "phone_number": "736258265",
+                          "phone_number_formatted": "+33736258265",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5729,13 +5714,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 836,
+                        "id": 203,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2026-01-06 14:29:40 +0100",
+                        "created_at": "2025-10-06 13:36:44 +0200",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -5744,19 +5729,18 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "0613501853",
-                        "phone_number_formatted": "+33613501853",
+                        "phone_number": "06 33 09 76 25",
+                        "phone_number_formatted": "+33633097625",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 754,
+                              "id": 322,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
-                              "verticale": "rdv_solidarites",
-                              "website": null
+                              "verticale": "rdv_solidarites"
                             }
                           }
                         ]
@@ -6059,7 +6043,7 @@
                     "value": {
                       "webhook_endpoint": {
                         "id": 26,
-                        "organisation_id": 774,
+                        "organisation_id": 342,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -6256,7 +6240,7 @@
                     "value": {
                       "webhook_endpoint": {
                         "id": 28,
-                        "organisation_id": 781,
+                        "organisation_id": 349,
                         "subscriptions": [
                           "rdv",
                           "user",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -1293,22 +1293,23 @@
                       "absence": {
                         "id": 12,
                         "agent": {
-                          "id": 12,
+                          "id": 15,
                           "email": "agent@example.com",
-                          "first_name": "Barbe",
-                          "last_name": "Colin"
+                          "first_name": "Althée",
+                          "last_name": "Guillot"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113628Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142249Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/12/planning/absences/12/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Super absence\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_12@RDV Solidarités",
                         "organisation": {
                           "id": 12,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "rrule": null,
                         "start_time": "08:00:00",
@@ -1477,22 +1478,23 @@
                       "absence": {
                         "id": 21,
                         "agent": {
-                          "id": 23,
+                          "id": 33,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Adeline",
-                          "last_name": "Paul"
+                          "first_name": "Amaranthe",
+                          "last_name": "Nguyen"
                         },
-                        "end_day": "2025-10-07",
+                        "end_day": "2026-01-07",
                         "end_time": "15:30:00",
-                        "first_day": "2025-10-07",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113629Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20251007T100000\r\nDTEND;TZID=Europe/Paris:20251007T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "first_day": "2026-01-07",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142249Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/26/planning/absences/21/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Indisponibilité 1\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_21@RDV Solidarités",
                         "organisation": {
                           "id": 26,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "rrule": null,
                         "start_time": "10:00:00",
@@ -1683,22 +1685,23 @@
                       "absence": {
                         "id": 33,
                         "agent": {
-                          "id": 35,
+                          "id": 45,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Gérard",
-                          "last_name": "Fabre"
+                          "first_name": "Coralie",
+                          "last_name": "Chevallier"
                         },
-                        "end_day": "2025-10-07",
+                        "end_day": "2026-01-07",
                         "end_time": "15:30:00",
-                        "first_day": "2025-10-07",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113629Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20251007T100000\r\nDTEND;TZID=Europe/Paris:20251007T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "first_day": "2026-01-07",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142250Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/38/planning/absences/33/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Nouveau titre\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_33@RDV Solidarités",
                         "organisation": {
                           "id": 38,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "rrule": null,
                         "start_time": "10:00:00",
@@ -1978,10 +1981,10 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 59,
+                          "id": 69,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Suzanne",
-                          "last_name": "Pasquier"
+                          "first_name": "Régine",
+                          "last_name": "Renault"
                         }
                       ],
                       "meta": {
@@ -2484,35 +2487,40 @@
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
                           "id": 118,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
                           "id": 119,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
                           "id": 120,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
                           "id": 121,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         }
                       ],
                       "meta": {
@@ -2630,7 +2638,8 @@
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
-                        "verticale": "rdv_solidarites"
+                        "verticale": "rdv_solidarites",
+                        "website": null
                       }
                     }
                   }
@@ -2739,7 +2748,8 @@
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
-                        "verticale": "rdv_solidarites"
+                        "verticale": "rdv_solidarites",
+                        "website": null
                       }
                     }
                   }
@@ -2846,9 +2856,9 @@
                     "value": {
                       "rdv_plan": {
                         "id": 2,
-                        "created_at": "2025-10-06 13:36:33 +0200",
+                        "created_at": "2026-01-06 15:22:54 +0100",
                         "rdv": null,
-                        "updated_at": "2025-10-06 13:36:33 +0200",
+                        "updated_at": "2026-01-06 15:22:54 +0100",
                         "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/2",
                         "user_id": 8
                       }
@@ -2960,14 +2970,14 @@
                     "value": {
                       "rdv_plan": {
                         "id": 4,
-                        "created_at": "2025-10-06 13:36:34 +0200",
+                        "created_at": "2026-01-06 15:22:54 +0100",
                         "rdv": {
                           "id": 5,
                           "status": "unknown",
-                          "starts_at": "2025-10-09 13:36:00 +0200",
+                          "starts_at": "2026-01-09 15:22:00 +0100",
                           "location_type": "public_office"
                         },
-                        "updated_at": "2025-10-06 13:36:34 +0200",
+                        "updated_at": "2026-01-06 15:22:54 +0100",
                         "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/4",
                         "user_id": 12
                       }
@@ -3051,15 +3061,15 @@
           {
             "name": "status",
             "in": "query",
-            "description": "Filtre les rendez-vous par statut.\nVous pouvez passer soit une seule chaine de caractères, soit un tableau de chaines de caractères.\nLes différentes valeurs possibles sont [\"unknown\", \"seen\", \"excused\", \"revoked\", \"noshow\"].\nSi vous passez un tableau, le format attendu est status[]=excused&status[]=revoked\n",
-            "example": "seen ou status[]=excused&status[]=revoked",
+            "description": "Filtre les rendez-vous par statut.\nVous pouvez passer soit une seule chaine de caractères, soit un tableau de chaines de caractères.\nLes différentes valeurs possibles sont [\"unknown\", \"seen\", \"excused\", \"revoked\", \"noshow\"].\nSi vous passez un tableau, vous pouvez utiliser le format `status[]=excused&status[]=revoked` ou `status=excused,revoked`.\n",
+            "example": "seen ou status[]=excused&status[]=revoked ou status=excused,revoked",
             "required": false
           },
           {
             "name": "id",
             "in": "query",
-            "description": "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.\nVous pouvez passer soit un tableau d'entier pour obtenir plusieurs rdvs, soit un seul entier pour obtenir un seul rdv.\nSi vous passez un tableau d'entier, le format attendu est id[]=1234&id[]=5678\n",
-            "example": "789 ou id[]=1234&id[]=5678",
+            "description": "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.\nVous pouvez passer soit un tableau d'entier pour obtenir plusieurs rdvs, soit un seul entier pour obtenir un seul rdv.\nSi vous passez un tableau d'entier, le format attendu est\nSi vous passez un tableau, vous pouvez utiliser le format id[]=1234&id[]=5678 ou id=1234,5678.\n",
+            "example": "789 ou id[]=1234&id[]=5678 id=1234,5678",
             "required": false
           },
           {
@@ -3087,7 +3097,7 @@
           "RDV"
         ],
         "operationId": "getRdvs",
-        "description": "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres facultatifs passés en paramètre. <br /> Par défaut, toutes les associations disponibles sont renvoyées (participants, agents, motif, etc...), ce qui peut considérablement ralentir le temps de réponse. Vous pouvez passer le paramètre `include` pour choisir quelles associations inclure dans la réponse. Il prend un tableau de chaines de caractères, et les valeurs possibles sont : <ul> <li>organisation</li> <li>lieu</li> <li>motifs</li> <li>agents</li> <li>users</li> <li>participations</li> </ul> Par exemple, vous pouvez passer `include[]=agents&include[]=users` en query params.",
+        "description": "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres facultatifs passés en paramètre. <br /> Par défaut, toutes les associations disponibles sont renvoyées (participants, agents, motif, etc...), ce qui peut considérablement ralentir le temps de réponse. Vous pouvez passer le paramètre `include` pour choisir quelles associations inclure dans la réponse. Il prend un tableau de chaines de caractères, et les valeurs possibles sont : <ul> <li>organisation</li> <li>lieu</li> <li>motifs</li> <li>agents</li> <li>users</li> <li>participations</li> </ul> Par exemple, vous pouvez passer `include[]=agents&include[]=users` ou `include=agents,users` en query params.",
         "responses": {
           "200": {
             "description": "Appel API réussi",
@@ -3102,18 +3112,18 @@
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 127,
+                              "id": 141,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Clodion",
-                              "last_name": "Leclercq"
+                              "first_name": "Florent",
+                              "last_name": "Mercier"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-10-06 13:36:34 +0200",
+                          "created_at": "2026-01-06 15:22:54 +0100",
                           "created_by": "agent",
-                          "created_by_id": 127,
+                          "created_by_id": 141,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
@@ -3152,14 +3162,15 @@
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites"
+                            "verticale": "rdv_solidarites",
+                            "website": null
                           },
                           "participations": [
                             {
                               "id": 9,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 127,
+                              "created_by_id": 141,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
@@ -3171,17 +3182,17 @@
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2025-10-06 13:36:34 +0200",
+                                "created_at": "2026-01-06 15:22:54 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Florian",
+                                "first_name": "Chrysole",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "PICHON",
+                                "last_name": "LE GALL",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "6 19 21 39 36",
-                                "phone_number_formatted": "+33619213936",
+                                "phone_number": "7 70 91 44 97",
+                                "phone_number_formatted": "+33770914497",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3199,24 +3210,24 @@
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2025-10-06 13:36:34 +0200",
+                              "created_at": "2026-01-06 15:22:54 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Florian",
+                              "first_name": "Chrysole",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "PICHON",
+                              "last_name": "LE GALL",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "6 19 21 39 36",
-                              "phone_number_formatted": "+33619213936",
+                              "phone_number": "7 70 91 44 97",
+                              "phone_number_formatted": "+33770914497",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "c72fa749-69a2-49b6-a28a-4bbae50df1d8"
+                          "uuid": "6383d3b9-98f3-4ec5-9279-aeef43b74079"
                         }
                       ],
                       "meta": {
@@ -3346,18 +3357,18 @@
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 134,
+                              "id": 148,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Annibal",
-                              "last_name": "Meyer"
+                              "first_name": "Gédéon",
+                              "last_name": "Mallet"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-10-06 13:36:34 +0200",
+                          "created_at": "2026-01-06 15:22:55 +0100",
                           "created_by": "agent",
-                          "created_by_id": 134,
+                          "created_by_id": 148,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
@@ -3396,14 +3407,15 @@
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites"
+                            "verticale": "rdv_solidarites",
+                            "website": null
                           },
                           "participations": [
                             {
                               "id": 14,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 134,
+                              "created_by_id": 148,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
@@ -3415,17 +3427,17 @@
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2025-10-06 13:36:34 +0200",
+                                "created_at": "2026-01-06 15:22:55 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Julien",
+                                "first_name": "Armandine",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "DUPUY",
+                                "last_name": "ROUSSEL",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "0686864704",
-                                "phone_number_formatted": "+33686864704",
+                                "phone_number": "6 60 77 38 60",
+                                "phone_number_formatted": "+33660773860",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3443,42 +3455,42 @@
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2025-10-06 13:36:34 +0200",
+                              "created_at": "2026-01-06 15:22:55 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Julien",
+                              "first_name": "Armandine",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "DUPUY",
+                              "last_name": "ROUSSEL",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "0686864704",
-                              "phone_number_formatted": "+33686864704",
+                              "phone_number": "6 60 77 38 60",
+                              "phone_number_formatted": "+33660773860",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "cd32d504-532f-428a-b4fb-163e87de7dbc"
+                          "uuid": "97a3de97-1822-4d4a-b42b-8dde8a597b9a"
                         },
                         {
                           "id": 14,
                           "address": "4 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 137,
+                              "id": 151,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Romain",
-                              "last_name": "Pichon"
+                              "first_name": "Emmelie",
+                              "last_name": "David"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-10-06 13:36:34 +0200",
+                          "created_at": "2026-01-06 15:22:55 +0100",
                           "created_by": "agent",
-                          "created_by_id": 137,
+                          "created_by_id": 151,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2024-01-01 08:45:00 +0100",
@@ -3517,14 +3529,15 @@
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites"
+                            "verticale": "rdv_solidarites",
+                            "website": null
                           },
                           "participations": [
                             {
                               "id": 17,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 137,
+                              "created_by_id": 151,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
@@ -3536,17 +3549,17 @@
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2025-10-06 13:36:34 +0200",
+                                "created_at": "2026-01-06 15:22:55 +0100",
                                 "email": "usager_4@lapin.fr",
-                                "first_name": "Édouard",
+                                "first_name": "Narcisse",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "DUMONT",
+                                "last_name": "REYNAUD",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "0622502309",
-                                "phone_number_formatted": "+33622502309",
+                                "phone_number": "651303455",
+                                "phone_number_formatted": "+33651303455",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3564,24 +3577,24 @@
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2025-10-06 13:36:34 +0200",
+                              "created_at": "2026-01-06 15:22:55 +0100",
                               "email": "usager_4@lapin.fr",
-                              "first_name": "Édouard",
+                              "first_name": "Narcisse",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "DUMONT",
+                              "last_name": "REYNAUD",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "0622502309",
-                              "phone_number_formatted": "+33622502309",
+                              "phone_number": "651303455",
+                              "phone_number_formatted": "+33651303455",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "59021b59-15f5-4ec5-b0da-c81987f1270e"
+                          "uuid": "b682efe9-b19a-412d-9c67-f6e3db780bb9"
                         }
                       ],
                       "meta": {
@@ -3694,7 +3707,7 @@
                         ]
                       },
                       "error_messages": [
-                        "status doit être rempli(e)"
+                        "status doit être rempli·e"
                       ]
                     }
                   }
@@ -3798,29 +3811,29 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 252,
+                          "id": 270,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Aurélie",
-                          "last_name": "Perez"
+                          "first_name": "Guérin",
+                          "last_name": "Legrand"
                         },
                         "user": {
-                          "id": 111,
+                          "id": 113,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:39 +0200",
+                          "created_at": "2026-01-06 15:23:00 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Aimable",
+                          "first_name": "Ombline",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "ARNAUD",
+                          "last_name": "LEVEQUE",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0642890191",
-                          "phone_number_formatted": "+33642890191",
+                          "phone_number": "07 49 59 08 84",
+                          "phone_number_formatted": "+33749590884",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4073,27 +4086,27 @@
                           "id": 5,
                           "agents": [
                             {
-                              "id": 284,
+                              "id": 302,
                               "email": "agent_2@lapin.fr",
-                              "first_name": "Arian",
-                              "last_name": "Le Goff"
+                              "first_name": "Maguelone",
+                              "last_name": "Weber"
                             },
                             {
-                              "id": 285,
+                              "id": 303,
                               "email": "agent_3@lapin.fr",
-                              "first_name": "Arielle",
-                              "last_name": "Morel"
+                              "first_name": "Mathilde",
+                              "last_name": "Collin"
                             },
                             {
-                              "id": 286,
+                              "id": 304,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Armelle",
-                              "last_name": "Guérin"
+                              "first_name": "Zénobe",
+                              "last_name": "Fontaine"
                             }
                           ],
-                          "name": "Aquitaine ghosts 799285ed",
+                          "name": "Champagne-Ardenne buffalo b681b280",
                           "territory": {
-                            "id": 232,
+                            "id": 234,
                             "departement_number": "01",
                             "motif_categories": [],
                             "name": "Espace n°1"
@@ -4210,30 +4223,31 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 236,
+                          "id": 238,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "user": {
-                          "id": 127,
+                          "id": 129,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:41 +0200",
+                          "created_at": "2026-01-06 15:23:02 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Agilberte",
+                          "first_name": "Philibert",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "DENIS",
+                          "last_name": "GUILLOT",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0631339353",
-                          "phone_number_formatted": "+33631339353",
+                          "phone_number": "649074046",
+                          "phone_number_formatted": "+33649074046",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4292,7 +4306,7 @@
             }
           },
           "422": {
-            "description": "Renvoie 'unprocessable_entity' quand l'utilisateur ou l'organisation est inconnu(e) ou ce profil existe déjà",
+            "description": "Renvoie 'unprocessable_entity' quand l'utilisateur ou l'organisation est inconnu·e ou ce profil existe déjà",
             "content": {
               "application/json": {
                 "examples": {
@@ -4518,13 +4532,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 144,
+                        "id": 146,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2025-10-06 13:36:42 +0200",
+                        "created_at": "2026-01-06 15:23:03 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -4533,18 +4547,19 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "666609679",
-                        "phone_number_formatted": "+33666609679",
+                        "phone_number": "6 18 69 74 08",
+                        "phone_number_formatted": "+33618697408",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 257,
+                              "id": 259,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
-                              "verticale": "rdv_solidarites"
+                              "verticale": "rdv_solidarites",
+                              "website": null
                             }
                           }
                         ]
@@ -4828,13 +4843,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 151,
+                        "id": 153,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2025-10-06 13:36:42 +0200",
+                        "created_at": "2026-01-06 15:23:03 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Alain",
                         "invitation_accepted_at": null,
@@ -4846,28 +4861,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 150,
+                          "id": 152,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:42 +0200",
+                          "created_at": "2026-01-06 15:23:03 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Huguette",
+                          "first_name": "Amaryllis",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MARCHAND",
+                          "last_name": "LEMAITRE",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "07 73 48 85 78",
-                          "phone_number_formatted": "+33773488578",
+                          "phone_number": "0730968393",
+                          "phone_number_formatted": "+33730968393",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 150,
+                        "responsible_id": 152,
                         "user_profiles": null
                       }
                     }
@@ -4899,8 +4914,8 @@
                         ]
                       },
                       "error_messages": [
-                        "last_name doit être rempli(e)",
-                        "first_name doit être rempli(e)"
+                        "last_name doit être rempli·e",
+                        "first_name doit être rempli·e"
                       ]
                     }
                   }
@@ -4996,7 +5011,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "793HRDC6"
+                      "invitation_token": "5RBQLEW7"
                     }
                   }
                 },
@@ -5129,23 +5144,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 178,
+                          "id": 180,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:43 +0200",
+                          "created_at": "2026-01-06 15:23:04 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Maxime",
+                          "first_name": "Fabien",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "GRONDIN",
+                          "last_name": "ANDRÉ",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "7 39 50 85 46",
-                          "phone_number_formatted": "+33739508546",
+                          "phone_number": "0686706215",
+                          "phone_number_formatted": "+33686706215",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5402,13 +5417,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 189,
+                        "id": 191,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2025-10-06 13:36:43 +0200",
+                        "created_at": "2026-01-06 15:23:04 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Johnny",
                         "invitation_accepted_at": null,
@@ -5420,28 +5435,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 188,
+                          "id": 190,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:43 +0200",
+                          "created_at": "2026-01-06 15:23:04 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Argine",
+                          "first_name": "Sylviane",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LE GOFF",
+                          "last_name": "ANTOINE",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "06 86 16 99 55",
-                          "phone_number_formatted": "+33686169955",
+                          "phone_number": "6 72 78 90 58",
+                          "phone_number_formatted": "+33672789058",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 188,
+                        "responsible_id": 190,
                         "user_profiles": null
                       }
                     }
@@ -5492,8 +5507,8 @@
                         ]
                       },
                       "error_messages": [
-                        "last_name doit être rempli(e)",
-                        "first_name doit être rempli(e)"
+                        "last_name doit être rempli·e",
+                        "first_name doit être rempli·e"
                       ]
                     }
                   }
@@ -5581,23 +5596,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 198,
+                          "id": 200,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:44 +0200",
+                          "created_at": "2026-01-06 15:23:05 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Eusèbe",
+                          "first_name": "Eubert",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "PERRIER",
+                          "last_name": "REYNAUD",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "736258265",
-                          "phone_number_formatted": "+33736258265",
+                          "phone_number": "07 98 65 29 65",
+                          "phone_number_formatted": "+33798652965",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5714,13 +5729,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 203,
+                        "id": 205,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2025-10-06 13:36:44 +0200",
+                        "created_at": "2026-01-06 15:23:05 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -5729,18 +5744,19 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "06 33 09 76 25",
-                        "phone_number_formatted": "+33633097625",
+                        "phone_number": "07 87 23 05 13",
+                        "phone_number_formatted": "+33787230513",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 322,
+                              "id": 324,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
-                              "verticale": "rdv_solidarites"
+                              "verticale": "rdv_solidarites",
+                              "website": null
                             }
                           }
                         ]
@@ -6043,7 +6059,7 @@
                     "value": {
                       "webhook_endpoint": {
                         "id": 26,
-                        "organisation_id": 342,
+                        "organisation_id": 344,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -6240,7 +6256,7 @@
                     "value": {
                       "webhook_endpoint": {
                         "id": 28,
-                        "organisation_id": 349,
+                        "organisation_id": 351,
                         "subscriptions": [
                           "rdv",
                           "user",


### PR DESCRIPTION
# Contexte

Dans le cadre d'une amélioration de leur itnégration avec nous, l'équipe de Mon Suivi Social aimerait faire des appels en direct à notre api plutôt que de garder des rendez-vous en cache.
Le problème, c'est que notre api peut parfois être très lente : jusqu'à 500ms en démo pour juste 9 rdvs.

On a fait un poc en restreignant le nombre d'associations qu'on renvoie (beaucoup sont inutiles pour leur cas d'usage), et ça permet d'avoir des réponses beaucoup plus rapides.


# Solution

Plutôt que de partir sur une refonte complète de notre api avec du graphql, cette pr prend exemple sur l'api rest de Stripe qui propose un paramètre `include` facultatif qui permet de décider quelles associations sont utiles.

Le comportement de l'api ne change pas pour les clients qui n'utilisent pas ce paramètre.

La gem BluePrinter n'est pas très pratique pour implémenter ça, donc on se retrouve à mettre des champs facultatifs.

L'approche dans le controller est un peu verbeuse aussi, mais j'ai l'impression que c'est plus simple à long terme d'avoir du code long mais simple que court mais difficile à comprendre.