### PR TITLE
Supprimer l’étape de définition du mot de passe du parcours de prise de RDV usager

### DIFF
--- a/app/controllers/concerns/users/devise_or_sso_logout.rb
+++ b/app/controllers/concerns/users/devise_or_sso_logout.rb
@@ -10,6 +10,7 @@ module Users::DeviseOrSsoLogout
     pro_connect_id_token = session.delete(:pro_connect_id_token) || session.delete(:agent_connect_id_token)
 
     session.delete(:invitation) # créé par TokenInvitable
+    current_user_before = current_user
     sign_out(:user)
     set_flash_message!(:notice, flash_message_key)
 
@@ -23,6 +24,8 @@ module Users::DeviseOrSsoLogout
       session[:france_connect_v2_logout_state] = fc_client.state
       redirect_to fc_client.pro_connect_logout_url(franceconnect_v2_post_logout_url), allow_other_host: true
 
+    elsif params[:redirect_to_reset_password]
+      redirect_to new_user_password_path(email: current_user_before.email)
     else
       redirect_to after_sign_out_path_for(:user)
     end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -6,18 +6,13 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
     if resource.errors.empty?
       set_flash_message!(:notice, :confirmed)
+
+      sign_in(:user, resource)
       respond_with_navigational(resource) do
-        redirect_to after_confirmation_path_for(resource_name, resource)
+        redirect_to after_sign_in_path_for(resource_name)
       end
     else
       redirect_to new_user_session_path, flash: { error: resource.errors.full_messages.join(", ") }
     end
-  end
-
-  protected
-
-  def after_confirmation_path_for(_resource_name, resource)
-    token = resource.send(:set_reset_password_token)
-    edit_password_path(resource, reset_password_token: token, from_confirmation: true)
   end
 end

--- a/app/views/common/form/_current_password_input.html.slim
+++ b/app/views/common/form/_current_password_input.html.slim
@@ -1,4 +1,4 @@
-/# locals: (f:, name: :password, hint: nil, password_label: nil, forgotten_password_link: false)
+/# locals: (f:, name: :password, hint: nil, password_label: nil, forgotten_password_link: false, forgotten_password_link_label: "Mot de passe oublié ?")
 
 = f.dsfr_input_group name, class: "fr-password fr-mt-2w"
   = f.dsfr_label_with_hint name, class: "fr-label", for: "password", hint: hint, label: password_label
@@ -9,4 +9,4 @@
     input type="checkbox" aria-label="Afficher le mot de passe" id="password-show"
     label for="password-show" class="fr-password__checkbox fr-label" Afficher
   - if forgotten_password_link
-    = link_to "Mot de passe oublié ?", new_password_path(resource_name), class: "fr-link"
+    = link_to forgotten_password_link_label, new_password_path(resource_name), class: "fr-link"

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "Mot de passe oublié ?"
+- content_for :title, "Mot de passe oublié ou première connexion ?"
 
 .card
   .card-body

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -25,7 +25,7 @@
         |> Le mot de passe vous permet de vous reconnecter à votre compte pour une future prise de RDV. Vous n’avez pas défini de mot de passe.
         |> Ce n’est pas obligatoire. Vous pourrez le faire plus tard.
         |> Si vous souhaitez le faire maintenant, suivez ce lien :
-        = link_to "définir un mot de passe", new_user_password_path
+        = link_to "définir un nouveau mot de passe…", destroy_user_session_path(redirect_to_reset_password: true), method: :delete
       .mt-5
         hr
     p Vous souhaitez supprimer votre compte ?

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -19,6 +19,15 @@
         .rdv-text-align-right= f.submit "Modifier", class: "fr-btn"
       .mt-5
         hr
+    - else
+      p.rdv-font-weight-bold Mot de passe
+      p
+        |> Le mot de passe vous permet de vous reconnecter à votre compte pour une future prise de RDV. Vous n’avez pas défini de mot de passe.
+        |> Ce n’est pas obligatoire. Vous pourrez le faire plus tard.
+        |> Si vous souhaitez le faire maintenant, suivez ce lien :
+        = link_to "définir un mot de passe", new_user_password_path
+      .mt-5
+        hr
     p Vous souhaitez supprimer votre compte ?
     - if resource.can_be_soft_deleted?
       = link_to "Supprimer",

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -20,7 +20,7 @@
     = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
       = render "devise/shared/error_messages", resource: resource
       = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email", autocomplete: "email"
-      = render "common/form/current_password_input", f:, forgotten_password_link: true, forgotten_password_link_label: "Mot de passe oublié ou première connexion ?"
+      = render "common/form/current_password_input", f:, forgotten_password_link: true, forgotten_password_link_label: @rdv_wizard.present? ? "Mot de passe oublié ?" : "Mot de passe oublié ou première connexion ?"
 
       .rdv-text-align-center
         = f.submit "Se connecter", class: "fr-mt-2v fr-btn"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -20,7 +20,7 @@
     = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
       = render "devise/shared/error_messages", resource: resource
       = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email", autocomplete: "email"
-      = render "common/form/current_password_input", f:, forgotten_password_link: true
+      = render "common/form/current_password_input", f:, forgotten_password_link: true, forgotten_password_link_label: "Mot de passe oublié ou première connexion ?"
 
       .rdv-text-align-center
         = f.submit "Se connecter", class: "fr-mt-2v fr-btn"

--- a/spec/features/agents/account/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/account/agent_can_reset_his_password_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Agent resets his password spec" do
 
   it "works when using the user's password reset form" do
     visit new_user_password_path
-    expect(page).to have_content("Mot de passe oublié ?")
+    expect(page).to have_content("Mot de passe oublié ou première connexion ?")
     expect(page).to have_link("Se connecter")
 
     fill_in "user_email", with: agent.email

--- a/spec/features/users/account/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/account/user_can_reset_his_password_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "User resets his password spec" do
 
   it "works by sending a reset email" do
     visit new_user_password_path
-    expect(page).to have_content("Mot de passe oublié ?")
+    expect(page).to have_content("Mot de passe oublié ou première connexion ?")
     expect(page).to have_link("Se connecter")
 
     fill_in "user_email", with: user.email

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -17,10 +17,7 @@ RSpec.describe "User signs up and signs in" do
       open_email(user.email)
       current_email.click_link "Confirmer mon compte"
       expect_flash_info(I18n.t("devise.confirmations.confirmed"))
-      expect(page).to have_content("Définir mon mot de passe")
-      fill_in "Mot de passe", with: user.password
-      click_on "Enregistrer"
-      expect_flash_info(I18n.t("devise.passwords.updated")) # auto-connected
+      expect(page).to have_content("Vos rendez-vous")
       click_link "Déconnexion"
       expect(page).to have_current_path(root_path, ignore_query: true)
     end

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -528,11 +528,8 @@ RSpec.describe "User can search for rdvs" do
     expect(current_email).to have_content("Merci pour votre inscription")
     current_email.click_link("Confirmer mon compte")
 
-    # Password reset page after confirmation
     expect(page).to have_content("Votre compte a été validé")
-    expect(page).to have_content("Définir mon mot de passe")
-    fill_in("Mot de passe", with: "Rdvservicepublictest1€")
-    click_button("Enregistrer")
+    expect(page).to have_content("Étape 1 sur 3")
   end
 
   def continue_to_rdv(motif, address: nil)

--- a/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
@@ -58,10 +58,9 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
 
       open_email("davidnchicode@crotonmail.com")
       current_email.click_link("Confirmer mon compte")
-      fill_in "Mot de passe", with: "Rdvservicepublictest1!"
-      click_on("Enregistrer")
 
       # Page de formulaire où l'on peut ajouter le nom de naissance, la date de naissance, le téléphone...
+      expect(page).to have_content("Étape 1 sur 3")
       fill_in "user_birth_date", with: "02/04/1990"
       click_on("Continuer")
 

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -494,9 +494,6 @@ RSpec.describe "User can search rdv on rdv mairie" do
       perform_enqueued_jobs
       open_email("elo@ise.fr")
       current_email.click_link "Confirmer mon compte"
-      expect(page).to have_content("Définir mon mot de passe")
-      fill_in "Mot de passe", with: "Rdvservicepublictest1!"
-      click_on "Enregistrer"
       # Parcours post-connexion
       expect(page).to have_content("Étape 1 sur 3")
       expect(page).to have_content("Vos informations")


### PR DESCRIPTION
# Contexte

On souhaite simplifier le parcours usager.

On se dirige vers un parcours « sans création de compte », ou plutôt avec une création invisible : 

- ne plus demander à l’usager s’il a un compte ou non (Connexion / Inscription)
- ne plus demander de mot de passe mais simplement une confirmation email par code à 6 chiffres

# Changements proposés ici

Dans cette première étape je propose simplement de supprimer l’étape de définition du parcours de prise de RDV actuel. 

<img width="1220" height="609" alt="image" src="https://github.com/user-attachments/assets/69b3bcc1-2a2e-4f17-894a-085b77755825" />

Dans une étape à venir toute proche on va proposer de se connecter via un code à 6 chiffres et donc réduire encore la présence des champs mots de passes, jusqu’à la supprimer.

On impacte ici uniquement les usagers qui se créent un compte via email (et pas les FranceConnect ou les usagers qui ont déjà un compte et se reconnectent).

On peut faire ce changement à très bas coût, quelques dizaines de lignes changées seulement. 

Les usagers peuvent toujours définir un mot de passe une fois connectés ou lorsqu’ils reviennent.  

| avant | après |
| - | - |
| <img width="390" height="1229" alt="Connexion - RDV Solidarités" src="https://github.com/user-attachments/assets/550da031-6138-44c7-8ef3-420d37c4b8c8" /> | <img width="868" height="2505" alt="image" src="https://github.com/user-attachments/assets/7ce0ba44-9dec-46c8-8eb4-b2441458810c" /> |
| <img width="780" height="1688" alt="image" src="https://github.com/user-attachments/assets/bc859a30-5961-44dc-ac77-c490f538b07c" /> | <img width="780" height="1688" alt="image" src="https://github.com/user-attachments/assets/92f85cb9-668f-4914-84ea-82db3ad39379" /> |

# Review app

https://rdv-service-public-review-app-pr5942.osc-secnum-fr1.scalingo.io/prendre_rdv?address=Paris%2C+75001&city_code=75056&date=2025-12-11+08%3A00%3A00+%2B0100&departement=75&latitude=48.859&lieu_id=5&longitude=2.347&motif_name_with_location_type=consultation_prenatale-public_office&service_id=2&street_ban_id=

puis sélectionner le parcours « Créer un compte »