### PR TITLE
Correction marge inférieur dans la config d’espace

### DIFF
--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -75,7 +75,7 @@ h1.fr-my-2w.rdv-text-align-center.fr-pb-2w =  t("admin.territories.show.title", 
 
 h2.rdv-text-align-center.fr-pt-4w.fr-pb-2w Paramètres avancés
 
-.fr-container-fluid.fr-mb-16w
+.fr-container-fluid
   .fr-grid-row.fr-grid-row--gutters
     - if Agent::TeamPolicy.allowed_to_manage_teams_in?(current_territory, current_agent)
       .fr-col-12.fr-col-md-6.fr-col-lg-4.fr-mb-2w

--- a/app/views/layouts/application_configuration.html.slim
+++ b/app/views/layouts/application_configuration.html.slim
@@ -6,7 +6,7 @@ html lang="fr"
   body
     = render "layouts/agent_header"
 
-    main.fr-container.fr-mt-4v
+    main.fr-container.fr-mt-4v.fr-mb-20v
       = content_for(:breadcrumbs)
       = render "layouts/flash"
       = yield


### PR DESCRIPTION
Closes #5943 

# Contexte

En retravaillant sur les pages de configuration d’espace, j’ai changé le container utilisé. Le problème étant que je n’ai pas remis de marge inférieure ce qui provoque une superposition du footer avec le contenu dans certains cas.

# Solution

On corrige rapidement ici.
Dans tous les cas, il faudra repenser ce footer qui n’est déjà pas adapté aux pages d’admin d’espace.

## Captures d'écran

Avant | Après
:- | -:
<img width="1281" height="201" alt="image" src="https://github.com/user-attachments/assets/b1cb46d4-bc50-44d4-a922-d44514b8ac68" /> | <img width="1285" height="271" alt="image" src="https://github.com/user-attachments/assets/d87b412e-15bc-4a18-a658-f2dbc4f79fe0" />

