### PR TITLE
[SPIKE] Connexion usager par code à 6 chiffres

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,4 +82,12 @@ class ApplicationController < ActionController::Base
   def page_number
     params[:page].presence&.to_i || 1
   end
+
+  def current_user_email
+    session[:current_user_email].presence
+  end
+
+  def current_user_email=(email)
+    session[:current_user_email] = email
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,4 +90,8 @@ class ApplicationController < ActionController::Base
   def current_user_email=(email)
     session[:current_user_email] = email
   end
+
+  def logout_current_user_email
+    session.delete(:current_user_email)
+  end
 end

--- a/app/controllers/users/login_by_code_controller.rb
+++ b/app/controllers/users/login_by_code_controller.rb
@@ -1,7 +1,4 @@
 class Users::LoginByCodeController < ApplicationController
-  include Devise::Controllers::Helpers
-
-  respond_to :html
   layout "application_narrow"
 
   def code_form
@@ -11,8 +8,8 @@ class Users::LoginByCodeController < ApplicationController
 
   def submit_login_code
     email = params.require(:email)
-
     submitted_login_code = params[:login_code]
+
     if submitted_login_code == UserLoginCode.code_for(email)
       self.current_user_email = email
       users = User.where(email:).or(User.where(notification_email: email)).to_a
@@ -24,7 +21,7 @@ class Users::LoginByCodeController < ApplicationController
         user = users.first
         sign_in(:user, user)
         flash[:success] = "Connexion réussie"
-        redirect_to users_rdvs_path
+        redirect_to after_sign_in_path_for(user)
       else
         redirect_to users_choix_fiche_path
       end
@@ -48,10 +45,16 @@ class Users::LoginByCodeController < ApplicationController
     if user.email_or_notification_email == current_user_email
       user.confirm
       sign_in(:user, user)
-      redirect_to users_rdvs_path
+      redirect_to after_sign_in_path_for(user)
     else
       flash[:error] = "Impossible de se connecter avec cette fiche : elle ne porte pas votre e-mail"
       redirect_to users_choix_fiche_path
     end
+  end
+
+  private
+
+  def storable_location?
+    false
   end
 end

--- a/app/controllers/users/login_by_code_controller.rb
+++ b/app/controllers/users/login_by_code_controller.rb
@@ -10,22 +10,20 @@ class Users::LoginByCodeController < ApplicationController
     email = params.require(:email)
     submitted_login_code = params[:login_code]
 
-    if submitted_login_code == UserLoginCode.code_for(email)
+    if submitted_login_code.present? && submitted_login_code == UserLoginCode.code_for(email)
       self.current_user_email = email
-      users = User.where(email:).or(User.where(notification_email: email)).to_a
-      case users.size
+
+      users_matching_email = User.where(email:).or(User.where(notification_email: email)).to_a
+      case users_matching_email.size
       when 0
         flash[:error] = "Il n'existe aucune fiche usager avec l'email #{email}"
         redirect_to users_code_form_path(email:)
       when 1
-        user = users.first
-        user.confirm
-        sign_in(:user, user)
-        flash[:success] = "Connexion réussie"
-        redirect_to after_sign_in_path_for(user)
+        login_user_and_redirect(users_matching_email.sole)
       else
         redirect_to users_choix_fiche_path
       end
+
     else
       flash[:error] = "Code invalide"
       redirect_to users_code_form_path(email:)
@@ -44,9 +42,7 @@ class Users::LoginByCodeController < ApplicationController
 
     user = User.find(params[:user_id])
     if user.email_or_notification_email == current_user_email
-      user.confirm
-      sign_in(:user, user)
-      redirect_to after_sign_in_path_for(user)
+      login_user_and_redirect(user)
     else
       flash[:error] = "Impossible de se connecter avec cette fiche : elle ne porte pas votre e-mail"
       redirect_to users_choix_fiche_path
@@ -54,6 +50,13 @@ class Users::LoginByCodeController < ApplicationController
   end
 
   private
+
+  def login_user_and_redirect(user)
+    user.confirm
+    sign_in(:user, user)
+    flash[:success] = "Connexion réussie"
+    redirect_to after_sign_in_path_for(user)
+  end
 
   def storable_location?
     false

--- a/app/controllers/users/login_by_code_controller.rb
+++ b/app/controllers/users/login_by_code_controller.rb
@@ -1,0 +1,57 @@
+class Users::LoginByCodeController < ApplicationController
+  include Devise::Controllers::Helpers
+
+  respond_to :html
+  layout "application_narrow"
+
+  def code_form
+    @email = params[:email].presence
+    redirect_to new_user_session_path unless @email
+  end
+
+  def submit_login_code
+    email = params.require(:email)
+
+    submitted_login_code = params[:login_code]
+    if submitted_login_code == UserLoginCode.code_for(email)
+      self.current_user_email = email
+      users = User.where(email:).or(User.where(notification_email: email)).to_a
+      case users.size
+      when 0
+        flash[:error] = "Il n'existe aucune fiche usager avec l'email #{email}"
+        redirect_to users_code_form_path(email:)
+      when 1
+        user = users.first
+        sign_in(:user, user)
+        flash[:success] = "Connexion réussie"
+        redirect_to users_rdvs_path
+      else
+        redirect_to users_choix_fiche_path
+      end
+    else
+      flash[:error] = "Code invalide"
+      redirect_to users_code_form_path(email:)
+    end
+  end
+
+  def choix_fiche
+    redirect_to root_path and return unless current_user_email
+
+    @email = current_user_email
+    @fiches_usagers = User.where(email: @email).or(User.where(notification_email: @email)).to_a
+  end
+
+  def submit_choix_fiche
+    redirect_to root_path and return unless current_user_email
+
+    user = User.find(params[:user_id])
+    if user.email_or_notification_email == current_user_email
+      user.confirm
+      sign_in(:user, user)
+      redirect_to users_rdvs_path
+    else
+      flash[:error] = "Impossible de se connecter avec cette fiche : elle ne porte pas votre e-mail"
+      redirect_to users_choix_fiche_path
+    end
+  end
+end

--- a/app/controllers/users/login_by_code_controller.rb
+++ b/app/controllers/users/login_by_code_controller.rb
@@ -19,6 +19,7 @@ class Users::LoginByCodeController < ApplicationController
         redirect_to users_code_form_path(email:)
       when 1
         user = users.first
+        user.confirm
         sign_in(:user, user)
         flash[:success] = "Connexion réussie"
         redirect_to after_sign_in_path_for(user)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -28,13 +28,14 @@ class Users::SessionsController < Devise::SessionsController
       respond_with resource, location: after_sign_in_path_for(resource)
     else
       email = params[:user]["email"]
-      UserLoginCode.store_code_for(email)
+      UserLoginCode.store_new_code_for(email)
       Users::LoginCodeMailer.send_login_code(email:, domain_id: current_domain.id).deliver_later
       redirect_to users_code_form_path(email:) and return
     end
   end
 
   def destroy
+    logout_current_user_email
     logout_and_redirect_user(flash_message_key: :signed_out)
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -27,7 +27,10 @@ class Users::SessionsController < Devise::SessionsController
       yield resource if block_given?
       respond_with resource, location: after_sign_in_path_for(resource)
     else
-      super
+      email = params[:user]["email"]
+      UserLoginCode.store_code_for(email)
+      Users::LoginCodeMailer.send_login_code(email:, domain_id: current_domain.id).deliver_later
+      redirect_to users_code_form_path(email:) and return
     end
   end
 

--- a/app/mailers/users/login_code_mailer.rb
+++ b/app/mailers/users/login_code_mailer.rb
@@ -1,0 +1,13 @@
+class Users::LoginCodeMailer < ApplicationMailer
+  attr_reader :domain
+
+  def send_login_code(email:, domain_id:)
+    @email = email
+    @domain = Domain.find(domain_id)
+    @login_code = UserLoginCode.code_for(email)
+    mail(
+      subject: "Votre code de connexion est #{@login_code}",
+      to: email
+    )
+  end
+end

--- a/app/mailers/users/login_code_mailer.rb
+++ b/app/mailers/users/login_code_mailer.rb
@@ -5,6 +5,12 @@ class Users::LoginCodeMailer < ApplicationMailer
     @email = email
     @domain = Domain.find(domain_id)
     @login_code = UserLoginCode.code_for(email)
+
+    unless @login_code
+      Sentry.capture_message("Could not retrieve login code from mailer", extras: { email:, domain_id: })
+      return
+    end
+
     mail(
       subject: "Votre code de connexion est #{@login_code}",
       to: email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,6 +113,10 @@ class User < ApplicationRecord
     super(sanitize_email(email))
   end
 
+  def email_or_notification_email
+    email || notification_email
+  end
+
   def add_organisation(organisation)
     self_and_relatives_and_responsible.each do |u|
       u.organisations << organisation if u.organisation_ids.exclude?(organisation.id)

--- a/app/services/user_login_code.rb
+++ b/app/services/user_login_code.rb
@@ -1,0 +1,17 @@
+class UserLoginCode
+  EXPIRES_IN = 30.minutes
+
+  def self.code_for(email)
+    Redis.with_connection { |redis| redis.get(cache_key_for(email)) }
+  end
+
+  def self.store_code_for(email)
+    code = SecureRandom.random_number(100_000..999_999).to_s
+    Redis.with_connection { |redis| redis.set(cache_key_for(email), code, ex: EXPIRES_IN) }
+    code
+  end
+
+  def self.cache_key_for(email)
+    "user_login_code_#{email}"
+  end
+end

--- a/app/services/user_login_code.rb
+++ b/app/services/user_login_code.rb
@@ -5,7 +5,7 @@ class UserLoginCode
     Redis.with_connection { |redis| redis.get(cache_key_for(email)) }
   end
 
-  def self.store_code_for(email)
+  def self.store_new_code_for(email)
     code = SecureRandom.random_number(100_000..999_999).to_s
     Redis.with_connection { |redis| redis.set(cache_key_for(email), code, ex: EXPIRES_IN) }
     code

--- a/app/views/mailers/users/login_code_mailer/send_login_code.html.slim
+++ b/app/views/mailers/users/login_code_mailer/send_login_code.html.slim
@@ -1,0 +1,1 @@
+| Votre code de connexion est #{@login_code}

--- a/app/views/users/login_by_code/choix_fiche.html.slim
+++ b/app/views/users/login_by_code/choix_fiche.html.slim
@@ -1,0 +1,10 @@
+- content_for :title, "Choix de la fiche usager pour #{@email}"
+
+.card
+  .card-body
+    p Veuillez choisir sur quelle fiche usager vous connecter :
+
+    ul
+    - @fiches_usagers.each do |user|
+      li
+        = link_to "#{user.full_name} (id=#{user.id})", users_submit_choix_fiche_path(user_id: user.id)

--- a/app/views/users/login_by_code/code_form.html.slim
+++ b/app/views/users/login_by_code/code_form.html.slim
@@ -1,0 +1,10 @@
+- content_for :title, "Connexion pour #{@email}"
+
+.card
+  .card-body
+    p Veuillez saisir le code à 6 chiffre envoyé à #{@email}
+
+    = form_with url: "/users/submit_login_code", method: :post, builder: Dsfr::FormBuilder, model: User.new, scope: "" do |form|
+      = form.hidden_field :email, value: @email
+      = form.dsfr_text_field :login_code, label: "Code à 6 chiffres"
+      = form.submit "Valider", class: "fr-btn"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -18,10 +18,15 @@
     h2 Se connecter par e-mail
 
     = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
+      = render "devise/shared/error_messages", resource: resource
       = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse e-mail", autocomplete: "email"
-
       .rdv-text-align-center
         = f.submit "Se connecter", class: "fr-mt-2v fr-btn"
+
+    hr.fr-my-2w
+    h2 Vous n'avez pas de compte ?
+    .rdv-text-align-center
+      = link_to "Créer un compte", new_user_registration_path, class: "fr-btn fr-btn--secondary"
 
     - if @rdv_wizard
       hr.fr-my-2w

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -15,20 +15,13 @@
         = render "common/proconnect_button_dsfr", login_hint: resource.email, user_type: "user"
 
       p.fr-hr-or ou
-    h2 Se connecter avec son compte
+    h2 Se connecter par e-mail
 
     = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
-      = render "devise/shared/error_messages", resource: resource
-      = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email", autocomplete: "email"
-      = render "common/form/current_password_input", f:, forgotten_password_link: true
+      = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse e-mail", autocomplete: "email"
 
       .rdv-text-align-center
         = f.submit "Se connecter", class: "fr-mt-2v fr-btn"
-
-    hr.fr-my-2w
-    h2 Vous n'avez pas de compte ?
-    .rdv-text-align-center
-      = link_to "Créer un compte", new_user_registration_path, class: "fr-btn fr-btn--secondary"
 
     - if @rdv_wizard
       hr.fr-my-2w

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,11 @@ Rails.application.routes.draw do
   devise_for :users,
              controllers: { registrations: "users/registrations", sessions: "users/sessions", passwords: "users/passwords", confirmations: "users/confirmations", invitations: "users/invitations" }
 
+  get "users/code_form" => "users/login_by_code#code_form"
+  post "users/submit_login_code" => "users/login_by_code#submit_login_code"
+  get "users/choix_fiche" => "users/login_by_code#choix_fiche"
+  get "users/submit_choix_fiche" => "users/login_by_code#submit_choix_fiche"
+
   namespace :users do
     resource :rdv_wizard_step, only: %i[new create]
     resources :rdvs, only: %i[index create show edit update] do
@@ -101,6 +106,7 @@ Rails.application.routes.draw do
     patch "users/informations", to: "users/users#update"
     resources :relatives, except: %i[index show], controller: "users/relatives"
   end
+
   authenticated :user do
     get "/users/rdvs", to: "users/rdvs#index"
   end

--- a/spec/features/users/account/logout_spec.rb
+++ b/spec/features/users/account/logout_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe "Déconnexion" do
     click_on lieu.name
     first(:link, "11:00").click
 
-    fill_in("Adresse email", with: user.email)
-    fill_in("Mot de passe", with: user.password)
-    find("input[value='Se connecter']").click
+    login_via_6_digit_code(user.email)
 
     click_button("Continuer")
     click_button("Continuer")

--- a/spec/features/users/account/user_can_login_using_login_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_login_code_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe "User can login using 6-digits login code" do
+  it "sends an email with the code and validates it" do
+    email = "user@example.com"
+    user = create(:user, email:)
+
+    visit new_user_session_path
+    fill_in "Adresse e-mail", with: email
+    within("main") { click_on "Se connecter" }
+    expect(page).to have_content("Veuillez saisir le code à 6 chiffre envoyé à #{email}")
+
+    perform_enqueued_jobs
+    open_email(email)
+    expect(current_email.subject).to eq("Votre code de connexion est #{UserLoginCode.code_for(email)}")
+
+    fill_in("Code à 6 chiffres", with: UserLoginCode.code_for(email))
+    click_on "Valider"
+    expect(page).to have_content("Connexion réussie")
+    expect(page).to have_current_path("/users/rdvs")
+    click_on "Vos informations"
+    expect(page).to have_field("user_first_name", with: user.first_name)
+  end
+end

--- a/spec/features/users/account/user_is_redirected_back_after_login_spec.rb
+++ b/spec/features/users/account/user_is_redirected_back_after_login_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe "User is redirected back to requested page after login" do
     expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
     find(".fr-alert--info") # On vérifie que le flash est une info et pas une alerte
 
-    fill_in("user_email", with: user.email)
-    fill_in("user_password", with: user.password)
-    click_button("Se connecter")
+    login_via_6_digit_code(user.email)
     expect(page).to have_current_path("/users/rdvs")
   end
 

--- a/spec/features/users/account/user_session_expires_spec.rb
+++ b/spec/features/users/account/user_session_expires_spec.rb
@@ -9,14 +9,15 @@ RSpec.describe "User session expiration" do
 
   def expect_to_be_logged_out
     visit users_informations_path
-    expect(page).to have_content("Se connecter avec son compte")
+    expect(page).to have_content("Se connecter par e-mail")
   end
 
   it "is done 30 minutes after last visit" do
     visit new_user_session_path
-    fill_in "Adresse email", with: user.email
-    fill_in "user_password", with: password
+    fill_in "Adresse e-mail", with: user.email
     within("main") { click_on "Se connecter" }
+    fill_in("Code à 6 chiffres", with: UserLoginCode.code_for(user.email))
+    click_on "Valider"
     expect_to_be_logged_in
 
     travel_to(28.minutes.from_now)

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -68,47 +68,6 @@ RSpec.describe "User signs up and signs in" do
     end
   end
 
-  context "if agent tries to sign in through the user signin form" do
-    let!(:agent) { create(:agent, password: "c0rRecthorse!", basic_role_in_organisations: [create(:organisation)]) }
-
-    it ".sign_in as user and be signed in as agent" do
-      visit "http://www.rdv-solidarites-test.localhost/"
-      click_link "Se connecter"
-      within("form") do
-        fill_in :user_email, with: agent.email
-        fill_in :user_password, with: agent.password
-        click_on "Se connecter"
-      end
-      expect(page).to have_current_path(admin_organisation_planning_agenda_path(agent.organisations.first))
-    end
-
-    context "when the agent's password is too weak" do
-      let(:agent) do
-        build(:agent, password: "tropfaible").tap do |a|
-          a.save(validate: false)
-        end
-      end
-
-      it "expire le mot de passe et redirige vers la page pour en définir un nouveau" do
-        previous_encrypted_password = agent.reload.encrypted_password
-        visit new_user_session_path
-        fill_in "Adresse email", with: agent.email
-        fill_in "Mot de passe", with: "tropfaible"
-        within("main") { click_on "Se connecter" }
-        expect(page).to have_content("nous vous demandons de changer votre mot de passe")
-        expect(agent.reload.encrypted_password).not_to eq(previous_encrypted_password) # vérifie que le mot de passe a été modifié
-        fill_in "Mot de passe", with: "tropfaible2"
-        click_on "Enregistrer"
-        # expect(page.status_code).to eq 422 # je ne sais pas trop pourquoi devise renvoie une 422 ici
-        expect(page).to have_content("Pour assurer la sécurité de votre compte, votre mot de passe doit faire au moins 12 caractères")
-        fill_in "Mot de passe", with: "Rdvservicepublictest1!"
-        click_on "Enregistrer"
-        expect(page).to have_content("Votre mot de passe a été édité avec succès, votre connexion est désormais active")
-        expect(page).to have_content("Bienvenue !")
-      end
-    end
-  end
-
   def expect_flash_info(message)
     expect(page).to have_selector(".fr-alert.fr-alert--info", text: message)
   end

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -113,9 +113,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         ants_pre_demandes_count: "2"
       ))
 
-      fill_in("user_email", with: user.email)
-      fill_in("user_password", with: user.password)
-      click_button("Se connecter")
+      login_via_6_digit_code(user.email)
 
       expect(page).to have_field("Numéro de pré-demande ANTS")
       fill_in("user_ants_pre_demande_number", with: "1122334455")
@@ -180,9 +178,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         ants_pre_demandes_count: "2"
       )
 
-      fill_in "user_email", with: user.email
-      fill_in "user_password", with: user.password
-      click_button "Se connecter"
+      login_via_6_digit_code(user.email)
 
       fill_in "user_ants_pre_demande_number", with: "1122334455"
       click_button "Continuer"
@@ -249,9 +245,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         ants_pre_demandes_count: "2"
       )
 
-      fill_in "user_email", with: user.email
-      fill_in "user_password", with: user.password
-      click_button "Se connecter"
+      login_via_6_digit_code(user.email)
 
       fill_in "user_ants_pre_demande_number", with: "1122334455"
       click_button "Continuer"
@@ -291,9 +285,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         ants_pre_demandes_count: "2"
       )
 
-      fill_in("user_email", with: user.email)
-      fill_in("user_password", with: user.password)
-      click_button("Se connecter")
+      login_via_6_digit_code(user.email)
 
       fill_in("user_ants_pre_demande_number", with: "1234ABC")
       click_button("Continuer")
@@ -314,9 +306,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
           ants_pre_demandes_count: "2"
         )
 
-        fill_in("user_email", with: user.email)
-        fill_in("user_password", with: user.password)
-        click_button("Se connecter")
+        login_via_6_digit_code(user.email)
 
         fill_in("user_ants_pre_demande_number", with: "abcd1234ef")
         click_button("Continuer")
@@ -338,9 +328,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
           ants_pre_demandes_count: "2"
         )
 
-        fill_in("user_email", with: user.email)
-        fill_in("user_password", with: user.password)
-        click_button("Se connecter")
+        login_via_6_digit_code(user.email)
 
         fill_in("user_ants_pre_demande_number", with: "  ")
         click_button("Continuer")
@@ -364,9 +352,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
           ants_pre_demandes_count: "2"
         )
 
-        fill_in("user_email", with: user.email)
-        fill_in("user_password", with: user.password)
-        click_button("Se connecter")
+        login_via_6_digit_code(user.email)
 
         fill_in("user_ants_pre_demande_number", with: "5544332211")
         click_button("Continuer")
@@ -389,9 +375,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         )
         expect(page).to have_content("Motif : Passeport")
 
-        fill_in("user_email", with: user.email)
-        fill_in("user_password", with: user.password)
-        click_button("Se connecter")
+        login_via_6_digit_code(user.email)
 
         expect(page).to have_field("Numéro de pré-demande ANTS")
       end
@@ -417,9 +401,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         )
         expect(page).to have_content("Motif : Retrait")
 
-        fill_in("user_email", with: user.email)
-        fill_in("user_password", with: user.password)
-        click_button("Se connecter")
+        login_via_6_digit_code(user.email)
 
         expect(page).not_to have_field("Numéro de pré-demande ANTS")
       end
@@ -441,9 +423,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
           )
           expect(page).to have_content("Motif : Retrait")
 
-          fill_in("user_email", with: user.email)
-          fill_in("user_password", with: user.password)
-          click_button("Se connecter")
+          login_via_6_digit_code(user.email)
 
           expect(page).not_to have_field("Numéro de pré-demande ANTS")
         end

--- a/spec/features/users/online_booking/on_rdv_service_public_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_service_public_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe "User can search rdv on rdv service public" do
     expect(page).to have_current_path("/users/sign_in")
     expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
 
-    fill_in("user_email", with: user.email)
-    fill_in("user_password", with: user.password)
-    click_button("Se connecter")
+    login_via_6_digit_code(user.email)
 
     expect(page).not_to have_field("Numéro de pré-demande ANTS")
 

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -128,10 +128,9 @@ RSpec.describe "Adding a user to a collective RDV" do
       click_link("S'inscrire")
 
       expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer.")
-      fill_in("user_email", with: logged_user.email)
-      fill_in("user_password", with: logged_user.password)
 
-      click_button("Se connecter")
+      login_via_6_digit_code(logged_user.email)
+
       click_button("Continuer")
       expect(page).to have_content("Choix de l’usager")
       click_button("Continuer")

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -1,0 +1,6 @@
+def login_via_6_digit_code(email)
+  fill_in("user_email", with: email)
+  click_button("Se connecter")
+  fill_in("Code à 6 chiffres", with: UserLoginCode.code_for(email))
+  click_on "Valider"
+end


### PR DESCRIPTION
:construction: WIP :construction: 

Fixes #5947
Fixes #4395

# Contexte

Le problème est très bien décrit dans #5481 (merci @aminedhobb).

Cette PR propose le premier pas vers une solution à ce problème : **retirer l'unicité sur `users.email`**. Cette unicité n'est nécessaire que pour que Devise trouve une unique fiche usager avec l'email/mdp saisi lors de la connexion.

Proposition : ne plus se connecter par e-mail/mdp mais seulement par email, et que ça donne accès à toutes les fiches usager qui ont cet email. 

# La suite

La prochaine étape sera de fusionner `notification_email` dans `email`, de supprimer `notification_email` et de virer la contrainte d'unicité.

Nous pourrons alors cloisonner les fiches usager par espace.

Note de détail : côté perfs, avec un peu de chance, on pourra peut-être segmenter l'index de fulltext search par territory_id et énormément améliorer les perfs de recherche usager.

# Comment tester

[Review app](https://rdv-service-public-review-app-pr5945.osc-secnum-fr1.scalingo.io/)

J'ai activé l'envoi de mail sur la review app. :love_letter: 

1. Se connecter avec un agent
2. Créer une fiche usager ou RDV pour un usager qui a une adresse mail à laquelle vous avez accès
3. Se déconnecter
4. Cliquer sur "Se connecter" et suivre la marche à suivre

Vous pouvez aussi tester de prendre RDV maintenant que vous avez un compte :

1. Se déconnecter
2. Sur la page d'accueil, taper "Paris" puis suivre le workflow de prise de RDV
