### PR TITLE
Suppression du fichier config/initializers/routing_draw.rb

### DIFF
--- a/config/initializers/routing_draw.rb
+++ b/config/initializers/routing_draw.rb
@@ -1,9 +1,0 @@
-# config/initializers/routing_draw.rb
-
-# Adds draw method into Rails routing
-# It allows us to keep routing splitted into files
-class ActionDispatch::Routing::Mapper
-  def draw(routes_name)
-    instance_eval(File.read(Rails.root.join("config/routes/#{routes_name}.rb"))) # rubocop:disable Rails/RootPathnameMethods
-  end
-end


### PR DESCRIPTION
# Contexte

Je ne suis pas certain que ce fichier soit nécessaire. Je ne le retrouve pas dans la documentation officielle, ni ici : https://guides.rubyonrails.org/routing.html#breaking-up-a-large-route-file-with-draw, ni là : https://api.rubyonrails.org/v8.1.1/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-draw et je me sers de `draw` dans mes apps sans cet initializer également sans problème.

Il est peut-être simplement inspiré d’un article de blog comme celui-ci : https://mattboldt.com/separate-rails-route-files/ ou de ce gist : https://gist.github.com/dhh/2492118](https://gist.github.com/dhh/2492118.


# Solution

On peut tester avec par exemple la commande:
```bash
$ rails routes -g v1/plage_ouvertures
```

Le résultat devrait être identique à celui obtenu avec le fichier, même si je n’ai pas testé le lancement de l’application.