### PR TITLE
ProConnect - Écraser le sub en cas de réconciliation par e-mail

### DIFF
--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -155,7 +155,8 @@ class ProConnectController < ApplicationController
 
     # On ne trouve un agent que par e-mail et cet agent porte un autre sub.
     if !agent_by_sub && agent_by_email&.pro_connect_openid_sub && agent_by_email.pro_connect_openid_sub != sub
-      Sentry.capture_message("Réconciliation ProConnect via e-mail, sub existant écrasé", extra: { user_info: callback_client.user_info })
+      extra = { user_info: callback_client.user_info, old_sub: agent_by_email.pro_connect_openid_sub }
+      Sentry.capture_message("Réconciliation ProConnect via e-mail, sub existant écrasé", extra:)
     end
 
     agent = agent_by_sub || agent_by_email

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -153,16 +153,9 @@ class ProConnectController < ApplicationController
       redirect_to new_agent_session_path and return
     end
 
-    # On trouve un agent par e-mail et cet agent porte un autre sub.
-    if agent_by_email&.pro_connect_openid_sub && agent_by_email.pro_connect_openid_sub != sub
-      error_message = <<~ERROR
-        Votre compte ProConnect est lié à l'adresse e-mail #{callback_client.user_email}.<br />
-        Un compte agent existe déjà sur #{current_domain.name} pour cette adresse email, cependant il est lié à un autre compte ProConnect.<br />
-        Nous vous invitons à #{link_to_demande_support('contacter le support', callback_client)}.
-      ERROR
-      Sentry.capture_message(error_message, extra: { user_info: callback_client.user_info })
-      flash[:error] = error_message
-      redirect_to new_agent_session_path and return
+    # On ne trouve un agent que par e-mail et cet agent porte un autre sub.
+    if !agent_by_sub && agent_by_email&.pro_connect_openid_sub && agent_by_email.pro_connect_openid_sub != sub
+      Sentry.capture_message("Réconciliation ProConnect via e-mail, sub existant écrasé", extra: { user_info: callback_client.user_info })
     end
 
     agent = agent_by_sub || agent_by_email

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe ProConnectController do
 
           sentry_warning_message = "Réconciliation ProConnect via e-mail, sub existant écrasé"
           expect(sentry_events.last.message).to include(sentry_warning_message)
-          expect(sentry_events.last.extra).to eq({ user_info: })
+          expect(sentry_events.last.extra).to eq({ user_info:, old_sub: "another_sub" })
           expect(sentry_events.last.user[:email]).to eq(user_info["email"])
         end
       end

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -175,17 +175,18 @@ RSpec.describe ProConnectController do
       end
 
       context "when an agent exists with the given email but with another sub" do
-        it "displays an error and warns Sentry" do
-          create(:agent, pro_connect_openid_sub: "another_sub", email: user_info["email"])
+        it "replaces the existing sub and warns Sentry" do
+          agent = create(:agent, pro_connect_openid_sub: "another_sub", email: user_info["email"])
           expect do
             get :callback, params: { state:, code: }
-          end.not_to change { Agent.maximum(:updated_at) }
-          expected_error_message = "Un compte agent existe déjà sur RDV Service Public pour cette adresse email"
-          expect(flash[:error]).to include(expected_error_message)
-          expect(sentry_events.last.message).to include(expected_error_message)
+          end.to change { Agent.find(agent.id).pro_connect_openid_sub }.from("another_sub").to(user_info["sub"])
+
+          expect_agent_to_be_updated_and_logged_in(agent.reload)
+
+          sentry_warning_message = "Réconciliation ProConnect via e-mail, sub existant écrasé"
+          expect(sentry_events.last.message).to include(sentry_warning_message)
           expect(sentry_events.last.extra).to eq({ user_info: })
           expect(sentry_events.last.user[:email]).to eq(user_info["email"])
-          expect(current_agent_id).to be_nil
         end
       end
 


### PR DESCRIPTION
Issue Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/213786/

# Contexte

Nous avons des cas rares où un agent se ProConnecte, et où nous trouvons un compte qui porte l'e-mail founit par ProConnect, mais qui a déjà un sub, et ce sub est différent de celui fournit lors de la connexion en cours.

Jusqu'ici, dans ce cas, nous bloquions l'agent et lui demandions de contacter le support. Nous avions espoir de récolter au support plus de contexte, afin de comprendre comment on peut se retrouver dans ce cas.

Hélas, les agents qui nous contactent au support n'ont en général ni le temps ni la connaissance pour nous renseigner.

# Solution

Nous pensons donc continuer de logger ces cas rares (pour s'assurer qu'ils restent rares, et glaner des données de debug), mais **ne plus bloquer les agents**. Pour ce faire, nous écrasons le sub existant.
