### PR TITLE
Retrait complet de font awesome

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -93,15 +93,12 @@ module ApplicationHelper
     tag.span(sector.human_id, class: "badge badge-light text-monospace")
   end
 
-  def aligned_flex_row(fa_icon_name, &block)
-    tag.div(class: "flex-row-aligned") do
-      tag.i(class: class_names("fa", fa_icon_name)) + tag.div(&block)
-    end
-  end
-
   def boolean_tag(value, &block)
-    fa_icon_name = value ? "fa-check" : "fa-exclamation-triangle text-warning"
-    aligned_flex_row(fa_icon_name, &block)
+    icon_classes = value ? "fr-icon-checkbox-fill" : "fr-icon-warning-fill text-warning"
+
+    tag.div(class: "flex-row-aligned") do
+      tag.span(class: icon_classes) + tag.div(&block)
+    end
   end
 
   def boolean_attribute_tag(object, attribute_name)

--- a/app/javascript/stylesheets/_fontawesome_imports.scss
+++ b/app/javascript/stylesheets/_fontawesome_imports.scss
@@ -1,4 +1,0 @@
-$fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
-@import "~@fortawesome/fontawesome-free/scss/fontawesome";
-@import "~@fortawesome/fontawesome-free/scss/regular";
-@import "~@fortawesome/fontawesome-free/scss/solid";

--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -2,7 +2,6 @@
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
 @import "./_variables";
-@import "./fontawesome_imports";
 
 // import bootstrap file by file so we can remove unwanted rules component by component
 // cf https://github.com/twbs/bootstrap/blob/v4.3.1/scss/bootstrap.scss

--- a/app/javascript/stylesheets/application_agent_config.scss
+++ b/app/javascript/stylesheets/application_agent_config.scss
@@ -2,7 +2,6 @@
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
 @import "./_variables";
-@import "./fontawesome_imports";
 
 @import "~bootstrap/scss/bootstrap";
 @import "~select2/dist/css/select2";

--- a/app/javascript/stylesheets/components/_forms.scss
+++ b/app/javascript/stylesheets/components/_forms.scss
@@ -166,14 +166,6 @@ select.form-control-sm {
   }
 }
 
-// allow using FontAwesome icons as buttons, without
-// having an ugly grey rectangle around the icon
-button.fa {
-  background: none;
-  border: none;
-  color: inherit;
-}
-
 input:placeholder-shown {
   font-style: italic;
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "build": "webpack --config webpack.config.js"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^6.1.1",
     "@fullcalendar/core": "^5.11.5",
     "@fullcalendar/daygrid": "^5.11.5",
     "@fullcalendar/interaction": "^5.11.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,11 +7,6 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
   integrity sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==
 
-"@fortawesome/fontawesome-free@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.1.tgz#bf5d45611ab74890be386712a0e5d998c65ee2a1"
-  integrity sha512-J/3yg2AIXc9wznaVqpHVX3Wa5jwKovVF0AMYSnbmcXTiL3PpRPfF58pzWucCwEiCJBp+hCNRLWClTomD8SseKg==
-
 "@fullcalendar/common@~5.11.5":
   version "5.11.5"
   resolved "https://registry.yarnpkg.com/@fullcalendar/common/-/common-5.11.5.tgz#1a30a852b33ab5c1b04f4ee558941bed3c72d07f"


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr5952.osc-secnum-fr1.scalingo.io/)

# Contexte

Maintenant que nous avons retiré complètement les font awesome côté usagers et côté agents dans de multiples PR, nous pouvons retirer son installation et chargement.

Le CSS côté agent passe de 350ko à 268ko 🎉 

