### PR TITLE
Nettoyage post-renommage ProConnect

### DIFF
--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -49,7 +49,7 @@ class Agents::SessionsController < Devise::SessionsController
       @oauth_client_app_post_logout_redirect_url = oauth_app.post_logout_redirect_uri
     end
 
-    pro_connect_id_token = session.delete(:pro_connect_id_token) || session.delete(:agent_connect_id_token)
+    pro_connect_id_token = session.delete(:pro_connect_id_token)
 
     sign_out(:agent)
 

--- a/app/controllers/concerns/users/devise_or_sso_logout.rb
+++ b/app/controllers/concerns/users/devise_or_sso_logout.rb
@@ -7,7 +7,7 @@ module Users::DeviseOrSsoLogout
   # - FranceConnect v2
   def logout_and_redirect_user(flash_message_key:)
     france_connect_v2_id_token = session.delete(:france_connect_v2_id_token)
-    pro_connect_id_token = session.delete(:pro_connect_id_token) || session.delete(:agent_connect_id_token)
+    pro_connect_id_token = session.delete(:pro_connect_id_token)
 
     session.delete(:invitation) # créé par TokenInvitable
     current_user_before = current_user

--- a/app/controllers/operators/sessions_controller.rb
+++ b/app/controllers/operators/sessions_controller.rb
@@ -1,6 +1,6 @@
 class Operators::SessionsController < Devise::SessionsController
   def destroy
-    pro_connect_id_token = session.delete(:pro_connect_id_token) || session.delete(:agent_connect_id_token)
+    pro_connect_id_token = session.delete(:pro_connect_id_token)
 
     sign_out(:operator_manager)
 

--- a/app/controllers/super_admins/sessions_controller.rb
+++ b/app/controllers/super_admins/sessions_controller.rb
@@ -1,7 +1,7 @@
 module SuperAdmins
   class SessionsController < ApplicationController
     def destroy
-      pro_connect_id_token = session.delete(:pro_connect_id_token) || session.delete(:agent_connect_id_token)
+      pro_connect_id_token = session.delete(:pro_connect_id_token)
       skip_authorization
       sign_out_all_scopes if super_admin_signed_in?
 


### PR DESCRIPTION
On supprime les fallbacks laissés quelques jours dans #5918. Les sessions durent 8h donc on est vraiment plutôt sûrs qu'il ne reste aucune trace de `agent_connect_id_token`.