### PR TITLE
CRM : ajout de la date de création d’espace et du nombre d’agents actifs

### DIFF
--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -26,10 +26,10 @@ class CronJob::SynchronizeCrm < CronJob
         territory = Organisation.find(ids.first).territory
         last_rdv = Rdv.where(organisation: ids).order(created_at: :desc).first
         properties = {
-          "NOMBRE DE RDV": Rdv.where(organisation: ids).count,
-          "DATE CREATION DERNIER RDV": last_rdv ? { start: last_rdv.created_at.strftime("%Y-%m-%d") } : nil,
-          "DATE CREATION ESPACE": { start: territory.created_at.strftime("%Y-%m-%d") },
-          "NOMBRE AGENTS ACTIFS": territory.organisations_agents.where("last_sign_in_at >= ?", 30.days.ago).count,
+          "NOMBRE DE RDV" => Rdv.where(organisation: ids).count,
+          "DATE CREATION DERNIER RDV" => last_rdv ? { start: last_rdv.created_at.strftime("%Y-%m-%d") } : nil,
+          "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
+          "NOMBRE AGENTS ACTIFS" => territory.organisations_agents.where("last_sign_in_at >= ?", 30.days.ago).count,
         }
         client.update_page(page_id: notion_page.id, properties:)
       end

--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -21,13 +21,17 @@ class CronJob::SynchronizeCrm < CronJob
     client.database_query(database_id: NOTION_DATABASE_ID, filter:) do |page|
       page.results.each do |notion_page|
         ids = organisations_ids(notion_page)
-        rdv_count = ids.blank? ? nil : Rdv.where(organisation: ids).count
+        next if ids.blank?
+
+        territory = Organisation.find(ids.first).territory
         last_rdv = Rdv.where(organisation: ids).order(created_at: :desc).first
-        if last_rdv
-          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count, "DATE CREATION DERNIER RDV" => { start: last_rdv.created_at&.strftime("%Y-%m-%d") } })
-        else
-          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count, "DATE CREATION DERNIER RDV" => nil })
-        end
+        properties = {
+          "NOMBRE DE RDV": Rdv.where(organisation: ids).count,
+          "DATE CREATION DERNIER RDV": last_rdv ? { start: last_rdv.created_at.strftime("%Y-%m-%d") } : nil,
+          "DATE CREATION ESPACE": { start: territory.created_at.strftime("%Y-%m-%d") },
+          "NOMBRE AGENTS ACTIFS": territory.organisations_agents.where("last_sign_in_at >= ?", 30.days.ago).count,
+        }
+        client.update_page(page_id: notion_page.id, properties:)
       end
     end
   end

--- a/spec/jobs/cron_job/synchronize_crm_spec.rb
+++ b/spec/jobs/cron_job/synchronize_crm_spec.rb
@@ -40,7 +40,12 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
 
         expect(notion_client).to have_received(:update_page).with(
           page_id: "page_id",
-          properties: { "NOMBRE DE RDV" => 2, "DATE CREATION DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") } }
+          properties: {
+            "NOMBRE DE RDV" => 2,
+            "DATE CREATION DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") },
+            "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
+            "NOMBRE AGENTS ACTIFS" => 0,
+          }
         )
       end
     end
@@ -53,7 +58,12 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
 
         expect(notion_client).to have_received(:update_page).with(
           page_id: "page_id",
-          properties: { "NOMBRE DE RDV" => 1, "DATE CREATION DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") } }
+          properties: {
+            "NOMBRE DE RDV" => 1,
+            "DATE CREATION DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") },
+            "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
+            "NOMBRE AGENTS ACTIFS" => 0,
+          }
         )
       end
 
@@ -63,7 +73,15 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
         it "le nombre de RDV est mis à jour dans la page Notion avec 0 et la date du dernier RDV est nulle" do
           described_class.new.perform
 
-          expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 0, "DATE CREATION DERNIER RDV" => nil })
+          expect(notion_client).to have_received(:update_page).with(
+            page_id: "page_id",
+            properties: {
+              "NOMBRE DE RDV" => 0,
+              "DATE CREATION DERNIER RDV" => nil,
+              "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
+              "NOMBRE AGENTS ACTIFS" => 0,
+            }
+          )
         end
       end
     end
@@ -71,10 +89,10 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
     context "quand la variable COMPTE PROD de la page Notion est une organisation inconnue" do
       let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/organisations/26739" }
 
-      it "retourne un compte nul et une date nulle" do
+      it "ne fait rien" do
         described_class.new.perform
 
-        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => nil, "DATE CREATION DERNIER RDV" => nil })
+        expect(notion_client).not_to have_received(:update_page)
       end
     end
   end


### PR DESCRIPTION
# Contexte

Afin de faciliter la tâche du déploiement, on ajoute la date de création d’epsace et le nombre d’agents actifs dans le CRM.
