### PR TITLE
Afficher un bouton plutôt qu'un fil d'ariane pour revenir à l'agenda depuis un RDV

### DIFF
--- a/app/views/admin/rdvs/_bouton_retour_agenda.html.slim
+++ b/app/views/admin/rdvs/_bouton_retour_agenda.html.slim
@@ -1,0 +1,12 @@
+/# locals: (rdv:, contextual_agents:)
+
+ruby:
+  href = admin_organisation_planning_agenda_path(current_organisation, agent_id: contextual_agents.map(&:id))
+  label = if contextual_agents.size == 1 || !current_agent.feature_enabled?(Agent::FeatureFlags::NEW_PLANNING)
+            contextual_agents == [current_agent] ? "Retour à votre agenda" : "Retour à l'agenda de #{contextual_agents.first.full_name_or_email}"
+          else
+            "Retour aux agendas de #{contextual_agents.map(&:short_name_or_email).to_sentence.truncate(50)}"
+          end
+
+.fr-m-4v
+  = link_to label, href, class: "fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"

--- a/app/views/admin/rdvs/_fil_ariane_rdv.html.slim
+++ b/app/views/admin/rdvs/_fil_ariane_rdv.html.slim
@@ -1,16 +1,7 @@
-/# locals: (rdv:, b:, contextual_agents:)
+/# locals: (rdv:, b:)
 
-- if contextual_agents.blank?
-  - if rdv.collectif?
-    = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)
-  - else
-    = b.with_breadcrumb label: "Liste des RDV", href: admin_organisation_rdvs_path(current_organisation)
-- elsif contextual_agents.size == 1 || !current_agent.feature_enabled?(Agent::FeatureFlags::NEW_PLANNING)
-  - contextual_agent = contextual_agents.first
-  - if contextual_agent != current_agent
-    = b.with_breadcrumb label: "Agenda de #{contextual_agent.full_name_or_email}", href: admin_organisation_planning_agenda_path(current_organisation, agent_id: contextual_agent.id)
-  - else
-    = b.with_breadcrumb label: "Votre agenda", href: admin_organisation_planning_agenda_path(current_organisation)
+- if rdv.collectif?
+  = b.with_breadcrumb label: "RDV collectifs", href: admin_organisation_rdvs_collectifs_path(current_organisation)
 - else
-  = b.with_breadcrumb label: "Agendas de #{contextual_agents.map(&:short_name_or_email).join(', ').truncate(80)}", href: admin_organisation_planning_agenda_path(current_organisation, agent_id: contextual_agents.map(&:id))
+  = b.with_breadcrumb label: "Liste des RDV", href: admin_organisation_rdvs_path(current_organisation)
 = b.with_breadcrumb label: "RDV #{rdv_title_for_agent(rdv)}"

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -1,9 +1,12 @@
 - content_for(:menu_item) { @contextual_agents ? "menu-agendas" : "menu-rdvs-list" }
 
 - content_for :fil_ariane do
-  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
-    = render partial: "admin/rdvs/fil_ariane_rdv", locals: { rdv: @rdv, b: b, contextual_agents: @contextual_agents }
-    = b.with_breadcrumb label: "Modifier le RDV"
+  - if @contextual_agents.present?
+    = render partial: "admin/rdvs/bouton_retour_agenda", locals: { rdv: @rdv, contextual_agents: @contextual_agents }
+  - else
+    = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
+      = render partial: "admin/rdvs/fil_ariane_rdv", locals: { rdv: @rdv, b: b }
+      = b.with_breadcrumb label: "Modifier le RDV"
 
 - content_for :title do
   | Modifier le RDV

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -1,8 +1,11 @@
 - content_for(:menu_item) { @contextual_agents.present? ? "menu-agendas" : "menu-rdvs-list" }
 
 - content_for :fil_ariane do
-  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
-    = render partial: "admin/rdvs/fil_ariane_rdv", locals: { rdv: @rdv, b: b, contextual_agents: @contextual_agents }
+  - if @contextual_agents.present?
+    = render partial: "admin/rdvs/bouton_retour_agenda", locals: { rdv: @rdv, contextual_agents: @contextual_agents }
+  - else
+    = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
+      = render partial: "admin/rdvs/fil_ariane_rdv", locals: { rdv: @rdv, b: b }
 
 - content_for :title do
   = "RDV #{rdv_title_for_agent(@rdv)}"

--- a/spec/features/agents/planning/keeping_agent_context_spec.rb
+++ b/spec/features/agents/planning/keeping_agent_context_spec.rb
@@ -24,16 +24,16 @@ RSpec.describe "permettre de revenir à l'agenda d'un collègue après avoir cli
     expect(page).to have_content("Agenda de Mon COLLEGUE")
     click_on "Usager DU RDV" # on clique sur le RDV dans l'agenda
 
-    expected_fil_ariane = "Agenda de Mon COLLEGUE  RDV Usager DU RDV"
-    expect(page).to have_content(expected_fil_ariane)
+    back_button = "Retour à l'agenda de Mon COLLEGUE"
+    expect(page).to have_link(back_button)
     click_on "Modifier"
-    expect(page).to have_content(expected_fil_ariane)
+    expect(page).to have_link(back_button)
     fill_in "rdv_duration_in_min", with: "240"
     click_on "Enregistrer"
     click_on "Confirmer en ignorant les avertissements" if page.body.include?("Confirmer en ignorant les avertissements") # modification d'un RDV dans le passé
     expect(rdv_du_collegue.reload.duration_in_min).to eq(240)
-    expect(page).to have_content(expected_fil_ariane)
-    click_on "Agenda de Mon COLLEGUE"
+    expect(page).to have_link(back_button)
+    click_on back_button
     expect(page).to have_content("Agenda de Mon COLLEGUE")
   end
 
@@ -48,16 +48,16 @@ RSpec.describe "permettre de revenir à l'agenda d'un collègue après avoir cli
     find("#submit_agents").click
     click_on "Usager DU RDV" # on clique sur le RDV dans l'agenda
 
-    expected_fil_ariane = "Agendas de M. COLLEGUE, A. COURANT  RDV Usager DU RDV"
-    expect(page).to have_content(expected_fil_ariane)
+    back_button = "Retour aux agendas de M. COLLEGUE et A. COURANT"
+    expect(page).to have_link(back_button)
     click_on "Modifier"
-    expect(page).to have_content(expected_fil_ariane)
+    expect(page).to have_link(back_button)
     fill_in "rdv_duration_in_min", with: "240"
     click_on "Enregistrer"
     click_on "Confirmer en ignorant les avertissements" if page.body.include?("Confirmer en ignorant les avertissements") # modification d'un RDV dans le passé
     expect(rdv_du_collegue.reload.duration_in_min).to eq(240)
-    expect(page).to have_content(expected_fil_ariane)
-    click_on "Agendas de M. COLLEGUE, A. COURANT"
+    expect(page).to have_link(back_button)
+    click_on back_button
     expect(page).to have_content("Revenir à mon agenda")
     expect(page).to have_current_path(admin_organisation_planning_agenda_path(organisation, agent_id: [collegue, current_agent]))
   end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr5957.osc-secnum-fr1.scalingo.io/)

# Contexte

Nous savons qu'un use case très fréquent est de cliquer sur un RDV sur l'agenda pour aller le voir et / ou l'éditer. Nous voulons alors faciliter le retour vers l'agenda précédemment visualisé. 

Actuellement, ce "retour facile" est proposé à travers un fil d'ariane, discret et petit en taille. Nous voulons plutôt afficher un lien sous forme de bouton, plus visible.
 
# Solution

Les captures d'écran parlent d'elles-mêmes je crois.

Côté technique, j'ai simplifié `app/views/admin/rdvs/_fil_ariane_rdv.html.slim` en le divisant en 2 partials : 
- `app/views/admin/rdvs/_bouton_retour_agenda.html.slim` pour afficher le bouton quand on a des agent(s) de contexte
- `app/views/admin/rdvs/_fil_ariane_rdv.html.slim` pour afficher le fil d'ariane quand on a pas d'agent(s) de contexte

## Captures d'écran

Avant | Après
:- | -:
<img width="891" height="317" alt="image" src="https://github.com/user-attachments/assets/3255f56f-5064-4a73-9b3c-97e8e2211618" /> | <img width="891" height="317" alt="image" src="https://github.com/user-attachments/assets/855f41a2-2147-46ee-8701-348b50f27977" />
<img width="891" height="317" alt="image" src="https://github.com/user-attachments/assets/21eeb529-c3fd-4c98-a274-d1c046685e81" /> | <img width="891" height="317" alt="image" src="https://github.com/user-attachments/assets/052addb2-2364-40a5-9c46-48cff8061030" />
<img width="891" height="317" alt="image" src="https://github.com/user-attachments/assets/64d7e2ba-3328-4b43-bd09-b75e936335e7" /> | <img width="891" height="317" alt="image" src="https://github.com/user-attachments/assets/622651c5-6b41-4216-9b23-cc3213a1fea6" />


