### PR TITLE
Corrige une flaky spec sur les 3 lettres du nom de famille

### DIFF
--- a/spec/features/users/online_booking/with_short_rdv_link_spec.rb
+++ b/spec/features/users/online_booking/with_short_rdv_link_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Les usagers peuvent accéder à leur RDV via des liens court" do
     it "ils sont redirigés vers la page d’authentification avec le nom de famille puis vers la page du rendez-vous" do
       visit rdv_short_from_token_path(rdv.participations.first.restricted_auth_token)
       expect(page).to have_current_path(new_users_user_name_initials_verification_path)
-      fill_in(:letters, with: rdv.participations.first.user.last_name[0..2].upcase)
+      fill_in(:letters, with: rdv.participations.first.user.last_name.gsub(/\s+/, "").first(3).upcase)
       click_on "Valider"
       expect(page).to have_current_path(users_rdv_path(rdv))
     end
@@ -16,7 +16,7 @@ RSpec.describe "Les usagers peuvent accéder à leur RDV via des liens court" do
     it "ils sont redirigés vers la page d’authentification avec le nom de famille puis vers la page du rendez-vous" do
       visit rdv_short_path(rdv.id, tkn: rdv.participations.first.restricted_auth_token)
       expect(page).to have_current_path(new_users_user_name_initials_verification_path)
-      fill_in(:letters, with: rdv.participations.first.user.last_name[0..2].upcase)
+      fill_in(:letters, with: rdv.participations.first.user.last_name.gsub(/\s+/, "").first(3).upcase)
       click_on "Valider"
       expect(page).to have_current_path(users_rdv_path(rdv))
     end


### PR DESCRIPTION
La spec a plantait par exemple avec le nom de famille "DA SILVA".

J'ai repris dans la spec le code utilisé pour la vérification. :shrug: 