### PR TITLE
Inclure les appels Faraday en breadcrumbs Sentry

### DIFF
--- a/app/lib/mattermost_api_client.rb
+++ b/app/lib/mattermost_api_client.rb
@@ -9,6 +9,7 @@ class MattermostApiClient
       builder.request :json
       builder.response :json
       builder.response :raise_error # raise an error on 4xx and 5xx responses
+      builder.use :sentry_breadcrumbs
     end
   end
 

--- a/app/lib/zammad_api_client.rb
+++ b/app/lib/zammad_api_client.rb
@@ -9,7 +9,7 @@ class ZammadApiClient
       builder.request :json
       builder.response :json
       builder.response :raise_error # raise an error on 4xx and 5xx responses
-      builder.use :sentry_breadcrumbs
+      builder.use :sentry_breadcrumbs, scrub_request_body: true
     end
   end
 

--- a/app/lib/zammad_api_client.rb
+++ b/app/lib/zammad_api_client.rb
@@ -9,6 +9,7 @@ class ZammadApiClient
       builder.request :json
       builder.response :json
       builder.response :raise_error # raise an error on 4xx and 5xx responses
+      builder.use :sentry_breadcrumbs
     end
   end
 

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -1,0 +1,44 @@
+class FaradaySentryBreadcrumbsMiddleware < Faraday::Middleware
+  def call(request_env)
+    add_request_breadcrumb(request_env)
+
+    @app.call(request_env).on_complete do |response_env|
+      add_response_breadcrumb(response_env)
+    end
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+    add_timeout_breadcrumb(e)
+    raise
+  end
+
+  private
+
+  def add_request_breadcrumb(request_env)
+    breadcrumb = {
+      message: "HTTP request",
+      data: {
+        method: request_env.method,
+        url: request_env.url,
+        headers: request_env.request_headers,
+        body: options[:scrub_request_body] ? "[SCRUBBED]" : request_env.body,
+      },
+    }
+    Sentry.add_breadcrumb(Sentry::Breadcrumb.new(**breadcrumb))
+  end
+
+  def add_response_breadcrumb(response_env)
+    breadcrumb = {
+      message: "HTTP response",
+      data: {
+        status: response_env.status,
+        headers: response_env.response_headers,
+        body: response_env.response_body,
+      },
+    }
+    Sentry.add_breadcrumb(Sentry::Breadcrumb.new(**breadcrumb))
+  end
+
+  def add_timeout_breadcrumb(exception)
+    Sentry.add_breadcrumb Sentry::Breadcrumb.new(message: "HTTP timeout", data: { exception_message: exception.message })
+  end
+end
+Faraday::Middleware.register_middleware(sentry_breadcrumbs: FaradaySentryBreadcrumbsMiddleware)

--- a/spec/initializers/faraday_sentry_breadcrumbs_middleware_spec.rb
+++ b/spec/initializers/faraday_sentry_breadcrumbs_middleware_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe FaradaySentryBreadcrumbsMiddleware do
+  it "provides info about the request and response" do
+    stub_request(:post, "https://example.com/posts")
+      .to_return(
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+        body: '{"status": "ok"}'
+      )
+
+    connection = Faraday.new("https://example.com") do |builder|
+      builder.use :sentry_breadcrumbs
+    end
+
+    connection.post("/posts", { title: "Mon article de blog" }, { Authorization: "Token token=abcd1234efgh" })
+    Sentry.capture_message("woops")
+
+    request_breadcrumb, response_breadcrumb = sentry_events.last.breadcrumbs.compact
+
+    expect(request_breadcrumb.message).to eq("HTTP request")
+    expect(request_breadcrumb.data[:body]).to eq({ title: "Mon article de blog" })
+    expect(request_breadcrumb.data[:headers]).to eq({ "Authorization" => "Token token=abcd1234efgh", "User-Agent" => "Faraday v2.9.0" })
+    expect(request_breadcrumb.data[:method]).to eq(:post)
+    expect(request_breadcrumb.data[:url].to_s).to eq("https://example.com/posts")
+
+    expect(response_breadcrumb.message).to eq("HTTP response")
+    expect(response_breadcrumb.data[:status]).to eq(201)
+    expect(response_breadcrumb.data[:headers]).to eq({ "content-type" => "application/json" })
+    expect(response_breadcrumb.data[:body]).to eq('{"status": "ok"}')
+  end
+
+  context "when used after the :raise_error middleware" do
+    it "still works" do
+      stub_request(:post, "https://example.com/posts")
+        .to_return(status: 500)
+
+      connection = Faraday.new("https://example.com") do |builder|
+        builder.response :raise_error # raise an error on 4xx and 5xx responses
+        builder.use :sentry_breadcrumbs
+      end
+
+      expect { connection.post("/posts") }.to raise_error(Faraday::ServerError)
+      Sentry.capture_message("woops")
+
+      request_breadcrumb, response_breadcrumb = sentry_events.last.breadcrumbs.compact
+      expect(request_breadcrumb.message).to eq("HTTP request")
+
+      expect(response_breadcrumb.message).to eq("HTTP response")
+      expect(response_breadcrumb.data[:status]).to eq(500)
+    end
+  end
+
+  context "when the request times out" do
+    it "adds a breadcrumb" do
+      stub_request(:post, "https://example.com/posts")
+        .to_timeout
+
+      connection = Faraday.new("https://example.com") do |builder|
+        builder.use :sentry_breadcrumbs
+      end
+
+      expect { connection.post("/posts") }.to raise_error(Faraday::ConnectionFailed)
+      Sentry.capture_message("woops")
+      _request_breadcrumb, timeout_breadcrumb = sentry_events.last.breadcrumbs.compact
+
+      expect(timeout_breadcrumb.data).to eq(exception_message: "execution expired")
+    end
+  end
+
+  describe "scrub_request_body option" do
+    it "scrubs the request body when set to true" do
+      stub_request(:post, "https://example.com/posts")
+
+      connection = Faraday.new("https://example.com") do |builder|
+        builder.use :sentry_breadcrumbs, scrub_request_body: true
+      end
+
+      connection.post("/posts", { title: "Mon article de blog" })
+      Sentry.capture_message("woops")
+
+      request_breadcrumb, _response_breadcrumb = sentry_events.last.breadcrumbs.compact
+
+      expect(request_breadcrumb.message).to eq("HTTP request")
+      expect(request_breadcrumb.data[:body]).to eq("[SCRUBBED]")
+    end
+  end
+end


### PR DESCRIPTION
(voici comment j'ai occupé mes 3 heures de train entre Aix-les-Bains et Paris)

On utilise de plus en plus Faraday pour nos appels HTTP (MSS, Zammad, Mattermost, Annuaire du service public).

Cette PR met en place un middleware Faraday qui ajoute en breadcrumbs Sentry les requêtes, réponses et timeouts HTTP.

Pour le moment j'ajoute ce middleware aux appels qu'on fait en utilsant `Faraday.new`, mais je ferai une autre PR pour l'ajouter aux `Faraday.get`, `Faraday.post`, `Notion::Client`, etc.