### PR TITLE
Stocker les préférences agent dans une seule colonne

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,9 +1,10 @@
 class SoftDeleteError < StandardError; end
 
 class Agent < ApplicationRecord
-  self.ignored_columns += %w[connected_with_agent_connect]
+  self.ignored_columns += %w[connected_with_agent_connect display_saturdays display_cancelled_rdv]
   include Agent::CaldavConfiguration
   include Agent::FeatureFlags
+  include Agent::HasPreferences
 
   encrypts :caldav_password, deterministic: true
 

--- a/app/models/concerns/agent/has_preferences.rb
+++ b/app/models/concerns/agent/has_preferences.rb
@@ -1,0 +1,22 @@
+module Agent::HasPreferences
+  extend ActiveSupport::Concern
+
+  DISPLAY_SATURDAYS = "display_saturdays".freeze
+  DISPLAY_CANCELLED_RDV = "display_cancelled_rdv".freeze
+
+  def display_saturdays
+    preferences[DISPLAY_SATURDAYS] || false
+  end
+
+  def display_saturdays=(value)
+    preferences[DISPLAY_SATURDAYS] = value.to_b
+  end
+
+  def display_cancelled_rdv
+    preferences[DISPLAY_CANCELLED_RDV] || false
+  end
+
+  def display_cancelled_rdv=(value)
+    preferences[DISPLAY_CANCELLED_RDV] = value.to_b
+  end
+end

--- a/db/migrate/20251217221244_add_preferences_to_agents.rb
+++ b/db/migrate/20251217221244_add_preferences_to_agents.rb
@@ -1,0 +1,5 @@
+class AddPreferencesToAgents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :agents, :preferences, :jsonb, null: false, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_01_130457) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_17_221244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -153,6 +153,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_130457) do
     t.datetime "blog_read_at"
     t.string "pro_connect_openid_sub"
     t.string "caldav_sync_token"
+    t.jsonb "preferences", default: {}, null: false
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true


### PR DESCRIPTION
Je m'apprête à travailler sur un changement de l'interface de réglage des préférences de l'agent pour l'agenda (affichage des samedis, affichage des rendez-vous annulés), et à l'avenir j'aimerais introduire davantage de réglages de préférences.

Afin de ne pas avoir une table `agents` trop large, je propose de stocker les préférences dans une colonne JSONB.

Un des avantages est qu'on peut définir la valeur par défaut dans le code plutôt que dans Postgres, ça évite de pré-remplir toute une colonne pour rien.

Une autre option était de créer une table `agent_preferences` mais les perfs auraient été moins bonnes car il aurait fallu faire une jointure ou une autre requête.