### PR TITLE
Connexion usager par code à 6 chiffres envoyé par email

### DIFF
--- a/app/controllers/users/login_codes_controller.rb
+++ b/app/controllers/users/login_codes_controller.rb
@@ -4,12 +4,12 @@ class Users::LoginCodesController < ApplicationController
   include CanHaveRdvWizardContext
 
   def create
-    email = params[:demande_login_code_form][:email]
+    email = params[:login_code_form_request][:email]
 
-    @demande_login_code_form = Users::DemandeLoginCodeForm.new(LoginCode.new(email:, domain_id: current_domain.id))
+    @login_code_form_request = Users::LoginCodeRequestForm.new(LoginCode.new(email:, domain_id: current_domain.id))
 
-    if @demande_login_code_form.save
-      Users::LoginCodeMailer.with(login_code: @demande_login_code_form.login_code).login_code.deliver_later
+    if @login_code_form_request.save
+      Users::LoginCodeMailer.with(login_code: @login_code_form_request.login_code).login_code.deliver_later
       redirect_to new_users_sessions_by_code_path(email:)
     else
       render "users/sessions/new"

--- a/app/controllers/users/login_codes_controller.rb
+++ b/app/controllers/users/login_codes_controller.rb
@@ -1,0 +1,29 @@
+class Users::LoginCodesController < ApplicationController
+  layout "application_narrow"
+
+  include CanHaveRdvWizardContext
+
+  def create
+    email = params[:login_code][:email]
+    if email && LoginCode.most_recent_usable_for(email:)&.very_recent?
+      return redirect_to new_users_sessions_by_code_path(email:), flash: { notice: <<~NOTICE }
+        Un code a été envoyé à #{email} il y a moins de deux minutes. Vous devriez recevoir ce code d’ici peu de temps.
+      NOTICE
+    end
+
+    @login_code = LoginCode.new(email:, domain_id: current_domain.id)
+
+    if @login_code.save
+      Users::LoginCodeMailer.with(login_code: @login_code).login_code.deliver_later
+      redirect_to new_users_sessions_by_code_path(email:)
+    elsif Agent.exists?(email:)
+      redirect_to new_agent_session_path(agent: { email: })
+    else
+      render "users/sessions/new"
+    end
+  end
+
+  private
+
+  def storable_location? = false
+end

--- a/app/controllers/users/login_codes_controller.rb
+++ b/app/controllers/users/login_codes_controller.rb
@@ -5,11 +5,6 @@ class Users::LoginCodesController < ApplicationController
 
   def create
     email = params[:demande_login_code_form][:email]
-    if email && LoginCode.most_recent_usable_for(email:)&.very_recent?
-      return redirect_to new_users_sessions_by_code_path(email:), flash: { notice: <<~NOTICE }
-        Un code a été envoyé à #{email} il y a moins de deux minutes. Vous devriez recevoir ce code d’ici peu de temps.
-      NOTICE
-    end
 
     @demande_login_code_form = Users::DemandeLoginCodeForm.new(LoginCode.new(email:, domain_id: current_domain.id))
 

--- a/app/controllers/users/login_codes_controller.rb
+++ b/app/controllers/users/login_codes_controller.rb
@@ -4,17 +4,17 @@ class Users::LoginCodesController < ApplicationController
   include CanHaveRdvWizardContext
 
   def create
-    email = params[:login_code][:email]
+    email = params[:demande_login_code_form][:email]
     if email && LoginCode.most_recent_usable_for(email:)&.very_recent?
       return redirect_to new_users_sessions_by_code_path(email:), flash: { notice: <<~NOTICE }
         Un code a été envoyé à #{email} il y a moins de deux minutes. Vous devriez recevoir ce code d’ici peu de temps.
       NOTICE
     end
 
-    @login_code = LoginCode.new(email:, domain_id: current_domain.id)
+    @demande_login_code_form = Users::DemandeLoginCodeForm.new(LoginCode.new(email:, domain_id: current_domain.id))
 
-    if @login_code.save
-      Users::LoginCodeMailer.with(login_code: @login_code).login_code.deliver_later
+    if @demande_login_code_form.save
+      Users::LoginCodeMailer.with(login_code: @demande_login_code_form.login_code).login_code.deliver_later
       redirect_to new_users_sessions_by_code_path(email:)
     else
       render "users/sessions/new"

--- a/app/controllers/users/login_codes_controller.rb
+++ b/app/controllers/users/login_codes_controller.rb
@@ -16,8 +16,6 @@ class Users::LoginCodesController < ApplicationController
     if @login_code.save
       Users::LoginCodeMailer.with(login_code: @login_code).login_code.deliver_later
       redirect_to new_users_sessions_by_code_path(email:)
-    elsif Agent.exists?(email:)
-      redirect_to new_agent_session_path(agent: { email: })
     else
       render "users/sessions/new"
     end

--- a/app/controllers/users/sessions_by_code_controller.rb
+++ b/app/controllers/users/sessions_by_code_controller.rb
@@ -9,8 +9,6 @@ class Users::SessionsByCodeController < ApplicationController
     @email = params[:email]
     return redirect_to(new_user_session_path) if @email.blank?
 
-    return redirect_to(new_user_session_path, flash: { error: "Veuillez recommencer votre connexion" }) unless User.exists?(email:)
-
     @existing_login_code = LoginCode.most_recent_usable_for(email:)
   end
 

--- a/app/controllers/users/sessions_by_code_controller.rb
+++ b/app/controllers/users/sessions_by_code_controller.rb
@@ -9,13 +9,12 @@ class Users::SessionsByCodeController < ApplicationController
     @email = params[:email]
     return redirect_to(new_user_session_path) if @email.blank?
 
-    user = User.find_by(email:)
-    agent = Agent.find_by(email:)
-    redirect_to new_agent_session_path(agent: { email: }) if !user && agent
+    return redirect_to(new_user_session_path, flash: { error: "Veuillez recommencer votre connexion" }) unless User.exists?(email:)
 
     @existing_login_code = LoginCode.most_recent_usable_for(email:)&.tap(&:safe_to_display!)
   end
 
+  # rubocop:disable Metrics/PerceivedComplexity
   def create
     @email = params[:login_code][:email]
     submitted_login_code = params[:login_code][:code]
@@ -26,23 +25,24 @@ class Users::SessionsByCodeController < ApplicationController
       user.confirm
       sign_in(:user, user)
       matching_login_code.update!(used_at: Time.zone.now)
-      flash[:success] = "Connexion réussie"
-      redirect_to after_sign_in_path_for(user)
+      redirect_to after_sign_in_path_for(user), flash: { success: "Connexion réussie" }
     elsif LoginCode.where(email:).usable.any?
-      flash[:error] = "Veuillez renseigner le dernier code qui vous a été envoyé par email, ou attendre quelques instants de le recevoir"
       @existing_login_code = LoginCode.most_recent_usable_for(email:)&.tap(&:safe_to_display!)
+      @existing_login_code.errors.add(:base, "Veuillez renseigner le dernier code qui vous a été envoyé par email, ou attendre quelques instants de le recevoir")
       render :new
-    elsif matching_login_code&.used?
-      flash[:error] = "Code déjà utilisé, veuillez en demander un nouveau"
-      redirect_to new_users_sessions_by_code_path(email:)
-    elsif matching_login_code&.expired?
-      flash[:error] = "Code expiré, veuillez en demander un nouveau"
-      redirect_to new_users_sessions_by_code_path(email:)
     else
-      flash[:error] = "Code invalide"
+      flash[:error] =
+        if matching_login_code&.used?
+          "Code déjà utilisé, veuillez en demander un nouveau"
+        elsif matching_login_code&.expired?
+          "Code expiré, veuillez en demander un nouveau"
+        else
+          "Code invalide"
+        end
       redirect_to new_users_sessions_by_code_path(email:)
     end
   end
+  # rubocop:enable Metrics/PerceivedComplexity
 
   private
 

--- a/app/controllers/users/sessions_by_code_controller.rb
+++ b/app/controllers/users/sessions_by_code_controller.rb
@@ -11,10 +11,9 @@ class Users::SessionsByCodeController < ApplicationController
 
     return redirect_to(new_user_session_path, flash: { error: "Veuillez recommencer votre connexion" }) unless User.exists?(email:)
 
-    @existing_login_code = LoginCode.most_recent_usable_for(email:)&.tap(&:safe_to_display!)
+    @existing_login_code = LoginCode.most_recent_usable_for(email:)
   end
 
-  # rubocop:disable Metrics/PerceivedComplexity
   def create
     @email = params[:login_code][:email]
     submitted_login_code = params[:login_code][:code]
@@ -27,7 +26,7 @@ class Users::SessionsByCodeController < ApplicationController
       matching_login_code.update!(used_at: Time.zone.now)
       redirect_to after_sign_in_path_for(user), flash: { success: "Connexion réussie" }
     elsif LoginCode.where(email:).usable.any?
-      @existing_login_code = LoginCode.most_recent_usable_for(email:)&.tap(&:safe_to_display!)
+      @existing_login_code = LoginCode.most_recent_usable_for(email:)
       @existing_login_code.errors.add(:base, "Veuillez renseigner le dernier code qui vous a été envoyé par email, ou attendre quelques instants de le recevoir")
       render :new
     else
@@ -42,7 +41,6 @@ class Users::SessionsByCodeController < ApplicationController
       redirect_to new_users_sessions_by_code_path(email:)
     end
   end
-  # rubocop:enable Metrics/PerceivedComplexity
 
   private
 

--- a/app/controllers/users/sessions_by_code_controller.rb
+++ b/app/controllers/users/sessions_by_code_controller.rb
@@ -1,0 +1,50 @@
+class Users::SessionsByCodeController < ApplicationController
+  attr_reader :email
+
+  layout "application_narrow"
+
+  include CanHaveRdvWizardContext
+
+  def new
+    @email = params[:email]
+    return redirect_to(new_user_session_path) if @email.blank?
+
+    user = User.find_by(email:)
+    agent = Agent.find_by(email:)
+    redirect_to new_agent_session_path(agent: { email: }) if !user && agent
+
+    @existing_login_code = LoginCode.most_recent_usable_for(email:)&.tap(&:safe_to_display!)
+  end
+
+  def create
+    @email = params[:login_code][:email]
+    submitted_login_code = params[:login_code][:code]
+    matching_login_code = LoginCode.where(email:, code: submitted_login_code).where("created_at > ?", 24.hours.ago).first
+
+    if matching_login_code&.usable?
+      user = User.find_by!(email:)
+      user.confirm
+      sign_in(:user, user)
+      matching_login_code.update!(used_at: Time.zone.now)
+      flash[:success] = "Connexion réussie"
+      redirect_to after_sign_in_path_for(user)
+    elsif LoginCode.where(email:).usable.any?
+      flash[:error] = "Veuillez renseigner le dernier code qui vous a été envoyé par email, ou attendre quelques instants de le recevoir"
+      @existing_login_code = LoginCode.most_recent_usable_for(email:)&.tap(&:safe_to_display!)
+      render :new
+    elsif matching_login_code&.used?
+      flash[:error] = "Code déjà utilisé, veuillez en demander un nouveau"
+      redirect_to new_users_sessions_by_code_path(email:)
+    elsif matching_login_code&.expired?
+      flash[:error] = "Code expiré, veuillez en demander un nouveau"
+      redirect_to new_users_sessions_by_code_path(email:)
+    else
+      flash[:error] = "Code invalide"
+      redirect_to new_users_sessions_by_code_path(email:)
+    end
+  end
+
+  private
+
+  def storable_location? = false
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,7 +14,7 @@ class Users::SessionsController < Devise::SessionsController
       flash[:alert] = nil
     end
 
-    @demande_login_code_form = Users::DemandeLoginCodeForm.new(LoginCode.new(email: params.dig(:login_code, :email)))
+    @demande_login_code_form = Users::DemandeLoginCodeForm.new(LoginCode.new(email: params.dig(:demande_login_code_form, :email)))
 
     super
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,7 +14,7 @@ class Users::SessionsController < Devise::SessionsController
       flash[:alert] = nil
     end
 
-    @demande_login_code_form = Users::DemandeLoginCodeForm.new(LoginCode.new(email: params.dig(:demande_login_code_form, :email)))
+    @login_code_form_request = Users::LoginCodeRequestForm.new(LoginCode.new(email: params.dig(:login_code_form_request, :email)))
 
     super
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,12 +14,15 @@ class Users::SessionsController < Devise::SessionsController
       flash[:alert] = nil
     end
 
+    @login_code = LoginCode.new(email: params.dig(:login_code, :email))
+
     super
   end
 
   def create
-    if auth_options[:scope] == :user && (self.resource = Agent.find_by(email: params[:user]["email"])) && resource.valid_password?(params[:user]["password"])
-      return if reset_current_agent_password_if_weak!(params[:user][:password])
+    email, password = params[:user].values_at("email", "password")
+    if auth_options[:scope] == :user && (self.resource = Agent.find_by(email:)) && resource.valid_password?(password)
+      return if reset_current_agent_password_if_weak!(password)
 
       set_flash_message!(:notice, :signed_in)
       sign_in(:agent, resource)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,9 +20,8 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def create
-    email, password = params[:user].values_at("email", "password")
-    if auth_options[:scope] == :user && (self.resource = Agent.find_by(email:)) && resource.valid_password?(password)
-      return if reset_current_agent_password_if_weak!(password)
+    if auth_options[:scope] == :user && (self.resource = Agent.find_by(email: params[:user]["email"])) && resource.valid_password?(params[:user]["password"])
+      return if reset_current_agent_password_if_weak!(params[:user][:password])
 
       set_flash_message!(:notice, :signed_in)
       sign_in(:agent, resource)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,7 +14,7 @@ class Users::SessionsController < Devise::SessionsController
       flash[:alert] = nil
     end
 
-    @login_code = LoginCode.new(email: params.dig(:login_code, :email))
+    @demande_login_code_form = Users::DemandeLoginCodeForm.new(LoginCode.new(email: params.dig(:login_code, :email)))
 
     super
   end

--- a/app/form_models/users/demande_login_code_form.rb
+++ b/app/form_models/users/demande_login_code_form.rb
@@ -8,6 +8,7 @@ module Users
 
     validate :validate_login_code
     validate :validate_user_exists_or_suggest_agent, if: -> { login_code.valid? }
+    validate :validate_not_sent_too_recently, if: -> { login_code.valid? && errors.empty? }
 
     def initialize(login_code)
       @login_code = login_code
@@ -34,6 +35,18 @@ module Users
           ERROR
         end
       errors.add(:base, error.html_safe) # rubocop:disable Rails/OutputSafety
+    end
+
+    def validate_not_sent_too_recently
+      if LoginCode.most_recent_usable_for(email:)&.very_recent?
+        errors.add(:base, <<~ERROR.html_safe) # rubocop:disable Rails/OutputSafety
+          Un code a été envoyé à #{email} il y a moins de deux minutes.
+          Vous devriez recevoir ce code d’ici peu de temps.
+          <a href="#{Rails.application.routes.url_helpers.new_users_sessions_by_code_path(email:)}">
+            Suivez ce lien pour saisir le code reçu.
+          </a>
+        ERROR
+      end
     end
 
     def validate_login_code

--- a/app/form_models/users/demande_login_code_form.rb
+++ b/app/form_models/users/demande_login_code_form.rb
@@ -1,0 +1,45 @@
+module Users
+  class DemandeLoginCodeForm
+    include ActiveModel::Model
+
+    attr_reader :login_code
+
+    delegate :email, to: :login_code
+
+    validate :validate_login_code
+    validate :validate_user_exists_or_suggest_agent, if: -> { login_code.valid? }
+
+    def initialize(login_code)
+      @login_code = login_code
+    end
+
+    def validate_user_exists_or_suggest_agent
+      return true if User.where(email:).any?
+
+      error =
+        if Agent.exists?(email:)
+          <<~ERROR
+            Aucun compte usager n’existe pour cet email.
+            Si vous souhaitez vous connecter en tant qu’agent, veuillez vous rendre sur
+            <a href="#{Rails.application.routes.url_helpers.new_agent_session_path(agent: { email: })}">
+              la page de connexion agents
+            </a>.
+          ERROR
+        else
+          <<~ERROR
+            Aucun compte usager n’existe pour cet email, veuillez
+            <a href='#{Rails.application.routes.url_helpers.new_user_registration_path(user: { email: })}'>
+              créer un compte
+            </a>
+          ERROR
+        end
+      errors.add(:base, error.html_safe) # rubocop:disable Rails/OutputSafety
+    end
+
+    def validate_login_code
+      errors.merge!(login_code) if login_code.invalid?
+    end
+
+    def save = valid? && login_code.save
+  end
+end

--- a/app/form_models/users/login_code_request_form.rb
+++ b/app/form_models/users/login_code_request_form.rb
@@ -1,5 +1,5 @@
 module Users
-  class DemandeLoginCodeForm
+  class LoginCodeRequestForm
     include ActiveModel::Model
 
     attr_reader :login_code

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -10,6 +10,7 @@ import CounterField from './components/counter-field';
 import DsfrNewPassword from "./components/dsfr-new-password";
 import DsfrAlertClose from "./components/dsfr-alert-close";
 import PreventDefault from "./components/prevent-default";
+import setupCopyToClipBoardButtons from './components/copy_to_clipboard_button.js'
 import './components/browser-detection';
 import 'bootstrap';
 
@@ -24,6 +25,7 @@ document.addEventListener("DOMContentLoaded", function() {
   DsfrNewPassword();
   DsfrAlertClose();
   PreventDefault();
+  setupCopyToClipBoardButtons()
 
   const whereInput = document.querySelector('#search_where');
   const submitButton = document.querySelector('#search_submit');

--- a/app/javascript/stylesheets/components/_forms.scss
+++ b/app/javascript/stylesheets/components/_forms.scss
@@ -175,17 +175,17 @@ input:placeholder-shown {
   font-size: 1.5rem;
 }
 
-.rdv-three-letters-form input[type="text"] {
+.rdv-legible-code-form input[type="text"] {
   text-transform: uppercase;
   letter-spacing: 1rem;
   font-size: 1.4rem;
   max-height: 4rem;
   height: 4rem;
   font-family: monospace;
-  max-width: 8rem;
 }
+
 @include media-breakpoint-down(md) {
-  .rdv-three-letters-form {
+  .rdv-legible-code-form {
     text-align: center;
 
     input[type="submit"] {
@@ -197,4 +197,8 @@ input:placeholder-shown {
       margin-right: auto;
     }
   }
+}
+
+.rdv-three-letters-form input[type="text"] {
+  max-width: 8rem;
 }

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -113,6 +113,12 @@
   width: 100%;
 }
 
+.rdv-width-md-auto {
+  @include media-breakpoint-up(md) {
+    width: auto;
+  }
+}
+
 .rdv-max-width-100 {
   max-width: 100%;
 }

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -165,6 +165,13 @@ class CronJob < ApplicationJob
     end
   end
 
+  class DestroyLoginCodesJob < CronJob
+    def perform
+      LoginCode.where("created_at < ?", 7.days.ago)
+      # on garde les codes quelques jours pour investiguer certaines situations et avoir une idée des volumes
+    end
+  end
+
   class WarnAboutExpiringAzureAppSecrets < CronJob
     def perform
       return if ENV["AZURE_APPLICATION_CLIENT_ID"].blank?

--- a/app/mailers/users/login_code_mailer.rb
+++ b/app/mailers/users/login_code_mailer.rb
@@ -1,0 +1,13 @@
+class Users::LoginCodeMailer < ApplicationMailer
+  attr_reader :domain
+
+  def login_code
+    @login_code = params[:login_code]
+    @domain = Domain.find(@login_code.domain_id)
+
+    mail(
+      subject: "Votre code de connexion est #{@login_code.code}",
+      to: @login_code.email
+    )
+  end
+end

--- a/app/models/login_code.rb
+++ b/app/models/login_code.rb
@@ -18,11 +18,6 @@ class LoginCode < ApplicationRecord
     self.code ||= SecureRandom.random_number(100_000..999_999).to_s
   end
 
-  def safe_to_display!
-    readonly!
-    self.code = nil
-  end
-
   def expired? = created_at < EXPIRE_AFTER.ago
   def used? = used_at.present?
   def usable? = !expired? && !used?

--- a/app/models/login_code.rb
+++ b/app/models/login_code.rb
@@ -6,7 +6,6 @@ class LoginCode < ApplicationRecord
   scope :usable, -> { not_expired.not_used }
 
   validates :email, presence: true
-  validate :validate_user_exists_or_suggest_agent, if: -> { email.present? }
 
   before_create :set_random_code
 
@@ -22,27 +21,4 @@ class LoginCode < ApplicationRecord
   def used? = used_at.present?
   def usable? = !expired? && !used?
   def very_recent? = created_at > 2.minutes.ago
-
-  def validate_user_exists_or_suggest_agent
-    return true if User.where(email:).any?
-
-    error =
-      if Agent.exists?(email:)
-        <<~ERROR
-          Aucun compte usager n’existe pour cet email.
-          Si vous souhaitez vous connecter en tant qu’agent, veuillez vous rendre sur
-          <a href="#{Rails.application.routes.url_helpers.new_agent_session_path(agent: { email: })}">
-            la page de connexion agents
-          </a>.
-        ERROR
-      else
-        <<~ERROR
-          Aucun compte usager n’existe pour cet email, veuillez
-          <a href='#{Rails.application.routes.url_helpers.new_user_registration_path(user: { email: })}'>
-            créer un compte
-          </a>
-        ERROR
-      end
-    errors.add(:base, error.html_safe) # rubocop:disable Rails/OutputSafety
-  end
 end

--- a/app/models/login_code.rb
+++ b/app/models/login_code.rb
@@ -1,0 +1,41 @@
+class LoginCode < ApplicationRecord
+  EXPIRE_AFTER = 30.minutes
+
+  scope :not_expired, -> { where("created_at > ?", EXPIRE_AFTER.ago) }
+  scope :not_used, -> {  where(used_at: nil) }
+  scope :usable, -> { not_expired.not_used }
+
+  validates :email, presence: true
+  validate :validate_user_exists, if: -> { email.present? }
+
+  before_create :set_random_code
+
+  def self.most_recent_usable_for(email:)
+    where(email:).usable.order(created_at: :desc).first
+  end
+
+  def set_random_code
+    self.code ||= SecureRandom.random_number(100_000..999_999).to_s
+  end
+
+  def safe_to_display!
+    readonly!
+    self.code = nil
+  end
+
+  def expired? = created_at < EXPIRE_AFTER.ago
+  def used? = used_at.present?
+  def usable? = !expired? && !used?
+  def very_recent? = created_at > 2.minutes.ago
+
+  def validate_user_exists
+    return if User.where(email:).any?
+
+    errors.add(:base, <<~HTML.html_safe) # rubocop:disable Rails/OutputSafety
+      Aucun compte usager n’existe pour cet email, veuillez
+      <a href='#{Rails.application.routes.url_helpers.new_user_registration_path(user: { email: })}'>
+        créer un compte
+      </a>
+    HTML
+  end
+end

--- a/app/models/login_code.rb
+++ b/app/models/login_code.rb
@@ -6,7 +6,7 @@ class LoginCode < ApplicationRecord
   scope :usable, -> { not_expired.not_used }
 
   validates :email, presence: true
-  validate :validate_user_exists, if: -> { email.present? }
+  validate :validate_user_exists_or_suggest_agent, if: -> { email.present? }
 
   before_create :set_random_code
 
@@ -28,14 +28,26 @@ class LoginCode < ApplicationRecord
   def usable? = !expired? && !used?
   def very_recent? = created_at > 2.minutes.ago
 
-  def validate_user_exists
-    return if User.where(email:).any?
+  def validate_user_exists_or_suggest_agent
+    return true if User.where(email:).any?
 
-    errors.add(:base, <<~HTML.html_safe) # rubocop:disable Rails/OutputSafety
-      Aucun compte usager n’existe pour cet email, veuillez
-      <a href='#{Rails.application.routes.url_helpers.new_user_registration_path(user: { email: })}'>
-        créer un compte
-      </a>
-    HTML
+    error =
+      if Agent.exists?(email:)
+        <<~ERROR
+          Aucun compte usager n’existe pour cet email.
+          Si vous souhaitez vous connecter en tant qu’agent, veuillez vous rendre sur
+          <a href="#{Rails.application.routes.url_helpers.new_agent_session_path(agent: { email: })}">
+            la page de connexion agents
+          </a>.
+        ERROR
+      else
+        <<~ERROR
+          Aucun compte usager n’existe pour cet email, veuillez
+          <a href='#{Rails.application.routes.url_helpers.new_user_registration_path(user: { email: })}'>
+            créer un compte
+          </a>
+        ERROR
+      end
+    errors.add(:base, error.html_safe) # rubocop:disable Rails/OutputSafety
   end
 end

--- a/app/views/mailers/users/login_code_mailer/login_code.html.slim
+++ b/app/views/mailers/users/login_code_mailer/login_code.html.slim
@@ -3,6 +3,8 @@ p Votre code de connexion est :
 p{style="font-family: monospace; letter-spacing: .5rem; font-size: 1.4rem; max-height: 4rem; height: 4rem;"}
   = @login_code.code
 
+p Ce code est valable 30 minutes (jusqu’à #{I18n.l(@login_code.created_at + 30.minutes, format: :time_only)})
+
 hr{style="margin: 1rem 0;"}
 p
   | Si vous n’avez pas demandé de code de connexion, vous pouvez ignorer cet email.

--- a/app/views/mailers/users/login_code_mailer/login_code.html.slim
+++ b/app/views/mailers/users/login_code_mailer/login_code.html.slim
@@ -1,0 +1,8 @@
+p Votre code de connexion est :
+
+p{style="font-family: monospace; letter-spacing: .5rem; font-size: 1.4rem; max-height: 4rem; height: 4rem;"}
+  = @login_code.code
+
+hr{style="margin: 1rem 0;"}
+p
+  | Si vous n’avez pas demandé de code de connexion, vous pouvez ignorer cet email.

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -24,6 +24,9 @@
         = render "common/form/current_password_input", f:, forgotten_password_link: true, forgotten_password_link_label: @rdv_wizard.present? ? "Mot de passe oublié ?" : "Mot de passe oublié ou première connexion ?"
         .rdv-text-align-center
           = f.submit "Se connecter", class: "fr-mt-2v fr-btn"
+          .fr-mt-4w.fr-mb-2w.fr-text--sm
+            |> Vous pouvez aussi vous
+            = link_to "connecter via code à 6 chiffres", new_user_session_path
     - else
       = form_for @login_code_form_request, url: users_login_codes_path, method: :post, builder: Dsfr::FormBuilder, as: :login_code_form_request do |f|
         = render "model_errors", model: @login_code_form_request, form: f

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -25,8 +25,8 @@
         .rdv-text-align-center
           = f.submit "Se connecter", class: "fr-mt-2v fr-btn"
     - else
-      = form_for @demande_login_code_form, url: users_login_codes_path, method: :post, builder: Dsfr::FormBuilder, as: :demande_login_code_form do |f|
-        = render "model_errors", model: @demande_login_code_form, form: f
+      = form_for @login_code_form_request, url: users_login_codes_path, method: :post, builder: Dsfr::FormBuilder, as: :login_code_form_request do |f|
+        = render "model_errors", model: @login_code_form_request, form: f
         = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", required: true, label: "Adresse email", autocomplete: "email"
         .rdv-text-align-center
           = f.submit "Recevoir un code de connexion", class: "fr-mt-2v fr-btn"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -27,7 +27,7 @@
     - else
       = form_for [:users, @login_code], method: :post, builder: Dsfr::FormBuilder do |f|
         = render "model_errors", model: @login_code, form: f
-        = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email", autocomplete: "email"
+        = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", required: true, label: "Adresse email", autocomplete: "email"
         .rdv-text-align-center
           = f.submit "Recevoir un code de connexion", class: "fr-mt-2v fr-btn"
           .fr-mt-4w.fr-mb-2w.fr-text--sm

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -25,8 +25,8 @@
         .rdv-text-align-center
           = f.submit "Se connecter", class: "fr-mt-2v fr-btn"
     - else
-      = form_for [:users, @login_code], method: :post, builder: Dsfr::FormBuilder do |f|
-        = render "model_errors", model: @login_code, form: f
+      = form_for @demande_login_code_form, url: users_login_codes_path, method: :post, builder: Dsfr::FormBuilder, as: :demande_login_code_form do |f|
+        = render "model_errors", model: @demande_login_code_form, form: f
         = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", required: true, label: "Adresse email", autocomplete: "email"
         .rdv-text-align-center
           = f.submit "Recevoir un code de connexion", class: "fr-mt-2v fr-btn"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -29,7 +29,7 @@
         = render "model_errors", model: @login_code_form_request, form: f
         = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", required: true, label: "Adresse email", autocomplete: "email"
         .rdv-text-align-center
-          = f.submit "Recevoir un code de connexion", class: "fr-mt-2v fr-btn"
+          = f.submit "Recevoir un code de connexion", class: "fr-mt-2v fr-btn rdv-width-100 rdv-width-md-auto"
           .fr-mt-4w.fr-mb-2w.fr-text--sm
             |> Vous pouvez aussi vous
             = link_to "connecter par mot de passe", new_user_session_path(with_password: true)

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -15,15 +15,24 @@
         = render "common/proconnect_button_dsfr", login_hint: resource.email, user_type: "user"
 
       p.fr-hr-or ou
-    h2 Se connecter avec son compte
+    h2#with-email Se connecter par e-mail
 
-    = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
-      = render "devise/shared/error_messages", resource: resource
-      = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email", autocomplete: "email"
-      = render "common/form/current_password_input", f:, forgotten_password_link: true, forgotten_password_link_label: @rdv_wizard.present? ? "Mot de passe oublié ?" : "Mot de passe oublié ou première connexion ?"
-
-      .rdv-text-align-center
-        = f.submit "Se connecter", class: "fr-mt-2v fr-btn"
+    - if params[:with_password].present? || params[:user].present?
+      = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
+        = render "devise/shared/error_messages", resource: resource
+        = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email", autocomplete: "email"
+        = render "common/form/current_password_input", f:, forgotten_password_link: true, forgotten_password_link_label: @rdv_wizard.present? ? "Mot de passe oublié ?" : "Mot de passe oublié ou première connexion ?"
+        .rdv-text-align-center
+          = f.submit "Se connecter", class: "fr-mt-2v fr-btn"
+    - else
+      = form_for [:users, @login_code], method: :post, builder: Dsfr::FormBuilder do |f|
+        = render "model_errors", model: @login_code, form: f
+        = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email", autocomplete: "email"
+        .rdv-text-align-center
+          = f.submit "Recevoir un code de connexion", class: "fr-mt-2v fr-btn"
+          .fr-mt-4w.fr-mb-2w.fr-text--sm
+            |> Vous pouvez aussi vous
+            = link_to "connecter par mot de passe", new_user_session_path(with_password: true)
 
     hr.fr-my-2w
     h2 Vous n'avez pas de compte ?

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -15,7 +15,7 @@
         = render "common/proconnect_button_dsfr", login_hint: resource.email, user_type: "user"
 
       p.fr-hr-or ou
-    h2#with-email Se connecter par e-mail
+    h2 Se connecter par e-mail
 
     - if params[:with_password].present? || params[:user].present?
       = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|

--- a/app/views/users/sessions_by_code/new.html.slim
+++ b/app/views/users/sessions_by_code/new.html.slim
@@ -29,8 +29,8 @@
     .fr-mt-8w.fr-mb-4w
       - if @existing_login_code&.very_recent?
         |> Vous pouvez choisir un autre mode de connexion depuis la
-        => link_to "page de connexion", new_user_session_path(login_code: { email: @email }), class: "fr-link"
+        => link_to "page de connexion", new_user_session_path(demande_login_code_form: { email: @email }), class: "fr-link"
       - else
         |> Si vous n’avez pas reçu l’email contenant le code, vous pouvez en demander un nouveau depuis la
-        => link_to "page de connexion", new_user_session_path(login_code: { email: @email }), class: "fr-link"
+        => link_to "page de connexion", new_user_session_path(demande_login_code_form: { email: @email }), class: "fr-link"
         |> Vous pouvez aussi choisir un autre mode de connexion depuis cette page.

--- a/app/views/users/sessions_by_code/new.html.slim
+++ b/app/views/users/sessions_by_code/new.html.slim
@@ -8,6 +8,16 @@
       = render "model_errors", model: @existing_login_code
       p ✅ Un code à 6 chiffres a été envoyé à #{@existing_login_code.email} à #{l(@existing_login_code.created_at, format: :time_only)}
 
+      - if Rails.env.development?
+        / # on doit recharger le code ici car on l’avait nettoyé pour l’affichage via safe_to_display?
+        - code = LoginCode.find(@existing_login_code.id).code
+        .fr-mb-4w
+          = button_tag class: "fr-btn fr-btn--tertiary fr-btn--sm fr-mr-1w js-copy-to-clipboard", data: { "clipboard-content": code }
+            = icon("fr-icon-survey-line fr-icon--sm", class: "fr-mr-1w")
+            | copier le code #{code}
+          span.fr-text--sm
+            | (visible uniquement en env de dev)
+
     .rdv-legible-code-form
       = form_for LoginCode.new(email: @email), url: users_sessions_by_code_path, method: :post, builder: Dsfr::FormBuilder do |form|
         = form.hidden_field :email

--- a/app/views/users/sessions_by_code/new.html.slim
+++ b/app/views/users/sessions_by_code/new.html.slim
@@ -1,0 +1,27 @@
+- content_for :title, "Saisie du code de connexion"
+
+.card
+  = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard if @rdv_wizard.present?
+
+  .card-body.fr-pt-4w
+    - if @existing_login_code
+      p ✅ Un code à 6 chiffres a été envoyé à #{@existing_login_code.email} à #{l(@existing_login_code.created_at, format: :time_only)}
+
+    .rdv-legible-code-form
+      = form_for LoginCode.new(email: @email), url: users_sessions_by_code_path, method: :post, builder: Dsfr::FormBuilder do |form|
+        = form.hidden_field :email
+        = form.dsfr_text_field :code,
+          label: "Code à 6 chiffres",
+          maxlength: 6,
+          required: true,
+          autocomplete: "off"
+        = form.submit "Valider", class: "fr-btn"
+
+    .fr-mt-8w.fr-mb-4w
+      - if @existing_login_code&.very_recent?
+        |> Vous pouvez choisir un autre mode de connexion depuis la
+        => link_to "page de connexion", new_user_session_path(login_code: { email: @email }), class: "fr-link"
+      - else
+        |> Si vous n’avez pas reçu l’email contenant le code, vous pouvez en demander un nouveau depuis la
+        => link_to "page de connexion", new_user_session_path(login_code: { email: @email }), class: "fr-link"
+        |> Vous pouvez aussi choisir un autre mode de connexion depuis cette page.

--- a/app/views/users/sessions_by_code/new.html.slim
+++ b/app/views/users/sessions_by_code/new.html.slim
@@ -29,8 +29,8 @@
     .fr-mt-8w.fr-mb-4w
       - if @existing_login_code&.very_recent?
         |> Vous pouvez choisir un autre mode de connexion depuis la
-        => link_to "page de connexion", new_user_session_path(demande_login_code_form: { email: @email }), class: "fr-link"
+        => link_to "page de connexion", new_user_session_path(login_code_form_request: { email: @email }), class: "fr-link"
       - else
         |> Si vous n’avez pas reçu l’email contenant le code, vous pouvez en demander un nouveau depuis la
-        => link_to "page de connexion", new_user_session_path(demande_login_code_form: { email: @email }), class: "fr-link"
+        => link_to "page de connexion", new_user_session_path(login_code_form_request: { email: @email }), class: "fr-link"
         |> Vous pouvez aussi choisir un autre mode de connexion depuis cette page.

--- a/app/views/users/sessions_by_code/new.html.slim
+++ b/app/views/users/sessions_by_code/new.html.slim
@@ -5,6 +5,7 @@
 
   .card-body.fr-pt-4w
     - if @existing_login_code
+      = render "model_errors", model: @existing_login_code
       p ✅ Un code à 6 chiffres a été envoyé à #{@existing_login_code.email} à #{l(@existing_login_code.created_at, format: :time_only)}
 
     .rdv-legible-code-form

--- a/app/views/users/sessions_by_code/new.html.slim
+++ b/app/views/users/sessions_by_code/new.html.slim
@@ -6,7 +6,10 @@
   .card-body.fr-pt-4w
     - if @existing_login_code
       = render "model_errors", model: @existing_login_code
-      p ✅ Un code à 6 chiffres a été envoyé à #{@existing_login_code.email} à #{l(@existing_login_code.created_at, format: :time_only)}
+      p
+        |> ✅ Un code à 6 chiffres a été envoyé à
+        b> #{@existing_login_code.email}
+        | à #{l(@existing_login_code.created_at, format: :time_only)}
 
       - if Rails.env.development?
         .fr-mb-4w

--- a/app/views/users/sessions_by_code/new.html.slim
+++ b/app/views/users/sessions_by_code/new.html.slim
@@ -9,12 +9,10 @@
       p ✅ Un code à 6 chiffres a été envoyé à #{@existing_login_code.email} à #{l(@existing_login_code.created_at, format: :time_only)}
 
       - if Rails.env.development?
-        / # on doit recharger le code ici car on l’avait nettoyé pour l’affichage via safe_to_display?
-        - code = LoginCode.find(@existing_login_code.id).code
         .fr-mb-4w
-          = button_tag class: "fr-btn fr-btn--tertiary fr-btn--sm fr-mr-1w js-copy-to-clipboard", data: { "clipboard-content": code }
+          = button_tag class: "fr-btn fr-btn--tertiary fr-btn--sm fr-mr-1w js-copy-to-clipboard", data: { "clipboard-content": @existing_login_code.code }
             = icon("fr-icon-survey-line fr-icon--sm", class: "fr-mr-1w")
-            | copier le code #{code}
+            | copier le code #{@existing_login_code.code}
           span.fr-text--sm
             | (visible uniquement en env de dev)
 

--- a/app/views/users/user_name_initials_verification/new.html.slim
+++ b/app/views/users/user_name_initials_verification/new.html.slim
@@ -4,7 +4,7 @@ p.fr-mt-2w
   |> Pour sécuriser l’accès à vos données, veuillez entrer les 3 premières lettres de votre
   b> nom de famille.
 
-.fr-my-4w.rdv-three-letters-form
+.fr-my-4w.rdv-legible-code-form.rdv-three-letters-form
    = form_for @form, url: users_user_name_initials_verification_path, builder: Dsfr::FormBuilder, as: "", display_required_tags: false do |f|
     .fr-input-group
       = f.dsfr_text_field :letters,

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -517,3 +517,9 @@ tables:
   - table_name: territory_tags
     non_anonymized_column_names:
       - created_at
+  - table_name: login_codes
+    anonymized_column_names:
+      - email
+      - code
+    non_anonymized_column_names:
+      - used_at

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -113,5 +113,9 @@ Rails.application.configure do
       cron: "every 15 minutes",
       class: "CronJob::ImportCaldavAbsences",
     },
+    destroy_login_codes: {
+      cron: "every day at 05:00 Europe/Paris",
+      class: "CronJob::DestroyLoginAttemptsJob",
+    },
   }
 end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -115,7 +115,7 @@ Rails.application.configure do
     },
     destroy_login_codes: {
       cron: "every day at 05:00 Europe/Paris",
-      class: "CronJob::DestroyLoginAttemptsJob",
+      class: "CronJob::DestroyLoginCodesJob",
     },
   }
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,6 +7,18 @@ class Rack::Attack
     end
   end
 
+  throttle("demande de code de connexion usager - throttling par IP", limit: 60, period: 10.minutes) do |request|
+    if request.path.match(%r{users/login_codes}) && request.post?
+      request.ip
+    end
+  end
+
+  throttle("saisie de code de connexion usager - throttling par IP", limit: 60, period: 10.minutes) do |request|
+    if request.path.match(%r{users/sessions_by_code}) && request.post?
+      request.ip
+    end
+  end
+
   Rack::Attack.throttled_responder = lambda do |request|
     exception = ThrottleError.new(request.env["rack.attack.matched"])
     Sentry.set_context("rack_attack_match_data", request.env["rack.attack.match_data"])

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,12 +7,6 @@ class Rack::Attack
     end
   end
 
-  throttle("demande de code de connexion usager - throttling par email", limit: Rails.env.test? ? 2 : 60, period: 10.minutes) do |request|
-    if request.path.match(%r{users/login_codes}) && request.post? && request.params.dig("login_code", "email").present?
-      request.params.dig("login_code", "email")
-    end
-  end
-
   throttle("saisie de code de connexion usager - throttling par email", limit: Rails.env.test? ? 2 : 60, period: 10.minutes) do |request|
     if request.path.match(%r{users/sessions_by_code}) && request.post? && request.params.dig("login_code", "email").present?
       request.params.dig("login_code", "email")

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,15 +7,15 @@ class Rack::Attack
     end
   end
 
-  throttle("demande de code de connexion usager - throttling par IP", limit: 60, period: 10.minutes) do |request|
-    if request.path.match(%r{users/login_codes}) && request.post?
-      request.ip
+  throttle("demande de code de connexion usager - throttling par email", limit: Rails.env.test? ? 2 : 60, period: 10.minutes) do |request|
+    if request.path.match(%r{users/login_codes}) && request.post? && request.params.dig("login_code", "email").present?
+      request.params.dig("login_code", "email")
     end
   end
 
-  throttle("saisie de code de connexion usager - throttling par IP", limit: 60, period: 10.minutes) do |request|
-    if request.path.match(%r{users/sessions_by_code}) && request.post?
-      request.ip
+  throttle("saisie de code de connexion usager - throttling par email", limit: Rails.env.test? ? 2 : 60, period: 10.minutes) do |request|
+    if request.path.match(%r{users/sessions_by_code}) && request.post? && request.params.dig("login_code", "email").present?
+      request.params.dig("login_code", "email")
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,10 @@ Rails.application.routes.draw do
     get :user_name_initials_verification, to: redirect(path: "/users/user_name_initials_verification/new")
 
     post "file_attente", to: "file_attentes#create_or_delete"
+
+    resource :sessions_by_code, only: %i[new create], controller: "sessions_by_code"
+    resources :login_codes, only: %i[create]
+    get "login_codes", to: redirect(path: "/users/sign_in")
   end
   namespace :stats, controller: "stats", module: nil do
     get "/", action: "index"
@@ -101,6 +105,7 @@ Rails.application.routes.draw do
     patch "users/informations", to: "users/users#update"
     resources :relatives, except: %i[index show], controller: "users/relatives"
   end
+
   authenticated :user do
     get "/users/rdvs", to: "users/rdvs#index"
   end

--- a/db/migrate/20251229092428_create_login_codes.rb
+++ b/db/migrate/20251229092428_create_login_codes.rb
@@ -1,0 +1,14 @@
+class CreateLoginCodes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :login_codes do |t|
+      t.string :email, null: false
+      t.string :code, null: false
+      t.string :domain_id, null: false
+      t.datetime :used_at
+
+      t.timestamps
+
+      t.index %i[email created_at]
+    end
+  end
+end

--- a/db/migrate/20251229092428_create_login_codes.rb
+++ b/db/migrate/20251229092428_create_login_codes.rb
@@ -5,8 +5,7 @@ class CreateLoginCodes < ActiveRecord::Migration[8.0]
       t.string :code, null: false
       t.string :domain_id, null: false
       t.datetime :used_at
-
-      t.timestamps
+      t.datetime :created_at, null: false, comment: "pas de updated_at car les login_codes sont quasiment immutables"
 
       t.index %i[email created_at]
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -368,6 +368,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_30_134819) do
     t.index ["organisation_id"], name: "index_lieux_on_organisation_id"
   end
 
+  create_table "login_codes", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "code", null: false
+    t.string "domain_id", null: false
+    t.datetime "used_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email", "created_at"], name: "index_login_codes_on_email_and_created_at"
+  end
+
   create_table "motif_categories", force: :cascade do |t|
     t.string "name", null: false
     t.string "short_name", null: false, comment: "Le nom \"technique\" de la catégorie de motif, qui permet de l'identifier dans les paramètres de formulaires\"\n"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -373,8 +373,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_30_134819) do
     t.string "code", null: false
     t.string "domain_id", null: false
     t.datetime "used_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", null: false, comment: "pas de updated_at car les login_codes sont quasiment immutables"
     t.index ["email", "created_at"], name: "index_login_codes_on_email_and_created_at"
   end
 

--- a/spec/factories/login_code.rb
+++ b/spec/factories/login_code.rb
@@ -6,7 +6,5 @@ FactoryBot.define do
     code { SecureRandom.random_number(100_000..999_999).to_s }
     used_at { nil }
     domain_id { "RDV_SERVICE_PUBLIC" }
-
-    after(:build) { create(:user, email: _1.email) unless User.exists?(email: _1.email) } # necessary to pass validations
   end
 end

--- a/spec/factories/login_code.rb
+++ b/spec/factories/login_code.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  sequence(:login_code_email) { |n| "usager_#{n}@lapin.fr" }
+
+  factory :login_code do
+    email { generate(:login_code_email) }
+    code { SecureRandom.random_number(100_000..999_999).to_s }
+    used_at { nil }
+    domain_id { "RDV_SERVICE_PUBLIC" }
+
+    after(:build) { create(:user, email: _1.email) unless User.exists?(email: _1.email) } # necessary to pass validations
+  end
+end

--- a/spec/features/users/account/logout_spec.rb
+++ b/spec/features/users/account/logout_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe "Déconnexion" do
     click_on lieu.name
     first(:link, "11:00").click
 
-    fill_in("Adresse email", with: user.email)
-    fill_in("Mot de passe", with: user.password)
-    find("input[value='Se connecter']").click
+    login_via_6_digit_code(user.email)
 
     click_button("Continuer")
     click_button("Continuer")

--- a/spec/features/users/account/user_can_login_using_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_code_spec.rb
@@ -1,10 +1,12 @@
 RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
+  include_context "enable rack-attack" # en l’activant ici on teste que le cas normal fonctionne aussi
+
   before { create(:user, email: "marco@lolmail.fr", first_name: "Marco") }
 
   specify do
     visit new_user_session_path
     fill_in "Adresse email", with: "marco@lolmail.fr"
-    within("main") { click_on "Recevoir un code de connexion" }
+    click_on "Recevoir un code de connexion"
     expect(page).to have_content("code à 6 chiffres")
     expect(page).to have_content("marco@lolmail.fr")
 
@@ -25,7 +27,7 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
     specify do
       visit new_user_session_path
       fill_in "Adresse email", with: "nina@personne.fr"
-      within("main") { click_on "Recevoir un code de connexion" }
+      click_on "Recevoir un code de connexion"
       expect(page).to have_content("Aucun compte usager n’existe pour cet email")
       expect(page).not_to have_content("code à 6 chiffres")
     end
@@ -123,6 +125,42 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
       fill_in("Code à 6 chiffres", with: "123456")
       click_on "Valider"
       expect(page).to have_content("Connexion réussie")
+    end
+  end
+
+  context "tentatives d’innondations sur la page de demande de code" do
+    it "lève une erreur Rack Attack" do
+      2.times do
+        visit new_user_session_path
+        fill_in "Adresse email", with: "marco@lolmail.fr"
+        click_on "Recevoir un code de connexion"
+      end
+      visit new_user_session_path
+      fill_in "Adresse email", with: "marco@lolmail.fr"
+      click_on "Recevoir un code de connexion"
+      expect(page).not_to have_content("Connexion réussie")
+      expect(page).to have_content("erreur")
+      expect(sentry_events.last.level).to eq(:warning)
+      expect(sentry_events.last.exception.values.last.type).to eq("Rack::Attack::ThrottleError")
+    end
+  end
+
+  context "tentatives d’innondations sur la page de saisie de code" do
+    before { create(:login_code, email: "marco@lolmail.fr", code: "123456", created_at: 1.minute.ago) }
+
+    it "lève une erreur Rack Attack" do
+      2.times do
+        visit new_users_sessions_by_code_path(email: "marco@lolmail.fr")
+        fill_in("Code à 6 chiffres", with: "123456")
+        click_on "Valider"
+      end
+      visit new_users_sessions_by_code_path(email: "marco@lolmail.fr")
+      fill_in("Code à 6 chiffres", with: "123456")
+      click_on "Valider"
+      expect(page).not_to have_content("Connexion réussie")
+      expect(page).to have_content("erreur")
+      expect(sentry_events.last.level).to eq(:warning)
+      expect(sentry_events.last.exception.values.last.type).to eq("Rack::Attack::ThrottleError")
     end
   end
 end

--- a/spec/features/users/account/user_can_login_using_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_code_spec.rb
@@ -1,0 +1,128 @@
+RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
+  before { create(:user, email: "marco@lolmail.fr", first_name: "Marco") }
+
+  specify do
+    visit new_user_session_path
+    fill_in "Adresse email", with: "marco@lolmail.fr"
+    within("main") { click_on "Recevoir un code de connexion" }
+    expect(page).to have_content("code à 6 chiffres")
+    expect(page).to have_content("marco@lolmail.fr")
+
+    perform_enqueued_jobs
+    open_email("marco@lolmail.fr")
+    expect(current_email.subject).to include("Votre code de connexion est ")
+    code = current_email.subject.match(/Votre code de connexion est (\d{6})/)[1]
+    fill_in("Code à 6 chiffres", with: code)
+    click_on "Valider"
+
+    expect(page).to have_content("Connexion réussie")
+    expect(page).to have_current_path("/users/rdvs")
+    click_on "Vos informations"
+    expect(page).to have_field("user_first_name", with: "Marco")
+  end
+
+  context "l’usager rentre une adresse email pour laquelle il n’existe pas de compte usager" do
+    specify do
+      visit new_user_session_path
+      fill_in "Adresse email", with: "nina@personne.fr"
+      within("main") { click_on "Recevoir un code de connexion" }
+      expect(page).to have_content("Aucun compte usager n’existe pour cet email")
+      expect(page).not_to have_content("code à 6 chiffres")
+    end
+  end
+
+  context "l’usager demande deux codes en moins de deux minutes" do
+    specify do
+      visit new_user_session_path
+      fill_in "Adresse email", with: "marco@lolmail.fr"
+      click_on "Recevoir un code de connexion"
+      expect(page).to have_content("Saisie du code")
+      click_on "page de connexion"
+      click_on "Recevoir un code de connexion"
+      expect(page).to have_content("Un code a été envoyé à marco@lolmail.fr il y a moins de deux minutes")
+      expect(LoginCode.where(email: "marco@lolmail.fr").count).to eq(1)
+    end
+  end
+
+  context "l’usager rentre un code inexistant" do
+    before { create(:login_code, email: "marco@lolmail.fr", code: "123456", created_at: 1.hour.ago) }
+
+    it "ne permet pas de se connecter" do
+      visit new_users_sessions_by_code_path(email: "marco@lolmail.fr")
+      fill_in("Code à 6 chiffres", with: "992233")
+      click_on "Valider"
+      expect(page).not_to have_content("Connexion réussie")
+      expect(page).to have_content("Code invalide")
+    end
+  end
+
+  context "l’usager attend trop longtemps, le code est expiré" do
+    before { create(:login_code, email: "marco@lolmail.fr", code: "123456", created_at: 1.hour.ago) }
+
+    it "ne permet pas de se connecter" do
+      visit new_users_sessions_by_code_path(email: "marco@lolmail.fr")
+      fill_in("Code à 6 chiffres", with: "123456")
+      click_on "Valider"
+      expect(page).not_to have_content("Connexion réussie")
+      expect(page).to have_content("Code expiré, veuillez en demander un nouveau")
+    end
+  end
+
+  context "le code a déjà été utilisé" do
+    before { create(:login_code, email: "marco@lolmail.fr", code: "123456", created_at: 1.minute.ago, used_at: 30.seconds.ago) }
+
+    it "ne permet pas de se connecter" do
+      visit new_users_sessions_by_code_path(email: "marco@lolmail.fr")
+      fill_in("Code à 6 chiffres", with: "123456")
+      click_on "Valider"
+      expect(page).not_to have_content("Connexion réussie")
+      expect(page).to have_content("Code déjà utilisé")
+    end
+  end
+
+  context "plusieurs codes envoyés, l’usager essaie avec un déjà utilisé" do
+    before do
+      create(:login_code, email: "marco@lolmail.fr", code: "123456", created_at: 2.minutes.ago, used_at: 1.minute.ago)
+      create(:login_code, email: "marco@lolmail.fr", code: "998811", created_at: 1.minute.ago)
+    end
+
+    it "ne permet pas de se connecter" do
+      visit new_users_sessions_by_code_path(email: "marco@lolmail.fr")
+      fill_in("Code à 6 chiffres", with: "123456")
+      click_on "Valider"
+      expect(page).not_to have_content("Connexion réussie")
+      expect(page).to have_content("Veuillez renseigner le dernier code qui vous a été envoyé")
+    end
+  end
+
+  context "plusieurs codes envoyés, l’usager essaie avec un expiré" do
+    before do
+      create(:login_code, email: "marco@lolmail.fr", code: "123456", created_at: 1.hour.ago)
+      create(:login_code, email: "marco@lolmail.fr", code: "998811", created_at: 1.minute.ago)
+    end
+
+    it "ne permet pas de se connecter" do
+      visit new_users_sessions_by_code_path(email: "marco@lolmail.fr")
+      fill_in("Code à 6 chiffres", with: "123456")
+      click_on "Valider"
+      expect(page).not_to have_content("Connexion réussie")
+      expect(page).to have_content("Veuillez renseigner le dernier code qui vous a été envoyé")
+    end
+  end
+
+  context "plusieurs codes envoyés dont des usés et expirés, l’usager essaie avec un utilisable" do
+    before do
+      create(:login_code, email: "marco@lolmail.fr", code: "123456", created_at: 1.minute.ago)
+      create(:login_code, email: "marco@lolmail.fr", code: "789012", created_at: 2.minutes.ago)
+      create(:login_code, email: "marco@lolmail.fr", code: "332211", created_at: 2.minutes.ago, used_at: 1.minute.ago)
+      create(:login_code, email: "marco@lolmail.fr", code: "445566", created_at: 1.hour.ago)
+    end
+
+    it "permet de se connecter" do
+      visit new_users_sessions_by_code_path(email: "marco@lolmail.fr")
+      fill_in("Code à 6 chiffres", with: "123456")
+      click_on "Valider"
+      expect(page).to have_content("Connexion réussie")
+    end
+  end
+end

--- a/spec/features/users/account/user_can_login_using_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_code_spec.rb
@@ -127,23 +127,6 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
     end
   end
 
-  context "tentatives d’innondations sur la page de demande de code" do
-    it "lève une erreur Rack Attack" do
-      2.times do
-        visit new_user_session_path
-        fill_in "Adresse email", with: "marco@lolmail.fr"
-        click_on "Recevoir un code de connexion"
-      end
-      visit new_user_session_path
-      fill_in "Adresse email", with: "marco@lolmail.fr"
-      click_on "Recevoir un code de connexion"
-      expect(page).not_to have_content("Connexion réussie")
-      expect(page).to have_content("erreur")
-      expect(sentry_events.last.level).to eq(:warning)
-      expect(sentry_events.last.exception.values.last.type).to eq("Rack::Attack::ThrottleError")
-    end
-  end
-
   context "tentatives d’innondations sur la page de saisie de code" do
     before { create(:login_code, email: "marco@lolmail.fr", code: "123456", created_at: 1.minute.ago) }
 

--- a/spec/features/users/account/user_can_login_using_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_code_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
     specify do
       visit new_user_session_path
       fill_in "Adresse email", with: "nina@personne.fr"
-      click_on "Recevoir un code de connexion"
+      expect { click_on "Recevoir un code de connexion" }.not_to change(LoginCode, :count)
       expect(page).to have_content("Aucun compte usager n’existe pour cet email")
       expect(page).not_to have_content("code à 6 chiffres")
     end

--- a/spec/features/users/account/user_can_login_using_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_code_spec.rb
@@ -40,9 +40,8 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
       click_on "Recevoir un code de connexion"
       expect(page).to have_content("Saisie du code")
       click_on "page de connexion"
-      click_on "Recevoir un code de connexion"
+      expect { click_on "Recevoir un code de connexion" }.not_to change(LoginCode, :count)
       expect(page).to have_content("Un code a été envoyé à marco@lolmail.fr il y a moins de deux minutes")
-      expect(LoginCode.where(email: "marco@lolmail.fr").count).to eq(1)
     end
   end
 

--- a/spec/features/users/account/user_can_login_using_password_spec.rb
+++ b/spec/features/users/account/user_can_login_using_password_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "Un usager peut se logger via un mot de passe" do
+  before { create(:user, email: "marco@lolmail.fr", first_name: "Marco", password: "Rdvservicepublictest1!") }
+
+  specify do
+    visit new_user_session_path
+    find("a", text: /par mot de passe/).click
+    fill_in "Adresse email", with: "marco@lolmail.fr"
+    fill_in "Mot de passe", with: "Rdvservicepublictest1!"
+    within("main") { click_on "Se connecter" }
+    expect(page).to have_content("Connexion réussie")
+    expect(page).to have_current_path("/users/rdvs")
+  end
+end

--- a/spec/features/users/account/user_is_redirected_back_after_login_spec.rb
+++ b/spec/features/users/account/user_is_redirected_back_after_login_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe "User is redirected back to requested page after login" do
     expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
     find(".fr-alert--info") # On vérifie que le flash est une info et pas une alerte
 
-    fill_in("user_email", with: user.email)
-    fill_in("user_password", with: user.password)
-    click_button("Se connecter")
+    login_via_6_digit_code(user.email)
     expect(page).to have_current_path("/users/rdvs")
   end
 

--- a/spec/features/users/account/user_session_expires_spec.rb
+++ b/spec/features/users/account/user_session_expires_spec.rb
@@ -9,14 +9,12 @@ RSpec.describe "User session expiration" do
 
   def expect_to_be_logged_out
     visit users_informations_path
-    expect(page).to have_content("Se connecter avec son compte")
+    expect(page).to have_content("Se connecter par e-mail")
   end
 
   it "is done 30 minutes after last visit" do
     visit new_user_session_path
-    fill_in "Adresse email", with: user.email
-    fill_in "user_password", with: password
-    within("main") { click_on "Se connecter" }
+    login_via_6_digit_code(user.email)
     expect_to_be_logged_in
 
     travel_to(28.minutes.from_now)

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -65,44 +65,18 @@ RSpec.describe "User signs up and signs in" do
     end
   end
 
-  context "if agent tries to sign in through the user signin form" do
-    let!(:agent) { create(:agent, password: "c0rRecthorse!", basic_role_in_organisations: [create(:organisation)]) }
+  context "un agent essaie de se connecter depuis la page de connexion usagers" do
+    let!(:agent) { create(:agent, email: "dulce@agent.fr", basic_role_in_organisations: [create(:organisation)]) }
 
-    it ".sign_in as user and be signed in as agent" do
+    it "redirige vers la page de connexion agent" do
       visit "http://www.rdv-solidarites-test.localhost/"
       click_link "Se connecter"
       within("form") do
-        fill_in :user_email, with: agent.email
-        fill_in :user_password, with: agent.password
-        click_on "Se connecter"
+        fill_in "Adresse email", with: "dulce@agent.fr"
+        click_on "Recevoir un code de connexion"
       end
-      expect(page).to have_current_path(admin_organisation_planning_agenda_path(agent.organisations.first))
-    end
-
-    context "when the agent's password is too weak" do
-      let(:agent) do
-        build(:agent, password: "tropfaible").tap do |a|
-          a.save(validate: false)
-        end
-      end
-
-      it "expire le mot de passe et redirige vers la page pour en définir un nouveau" do
-        previous_encrypted_password = agent.reload.encrypted_password
-        visit new_user_session_path
-        fill_in "Adresse email", with: agent.email
-        fill_in "Mot de passe", with: "tropfaible"
-        within("main") { click_on "Se connecter" }
-        expect(page).to have_content("nous vous demandons de changer votre mot de passe")
-        expect(agent.reload.encrypted_password).not_to eq(previous_encrypted_password) # vérifie que le mot de passe a été modifié
-        fill_in "Mot de passe", with: "tropfaible2"
-        click_on "Enregistrer"
-        # expect(page.status_code).to eq 422 # je ne sais pas trop pourquoi devise renvoie une 422 ici
-        expect(page).to have_content("Pour assurer la sécurité de votre compte, votre mot de passe doit faire au moins 12 caractères")
-        fill_in "Mot de passe", with: "Rdvservicepublictest1!"
-        click_on "Enregistrer"
-        expect(page).to have_content("Votre mot de passe a été édité avec succès, votre connexion est désormais active")
-        expect(page).to have_content("Bienvenue !")
-      end
+      expect(page).to have_content("Connexion agent")
+      expect(page.find("input", id: "agent_email").value).to eq("dulce@agent.fr")
     end
   end
 

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -75,8 +75,7 @@ RSpec.describe "User signs up and signs in" do
         fill_in "Adresse email", with: "dulce@agent.fr"
         click_on "Recevoir un code de connexion"
       end
-      expect(page).to have_content("Connexion agent")
-      expect(page.find("input", id: "agent_email").value).to eq("dulce@agent.fr")
+      expect(page).to have_content(/Si vous souhaitez vous connecter en tant qu’agent/)
     end
   end
 

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -113,9 +113,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         ants_pre_demandes_count: "2"
       ))
 
-      fill_in("user_email", with: user.email)
-      fill_in("user_password", with: user.password)
-      click_button("Se connecter")
+      login_via_6_digit_code(user.email)
 
       expect(page).to have_field("Numéro de pré-demande ANTS")
       fill_in("user_ants_pre_demande_number", with: "1122334455")
@@ -180,9 +178,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         ants_pre_demandes_count: "2"
       )
 
-      fill_in "user_email", with: user.email
-      fill_in "user_password", with: user.password
-      click_button "Se connecter"
+      login_via_6_digit_code(user.email)
 
       fill_in "user_ants_pre_demande_number", with: "1122334455"
       click_button "Continuer"
@@ -249,9 +245,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         ants_pre_demandes_count: "2"
       )
 
-      fill_in "user_email", with: user.email
-      fill_in "user_password", with: user.password
-      click_button "Se connecter"
+      login_via_6_digit_code(user.email)
 
       fill_in "user_ants_pre_demande_number", with: "1122334455"
       click_button "Continuer"
@@ -291,9 +285,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         ants_pre_demandes_count: "2"
       )
 
-      fill_in("user_email", with: user.email)
-      fill_in("user_password", with: user.password)
-      click_button("Se connecter")
+      login_via_6_digit_code(user.email)
 
       fill_in("user_ants_pre_demande_number", with: "1234ABC")
       click_button("Continuer")
@@ -314,9 +306,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
           ants_pre_demandes_count: "2"
         )
 
-        fill_in("user_email", with: user.email)
-        fill_in("user_password", with: user.password)
-        click_button("Se connecter")
+        login_via_6_digit_code(user.email)
 
         fill_in("user_ants_pre_demande_number", with: "abcd1234ef")
         click_button("Continuer")
@@ -338,9 +328,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
           ants_pre_demandes_count: "2"
         )
 
-        fill_in("user_email", with: user.email)
-        fill_in("user_password", with: user.password)
-        click_button("Se connecter")
+        login_via_6_digit_code(user.email)
 
         fill_in("user_ants_pre_demande_number", with: "  ")
         click_button("Continuer")
@@ -364,9 +352,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
           ants_pre_demandes_count: "2"
         )
 
-        fill_in("user_email", with: user.email)
-        fill_in("user_password", with: user.password)
-        click_button("Se connecter")
+        login_via_6_digit_code(user.email)
 
         fill_in("user_ants_pre_demande_number", with: "5544332211")
         click_button("Continuer")
@@ -389,9 +375,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         )
         expect(page).to have_content("Motif : Passeport")
 
-        fill_in("user_email", with: user.email)
-        fill_in("user_password", with: user.password)
-        click_button("Se connecter")
+        login_via_6_digit_code(user.email)
 
         expect(page).to have_field("Numéro de pré-demande ANTS")
       end
@@ -417,9 +401,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         )
         expect(page).to have_content("Motif : Retrait")
 
-        fill_in("user_email", with: user.email)
-        fill_in("user_password", with: user.password)
-        click_button("Se connecter")
+        login_via_6_digit_code(user.email)
 
         expect(page).not_to have_field("Numéro de pré-demande ANTS")
       end
@@ -441,9 +423,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
           )
           expect(page).to have_content("Motif : Retrait")
 
-          fill_in("user_email", with: user.email)
-          fill_in("user_password", with: user.password)
-          click_button("Se connecter")
+          login_via_6_digit_code(user.email)
 
           expect(page).not_to have_field("Numéro de pré-demande ANTS")
         end

--- a/spec/features/users/online_booking/on_rdv_service_public_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_service_public_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe "User can search rdv on rdv service public" do
     expect(page).to have_current_path("/users/sign_in")
     expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
 
-    fill_in("user_email", with: user.email)
-    fill_in("user_password", with: user.password)
-    click_button("Se connecter")
+    login_via_6_digit_code(user.email)
 
     expect(page).not_to have_field("Numéro de pré-demande ANTS")
 

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -128,10 +128,9 @@ RSpec.describe "Adding a user to a collective RDV" do
       click_link("S'inscrire")
 
       expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer.")
-      fill_in("user_email", with: logged_user.email)
-      fill_in("user_password", with: logged_user.password)
 
-      click_button("Se connecter")
+      login_via_6_digit_code(logged_user.email)
+
       click_button("Continuer")
       expect(page).to have_content("Choix de l’usager")
       click_button("Continuer")

--- a/spec/form_models/users/demande_login_code_form_spec.rb
+++ b/spec/form_models/users/demande_login_code_form_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe Users::DemandeLoginCodeForm, type: :form_model do
+  context "l’usager existe et tout est correct" do
+    let!(:user) { create(:user, email: "us@ger.fr") }
+
+    it "le form est valide et la sauvegarde créé le login_code" do
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", domain_id: Domain::RDV_SERVICE_PUBLIC.id))
+      expect(form).to be_valid
+      expect { form.save }.to change(LoginCode, :count).by(1)
+    end
+  end
+
+  context "login_code est invalide" do
+    specify "le form est invalide" do
+      form = described_class.new(LoginCode.new(email: "", domain_id: Domain::RDV_SERVICE_PUBLIC.id))
+      expect(form).not_to be_valid
+      expect { form.save }.not_to change(LoginCode, :count)
+    end
+  end
+
+  context "l’usager n’existe pas" do
+    specify do
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", domain_id: Domain::RDV_SERVICE_PUBLIC.id))
+      expect(form).not_to be_valid
+      expect(form.errors[:base].first).to include(/aucun compte usager n’existe/i)
+      expect(form.errors[:base].first).not_to include(/si vous souhaitez vous connecter en tant qu’agent/i)
+    end
+  end
+
+  context "l’usager n’existe pas mais un compte agent existe pour cet email" do
+    let!(:agent) { create(:agent, email: "us@ger.fr") }
+
+    specify do
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", domain_id: Domain::RDV_SERVICE_PUBLIC.id))
+      expect(form).not_to be_valid
+      expect(form.errors[:base].first).to include(/aucun compte usager n’existe/i)
+      expect(form.errors[:base].first).to include(/si vous souhaitez vous connecter en tant qu’agent/i)
+    end
+  end
+end

--- a/spec/form_models/users/login_code_request_form_spec.rb
+++ b/spec/form_models/users/login_code_request_form_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Users::LoginCodeRequestForm, type: :form_model do
     let!(:user) { create(:user, email: "us@ger.fr") }
 
     it "le form est valide et la sauvegarde créé le login_code" do
-      form = described_class.new(LoginCode.new(email: "us@ger.fr", domain_id: Domain::RDV_SERVICE_PUBLIC.id))
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", domain_id: "RDV_SERVICE_PUBLIC"))
       expect(form).to be_valid
       expect { form.save }.to change(LoginCode, :count).by(1)
     end
@@ -11,7 +11,7 @@ RSpec.describe Users::LoginCodeRequestForm, type: :form_model do
 
   context "login_code est invalide" do
     specify "le form est invalide" do
-      form = described_class.new(LoginCode.new(email: "", domain_id: Domain::RDV_SERVICE_PUBLIC.id))
+      form = described_class.new(LoginCode.new(email: "", domain_id: "RDV_SERVICE_PUBLIC"))
       expect(form).not_to be_valid
       expect { form.save }.not_to change(LoginCode, :count)
     end
@@ -19,7 +19,7 @@ RSpec.describe Users::LoginCodeRequestForm, type: :form_model do
 
   context "l’usager n’existe pas" do
     specify do
-      form = described_class.new(LoginCode.new(email: "us@ger.fr", domain_id: Domain::RDV_SERVICE_PUBLIC.id))
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", domain_id: "RDV_SERVICE_PUBLIC"))
       expect(form).not_to be_valid
       expect(form.errors[:base].first).to include(/aucun compte usager n’existe/i)
       expect(form.errors[:base].first).not_to include(/si vous souhaitez vous connecter en tant qu’agent/i)
@@ -30,10 +30,23 @@ RSpec.describe Users::LoginCodeRequestForm, type: :form_model do
     let!(:agent) { create(:agent, email: "us@ger.fr") }
 
     specify do
-      form = described_class.new(LoginCode.new(email: "us@ger.fr", domain_id: Domain::RDV_SERVICE_PUBLIC.id))
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", domain_id: "RDV_SERVICE_PUBLIC"))
       expect(form).not_to be_valid
       expect(form.errors[:base].first).to include(/aucun compte usager n’existe/i)
       expect(form.errors[:base].first).to include(/si vous souhaitez vous connecter en tant qu’agent/i)
+    end
+  end
+
+  context "un login code a été généré très récemment" do
+    let!(:user) { create(:user, email: "us@ger.fr") }
+
+    before { create(:login_code, email: "us@ger.fr", created_at: 10.seconds.ago) }
+
+    it "ne génère pas un nouveau code et affiche une erreur" do
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", domain_id: "RDV_SERVICE_PUBLIC"))
+      expect(form).not_to be_valid
+      expect { form.save }.not_to change(LoginCode, :count)
+      expect(form.errors[:base].first).to include("Un code a été envoyé à us@ger.fr il y a moins de deux minutes")
     end
   end
 end

--- a/spec/form_models/users/login_code_request_form_spec.rb
+++ b/spec/form_models/users/login_code_request_form_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Users::DemandeLoginCodeForm, type: :form_model do
+RSpec.describe Users::LoginCodeRequestForm, type: :form_model do
   context "l’usager existe et tout est correct" do
     let!(:user) { create(:user, email: "us@ger.fr") }
 

--- a/spec/mailers/previews/users/login_code_mailer_preview.rb
+++ b/spec/mailers/previews/users/login_code_mailer_preview.rb
@@ -1,0 +1,12 @@
+class Users::LoginCodeMailerPreview < ActionMailer::Preview
+  def login_code
+    login_code = LoginCode.new(
+      email: "jean@moustache.fr",
+      code: "394522",
+      domain_id: "RDV_SERVICE_PUBLIC",
+      created_at: 10.minutes.ago
+    )
+    login_code.readonly!
+    Users::LoginCodeMailer.with(login_code:).login_code
+  end
+end

--- a/spec/models/login_code_spec.rb
+++ b/spec/models/login_code_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe LoginCode, type: :model do
+  describe ".most_recent_usable_for scope" do
+    before do
+      create(:login_code, email: "test@usager1.fr", code: "112233", created_at: 10.minutes.ago, used_at: 8.minutes.ago)
+      create(:login_code, email: "test@usager1.fr", code: "223344", created_at: 2.hours.ago)
+      create(:login_code, email: "test@usager1.fr", code: "556677", created_at: 1.minute.ago)
+      create(:login_code, email: "test@usager1.fr", code: "667788", created_at: 2.minutes.ago)
+      create(:login_code, email: "autre@personne.fr", code: "990099", created_at: 30.seconds.ago)
+    end
+
+    specify do
+      expect(described_class.most_recent_usable_for(email: "test@usager1.fr").code).to eq("556677")
+    end
+  end
+
+  describe "#set_random_code before_save callback" do
+    let(:login_code) { described_class.new(email: "test@usager.fr", domain_id: "RDV_SERVICE_PUBLIC") }
+
+    specify do
+      login_code.save
+      expect(login_code.reload.code).not_to be_blank
+    end
+  end
+end

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -1,6 +1,6 @@
 def login_via_6_digit_code(email)
-  fill_in("login_code[email]", with: email)
-  click_button("Recevoir un code de connexion")
-  fill_in("Code à 6 chiffres", with: LoginCode.most_recent_usable_for(email:).code)
+  fill_in "Adresse email", with: email
+  click_button "Recevoir un code de connexion"
+  fill_in "Code à 6 chiffres", with: LoginCode.most_recent_usable_for(email:).code
   click_on "Valider"
 end

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -1,0 +1,6 @@
+def login_via_6_digit_code(email)
+  fill_in("login_code[email]", with: email)
+  click_button("Recevoir un code de connexion")
+  fill_in("Code à 6 chiffres", with: LoginCode.most_recent_usable_for(email:).code)
+  click_on "Valider"
+end


### PR DESCRIPTION
Review app : https://rdv-service-public-review-app-pr5962.osc-secnum-fr1.scalingo.io/users/sign_in

⚠️ Les emails sont activés sur cette review app ! Il faut vous créer un compte avec un email auquel vous avez accès 

# 👀 TLDR; en capture d’écran

Nouveau parcours de connexion par code à 6 chiffres, sans mot de passe :

<img width="1356" height="637" alt="image" src="https://github.com/user-attachments/assets/bf19b01b-c145-4dae-9039-fb802ac199c0" />

# 📚 Contexte détaillé

## Actuellement

On itère pour simplifier le parcours usager. On a déjà supprimé l’étape de définition de mot de passe post inscription. Mais pour se connecter si jamais ils reviennent, les usagers doivent définir un mot de passe en cliquant sur « mot de passe oublié ou première connexion » puis l’utiliser.

Ci dessous une petite liste des choses déjà possibles aujourd’hui, pour évaluer les implications de sécurité de ce que je propose ici : 

- se connecter à un compte usager si on peut lire ses emails (via un reset password)
- savoir si un compte usager existe pour un email (explicitement dit depuis la page reset password)
- savoir si un compte agent existe pour un email (explicitement dit depuis la page reset password agent)

## Vision / prochaines étapes

On pense supprimer la page d’inscription complètement ET la possibilité de se connecter via mot de passe. Il n’y aurait que FranceConnect OU champ email + recevoir un code. Le compte serait créé automatiquement s’il n’existe pas encore.

# ⚙️ Solution / détails

Basé sur le fantastique PoC de François dans #5945. Discuté avec François, on va utilise une nouvelle table `login_codes` plutôt que Redis. Ça évite de nous rendre plus dépendant de Redis qu’actuellement.

## Codes acceptés

On accepte n’importe quel code envoyé dans les 30 dernières minutes à un email, pas uniquement le dernier. Mais on a mis en place du throttling, cf plus bas. Au max en 30 minutes pour un email tu peux en demander 15. 

## Développement

En dev on affiche le code envoyé par mail : 
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/9691aac4-33b5-4f7f-ae94-642cc999f91d" />
On pourrait éventuellement activer ça sur les envs de review app aussi ?

## Mail

visible en preview sur https://www.rdv-solidarites.localhost/rails/mailers/users/login_code_mailer/login_code

<img width="629" height="500" alt="image" src="https://github.com/user-attachments/assets/d67a50a3-fdd7-4f5f-891d-3ad5877535ed" />

Est-ce qu’on devrait rajouter un lien vers la page de saisie du code dans l’email ?

## Rate throttling

J’ai mis en place du throttling sur les endpoints de création de codes de login et de saisie de code. 
S’il y a plus de 60 demandes ou saisie pour un même email sur une heure, on bloque. 
J’ai choisi de faire sur base de l’email plutôt que l’IP car j’ai eu peur de bloquer des gens sur des ordis partagés.

## rdv wizard context

Lorsqu’on vient d’un parcours de prise de RDV, le contexte du RDV wizard est aussi affiché sur la page de saisie du code :

<img width="589" height="773" alt="image" src="https://github.com/user-attachments/assets/1ae5eaf9-cabc-4645-88cf-8508e416525e" />


## connexion par mot de passe

<img width="566" height="537" alt="image" src="https://github.com/user-attachments/assets/a05980a5-7f38-4de4-ac78-f870c7a85246" />

## re-demande d’un code, throttling doux

Sur la page de saisie de code, on affiche le lien pour suggérer de demander un nouveau code uniquement après 2 minutes. 

Depuis la page de demande de code (la page de connexion), si quelqu’un demande un nouveau code pour un email moins de deux minutes après, on ne créée pas de nouveau code et on affiche un message d’erreur avec un lien :

<img width="374" height="522" alt="image" src="https://github.com/user-attachments/assets/d13d3e81-68d6-4cd9-ada4-4485a9d616e3" />
