### PR TITLE
Permettre les RDV collectifs par visio, optionnellement avec une URL custom

### DIFF
--- a/app/controllers/admin/rdvs_collectifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs_controller.rb
@@ -34,7 +34,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
     authorize(@rdv, :new?, policy_class: Agent::RdvPolicy)
     if @rdv_form.save
       Notifiers::RdvCreated.perform_with(@rdv, current_agent)
-      flash[:success] = I18n.t("admin.rdvs.message.success.create")
+      flash[:success] = "Le rendez-vous a été créé : <a href='#{admin_organisation_rdv_path(@rdv.organisation, @rdv)}'>voir les détails du rendez-vous</a>"
       redirect_to admin_organisation_rdvs_collectifs_path(current_organisation)
     else
       render :new
@@ -70,7 +70,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
   private
 
   def create_attribute_names
-    %i[starts_at duration_in_min lieu_id name max_participants_count context motif_id ignore_benign_errors]
+    %i[starts_at duration_in_min lieu_id name max_participants_count context motif_id ignore_benign_errors visio_url_custom visio_url_type]
   end
 
   def create_attributes_rdvs
@@ -79,7 +79,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
 
   def create_params
     allowed_params = params.require(:rdv).permit(*create_attribute_names, *create_attributes_rdvs)
-    return allowed_params if params[:rdv][:lieu_id].present?
+    return allowed_params if params[:rdv][:lieu_id].present? || Motif.find_by(id: params[:rdv][:motif_id]).visio?
 
     allowed_params.to_h.deep_merge(lieu_attributes: { organisation: current_organisation, availability: :single_use })
   end

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -165,7 +165,7 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def rdv_update_params
-    allowed_params = params.require(:rdv).permit(:status, :lieu_id, :duration_in_min, :starts_at, :context, :ignore_benign_errors, :max_participants_count, :name,
+    allowed_params = params.require(:rdv).permit(:status, :lieu_id, :duration_in_min, :starts_at, :context, :ignore_benign_errors, :max_participants_count, :name, :visio_url_custom, :visio_url_type,
                                                  participations_attributes: %i[user_id send_lifecycle_notifications send_reminder_notification id _destroy],
                                                  lieu_attributes: %i[name address latitude longitude id],
                                                  agent_ids: [])

--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -7,6 +7,7 @@ module Admin::RdvFormConcern
     attr_accessor :rdv
 
     delegate(*::Rdv.hardcoded_attribute_names, to: :rdv)
+    delegate :visio_url_type, :visio?, to: :rdv
     delegate :motif, :organisation, :agents, :users, to: :rdv
     delegate :overlapping_plages_ouvertures, :overlapping_plages_ouvertures?, to: :rdv
     delegate :overlapping_absences, :overlapping_absences?, to: :rdv

--- a/app/javascript/application_agent.js
+++ b/app/javascript/application_agent.js
@@ -45,12 +45,14 @@ import { Application } from "@hotwired/stimulus"
 import CheckboxSelectAll from '@stimulus-components/checkbox-select-all'
 import MotifFormController from './controllers/motif_form_controller'
 import DestroyableController from './controllers/destroyable_controller'
+import DependentInputController from './controllers/dependent_input_controller'
 import './controllers'
 
 window.Stimulus = Application.start()
 Stimulus.register('checkbox-select-all', CheckboxSelectAll)
 Stimulus.register('motif-form', MotifFormController)
 Stimulus.register('destroyable', DestroyableController)
+Stimulus.register('dependent-input', DependentInputController)
 
 import './stylesheets/print'
 import './stylesheets/application_agent'

--- a/app/javascript/controllers/dependent_input_controller.js
+++ b/app/javascript/controllers/dependent_input_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="dependent-input"
+export default class extends Controller {
+  static targets = [
+    "controllingInput",
+    "dependentInputWrapper",
+    "dependentInput"
+  ]
+
+  connect() {
+    this.toggle()
+  }
+
+  toggle() {
+    this.controllingInputTarget.checked ? this.show() : this.hide()
+  }
+
+  show() {
+    window.dsfr(this.dependentInputWrapperTarget).collapse.disclose()
+    this.dependentInputTarget.removeAttribute("disabled")
+    // on veut que le champ qui apparaît soit required, mais on ne veut pas le mettre dans le HTML nu
+    // pour ne pas bloquer la version sans JS. Pas besoin de l’unset car ça n’impacte pas les input disabled
+    this.dependentInputTarget.setAttribute("required", "true")
+  }
+
+  hide() {
+    const dsfrElt = window.dsfr(this.dependentInputWrapperTarget)
+    if (dsfrElt) {
+      window.dsfr(this.dependentInputWrapperTarget).collapse.conceal()
+    } else {
+      // parfois au chargement de la page dsfrElt est null 🤷
+      this.dependentInputWrapperTarget.classList.remove("fr-collapse--expanded")
+    }
+    this.dependentInputTarget.setAttribute("disabled", "disabled")
+  }
+}

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -192,3 +192,7 @@
 .rdv-border-color-blue-france {
   border-color: var(--blue-france-main-525);
 }
+
+.rdv-display-inline-block {
+  display: inline-block;
+}

--- a/app/models/concerns/rdv/hardcoded_attribute_names_concern.rb
+++ b/app/models/concerns/rdv/hardcoded_attribute_names_concern.rb
@@ -22,6 +22,7 @@ module Rdv::HardcodedAttributeNamesConcern
     status
     created_by_id
     created_by_type
+    visio_url_custom
   ].freeze
 
   class_methods do

--- a/app/models/concerns/rdv/visio_concern.rb
+++ b/app/models/concerns/rdv/visio_concern.rb
@@ -4,7 +4,8 @@ module Rdv::VisioConcern
   VALID_DOMAINS = %w[
     webinaire.numerique.gouv.fr
     webconf.numerique.gouv.fr
-    teams.microsoft.com
+    visio.numerique.gouv.fr
+    teams.live.com
     meet.google.com
     zoom.us
     meet.jit.si
@@ -30,7 +31,7 @@ module Rdv::VisioConcern
     res = URI::DEFAULT_PARSER.make_regexp(%w[http https]).match(visio_url_custom)
     if !res
       errors.add :visio_url_custom, "n'est pas une URL valide"
-    elsif VALID_DOMAINS.exclude?(res[4])
+    elsif VALID_DOMAINS.none? { |domain| res[4].end_with?(domain) }
       errors.add :visio_url_custom, "doit provenir d’un des domaines suivants : #{VALID_DOMAINS.to_sentence}"
     end
   end

--- a/app/models/concerns/rdv/visio_concern.rb
+++ b/app/models/concerns/rdv/visio_concern.rb
@@ -11,7 +11,10 @@ module Rdv::VisioConcern
     meet.jit.si
   ].freeze
 
+  VISIO_URL_TYPES = %w[default custom].freeze
+
   included do
+    validates :visio_url_type, inclusion: { in: VISIO_URL_TYPES }
     validates :visio_url_custom, presence: true, if: -> { visio_url_type == "custom" }
     validate :validate_visio_url_custom, if: -> { visio_url_custom.present? }
   end

--- a/app/models/concerns/rdv/visio_concern.rb
+++ b/app/models/concerns/rdv/visio_concern.rb
@@ -1,0 +1,55 @@
+module Rdv::VisioConcern
+  extend ActiveSupport::Concern
+
+  VALID_DOMAINS = %w[
+    webinaire.numerique.gouv.fr
+    webconf.numerique.gouv.fr
+    teams.microsoft.com
+    meet.google.com
+    zoom.us
+    meet.jit.si
+  ].freeze
+
+  included do
+    validates :visio_url_custom, presence: true, if: -> { visio_url_type == "custom" }
+    validate :validate_visio_url_custom, if: -> { visio_url_custom.present? }
+  end
+
+  def visio_url
+    if !motif.visio?
+      nil
+    elsif visio_url_custom.present?
+      visio_url_custom
+    else
+      # webconf = Jitsi et Jitsi n'autorise pas les - et _ dans les liens de visio
+      "https://webconf.numerique.gouv.fr/RdvServicePublic#{uuid}".gsub(/[-_]/, "")
+    end
+  end
+
+  def validate_visio_url_custom
+    res = URI::DEFAULT_PARSER.make_regexp(%w[http https]).match(visio_url_custom)
+    if !res
+      errors.add :visio_url_custom, "n'est pas une URL valide"
+    elsif VALID_DOMAINS.exclude?(res[4])
+      errors.add :visio_url_custom, "doit provenir d’un des domaines suivants : #{VALID_DOMAINS.to_sentence}"
+    end
+  end
+
+  # visio_url_type est un attribut PORO non persisté qui permet d’afficher les radio buttons
+  # on pourra le déplacer vers les objets RdvForm lorsque ceux-ci seront correctement utilisés 😅
+  def visio_url_type
+    if defined?(@visio_url_type)
+      @visio_url_type
+    elsif visio_url_custom.present?
+      "custom"
+    else
+      "default"
+    end
+  end
+
+  # ce setter permet de vider l’URL custom lors de l’édition d’un RDV existant
+  def visio_url_type=(new_val)
+    @visio_url_type = new_val
+    self.visio_url_custom = nil if new_val == "default"
+  end
+end

--- a/app/models/concerns/rdv/visio_concern.rb
+++ b/app/models/concerns/rdv/visio_concern.rb
@@ -39,7 +39,7 @@ module Rdv::VisioConcern
   # visio_url_type est un attribut PORO non persisté qui permet d’afficher les radio buttons
   # on pourra le déplacer vers les objets RdvForm lorsque ceux-ci seront correctement utilisés 😅
   def visio_url_type
-    if defined?(@visio_url_type)
+    if @visio_url_type
       @visio_url_type
     elsif visio_url_custom.present?
       "custom"

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -66,7 +66,7 @@ class Motif < ApplicationRecord
   validate :booking_delay_validation
   validate :not_associated_with_secretariat
   validates :color, css_hex_color: true
-  validate :not_at_home_if_collectif
+  validate  :validate_location_type_for_rdv_collectif
   validate :cant_change_once_rdvs_exist
   validate :cant_be_for_secretariat_and_follow_up
   validate :unique_in_org
@@ -292,10 +292,10 @@ class Motif < ApplicationRecord
     errors.add(:service_id, "ne peut être le secrétariat") if service.secretariat?
   end
 
-  def not_at_home_if_collectif
-    return unless collectif? && !public_office?
+  def validate_location_type_for_rdv_collectif
+    return if !collectif? || public_office? || visio?
 
-    errors.add(:base, :not_at_home_if_collectif)
+    errors.add(:base, "Les RDV collectifs ne peuvent pas être faits par téléphone ou à domicile")
   end
 
   def cant_change_once_rdvs_exist

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -8,6 +8,7 @@ class Rdv < ApplicationRecord
   include WebhookDeliverable
   include Rdv::AddressConcern
   include Rdv::AuthoredConcern
+  include Rdv::VisioConcern
   include Rdv::Updatable
   include Rdv::UsingWaitingRoom
   include Rdv::HardcodedAttributeNamesConcern
@@ -381,13 +382,6 @@ class Rdv < ApplicationRecord
 
   def revoked!
     update!(cancelled_at: Time.zone.now, status: "revoked")
-  end
-
-  def visio_url
-    return nil unless motif.visio?
-
-    # Jitsi n'autorise pas les - et _ dans les liens de visio
-    "https://webconf.numerique.gouv.fr/RdvServicePublic#{uuid}".gsub(/[-_]/, "")
   end
 
   def not_cancelled_and_in_the_future?

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -60,6 +60,8 @@
                 span.font-14.font-weight-bold= "Avertissement : "
                 span.text-muted.font-14= I18n.t("activerecord.attributes.rdv/name.hint")
 
+              = render "admin/rdvs_collectifs/form_visio_fields", rdv_form: @rdv_form
+
               = f.input :max_participants_count, input_html: { min: 1 }
             .form-group
               = "#{User.model_name.human.pluralize} :"

--- a/app/views/admin/rdvs_collectifs/_form_visio_fields.html.slim
+++ b/app/views/admin/rdvs_collectifs/_form_visio_fields.html.slim
@@ -6,18 +6,18 @@
 
   fieldset.fr-fieldset[data-controller="dependent-input"]
     legend.fr-fieldset__legend--regular.fr-fieldset__legend.fr-mt-1w
-      | URL de visioconférence
+      | Outil de visioconférence
 
     = dsfr_f.dsfr_radio_option :visio_url_type,
       value: "default",
-      label_text: "Outil de visioconférence par défaut",
+      label_text: "Par défaut : Webconf",
       hint: "Une URL unique sera créée via webconf.numerique.gouv.fr",
       checked: rdv_form.visio_url_type == "default",
       "data-action": "change->dependent-input#toggle"
 
     - custom_label = capture do
       div
-        | URL de visioconférence personnalisée
+        | Outil de votre choix
         button.fr-btn--tooltip.fr-btn.fr-ml-1w.rdv-display-inline-block[
           type="button"
           aria-describedby="tooltip-visio-custom"

--- a/app/views/admin/rdvs_collectifs/_form_visio_fields.html.slim
+++ b/app/views/admin/rdvs_collectifs/_form_visio_fields.html.slim
@@ -1,4 +1,4 @@
-/# locals: (rdv_form:)rdvvisiohtm
+/# locals: (rdv_form:)
 - if rdv_form.visio?
 
   / on instancie un form builder DSFR ici tant que les forms edit et new RDV collectif ne sont pas encore au DSFR

--- a/app/views/admin/rdvs_collectifs/_form_visio_fields.html.slim
+++ b/app/views/admin/rdvs_collectifs/_form_visio_fields.html.slim
@@ -1,0 +1,41 @@
+/# locals: (rdv_form:)rdvvisiohtm
+- if rdv_form.visio?
+
+  / on instancie un form builder DSFR ici tant que les forms edit et new RDV collectif ne sont pas encore au DSFR
+  - dsfr_f = Dsfr::FormBuilder.new(:rdv, rdv_form, self, {})
+
+  fieldset.fr-fieldset[data-controller="dependent-input"]
+    legend.fr-fieldset__legend--regular.fr-fieldset__legend.fr-mt-1w
+      | URL de visioconférence
+
+    = dsfr_f.dsfr_radio_option :visio_url_type,
+      value: "default",
+      label_text: "Outil de visioconférence par défaut",
+      hint: "Une URL unique sera créée via webconf.numerique.gouv.fr",
+      checked: rdv_form.visio_url_type == "default",
+      "data-action": "change->dependent-input#toggle"
+
+    - custom_label = capture do
+      div
+        | URL de visioconférence personnalisée
+        button.fr-btn--tooltip.fr-btn.fr-ml-1w.rdv-display-inline-block[
+          type="button"
+          aria-describedby="tooltip-visio-custom"
+        ]
+        span.fr-tooltip.fr-placement#tooltip-visio-custom[role="tooltip"]
+          | Nous vous recommandons d’utiliser webinaire.numerique.gouv.fr
+
+    = dsfr_f.dsfr_radio_option :visio_url_type,
+      value: "custom",
+      label_text: custom_label,
+      hint: nil,
+      checked: rdv_form.visio_url_type == "custom",
+      "data-dependent-input-target": "controllingInput",
+      "data-action": "change->dependent-input#toggle"
+
+    .fr-fieldset__element.fr-collapse.fr-collapse--expanded.fr-mx-4w.fr-mt-n2w[
+      data-dependent-input-target="dependentInputWrapper"
+    ]
+      = dsfr_f.dsfr_text_field :visio_url_custom,
+        label: "URL de visioconférence",
+        "data-dependent-input-target": "dependentInput"

--- a/app/views/admin/rdvs_collectifs/_rdv.html.slim
+++ b/app/views/admin/rdvs_collectifs/_rdv.html.slim
@@ -12,8 +12,12 @@
     .row
       .col-md-6
         .d-flex.card-text.mb-2
-          = lieu_icon(class: "fr-mr-1w")
-          = rdv.lieu.name
+          - if rdv.public_office?
+            = lieu_icon(class: "fr-mr-1w")
+            = rdv.lieu.name
+          - elsif rdv.visio?
+            = visio_icon(class: "fr-mr-1w")
+            = link_to("Visioconférence", rdv.visio_url, target: :_blank)
 
         .d-flex.card-text.mb-2
           = user_icon(class: "fr-mr-1w")

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -31,8 +31,12 @@
 
             .col-md-6
               .d-flex.card-text.mb-2
+              - if @rdv.public_office?
                 = lieu_icon(class: "fr-mr-1w")
                 = @rdv.lieu.name
+              - elsif @rdv.visio?
+                = visio_icon(class: "fr-mr-1w")
+                = link_to("Visioconférence", @rdv.visio_url, target: :_blank)
 
               .d-flex.card-text.mb-2
                 = user_icon(class: "fr-mr-1w")

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -23,25 +23,29 @@
             span.text-muted.font-14= I18n.t("activerecord.attributes.rdv/name.hint")
           = f.input :context
           = f.hidden_field :motif_id, value: @rdv.motif_id
-          - new_lieu_record = @rdv.lieu&.new_record?
-          - controller_data = { "controller": "rdv-lieu",
-                  "initial-state": (new_lieu_record ? "single_use" : "existing"),
-                  "select-placeholder-single-use-lieu": t(".select_placeholder_single_use_lieu"),
-                  "select-placeholder-existing-lieu": t(".select_placeholder_existing_lieu"), }
-          .form-group data=controller_data
-            = f.label :lieu, required: true
-            fieldset
-              = f.association :lieu, collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name, label_method: :full_name,
-                label: false,  include_blank: true,  required: false,
-                input_html: { class: "select2-input", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true } }
-              small.form-text.text-muted data={"rdv-lieu-target": "new_lieu_link"}
-                = t(".single_use_lieu_hint_html")
-            fieldset data={ "rdv-lieu-target": "new_lieu_fieldset" }
-              .border.p-2.bg-light
-                = f.fields_for :lieu, (new_lieu_record ? @rdv.lieu : Lieu.new) do |f2|
-                  = render "admin/lieux/lieu_fields", f: f2
-              small.form-text.text-muted data={"rdv-lieu-target": "select_lieu_link"}
-                = t(".existing_lieu_hint_html")
+
+          = render "admin/rdvs_collectifs/form_visio_fields", rdv_form: @rdv_form
+
+          - if @rdv.public_office?
+            - new_lieu_record = @rdv.lieu&.new_record?
+            - controller_data = { "controller": "rdv-lieu",
+                    "initial-state": (new_lieu_record ? "single_use" : "existing"),
+                    "select-placeholder-single-use-lieu": t(".select_placeholder_single_use_lieu"),
+                    "select-placeholder-existing-lieu": t(".select_placeholder_existing_lieu"), }
+            .form-group data=controller_data
+              = f.label :lieu, required: true
+              fieldset
+                = f.association :lieu, collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name, label_method: :full_name,
+                  label: false,  include_blank: true,  required: false,
+                  input_html: { class: "select2-input", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true } }
+                small.form-text.text-muted data={"rdv-lieu-target": "new_lieu_link"}
+                  = t(".single_use_lieu_hint_html")
+              fieldset data={ "rdv-lieu-target": "new_lieu_fieldset" }
+                .border.p-2.bg-light
+                  = f.fields_for :lieu, (new_lieu_record ? @rdv.lieu : Lieu.new) do |f2|
+                    = render "admin/lieux/lieu_fields", f: f2
+                small.form-text.text-muted data={"rdv-lieu-target": "select_lieu_link"}
+                  = t(".existing_lieu_hint_html")
 
           = f.input :max_participants_count, input_html: { min: 1 }
 

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -135,6 +135,7 @@ tables:
     anonymized_column_names:
       - context
       - name
+      - visio_url_custom
     non_anonymized_column_names:
       - starts_at
       - organisation_id

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -90,6 +90,40 @@
         79
       ],
       "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "fd3d0da78475714fd8f20075072ba463b0a697f3662db636d19bff117b424659",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/admin/rdvs_collectifs/edit.html.slim",
+      "line": 39,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"Visioconf\\u00E9rence\", Rdv.find(params[:id]).visio_url, :target => :_blank)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Admin::RdvsCollectifsController",
+          "method": "edit",
+          "line": 52,
+          "file": "app/controllers/admin/rdvs_collectifs_controller.rb",
+          "rendered": {
+            "name": "admin/rdvs_collectifs/edit",
+            "file": "app/views/admin/rdvs_collectifs/edit.html.slim"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "admin/rdvs_collectifs/edit"
+      },
+      "user_input": "Rdv.find(params[:id]).visio_url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "l'attribute visio_url_custom est validée lors de la sauvegarde, les domaines sont filtrés"
     }
   ],
   "brakeman_version": "7.0.0"

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -84,7 +84,7 @@ fr:
         visio: Par visioconférence
       motif/location_types/hint:
         public_office: L'agent reçoit l'usager sur place, au lieu sélectionné (MDS…).
-        visio: L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV. L'agent se connecte au service de webconférence de l'État avec ProConnect pour démarrer la visioconférence.
+        visio: L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV. Pour les RDV individuels, l'agent se connecte au service de webconférence de l'État avec ProConnect pour démarrer la visioconférence.
         phone: L’agent appelle le numéro indiqué sur la fiche de l'usager.
         home: L’agent se rend à l'adresse indiquée sur la fiche de l'usager.
       motif/bookable_by/radio_label_html:
@@ -112,8 +112,6 @@ fr:
         motif:
           cant_change_because_already_used: ne peut être modifié car le motif est utilisé pour un RDV
           attributes:
-            base:
-              not_at_home_if_collectif: Les RDV collectifs doivent avoir lieu sur place.
             name:
               taken: "est déjà utilisé : un motif du même type et du même service porte déjà ce nom dans cette organisation."
             for_secretariat:

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -13,6 +13,8 @@ fr:
               must_be_positive: doit être supérieur à 0
             lieu:
               must_not_be_disabled: "doit être un lieu ouvert de l’organisation, ou un lieu ponctuel."
+            visio_url_custom:
+              format: "L’URL %{message}"
         participation:
           attributes:
             status:

--- a/db/migrate/20251218155053_add_custom_visio_url_to_rdvs.rb
+++ b/db/migrate/20251218155053_add_custom_visio_url_to_rdvs.rb
@@ -1,0 +1,5 @@
+class AddCustomVisioUrlToRdvs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :rdvs, :visio_url_custom, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -632,6 +632,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_08_161928) do
     t.enum "status", default: "unknown", null: false, enum_type: "rdv_status"
     t.integer "created_by_id"
     t.string "created_by_type", null: false
+    t.string "visio_url_custom"
     t.index "tsrange(starts_at, ends_at, '[)'::text)", name: "index_rdvs_on_tsrange_starts_at_ends_at", using: :gist
     t.index ["created_by_type", "created_by_id"], name: "index_rdvs_on_created_by_type_and_created_by_id"
     t.index ["ends_at"], name: "index_rdvs_on_ends_at"

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_and_edit_rdv_collectif_en_visio_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_and_edit_rdv_collectif_en_visio_spec.rb
@@ -58,9 +58,8 @@ RSpec.describe "Un agent peut créer et éditer un RDV collectif en visio en pas
     expect(page).to have_selector(:field, "URL de visioconférence", visible: true)
 
     # on modifie pour utiliser l’outil par défaut
-    # l’enjeu ici est que le radio button vide bien le champ visio_url_custom
     find("label", text: "Par défaut : Webconf").click
-    click_on "Enregistrer"
+    expect { click_on "Enregistrer" }.to change { Rdv.collectif.last.visio_url_custom }.to(nil)
 
     # on se retrouve sur le rdvs#show, on vérifie que le lien a été modifié
     expect(page).to have_content("Le rendez-vous a été modifié")

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_and_edit_rdv_collectif_en_visio_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_and_edit_rdv_collectif_en_visio_spec.rb
@@ -22,23 +22,22 @@ RSpec.describe "Un agent peut créer et éditer un RDV collectif en visio en pas
     select("DIALO Alain", from: "rdv_agent_ids")
 
     # au chargement de la page, le JS devrait cacher et disabler le champ texte URL personnalisée
-    fieldset = find("legend", text: "URL de visioconférence").ancestor("fieldset")
-    invisible_input = fieldset.find('input[type="text"]', visible: false)
-    expect(invisible_input["disabled"]).to be true
+    expect(page).to have_selector(:element, "label", text: "URL de visioconférence", visible: false)
+    expect(page).to have_selector(:field, "URL de visioconférence", visible: false, disabled: true)
 
     # on clique ensuite sur URL personnalisée et le champ apparait
-    find("label", text: "URL de visioconférence personnalisée").click
-    visible_input = fieldset.find('input[type="text"]', visible: true)
-    expect(visible_input["disabled"]).to be_nil
+    find("label", text: "Outil de votre choix").click
+    expect(page).to have_selector(:element, "label", text: "URL de visioconférence", visible: true)
+    expect(page).to have_selector(:element, "input", name: "rdv[visio_url_custom]", visible: true, disabled: false)
 
     # on rentre volontairement une URL invalide
-    visible_input.fill_in with: "https://test.fr/123"
+    fill_in "URL de visioconférence", with: "https://test.fr/123"
     click_on "Enregistrer"
     expect(page).to have_content("L’URL doit provenir d’un des domaines suivants")
 
     # on vérifie que c’est le bon radio qui est coché et que le champ URL personnalisée est visible
-    expect(find(:radio_button, "URL de visioconférence personnalisée", visible: false)).to be_checked
-    expect(find(:radio_button, "Outil de visioconférence par défaut", visible: false)).not_to be_checked
+    expect(find(:radio_button, "Outil de votre choix", visible: false)).to be_checked
+    expect(find(:radio_button, "Par défaut : Webconf", visible: false)).not_to be_checked
     expect(page).to have_selector(:field, "URL de visioconférence", visible: true)
 
     # on rentre une URL valide
@@ -54,13 +53,13 @@ RSpec.describe "Un agent peut créer et éditer un RDV collectif en visio en pas
     click_on "Modifier"
 
     # on vérifie que c’est le bon radio qui est coché et que le champ URL personnalisée est visible
-    expect(find(:radio_button, "URL de visioconférence personnalisée", visible: false)).to be_checked
-    expect(find(:radio_button, "Outil de visioconférence par défaut", visible: false)).not_to be_checked
+    expect(page).to have_selector(:radio_button, "Outil de votre choix", visible: false, checked: true)
+    expect(page).to have_selector(:radio_button, "Par défaut : Webconf", visible: false, checked: false)
     expect(page).to have_selector(:field, "URL de visioconférence", visible: true)
 
     # on modifie pour utiliser l’outil par défaut
     # l’enjeu ici est que le radio button vide bien le champ visio_url_custom
-    find("label", text: "Outil de visioconférence par défaut").click
+    find("label", text: "Par défaut : Webconf").click
     click_on "Enregistrer"
 
     # on se retrouve sur le rdvs#show, on vérifie que le lien a été modifié

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_and_edit_rdv_collectif_en_visio_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_and_edit_rdv_collectif_en_visio_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe "Un agent peut créer et éditer un RDV collectif en visio en passant et retirant une URL de visio personnalisée", js: true do
+  let(:organisation) { create(:organisation) }
+  let!(:lieu) { create(:lieu, organisation:) }
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation], first_name: "Alain", last_name: "DIALO") }
+
+  before do
+    create(:motif, :collectif, name: "Atelier visio", organisation: organisation, location_type: :visio)
+    stub_netsize_ok
+    travel_to(Time.zone.local(2022, 3, 14))
+    login_as(agent, scope: :agent)
+  end
+
+  specify do
+    visit admin_organisation_rdvs_collectifs_path(organisation)
+    click_link "Nouveau RDV collectif"
+    click_link "Atelier visio"
+
+    fill_in "Commence à", with: "17/3/2022 14:00"
+    fill_in "Durée en minutes", with: "30"
+    fill_in "Nombre de places", with: 4
+    fill_in "Intitulé", with: "Déblocages administratifs"
+    select("DIALO Alain", from: "rdv_agent_ids")
+
+    # au chargement de la page, le JS devrait cacher et disabler le champ texte URL personnalisée
+    fieldset = find("legend", text: "URL de visioconférence").ancestor("fieldset")
+    invisible_input = fieldset.find('input[type="text"]', visible: false)
+    expect(invisible_input["disabled"]).to be true
+
+    # on clique ensuite sur URL personnalisée et le champ apparait
+    find("label", text: "URL de visioconférence personnalisée").click
+    visible_input = fieldset.find('input[type="text"]', visible: true)
+    expect(visible_input["disabled"]).to be_nil
+
+    # on rentre volontairement une URL invalide
+    visible_input.fill_in with: "https://test.fr/123"
+    click_on "Enregistrer"
+    expect(page).to have_content("L’URL doit provenir d’un des domaines suivants")
+
+    # on vérifie que c’est le bon radio qui est coché et que le champ URL personnalisée est visible
+    expect(find(:radio_button, "URL de visioconférence personnalisée", visible: false)).to be_checked
+    expect(find(:radio_button, "Outil de visioconférence par défaut", visible: false)).not_to be_checked
+    expect(page).to have_selector(:field, "URL de visioconférence", visible: true)
+
+    # on rentre une URL valide
+    fill_in "URL de visioconférence", with: "https://webinaire.numerique.gouv.fr/test-123"
+    click_on "Enregistrer"
+
+    # on arrive sur la liste des RDV collectifs
+    expect(page).to have_content("Le rendez-vous a été créé")
+    click_on "voir les détails du rendez-vous"
+
+    # on vérifie que c’est le bon lien qui s’affiche sur le rdvs#show
+    expect(find("a", text: /démarrer la visioconférence/)[:href]).to eq("https://webinaire.numerique.gouv.fr/test-123")
+    click_on "Modifier"
+
+    # on vérifie que c’est le bon radio qui est coché et que le champ URL personnalisée est visible
+    expect(find(:radio_button, "URL de visioconférence personnalisée", visible: false)).to be_checked
+    expect(find(:radio_button, "Outil de visioconférence par défaut", visible: false)).not_to be_checked
+    expect(page).to have_selector(:field, "URL de visioconférence", visible: true)
+
+    # on modifie pour utiliser l’outil par défaut
+    # l’enjeu ici est que le radio button vide bien le champ visio_url_custom
+    find("label", text: "Outil de visioconférence par défaut").click
+    click_on "Enregistrer"
+
+    # on se retrouve sur le rdvs#show, on vérifie que le lien a été modifié
+    expect(page).to have_content("Le rendez-vous a été modifié")
+    expect(find("a", text: /démarrer la visioconférence/)[:href]).to match(%r{https://webconf\.numerique\.gouv\.fr})
+  end
+end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -65,6 +65,41 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       expect(mail.html_part.body.encoded).to match("<span>en appelant au <a href=\"tel:0601010101\">0601010101</a> ou</span> en cliquant sur le lien ci-dessous")
       expect(mail.html_part.body.encoded).to match("Annuler ou modifier le rendez-vous</a>")
     end
+
+    context "motif collectif sur place" do
+      let(:organisation) { create(:organisation) }
+      let(:lieu) { create(:lieu, organisation:, name: "Mairie centrale") }
+      let(:motif) { create(:motif, :collectif, organisation:, location_type: :public_office) }
+      let(:rdv) { create(:rdv, motif:, organisation:, lieu:) }
+
+      it "contient le nom du lieu" do
+        mail = described_class.with(rdv:, user:, token:).rdv_created
+        expect(mail.html_part.body.encoded).to include(/Mairie centrale/)
+      end
+    end
+
+    context "motif collectif en visio, pas de visio_url_custom" do
+      let(:organisation) { create(:organisation) }
+      let(:motif) { create(:motif, :collectif, organisation:, location_type: :visio) }
+      let(:rdv) { create(:rdv, motif:, organisation:, visio_url_custom: nil) }
+
+      it "contient un lien vers la visio" do
+        mail = described_class.with(rdv:, user:, token:).rdv_created
+        expect(mail.html_part.body.encoded).to include(%r{https://webconf.numerique.gouv.fr/RdvServicePublic})
+      end
+    end
+
+    context "motif collectif en visio, visio_url_custom présente" do
+      let(:organisation) { create(:organisation) }
+      let(:motif) { create(:motif, :collectif, organisation:, location_type: :visio) }
+      let(:rdv) { create(:rdv, motif:, organisation:, visio_url_custom: "https://webinaire.numerique.gouv.fr/test123") }
+
+      it "contient un lien vers la visio" do
+        mail = described_class.with(rdv:, user:, token:).rdv_created
+        expect(mail.html_part.body.encoded).not_to include(%r{https://webconf.numerique.gouv.fr/})
+        expect(mail.html_part.body.encoded).to include(%r{https://webinaire.numerique.gouv.fr/test123})
+      end
+    end
   end
 
   describe "#rdv_updated" do

--- a/spec/models/concerns/rdv/visio_concern_spec.rb
+++ b/spec/models/concerns/rdv/visio_concern_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe Rdv::VisioConcern, type: :concern do
+  describe "validation des URL custom" do
+    subject { rdv.valid? }
+
+    let(:rdv) { build(:rdv, visio_url_custom:) }
+
+    context "nil" do
+      let(:visio_url_custom) { nil }
+
+      it { is_expected.to be true }
+    end
+
+    context "vide" do
+      let(:visio_url_custom) { "" }
+
+      it { is_expected.to be true }
+    end
+
+    context "valide" do
+      let(:visio_url_custom) { "https://webinaire.numerique.gouv.fr/test-123" }
+
+      it { is_expected.to be true }
+    end
+
+    context "mal formée" do
+      let(:visio_url_custom) { "hptts://hackeverything" }
+
+      specify do
+        expect(rdv.valid?).to be false
+        expect(rdv.errors[:visio_url_custom].first).to eq("n'est pas une URL valide")
+      end
+    end
+
+    context "domaine non autorisé" do
+      let(:visio_url_custom) { "https://outil-inconnu.fr/test-123" }
+
+      specify do
+        expect(rdv.valid?).to be false
+        expect(rdv.errors[:visio_url_custom].first).to match(/doit provenir d’un des domaines suivants/)
+      end
+    end
+  end
+end

--- a/spec/models/concerns/rdv/visio_concern_spec.rb
+++ b/spec/models/concerns/rdv/visio_concern_spec.rb
@@ -1,32 +1,44 @@
 RSpec.describe Rdv::VisioConcern, type: :concern do
   describe "validation des URL custom" do
-    subject { rdv.valid? }
+    subject { rdv }
 
     let(:rdv) { build(:rdv, visio_url_custom:) }
 
     context "nil" do
       let(:visio_url_custom) { nil }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_valid }
     end
 
     context "vide" do
       let(:visio_url_custom) { "" }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_valid }
     end
 
-    context "valide" do
+    context "URL webinaire.numerique.gouv.fr" do
       let(:visio_url_custom) { "https://webinaire.numerique.gouv.fr/test-123" }
 
-      it { is_expected.to be true }
+      it { is_expected.to be_valid }
+    end
+
+    context "URL MS Teams" do
+      let(:visio_url_custom) { "https://teams.live.com/meet/93233334488899?p=cUKabcdEFG" }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "URL Zoom" do
+      let(:visio_url_custom) { "https://us04web.zoom.us/j/6022378945?pwd=dXV12345667" }
+
+      it { is_expected.to be_valid }
     end
 
     context "mal formée" do
       let(:visio_url_custom) { "hptts://hackeverything" }
 
       specify do
-        expect(rdv.valid?).to be false
+        expect(rdv).to be_invalid
         expect(rdv.errors[:visio_url_custom].first).to eq("n'est pas une URL valide")
       end
     end
@@ -35,7 +47,7 @@ RSpec.describe Rdv::VisioConcern, type: :concern do
       let(:visio_url_custom) { "https://outil-inconnu.fr/test-123" }
 
       specify do
-        expect(rdv.valid?).to be false
+        expect(rdv).to be_invalid
         expect(rdv.errors[:visio_url_custom].first).to match(/doit provenir d’un des domaines suivants/)
       end
     end

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -229,13 +229,21 @@ RSpec.describe Motif, type: :model do
   end
 
   describe "motif de rdv collectif" do
-    subject(:motif) { build(:motif, collectif: true, location_type: :home) }
+    context "à domicile" do
+      let(:motif) { build(:motif, collectif: true, location_type: :home) }
 
-    it "validates that a rdv collectif can't be at the user's home" do
-      expect(motif).not_to be_valid
-      expect(subject.errors.full_messages).to eq [
-        "Les RDV collectifs doivent avoir lieu sur place.",
-      ]
+      it "n’est pas valide" do
+        expect(motif).not_to be_valid
+        expect(motif.errors.full_messages).to eq ["Les RDV collectifs ne peuvent pas être faits par téléphone ou à domicile"]
+      end
+    end
+
+    context "en visio" do
+      let(:motif) { build(:motif, collectif: true, location_type: :visio) }
+
+      it "is valid" do
+        expect(motif).to be_valid
+      end
     end
   end
 


### PR DESCRIPTION
# 🧪 review app

https://rdv-service-public-review-app-pr5964.osc-secnum-fr1.scalingo.io/

credentials agent :  `martine@demo.rdv-solidarites.fr` : `Rdvservicepublictest1!` 

attention l’envoi d’email est activé sur cette review app ⚠️

# 📚 Contexte

Actuellement : Pour les RDV individuels nous proposons la visio, mais uniquement via l’outil webconf.numerique.gouv.fr (qui utilise Jitsi) et il est impossible de créer des RDV collectifs par visio. 

Les raisons principales pour cette limitation sont : 
- la fonctionnalité de RDV collectif a été créé rapidement 
- Jitsi n’est pas très adapté aux visios avec de nombreux·ses participant·es car les performances ne sont pas au RDV.

Nous, RDV Service Public, et Victor Grange de Protect'Envi (et probablement d’autres) utilisons déjà les RDV collectifs en visio en contournant cette limitation : on sélectionne « sur place » puis on met le lien de visio dans le nom du motif. Cela cause plusieurs incohérences et une UX médiocre pour les agents et les usager·es.

Note: on aimerait aussi proposer automatiquement webinaire.numerique.gouv.fr (BBB) plutôt que webconf (Jitsi) mais on est en attente d’un développement de leur côté pour que les agents puissent lancer leur conf sans se ProConnect - il me semble.

# ✅ Solution

Je propose ici de : 
- débloquer la possibilité de créer des RDV collectifs de type « visio »
- permettre aux agents de renseigner une URL custom pour chacun de ces RDV collectifs en visio

## Limitation des domaines

Je propose ici une liste d’autorisation pour les domaines utilisables dans ces URL custom. 
Le but est d’éviter que des liens malveillants soient introduits et que des usagers voient ces liens dans nos mails our sur notre site en `.gouv.fr`. On a aussi envie d’encourager les agents à utiliser des services sécurisés. 

<details>
  <summary>  voir la liste des domaines  </summary>
  <ul>
    <li>webinaire.numerique.gouv.fr</li>
     <li>webconf.numerique.gouv.fr</li>
     <li>teams.microsoft.com</li>
    <li>meet.google.com</li>
     <li>zoom.us</li>
     <li>meet.jit.si</li>
  </ul>
</details>


## Scope

On a discuté avec François et Victor et a priori on est d’accords qu’il n’y a pas besoin de cacher ça sous un feature flag, on a envie de le permettre à tous les agents.

## 📸 Captures d’écran

### formulaire de motif

<img width="3329" height="1252" alt="image" src="https://github.com/user-attachments/assets/486c4a43-bff1-45d3-923a-157fba1ec8d6" />

J’aimerais bien supprimer toute la deuxième phrase ici, mais je pense que ça reste bien d’avertir dans le cas majoritaire des RDV individuels.

Je pense qu’on pourra supprimer cette deuxième phrase si / quand on propose des URL de visio custom pour les RDV individuels.

### formulaire de RDV collectif

<img width="1207" height="1219" alt="image" src="https://github.com/user-attachments/assets/6b1ba20a-dfe9-4c83-9fe1-8d71d40f8df2" />


> [!NOTE]
> Ces champs apparaissent uniquement sur les formulaires de création et d’édition de RDV collectif avec un motif en visioconférence

j’ai utilisé l’animation `collapse` du DSFR pour l’apparition du champ custom, ce n’est peut-être pas nécessaire :

[anim2.2026-01-14T10:18:04Z.webm](https://github.com/user-attachments/assets/9fc9f5bb-d740-4eec-8f1a-ba0e4d730ead)


En JS désactivé ça fonctionne aussi : 
- le champ texte URL apparaît tout le temps
- il n’est pris en compte que si le bon radio button est sélectionné.


### vue erreur domaine non supporté

<img width="908" height="1137" alt="image" src="https://github.com/user-attachments/assets/a8ba687f-966f-4720-b4f0-315b4ce93400" />


On a discuté avec Téo du fait que l’erreur apparaît en double, c’est un comportement commun à tous les formulaires. Je vais faire une PR successive pour proposer de faire juste un message générique en haut.

Aussi, on pourrait peut-être rajouter un lien vers le formulaire de support pour nous demander d’ajouter des domaines autorisés ❓

### endroits où quasiment rien ne change

dans les vues suivantes, seul le lien change mais l’affichage reste identique : 

|l’interface agent|l’email envoyé a l’usager|l’interface usagers|
|-|-|-|
<img width="778" height="456" alt="image" src="https://github.com/user-attachments/assets/efc18328-6dcc-4f2a-9b23-92d70f5d86d9" />|<img width="607" height="546" alt="image" src="https://github.com/user-attachments/assets/e9678791-d33d-4569-a901-63cf29959322" />|<img width="643" height="488" alt="image" src="https://github.com/user-attachments/assets/eccd716f-a033-42c3-acb5-9130eef5558d" />
