### PR TITLE
Utilisation du DSFR Form Builder pour les lieux

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,25 +43,6 @@ module ApplicationHelper
     )
   end
 
-  # Le DSFR n'a pas de composant datetimepicker
-  # On crée donc un input personnalisé ici qui utilise notre datetimepicker habituel
-  def dsfr_datetime_input(form, field, data: {}, **options)
-    value = form.object.send(field)&.strftime("%d/%m/%Y %H:%M")
-    merged_data = { behaviour: "datetimepicker" }.merge(data)
-    label_text = options.delete(:label)
-    label_text ||= form.object.class.human_attribute_name(field) if form.object.class.respond_to?(:human_attribute_name)
-    label_text ||= field.to_s.humanize
-
-    content_tag(:div, class: "fr-input-group") do
-      safe_join(
-        [
-          form.label(field, label_text, class: "fr-label"),
-          form.text_field(field, value: value, data: merged_data, autocomplete: "off", class: "fr-input"),
-        ]
-      )
-    end
-  end
-
   def date_input(form, field, label = nil, input_html: {}, **kwargs)
     form.input(
       field,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,6 +43,8 @@ module ApplicationHelper
     )
   end
 
+  # Le DSFR n'a pas de composant datetimepicker
+  # On crée donc un input personnalisé ici qui utilise notre datetimepicker habituel
   def dsfr_datetime_input(form, field, data: {}, **options)
     value = form.object.send(field)&.strftime("%d/%m/%Y %H:%M")
     merged_data = { behaviour: "datetimepicker" }.merge(data)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,6 +43,15 @@ module ApplicationHelper
     )
   end
 
+  def dsfr_datetime_input(form, field, data: {}, **options)
+    value = form.object.send(field)&.strftime("%d/%m/%Y %H:%M")
+    merged_data = { behaviour: "datetimepicker" }.merge(data)
+    label = options.delete(:label)
+    label ||= form.object.class.human_attribute_name(field) if form.object.class.respond_to?(:human_attribute_name)
+    label ||= field.to_s.humanize
+    form.dsfr_text_field(field, value: value, data: merged_data, autocomplete: "off", label: label, **options)
+  end
+
   def date_input(form, field, label = nil, input_html: {}, **kwargs)
     form.input(
       field,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,10 +46,18 @@ module ApplicationHelper
   def dsfr_datetime_input(form, field, data: {}, **options)
     value = form.object.send(field)&.strftime("%d/%m/%Y %H:%M")
     merged_data = { behaviour: "datetimepicker" }.merge(data)
-    label = options.delete(:label)
-    label ||= form.object.class.human_attribute_name(field) if form.object.class.respond_to?(:human_attribute_name)
-    label ||= field.to_s.humanize
-    form.dsfr_text_field(field, value: value, data: merged_data, autocomplete: "off", label: label, **options)
+    label_text = options.delete(:label)
+    label_text ||= form.object.class.human_attribute_name(field) if form.object.class.respond_to?(:human_attribute_name)
+    label_text ||= field.to_s.humanize
+
+    content_tag(:div, class: "fr-input-group") do
+      safe_join(
+        [
+          form.label(field, label_text, class: "fr-label"),
+          form.text_field(field, value: value, data: merged_data, autocomplete: "off", class: "fr-input"),
+        ]
+      )
+    end
   end
 
   def date_input(form, field, label = nil, input_html: {}, **kwargs)

--- a/app/helpers/dsfr_helper.rb
+++ b/app/helpers/dsfr_helper.rb
@@ -72,4 +72,23 @@ module DsfrHelper
     # On met un margin-left négatif pour conserver l'alignement quand on n'est pas en train de hover sur le bouton
     { style: "margin-left: -16px", class: "fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-arrow-left-line" }
   end
+
+  # Le DSFR n'a pas de composant datetimepicker
+  # On crée donc un input personnalisé ici qui utilise notre datetimepicker habituel
+  def dsfr_datetime_input(form, field, data: {}, **options)
+    value = form.object.send(field)&.strftime("%d/%m/%Y %H:%M")
+    merged_data = { behaviour: "datetimepicker" }.merge(data)
+    label_text = options.delete(:label)
+    label_text ||= form.object.class.human_attribute_name(field) if form.object.class.respond_to?(:human_attribute_name)
+    label_text ||= field.to_s.humanize
+
+    content_tag(:div, class: "fr-input-group") do
+      safe_join(
+        [
+          form.label(field, label_text, class: "fr-label"),
+          form.text_field(field, value: value, data: merged_data, autocomplete: "off", class: "fr-input"),
+        ]
+      )
+    end
+  end
 end

--- a/app/views/admin/lieux/_lieu_fields.html.slim
+++ b/app/views/admin/lieux/_lieu_fields.html.slim
@@ -7,9 +7,9 @@
 / All forms
 = f.dsfr_text_field :name, label: Lieu.human_attribute_name(:name), required: true
 
-= f.dsfr_text_field :address, label: Lieu.human_attribute_name(:address), data: { "address-autocomplete": "on" }
+= f.dsfr_text_field :address, label: Lieu.human_attribute_name(:address), data: { "address-autocomplete": "on" }, required: true
 = f.hidden_field :latitude
 = f.hidden_field :longitude
 
 - unless is_nested_form
-  = f.dsfr_text_field :phone_number, label: Lieu.human_attribute_name(:phone_number), hint: I18n.t("simple_form.hints.lieu.phone_number", app_name: current_domain.name)
+  = f.dsfr_text_field :phone_number, label: Lieu.human_attribute_name(:phone_number), hint: "Facultatif. Ce numéro permet aux usagers de vous contacter. Faites en sorte que les personnes qui répondent au téléphone puissent avoir accès à #{current_domain.name}."

--- a/app/views/admin/lieux/_lieu_fields.html.slim
+++ b/app/views/admin/lieux/_lieu_fields.html.slim
@@ -2,20 +2,14 @@
   TODO: We might want to allow admins to create a new Lieu for a Rdv, and immediately save it in the organisation lieu.
   In this scenario, having this common partial (instead of a separate partial for the nested form) will be useful.
 
-- is_new_form = f.object_name == "lieu" && f.object.new_record?
-- is_edit_form = f.object_name == "lieu" && f.object.persisted?
 - is_nested_form = f.object_name != "lieu"
 
-/ New and Edit
-- if is_new_form || is_edit_form
-  = render "model_errors", model: f.object
-
 / All forms
-= f.input :name, required: true
+= f.dsfr_text_field :name, label: Lieu.human_attribute_name(:name), required: true
 
-= f.input :address, input_html: { data: { "address-autocomplete": "on" } }
+= f.dsfr_text_field :address, label: Lieu.human_attribute_name(:address), data: { "address-autocomplete": "on" }
 = f.hidden_field :latitude
 = f.hidden_field :longitude
 
 - unless is_nested_form
-  = f.input :phone_number, hint: I18n.t("simple_form.hints.lieu.phone_number", app_name: current_domain.name)
+  = f.dsfr_text_field :phone_number, label: Lieu.human_attribute_name(:phone_number), hint: I18n.t("simple_form.hints.lieu.phone_number", app_name: current_domain.name)

--- a/app/views/admin/lieux/_lieu_fields.html.slim
+++ b/app/views/admin/lieux/_lieu_fields.html.slim
@@ -5,9 +5,9 @@
 - is_nested_form = f.object_name != "lieu"
 
 / All forms
-= f.dsfr_text_field :name, label: Lieu.human_attribute_name(:name), required: true
+= f.dsfr_text_field :name, label: Lieu.human_attribute_name(:name), required: true, hint: "Le nom apparaît dans les notifications par email et SMS aux usagers."
 
-= f.dsfr_text_field :address, label: Lieu.human_attribute_name(:address), data: { "address-autocomplete": "on" }, required: true
+= f.dsfr_text_field :address, label: Lieu.human_attribute_name(:address), data: { "address-autocomplete": "on" }, required: true, hint: "L'adresse apparaît dans les notifications par email et SMS aux usagers."
 = f.hidden_field :latitude
 = f.hidden_field :longitude
 

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -8,8 +8,9 @@
   .col-md-12.col-lg-8
     .card
       .card-body
-        = form_for [:admin, @lieu.organisation, @lieu], builder: Dsfr::FormBuilder do |f|
+        = form_for [:admin, @lieu.organisation, @lieu], builder: Dsfr::FormBuilder, display_required_tags: false do |f|
           = render "model_errors", model: @lieu, f: f
+          p.fr-hint-text Sauf mention contraire, tous les champs sont obligatoires.
           = render "lieu_fields", f: f
           .col.text-right.fr-p-0
             = link_to t("helpers.cancel"), admin_organisation_lieux_path(@lieu.organisation), class: "fr-btn fr-btn--tertiary-no-outline fr-mr-1w"

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -8,7 +8,8 @@
   .col-md-12.col-lg-8
     .card
       .card-body
-        = simple_form_for [:admin, @lieu.organisation, @lieu] do |f|
+        = form_for [:admin, @lieu.organisation, @lieu], builder: Dsfr::FormBuilder do |f|
+          = render "model_errors", model: @lieu, f: f
           = render "lieu_fields", f: f
           .col.text-right.fr-p-0
             = link_to t("helpers.cancel"), admin_organisation_lieux_path(@lieu.organisation), class: "fr-btn fr-btn--tertiary-no-outline fr-mr-1w"

--- a/app/views/admin/lieux/new.html.slim
+++ b/app/views/admin/lieux/new.html.slim
@@ -8,7 +8,8 @@
   .col-md-12.col-lg-8
     .card
       .card-body
-        = simple_form_for [:admin, @lieu.organisation, @lieu] do |f|
+        = form_for [:admin, @lieu.organisation, @lieu], builder: Dsfr::FormBuilder do |f|
+          = render "model_errors", model: @lieu, f: f
           = render "lieu_fields", f: f
 
           .col.text-right.fr-p-0

--- a/app/views/admin/lieux/new.html.slim
+++ b/app/views/admin/lieux/new.html.slim
@@ -8,8 +8,9 @@
   .col-md-12.col-lg-8
     .card
       .card-body
-        = form_for [:admin, @lieu.organisation, @lieu], builder: Dsfr::FormBuilder do |f|
+        = form_for [:admin, @lieu.organisation, @lieu], builder: Dsfr::FormBuilder, display_required_tags: false do |f|
           = render "model_errors", model: @lieu, f: f
+          p.fr-hint-text Sauf mention contraire, tous les champs sont obligatoires.
           = render "lieu_fields", f: f
 
           .col.text-right.fr-p-0

--- a/app/views/admin/participations/_form.html.slim
+++ b/app/views/admin/participations/_form.html.slim
@@ -16,9 +16,9 @@ div data-controller="destroyable"
     = render "admin/users/notifications_preferences", user: participation.user.user_to_notify
     - if participation.user.user_to_notify.valid_email? || participation.user.user_to_notify.phone_number.present?
       h6= t("admin.participations.notifications_overrides")
-      = form.input :send_lifecycle_notifications, wrapper: false
+      = form.dsfr_check_box :send_lifecycle_notifications
       - if current_organisation.rdv_insertion?
         span.text-muted.font-14= participation.rdv.motif.human_attribute_value(:visibility_type, context: :hint_checkbox)
-      = form.input :send_reminder_notification, wrapper: false
+      = form.dsfr_check_box :send_reminder_notification
       - if current_organisation.rdv_insertion?
         span.text-muted.font-14= participation.rdv.motif.human_attribute_value(:visibility_type, context: :hint_checkbox)

--- a/app/views/admin/rdv_wizard_steps/_hidden_fields.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_hidden_fields.html.slim
@@ -4,7 +4,7 @@
 = hidden_field_tag "step", step.to_s
 
 - fields.each do |field_name|
-  = f.input field_name, as: :hidden
+  = f.hidden_field field_name
 
 / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
 - local_assigns[:user_ids]&.each do |user_id|

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -3,27 +3,25 @@ ruby:
   content_for(:title) { t(".page_title", starts_at: l(@rdv.starts_at, format: :dense)) }
 
 = render "card", rdv_wizard_form: @rdv_wizard, previous_steps: [ { step: 1, value: motif_name_and_location_type(@rdv.motif) }, { step: 2, value: users_inline_list_for_agents(@rdv.users) } ], step_title: t(".step_title"), current_step: 3, next_step_title: t("admin.rdv_wizard_steps.step4.step_title") do
-  = simple_form_for(@rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation), method: :get) do |f|
+  = form_for(@rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation), method: :get, builder: Dsfr::FormBuilder) do |f|
     = render "model_errors", model: @rdv_wizard, f: f
     = collapsible_form_fields_for_warnings(@rdv_wizard) do
       = render "hidden_fields", f: f, step: 3, fields: %i[motif_id context], user_ids: @rdv.user_ids
-      .form-row
-        .col-md-6 data={ "controller": "past-date-alert" }
-          = datetime_input(f, :starts_at, input_html: { data: { "past-date-alert-target": "date-input" } })
-        .col-md-6= f.input :duration_in_min, as: :integer
+      .fr-grid-row.fr-grid-row--gutters
+        .fr-col-md-6 data={ "controller": "past-date-alert" }
+          = dsfr_datetime_input(f, :starts_at, label: Rdv.human_attribute_name(:starts_at), data: { "past-date-alert-target": "date-input" })
+        .fr-col-md-6= f.dsfr_number_field :duration_in_min, label: Rdv.human_attribute_name(:duration_in_min)
       - if @rdv.public_office?
         - new_lieu_record = @rdv.lieu&.new_record?
         - controller_data = { "controller": "rdv-lieu",
                 "initial-state": (new_lieu_record ? "single_use" : "existing"),
                 "select-placeholder-single-use-lieu": t(".select_placeholder_single_use_lieu"),
                 "select-placeholder-existing-lieu": t(".select_placeholder_existing_lieu"), }
-        .form-group data=controller_data
-          = f.label :lieu, required: true
+        .fr-input-group data=controller_data
+          = f.label :lieu, class: "fr-label required"
           fieldset
             - lieux = Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name
-            = f.association :lieu, collection: lieux, label_method: :full_name,
-              label: false,  include_blank: true,  required: false,
-              input_html: { class: "select2-input", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true, "select2-config": { disableSearch: lieux.count <= 5  } } }
+            = f.select :lieu_id, lieux.collect { |l| [l.full_name, l.id] }, { include_blank: true }, class: "select2-input fr-select", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true, "select2-config": { disableSearch: lieux.count <= 5 } }
             small.form-text.text-muted data={"rdv-lieu-target": "new_lieu_link"}
               = t(".single_use_lieu_hint_html")
           fieldset data={ "rdv-lieu-target": "new_lieu_fieldset" }
@@ -33,8 +31,10 @@ ruby:
             small.form-text.text-muted data={"rdv-lieu-target": "select_lieu_link"}
               = t(".existing_lieu_hint_html")
       - elsif @rdv.home?
-        = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}", input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }
+        = f.dsfr_text_field :address, label: "Lieu (RDV à domicile)", disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}", data: { "address-autocomplete": "on" }, dir: "ltr"
       - elsif @rdv.phone?
-        = f.input :address, label: "Lieu (RDV téléphonique)",  disabled: true, hint: "Il n'y a pas d'adresse car le RDV est téléphonique", input_html: { data: { "address-autocomplete": "on", dir: "ltr" } }
-      = f.association :agents, collection: @rdv.motif.authorized_agents, label_method: :reverse_full_name_and_service, input_html: { multiple: true, class: "select2-input", data: { "auto-select-sole-option": true } }
+        = f.dsfr_text_field :address, label: "Lieu (RDV téléphonique)", disabled: true, hint: "Il n'y a pas d'adresse car le RDV est téléphonique", data: { "address-autocomplete": "on" }, dir: "ltr"
+      .fr-input-group
+        = f.label :agents, class: "fr-label"
+        = f.select :agent_ids, @rdv.motif.authorized_agents.collect { |a| [a.reverse_full_name_and_service, a.id] }, {}, multiple: true, class: "select2-input fr-select", data: { "auto-select-sole-option": true }
       = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -7,7 +7,7 @@ ruby:
     = render "model_errors", model: @rdv_wizard, f: f
     = collapsible_form_fields_for_warnings(@rdv_wizard) do
       = render "hidden_fields", f: f, step: 3, fields: %i[motif_id context], user_ids: @rdv.user_ids
-      .fr-grid-row.fr-grid-row--gutters
+      .fr-grid-row.fr-grid-row--gutters.fr-mb-4v
         .fr-col-md-6 data={ "controller": "past-date-alert" }
           = dsfr_datetime_input(f, :starts_at, label: Rdv.human_attribute_name(:starts_at), data: { "past-date-alert-target": "date-input" })
         .fr-col-md-6= f.dsfr_number_field :duration_in_min, label: Rdv.human_attribute_name(:duration_in_min)

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -75,7 +75,7 @@
                 - select2_url = search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id))
                 = select_tag :user_to_add,
                         options_for_select([]),
-                        include_blank: "Ajouter un usager",
+                        include_blank: "Rechercher un usager",
                         required: false,
                         class: "select2-input js-rdv-user-select fr-select",
                         data: { \

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -25,7 +25,7 @@
             = f.dsfr_select :motif_id, [[@rdv_form.motif.name, @rdv_form.motif.id]], label: Rdv.human_attribute_name(:motif), disabled: true
             - if @rdv_form.organisation.territory.enable_context_field
               = f.dsfr_text_area :context, label: Rdv.human_attribute_name(:context), rows: 3
-            .fr-grid-row.fr-grid-row--gutters
+            .fr-grid-row.fr-grid-row--gutters.fr-mb-4v
               .fr-col-md-6 data={ "controller": "past-date-alert" }
                 = dsfr_datetime_input(f, :starts_at, label: Rdv.human_attribute_name(:starts_at), data: { "past-date-alert-target": "date-input" })
               .fr-col-md-6= f.dsfr_number_field :duration_in_min, label: Rdv.human_attribute_name(:duration_in_min)

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -61,7 +61,7 @@
                 span.font-14.font-weight-bold= "Avertissement : "
                 span.text-muted.font-14= I18n.t("activerecord.attributes.rdv/name.hint")
 
-              = render "admin/rdvs_collectifs/form_visio_fields", rdv_form: @rdv_form
+              = render "admin/rdvs_collectifs/form_visio_fields", rdv: @rdv, f: f
 
               = f.dsfr_number_field :max_participants_count, label: Rdv.human_attribute_name(:max_participants_count), min: 1
 

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -19,28 +19,27 @@
   .col-md-12.col-lg-8
     .card
       .card-body
-        = simple_form_for(@rdv, url: admin_organisation_rdv_path(current_organisation, @rdv, contextual_agent_ids: @contextual_agents.map(&:id))) do |f|
+        = form_for(@rdv, url: admin_organisation_rdv_path(current_organisation, @rdv, contextual_agent_ids: @contextual_agents.map(&:id)), builder: Dsfr::FormBuilder) do |f|
           = render "model_errors", model: @rdv_form, f: f
           = collapsible_form_fields_for_warnings(@rdv_form) do
-            = f.association :motif, collection: [@rdv_form.motif], disabled: true
+            = f.dsfr_select :motif_id, [[@rdv_form.motif.name, @rdv_form.motif.id]], label: Rdv.human_attribute_name(:motif), disabled: true
             - if @rdv_form.organisation.territory.enable_context_field
-              = f.input :context, input_html: { rows: 3 }
-            .form-row
-              .col-md-6 data={ "controller": "past-date-alert" }
-                = datetime_input(f, :starts_at, input_html: { data: { "past-date-alert-target": "date-input" } })
-              .col-md-6= f.input :duration_in_min
+              = f.dsfr_text_area :context, label: Rdv.human_attribute_name(:context), rows: 3
+            .fr-grid-row.fr-grid-row--gutters
+              .fr-col-md-6 data={ "controller": "past-date-alert" }
+                = dsfr_datetime_input(f, :starts_at, label: Rdv.human_attribute_name(:starts_at), data: { "past-date-alert-target": "date-input" })
+              .fr-col-md-6= f.dsfr_number_field :duration_in_min, label: Rdv.human_attribute_name(:duration_in_min)
             - if @rdv_form.motif.public_office?
 
               - controller_data = { "controller": "rdv-lieu",
                       "initial-state": @rdv.lieu.availability,
                       "select-placeholder-single-use-lieu": t(".select_placeholder_single_use_lieu"),
                       "select-placeholder-existing-lieu": t(".select_placeholder_existing_lieu"), }
-              .form-group data=controller_data
-                = f.label :lieu, required: true
+              .fr-input-group data=controller_data
+                = f.label :lieu, class: "fr-label required"
                 fieldset
-                  = f.association :lieu, collection: [@rdv.lieu, *Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name].uniq, label_method: :full_name,
-                    label: false,  include_blank: true,  required: false,
-                    input_html: { class: "select2-input", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true } }
+                  - lieux = [@rdv.lieu, *Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name].uniq
+                  = f.select :lieu_id, lieux.collect { |l| [l.full_name, l.id] }, { include_blank: true }, class: "select2-input fr-select", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true }
                   small.form-text.text-muted data={"rdv-lieu-target": "new_lieu_link"}
                     = t(".single_use_lieu_hint_html")
                 fieldset data={ "rdv-lieu-target": "new_lieu_fieldset" }
@@ -51,45 +50,41 @@
                     = t(".existing_lieu_hint_html")
 
             - elsif @rdv_form.motif.home?
-              = f.input :address, label: "Lieu (RDV à domicile)", disabled: true, input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }
-            = f.association :agents,
-              collection: @rdv_form.motif.authorized_agents,
-              selected: @rdv.agent_ids,
-              label_method: :full_name_and_service,
-              input_html: { multiple: true, class: "select2-input", data: { "auto-select-sole-option": true } }
+              = f.dsfr_text_field :address, label: "Lieu (RDV à domicile)", disabled: true, data: { "address-autocomplete": "on" }, dir: "ltr"
+            .fr-input-group
+              = f.label :agents, class: "fr-label"
+              = f.select :agent_ids, @rdv_form.motif.authorized_agents.collect { |a| [a.full_name_and_service, a.id] }, { selected: @rdv.agent_ids }, multiple: true, class: "select2-input fr-select", data: { "auto-select-sole-option": true }
 
             - if @rdv_form.motif.collectif?
-              = f.input :name, wrapper_html: { class: "mb-1" }
+              = f.dsfr_text_field :name, label: Rdv.human_attribute_name(:name), class: "fr-mb-1w"
               p
                 span.font-14.font-weight-bold= "Avertissement : "
                 span.text-muted.font-14= I18n.t("activerecord.attributes.rdv/name.hint")
 
               = render "admin/rdvs_collectifs/form_visio_fields", rdv_form: @rdv_form
 
-              = f.input :max_participants_count, input_html: { min: 1 }
+              = f.dsfr_number_field :max_participants_count, label: Rdv.human_attribute_name(:max_participants_count), min: 1
 
-            .fr-mt-4w= "#{User.model_name.human.pluralize} :"
-            .fr-pl-2w.rdv-border-left-1px-solid
-              .form-group
-                = f.fields_for :participations, @rdv.participations do |participation_form|
-                  = render "admin/participations/form", form: participation_form
+            .fr-input-group
+              = "#{User.model_name.human.pluralize} :"
+              = f.fields_for :participations, @rdv.participations do |participation_form|
+                = render "admin/participations/form", form: participation_form
 
-              .fr-mt-4w.fr-mb-1w Ajouter un usager
-              div.form-row.grid-align-center.pb-4
-                .flex-grow-1.pr-4
-                  - select2_url = search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id))
-                  = select_tag :user_to_add,
-                    options_for_select([]),
-                    include_blank: "Rechercher un usager",
-                    required: false,
-                    class: "select2-input js-rdv-user-select",
-                    data: { \
-                      "width": "auto", \
-                      "scroll-to-bottom": params[:add_user].present?, \
-                      "select2-config": { ajax: { url: select2_url, dataType: "json", delay: 250 } }, \
-                   }
-                = render "admin/users/create_user_cta", path: new_admin_organisation_user_path(current_organisation, modal: true, return_location: request.url, role: default_service_selection_from(@rdv.motif.service))
+            .fr-grid-row.fr-grid-row--middle.fr-pb-4w
+              .flex-grow-1.fr-pr-4w
+                - select2_url = search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id))
+                = select_tag :user_to_add,
+                        options_for_select([]),
+                        include_blank: "Ajouter un usager",
+                        required: false,
+                        class: "select2-input js-rdv-user-select fr-select",
+                        data: { \
+                  width: "auto", \
+                  "scroll-to-bottom": params[:add_user].present?, \
+                  "select2-config": { ajax: { url: select2_url, dataType: "json", delay: 250 } }, \
+                 }
+              = render "admin/users/create_user_cta", path: new_admin_organisation_user_path(current_organisation, modal: true, return_location: request.url, role: default_service_selection_from(@rdv.motif.service))
 
             .text-right
-              = link_to t("helpers.back"), admin_organisation_rdv_path(current_organisation, @rdv), class: "btn btn-link"
-              = f.button :submit, t("helpers.submit.submit")
+              = link_to t("helpers.back"), admin_organisation_rdv_path(current_organisation, @rdv), class: "fr-btn fr-btn--tertiary-no-outline"
+              = f.submit t("helpers.submit.submit"), class: "fr-btn"

--- a/app/views/admin/rdvs_collectifs/_form_visio_fields.html.slim
+++ b/app/views/admin/rdvs_collectifs/_form_visio_fields.html.slim
@@ -1,18 +1,14 @@
-/# locals: (rdv_form:)
-- if rdv_form.visio?
-
-  / on instancie un form builder DSFR ici tant que les forms edit et new RDV collectif ne sont pas encore au DSFR
-  - dsfr_f = Dsfr::FormBuilder.new(:rdv, rdv_form, self, {})
-
+/# locals: (rdv:, f:)
+- if rdv.visio?
   fieldset.fr-fieldset[data-controller="dependent-input"]
     legend.fr-fieldset__legend--regular.fr-fieldset__legend.fr-mt-1w
       | Outil de visioconférence
 
-    = dsfr_f.dsfr_radio_option :visio_url_type,
+    = f.dsfr_radio_option :visio_url_type,
       value: "default",
       label_text: "Par défaut : Webconf",
       hint: "Une URL unique sera créée via webconf.numerique.gouv.fr",
-      checked: rdv_form.visio_url_type == "default",
+      checked: rdv.visio_url_type == "default",
       "data-action": "change->dependent-input#toggle"
 
     - custom_label = capture do
@@ -25,17 +21,17 @@
         span.fr-tooltip.fr-placement#tooltip-visio-custom[role="tooltip"]
           | Nous vous recommandons d’utiliser webinaire.numerique.gouv.fr
 
-    = dsfr_f.dsfr_radio_option :visio_url_type,
+    = f.dsfr_radio_option :visio_url_type,
       value: "custom",
       label_text: custom_label,
       hint: nil,
-      checked: rdv_form.visio_url_type == "custom",
+      checked: rdv.visio_url_type == "custom",
       "data-dependent-input-target": "controllingInput",
       "data-action": "change->dependent-input#toggle"
 
     .fr-fieldset__element.fr-collapse.fr-collapse--expanded.fr-mx-4w.fr-mt-n2w[
       data-dependent-input-target="dependentInputWrapper"
     ]
-      = dsfr_f.dsfr_text_field :visio_url_custom,
+      = f.dsfr_text_field :visio_url_custom,
         label: "URL de visioconférence",
         "data-dependent-input-target": "dependentInput"

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -5,7 +5,7 @@
 
 .row.justify-content-md-center
   .col-md-12.col-lg-8
-    = simple_form_for(@rdv, url: admin_organisation_rdvs_collectif_path(current_organisation), method: :put) do |f|
+    = form_for(@rdv, url: admin_organisation_rdvs_collectif_path(current_organisation), method: :put, builder: Dsfr::FormBuilder) do |f|
       .card
         .card-header
           h3 = rdv_title_for_agent(@rdv)

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -12,7 +12,7 @@
         .card-body.px-3
           = render "model_errors", model: @rdv, f: f
 
-          .fr-grid-row.fr-grid-row--gutters
+          .fr-grid-row.fr-grid-row--gutters.fr-mb-4v
             .fr-col-md-6 data={ "controller": "past-date-alert" }
               = dsfr_datetime_input(f, :starts_at, label: Rdv.human_attribute_name(:starts_at), data: { "past-date-alert-target": "date-input" })
             .fr-col-md-6= f.dsfr_number_field :duration_in_min, label: Rdv.human_attribute_name(:duration_in_min)

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -26,7 +26,7 @@
           = f.dsfr_text_field :context, label: Rdv.human_attribute_name(:context)
           = f.hidden_field :motif_id, value: @rdv.motif_id
 
-          = render "admin/rdvs_collectifs/form_visio_fields", rdv_form: @rdv_form
+          = render "admin/rdvs_collectifs/form_visio_fields", rdv: @rdv, f:
 
           - if @rdv.public_office?
             - new_lieu_record = @rdv.lieu&.new_record?

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -23,7 +23,7 @@
           p
             span.font-14.font-weight-bold= "Avertissement : "
             span.text-muted.font-14= I18n.t("activerecord.attributes.rdv/name.hint")
-          = f.dsfr_text_field :context, label: Rdv.human_attribute_name(:context)
+          = f.dsfr_text_area :context, label: Rdv.human_attribute_name(:context)
           = f.hidden_field :motif_id, value: @rdv.motif_id
 
           = render "admin/rdvs_collectifs/form_visio_fields", rdv: @rdv, f:

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -38,7 +38,7 @@
               = f.label :lieu, class: "fr-label required"
               fieldset
                 - lieux = Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name
-              = f.select :lieu_id, lieux.collect { |l| [l.full_name, l.id] }, { include_blank: true }, class: "select2-input fr-select", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true }
+                = f.select :lieu_id, lieux.collect { |l| [l.full_name, l.id] }, { include_blank: true }, class: "select2-input fr-select", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true }
                 small.form-text.text-muted data={"rdv-lieu-target": "new_lieu_link"}
                   = t(".single_use_lieu_hint_html")
               fieldset data={ "rdv-lieu-target": "new_lieu_fieldset" }

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -5,23 +5,25 @@
 
 .row.justify-content-md-center
   .col-md-12.col-lg-8
-    = simple_form_for(@rdv, url: admin_organisation_rdvs_collectifs_path(current_organisation), method: :post) do |f|
+    = form_for(@rdv, url: admin_organisation_rdvs_collectifs_path(current_organisation), method: :post, builder: Dsfr::FormBuilder) do |f|
       .card
         .card-header
           h3.rdv-text-align-center #{motif_name_and_service(@rdv.motif)}
         .card-body.px-3
           = render "model_errors", model: @rdv, f: f
 
-          .form-row
-            .col-md-6 data={ "controller": "past-date-alert" }
-              = datetime_input(f, :starts_at, input_html: { data: { "past-date-alert-target": "date-input" } })
-            .col-md-6= f.input :duration_in_min, as: :integer
-          = f.association :agents, collection: @rdv.motif.authorized_agents, label_method: :reverse_full_name_and_service, input_html: { multiple: true, class: "select2-input", data: { "auto-select-sole-option": true } }
-          = f.input :name, wrapper_html: { class: "mb-1" }
+          .fr-grid-row.fr-grid-row--gutters
+            .fr-col-md-6 data={ "controller": "past-date-alert" }
+              = dsfr_datetime_input(f, :starts_at, label: Rdv.human_attribute_name(:starts_at), data: { "past-date-alert-target": "date-input" })
+            .fr-col-md-6= f.dsfr_number_field :duration_in_min, label: Rdv.human_attribute_name(:duration_in_min)
+          .fr-input-group
+            = f.label :agents, class: "fr-label"
+            = f.select :agent_ids, @rdv.motif.authorized_agents.collect { |a| [a.reverse_full_name_and_service, a.id] }, {}, multiple: true, class: "select2-input fr-select", data: { "auto-select-sole-option": true }
+          = f.dsfr_text_field :name, label: Rdv.human_attribute_name(:name), class: "fr-mb-1w"
           p
             span.font-14.font-weight-bold= "Avertissement : "
             span.text-muted.font-14= I18n.t("activerecord.attributes.rdv/name.hint")
-          = f.input :context
+          = f.dsfr_text_field :context, label: Rdv.human_attribute_name(:context)
           = f.hidden_field :motif_id, value: @rdv.motif_id
 
           = render "admin/rdvs_collectifs/form_visio_fields", rdv_form: @rdv_form
@@ -32,12 +34,11 @@
                     "initial-state": (new_lieu_record ? "single_use" : "existing"),
                     "select-placeholder-single-use-lieu": t(".select_placeholder_single_use_lieu"),
                     "select-placeholder-existing-lieu": t(".select_placeholder_existing_lieu"), }
-            .form-group data=controller_data
-              = f.label :lieu, required: true
+            .fr-input-group data=controller_data
+              = f.label :lieu, class: "fr-label required"
               fieldset
-                = f.association :lieu, collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name, label_method: :full_name,
-                  label: false,  include_blank: true,  required: false,
-                  input_html: { class: "select2-input", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true } }
+                - lieux = Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name
+              = f.select :lieu_id, lieux.collect { |l| [l.full_name, l.id] }, { include_blank: true }, class: "select2-input fr-select", data: { "rdv-lieu-target": "existing_lieu_select", placeholder: "", "auto-select-sole-option": true }
                 small.form-text.text-muted data={"rdv-lieu-target": "new_lieu_link"}
                   = t(".single_use_lieu_hint_html")
               fieldset data={ "rdv-lieu-target": "new_lieu_fieldset" }
@@ -47,8 +48,8 @@
                 small.form-text.text-muted data={"rdv-lieu-target": "select_lieu_link"}
                   = t(".existing_lieu_hint_html")
 
-          = f.input :max_participants_count, input_html: { min: 1 }
+          = f.dsfr_number_field :max_participants_count, label: Rdv.human_attribute_name(:max_participants_count), min: 1
 
           .d-flex.justify-content-end
             .btn-group
-              = f.button :submit, t("helpers.submit.submit")
+              = f.submit t("helpers.submit.submit"), class: "fr-btn"

--- a/config/locales/models/lieu.fr.yml
+++ b/config/locales/models/lieu.fr.yml
@@ -31,4 +31,3 @@ fr:
           Si le lieu est ouvert, de nouveaux rendez-vous et plages d’ouvertures peuvent y être posés.
           Fermez un lieu pour ne plus le voir dans les menus.
         name: Le nom apparaît dans les notifications par email et SMS aux usagers.
-        phone_number: Ce numéro permet aux usagers de vous contacter. Faites en sorte que les personnes qui répondent au téléphone puissent avoir accès à %{app_name}.

--- a/config/locales/models/lieu.fr.yml
+++ b/config/locales/models/lieu.fr.yml
@@ -23,11 +23,3 @@ fr:
               format: "%{message}"
             address:
               must_be_valid: doit être valide
-  simple_form:
-    hints:
-      lieu:
-        address: L’adresse apparaît dans les notifications par email et SMS aux usagers.
-        enabled: |
-          Si le lieu est ouvert, de nouveaux rendez-vous et plages d’ouvertures peuvent y être posés.
-          Fermez un lieu pour ne plus le voir dans les menus.
-        name: Le nom apparaît dans les notifications par email et SMS aux usagers.


### PR DESCRIPTION
review app : https://rdv-service-public-review-app-pr5965.osc-secnum-fr1.scalingo.io/

# Contexte

En voulant rajouter un système permettant de saisir des adresses non française dans les lieux, je me suis rendu compte que les formulaires de lieux n’utilisaient pas encore le form builder DSFR. Je propose donc de faire la bascule ici.

# Solution

Cette bascule implique d’autres formulaires, car nous chargeons un partial utilisé à plusieurs endroits.