### PR TITLE
Corrige le crash quand un flash est vide

### DIFF
--- a/app/views/layouts/_flash.html.slim
+++ b/app/views/layouts/_flash.html.slim
@@ -1,4 +1,5 @@
 - %i[success notice error alert].each do |type|
-  - if flash[type]
+  - sanitized_flash = sanitize(flash[type], tags: %w[a br strong em], scrubber: :prune).presence
+  - if sanitized_flash
     = dsfr_alert type: alert_dsfr_type_for(type), size: :sm, close_button: true, html_attributes: { class: "fr-pb-1w fr-my-2w", role: "alert" } do
-      = sanitize(flash[type], tags: %w[a br strong em], scrubber: :prune)
+      = sanitized_flash


### PR DESCRIPTION
Ce matin nous avons vu cette erreur remonter pour un agent :

<img width="1869" height="1189" alt="image" src="https://github.com/user-attachments/assets/d88b58d3-af05-4c03-a2f1-7a36a9fdc133" />


Il semble que cet agent ait une session avec un contenu de flash vide mais non `nil` (peut-être `""` ou `" "` :shrug: ). Cela déclenche un exception de `dsfr-view-components` car cette gem vérifie qu'on a bien un contenu et pas de titre : 

> You must provide a title for medium alerts, but you can't use it for small alerts (use content instead)

Le code en question : 
https://github.com/betagouv/dsfr-view-components/blob/8e9bea5d13df7dea6305b3f6079de9a2274a1e37/app/components/dsfr_component/alert_component.rb#L70

Je ne sais donc pas comment il s'est retrouvé avec cette session, mais je propose d'éviter de planter et de simplement ne pas afficher de flash si il est blank.