### PR TITLE
Expirer les exports à minuit

### DIFF
--- a/app/models/concerns/redis_file_storable.rb
+++ b/app/models/concerns/redis_file_storable.rb
@@ -22,4 +22,10 @@ module RedisFileStorable
       end
     end
   end
+
+  private
+
+  def redis_file_key
+    "Export#redis_file_key-#{id}"
+  end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,8 +1,6 @@
 class Export < ApplicationRecord
   include RedisFileStorable
 
-  EXPIRATION_DELAY = 6.hours
-
   STATUS_PENDING = :pending
   STATUS_EXPIRED = :expired
   STATUS_AVAILABLE = :available
@@ -22,7 +20,7 @@ class Export < ApplicationRecord
   validates :expires_at, :file_name, presence: true
 
   # Hooks
-  after_initialize { self.expires_at ||= EXPIRATION_DELAY.from_now }
+  after_initialize :set_expires_at, if: :new_record?
 
   # Scopes
   scope :recent, -> { where("created_at > ?", 2.weeks.ago) }
@@ -55,7 +53,10 @@ class Export < ApplicationRecord
     expires_at <= Time.zone.now
   end
 
-  def redis_file_key
-    "Export#redis_file_key-#{id}"
+  def set_expires_at
+    # En expirant les exports à minuit, on empêche qu'ils soient inclus dans le
+    # backup Scalingo lancé tous les matins à 2h en été / 1h en hiver (0:00 UTC).
+    midnight = Time.zone.tomorrow.change(hour: 0, minute: 0)
+    self.expires_at = midnight
   end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -56,7 +56,6 @@ class Export < ApplicationRecord
   def set_expires_at
     # En expirant les exports à minuit, on empêche qu'ils soient inclus dans le
     # backup Scalingo lancé tous les matins à 2h en été / 1h en hiver (0:00 UTC).
-    midnight = Time.zone.tomorrow.change(hour: 0, minute: 0)
-    self.expires_at = midnight
+    self.expires_at = Time.zone.today.end_of_day
   end
 end

--- a/app/views/agents/exports/index.html.slim
+++ b/app/views/agents/exports/index.html.slim
@@ -5,7 +5,7 @@
     .col-md-12
       .text-muted.font-14
         |> Vous trouverez ci-dessous les exports réalisés au cours de ces deux dernières semaines.
-        => "Les liens de téléchargement ne sont valables que pour une durée de #{Export::EXPIRATION_DELAY.in_hours.to_i}h."
+        => "Les liens de téléchargement expirent chaque soir à minuit."
         |> Si le lien a expiré, vous pouvez générer un nouvel export à partir de la
         = link_to("liste des RDV", admin_organisation_rdvs_path(organisation_id: current_agent.organisations.ordered_by_name.first.id))
         | .

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Export do
     it "is set upon build to tomorrow at 00:00 (aka today at midnight)" do
       travel_to(Time.zone.parse("2025-10-22 20:30")) do
         export = build(:export)
-        expect(export.expires_at).to eq(Time.zone.parse("2025-10-23 00:00"))
+        expect(export.expires_at).to be_within(1.second).of(Time.zone.parse("2025-10-23 00:00"))
       end
     end
   end

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -8,9 +8,11 @@ RSpec.describe Export do
   end
 
   describe "#expires_at" do
-    it "is set upon build" do
-      export = build(:export)
-      expect(export.expires_at).to be_within(1.second).of(6.hours.from_now)
+    it "is set upon build to tomorrow at 00:00 (aka today at midnight)" do
+      travel_to(Time.zone.parse("2025-10-22 20:30")) do
+        export = build(:export)
+        expect(export.expires_at).to eq(Time.zone.parse("2025-10-23 00:00"))
+      end
     end
   end
 


### PR DESCRIPTION
Avant : les exports expirent après 6 heures
Après : les exports expirent à minuit le jour de leur création

Avantages : 
- les exports ne sont pas inclus dans le backup Redis fait à 00:00 UTC tous les jours
- L'export reste dispo au téléchargement toute la journée, plutôt que d'expirer au cours de la journée (s'il est créé le matin)

On est un peu sur de la micro-optimisation, mais ça ne coûte pas cher.