### PR TITLE
Améliore la consommation en RAM des exports

### DIFF
--- a/app/jobs/participations_export_send_email_job.rb
+++ b/app/jobs/participations_export_send_email_job.rb
@@ -1,26 +1,26 @@
 class ParticipationsExportSendEmailJob < ExportJob
   def perform(batch, _params)
     export = Export.find(batch.properties[:export_id])
-
     redis_key = redis_key(export.id)
 
-    pages = Redis.with_connection { |redis| redis.hgetall(redis_key) }
+    page_numbers = Redis.with_connection { |redis| redis.hkeys(redis_key).map(&:to_i).sort }
 
-    page_numbers = pages.keys.map(&:to_i).sort
+    rows_enum = Enumerator.new do |yielder|
+      page_numbers.each do |page_number|
+        json = Redis.with_connection { |redis| redis.hget(redis_key, page_number) }
 
-    rdvs_rows = []
-    page_numbers.each do |page_number|
-      page = JSON.parse(pages[page_number.to_s])
-
-      rdvs_rows += page
+        JSON.parse(json).each do |row|
+          yielder << row
+        end
+      end
     end
 
-    xls_string = ParticipationExporter.xls_string_from_participations_rows(rdvs_rows)
-
-    export.store_file(xls_string)
+    Tempfile.create do |file|
+      ParticipationExporter.write_xls_to_io(file, rows_enum)
+      file.rewind
+      export.store_file(file.read)
+    end
 
     Agents::ExportMailer.participations_export(export.id).deliver_later
-
-    Redis.with_connection { |redis| redis.del(redis_key) }
   end
 end

--- a/app/jobs/rdvs_export_send_email_job.rb
+++ b/app/jobs/rdvs_export_send_email_job.rb
@@ -1,26 +1,26 @@
 class RdvsExportSendEmailJob < ExportJob
   def perform(batch, _params)
     export = Export.find(batch.properties[:export_id])
-
     redis_key = redis_key(export.id)
 
-    pages = Redis.with_connection { |redis| redis.hgetall(redis_key) }
+    page_numbers = Redis.with_connection { |redis| redis.hkeys(redis_key).map(&:to_i).sort }
 
-    page_numbers = pages.keys.map(&:to_i).sort
+    rows_enum = Enumerator.new do |yielder|
+      page_numbers.each do |page_number|
+        json = Redis.with_connection { |redis| redis.hget(redis_key, page_number) }
 
-    rdvs_rows = []
-    page_numbers.each do |page_number|
-      page = JSON.parse(pages[page_number.to_s])
-
-      rdvs_rows += page
+        JSON.parse(json).each do |row|
+          yielder << row
+        end
+      end
     end
 
-    xls_string = RdvExporter.xls_string_from_rdvs_rows(rdvs_rows)
-
-    export.store_file(xls_string)
+    Tempfile.create do |file|
+      RdvExporter.write_xls_to_io(file, rows_enum)
+      file.rewind
+      export.store_file(file.read)
+    end
 
     Agents::ExportMailer.rdv_export(export.id).deliver_later
-
-    Redis.with_connection { |redis| redis.del(redis_key) }
   end
 end

--- a/app/services/participation_exporter.rb
+++ b/app/services/participation_exporter.rb
@@ -27,24 +27,26 @@ module ParticipationExporter
     "rdv collectif",
   ].freeze
 
-  def self.xls_string_from_participations_rows(participations_rows)
+  def self.write_xls_to_io(io, rows_enum)
     workbook = Spreadsheet::Workbook.new
     sheet = workbook.create_worksheet
     sheet.row(0).concat(HEADER)
 
-    participations_rows.each.with_index(1) do |row_content, row_index|
-      row = sheet.row(row_index)
-      row.set_format 3, DateFormat
-      row.set_format 4, HourFormat
-      row.set_format 6, DateFormat
-      row.set_format 7, HourFormat
+    row_index = 1
 
-      row.concat(row_content)
+    rows_enum.each do |row|
+      sheet_row = sheet.row(row_index)
+      # Apply formatting
+      sheet_row.set_format 3, DateFormat
+      sheet_row.set_format 4, HourFormat
+      sheet_row.set_format 6, DateFormat
+      sheet_row.set_format 7, HourFormat
+
+      sheet_row.concat(row)
+      row_index += 1
     end
 
-    file = StringIO.new
-    workbook.write(file)
-    file.string
+    workbook.write(io)
   end
 
   def self.rows_from_participations(participations)

--- a/app/services/rdv_exporter.rb
+++ b/app/services/rdv_exporter.rb
@@ -26,24 +26,26 @@ module RdvExporter
     "rdv collectif",
   ].freeze
 
-  def self.xls_string_from_rdvs_rows(rdvs_rows)
+  def self.write_xls_to_io(io, rows_enum)
     workbook = Spreadsheet::Workbook.new
     sheet = workbook.create_worksheet
     sheet.row(0).concat(HEADER)
 
-    rdvs_rows.each.with_index(1) do |row_content, row_index|
-      row = sheet.row(row_index)
-      row.set_format 1, DateFormat
-      row.set_format 2, HourFormat
-      row.set_format 4, DateFormat
-      row.set_format 5, HourFormat
+    row_index = 1
 
-      row.concat(row_content)
+    rows_enum.each do |row|
+      sheet_row = sheet.row(row_index)
+      # Apply formatting
+      sheet_row.set_format 3, DateFormat
+      sheet_row.set_format 4, HourFormat
+      sheet_row.set_format 6, DateFormat
+      sheet_row.set_format 7, HourFormat
+
+      sheet_row.concat(row)
+      row_index += 1
     end
 
-    file = StringIO.new
-    workbook.write(file)
-    file.string
+    workbook.write(io)
   end
 
   def self.rows_from_rdvs(rdvs)

--- a/spec/features/agents/agent_can_export_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_export_rdvs_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe "agent can export RDVs" do
   end
 
   it "exports by RDV" do
-    rdvs = create_list(:rdv, 4, organisation: organisation)
+    rdvs = 4.times.map do |i|
+      create(:rdv, organisation: organisation, starts_at: 3.days.from_now + i.hours)
+    end
+
     visit admin_organisation_rdvs_url(organisation)
     perform_enqueued_jobs do
       click_on "Exporter les 4 RDV en XLS"
@@ -45,14 +48,11 @@ RSpec.describe "agent can export RDVs" do
     expect(book.worksheets[0].rows.size).to eq(5)
     expect(book.worksheets[0].row(0)[11]).to eq("professionnel.le(s)")
 
+    rdvs = rdvs.sort_by(&:starts_at).reverse # les exports sont ordonnés par `starts_at DESC`
     4.times do |i|
       expect(book.worksheets[0].row(i + 1)[7]).to eq(rdvs[i].motif.name)
       expect(book.worksheets[0].row(i + 1)[11]).to eq(rdvs[i].agents.first.full_name)
     end
-
-    expect(book.worksheets[0].row(0)[7]).to eq("motif")
-    motif_names = 4.times.map { book.worksheets[0].row(_1 + 1)[7] }
-    expect(motif_names).to match_array(rdvs.map(&:motif).map(&:name))
   end
 
   it "exports by participation" do

--- a/spec/features/agents/agent_can_export_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_export_rdvs_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe "agent can export RDVs" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-  let!(:rdv) { create(:rdv, organisation: organisation) }
 
   before do
     travel_to(Time.zone.parse("2022-09-14 09:00:00"))
@@ -9,6 +8,7 @@ RSpec.describe "agent can export RDVs" do
   end
 
   it "displays export list" do
+    create(:rdv, organisation: organisation)
     visit admin_organisation_rdvs_url(organisation)
     click_on "Exporter le RDV en XLS"
     perform_enqueued_jobs
@@ -24,9 +24,10 @@ RSpec.describe "agent can export RDVs" do
   end
 
   it "exports by RDV" do
+    rdvs = create_list(:rdv, 4, organisation: organisation)
     visit admin_organisation_rdvs_url(organisation)
     perform_enqueued_jobs do
-      click_on "Exporter le RDV en XLS"
+      click_on "Exporter les 4 RDV en XLS"
     end
 
     open_email(agent.email)
@@ -41,11 +42,21 @@ RSpec.describe "agent can export RDVs" do
     expect(response_headers["Content-Disposition"]).to include(expected_file_name)
 
     book = Spreadsheet.open(StringIO.new(page.body))
+    expect(book.worksheets[0].rows.size).to eq(5)
     expect(book.worksheets[0].row(0)[11]).to eq("professionnel.le(s)")
-    expect(book.worksheets[0].row(1)[11]).to eq(rdv.agents.first.full_name)
+
+    4.times do |i|
+      expect(book.worksheets[0].row(i + 1)[7]).to eq(rdvs[i].motif.name)
+      expect(book.worksheets[0].row(i + 1)[11]).to eq(rdvs[i].agents.first.full_name)
+    end
+
+    expect(book.worksheets[0].row(0)[7]).to eq("motif")
+    motif_names = 4.times.map { book.worksheets[0].row(_1 + 1)[7] }
+    expect(motif_names).to match_array(rdvs.map(&:motif).map(&:name))
   end
 
   it "exports by participation" do
+    rdvs = create_list(:rdv, 4, organisation: organisation)
     visit admin_organisation_rdvs_url(organisation)
     perform_enqueued_jobs do
       click_on "Exporter les RDV par usager en XLS"
@@ -62,7 +73,9 @@ RSpec.describe "agent can export RDVs" do
     expect(response_headers["Content-Disposition"]).to include("export-rdvs-user-2022-09-14.xls")
 
     book = Spreadsheet.open(StringIO.new(page.body))
+    expect(book.worksheets[0].rows.size).to eq(5)
     expect(book.worksheets[0].row(0)[1]).to eq("rdv_id")
-    expect(book.worksheets[0].row(1)[1]).to eq(rdv.id)
+    rdv_ids = 4.times.map { book.worksheets[0].row(_1 + 1)[1] }
+    expect(rdv_ids).to match_array(rdvs.map(&:id))
   end
 end

--- a/spec/services/participation_exporter_spec.rb
+++ b/spec/services/participation_exporter_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe ParticipationExporter, type: :service do
         users: [create(:user, first_name: "Gaston", last_name: "Bidon", birth_date: Date.new(2000, 1, 1), address: nil)]
       )
       participation_row = described_class.row_array_from(rdv.participations.first)
-      xls_string = described_class.xls_string_from_participations_rows([participation_row])
+      io = StringIO.new
+      described_class.write_xls_to_io(io, [participation_row])
 
-      header_row, first_data_row = Spreadsheet.open(StringIO.new(xls_string)).worksheets.first.rows
+      header_row, first_data_row = Spreadsheet.open(io).worksheets.first.rows
 
       # Les lettres sont les noms de colonnes Excel.
       # Il est important de toujours ajouter les nouvelles colonnes

--- a/spec/services/rdv_exporter_spec.rb
+++ b/spec/services/rdv_exporter_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe RdvExporter, type: :service do
-  describe "#xls_string_from_rdvs_rows" do
+  describe "#write_xls_to_io" do
     it "return export with header" do
       rdv = create(:rdv, created_at: Time.zone.parse("2023-01-01"), agents: [create(:agent, email: "agent@mail.com")])
       rdv_row = described_class.row_array_from(rdv)
-      xls_string = described_class.xls_string_from_rdvs_rows([rdv_row])
+      io = StringIO.new
+      described_class.write_xls_to_io(io, [rdv_row])
 
-      header_row, first_data_row = Spreadsheet.open(StringIO.new(xls_string)).worksheets.first.rows
+      header_row, first_data_row = Spreadsheet.open(io).worksheets.first.rows
 
       # Les lettres sont les noms de colonnes Excel.
       # Il est important de toujours ajouter les nouvelles colonnes


### PR DESCRIPTION
Nous avons eu aujourd'hui de gros soucis de swap sur des exports de 350 000 à 400 000 RDV.

Je propose donc ici un refactor des des jobs d’export `RdvsExportSendEmailJob` et `ParticipationsExportSendEmailJob` selon ces axes d'amélioration :

- Lecture incrémentale des pages Redis, pas de chargement complet en mémoire (ça évite aussi de monopoliser Redis (qui est mono-thread) pendant la récupération des pages)
- Utilisation d'un fichier fichier temporaire plutôt que de Strings en mémoire
- Concaténation en streaming, basée sur un StringIO plutôt que des sommes de Strings

J'ai complété les tests d'intégration existants pour vérifier que toute la tuyauterie fonctionne toujours.

Testé en local 
- avec un export de 160 000 RDV : avant on atteignait 1 GB de RAM, maintenant on est à 760 MB
- avec un export de 400 000 RDV : avant on atteignait 2 GB de RAM, maintenant on est à 1,5 GB

Tout ceci n'est pas hyper spectaculaire mais ça ne peut pas faire de mal je pense. 