### PR TITLE
Passage du formulaire de champ optionels motifs au DSFR

### DIFF
--- a/app/controllers/admin/territories/motif_categories_controller.rb
+++ b/app/controllers/admin/territories/motif_categories_controller.rb
@@ -9,6 +9,6 @@ class Admin::Territories::MotifCategoriesController < Admin::Territories::BaseCo
   private
 
   def motif_categories_params
-    params.require(:territory).permit(motif_category_ids: [])
+    params.fetch(:territory, { motif_category_ids: [] }).permit(motif_category_ids: [])
   end
 end

--- a/app/views/admin/territories/motif_fields/edit.html.slim
+++ b/app/views/admin/territories/motif_fields/edit.html.slim
@@ -4,15 +4,17 @@
   .col-md-6
     .card
       .card-body
-        h5.card-title= t(".card_title")
-        p.text-muted.font-14= t(".hint_1")
-
-        = simple_form_for current_territory, url: admin_territory_motif_categories_path(current_territory) do |f|
+        = form_for current_territory, url: admin_territory_motif_categories_path(current_territory), builder: Dsfr::FormBuilder do |f|
           = render "model_errors", model: current_territory
+
+          h1.card-title= t(".card_title")
+          p.text-muted.font-14= t(".hint_1")
 
           h6= t("admin.territories.motif_categories.edit.title")
           p.text-muted.font-14= t("admin.territories.motif_categories.edit.hint_1")
-          = f.association :motif_categories, collection: MotifCategory.all, label: "", as: :check_boxes
+
+          - MotifCategory.all.each do |motif_category|
+            = f.dsfr_check_box "motif_category_ids_#{motif_category.id}", { label: motif_category.name, checked: current_territory.motif_category_ids.include?(motif_category.id), name: "territory[motif_category_ids][]" }, motif_category.id, nil
 
           .text-right
-            = f.button :submit
+            = f.submit "Enregistrer", class: "fr-btn"


### PR DESCRIPTION
# Contexte

On continue de passer les formulaires côté agent au DSFR.

# Solution

## Captures d'écran

Avant | Après
:- | -:
<img width="687" height="887" alt="image" src="https://github.com/user-attachments/assets/e34dbd29-fb33-4adc-85e8-c6653f497088" /> | <img width="666" height="986" alt="image" src="https://github.com/user-attachments/assets/450773ac-4a5f-4ba1-8de4-1e999ce0351d" />
