### PR TITLE
Corrige une flaky spec dans agents_controller_search_spec.rb

### DIFF
--- a/spec/requests/agents/agents_controller_search_spec.rb
+++ b/spec/requests/agents/agents_controller_search_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe Agents::AgentsController, "#search" do
   let!(:territory) { create(:territory) }
   let!(:organisation) { create(:organisation, territory: territory) }
-  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let!(:current_agent) { create(:agent, first_name: "Martine", last_name: "Validay", admin_role_in_organisations: [organisation]) }
 
   before do
-    sign_in agent
+    sign_in current_agent
   end
 
   it "works" do
@@ -28,7 +28,7 @@ RSpec.describe Agents::AgentsController, "#search" do
   context "quand un agent est présent dans plusieurs de mes orgas" do
     let!(:orga_1) { create(:organisation) }
     let!(:orga_2) { create(:organisation) }
-    let!(:agent) { create(:agent, admin_role_in_organisations: [orga_1, orga_2]) }
+    let!(:current_agent) { create(:agent, first_name: "Martine", last_name: "Validay", admin_role_in_organisations: [orga_1, orga_2]) }
     let!(:francis) { create(:agent, first_name: "Francis", last_name: "Factice", basic_role_in_organisations: [orga_1, orga_2]) }
 
     it "ne s'affiche qu'une seule fois dans la liste" do


### PR DESCRIPTION
Quand l'agent courant a un nom en "fra" (du genre "FRANCOIS" par exemple), la spec échoue :

```
Failures:

  1) Agents::AgentsController#search works
     Failure/Error: expect(parsed_response_body[:results]).to eq([{ "id" => francis.id, "text" => "FACTICE Francis" }])
     
       expected: [{"id" => 58, "text" => "FACTICE Francis"}]
            got: [{"id" => 57, "text" => "FRANCOIS Baptiste"}, {"id" => 58, "text" => "FACTICE Francis"}]

```