### PR TITLE
Ajoute un CRON Scalingo d'auto-restart

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,7 @@
+{
+  "jobs": [
+    {
+      "command": "0 6 * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart"
+    }
+  ]
+}


### PR DESCRIPTION
Afin de nous prémunir contre l'explosion de l'usage mémoire, nous cherchons à redémarrer régulièrement nos containers Scalingo (une fois par jour c'est déjà bien).

Nous avons contacté Scalingo pour savoir quelle était la meilleure stratégie, et voici leur réponse : 

> Bonjour
> 
> 
> Merci de nous avoir contacté.
> 
> 
> Nous n'avons pour le moment pas la possibilité d'effectuer le redémarrage de conteneur de façon automatique directement depuis le dashboard. Il n'est également pas possible de mettre en place des clefs API avec des scopes restrictifs. Cela dit, je souhaite créer un notes pour ces remarques afin que notre équipe Produit puissent les voir. Nous n'avons pas cela de prévu à court terme mais vos retours sont importants et nous permettent d'améliorer la plateforme.
> 
> 
> Concernant le redémarrage de vos conteneur, vous pourriez utiliser notre CLI au travers de notre Scheduler. En effet, vous pourriez faire en sorte qu'une tâche cron soit lancée lorsque vous avez besoin et que celle-ci utilise notre CLI pour redémarrer vos conteneurs.
> 
>     Vous pourrez trouver plus d'information sur la mise en place de cette tâche cron via notre Scheduler ici dans notre documentation: https://doc.scalingo.com/platform/app/task-scheduling/scalingo-scheduler
> 
> 
> Concernant l'authentification à notre CLI vous pourriez créer un utilisateurs dédié que vous ajouteriez en collaborateur limité à cette application seulement. Il disposera donc de droit limités, à cette application seulement, dont la possibilité de la redémarrer: https://doc.scalingo.com/platform/user-management/teamwork/roles#permissions-matrices
> 
> 
> Vous pourrez stocker la clef API de ce collaborateur limité dans une [variable d'environnement ](https://doc.scalingo.com/platform/app/environment)que vous utiliserez lors de la connexion à la CLI avec l'option --api-token :
> 
> scalingo login --api-token $API_KEY_ENV_VAR
> 
> 
> Concernant les redémarrages, vous pourrez utiliser une des commandes suivantes:
> 
> scalingo --app my-app restart        # Restart all the processes
> scalingo --app my-app restart web    # Restart all the web processes
> scalingo --app my-app restart web-1  # Restart a specific container 
> 
> 
> J'espère que cela vous aide dans la mise en place de votre redémarrage automatique.
> 
> Bien sur, n’hésitez pas à revenir vers nous si besoin, nous serons ravi de vous aider.
> 
> Cordialement,
> Scalingo 
> 

J'ai donc créé un limited collaborator scalingo-restarter@rdv-solidarites.fr et je l'ai invité à collaborer (sur la démo pour l'instant) j'ai créé un clé d'API pour ce user et je l'ai définie dans `RESTARTER_BOT_API_TOKEN`.

Cette PR met donc en place la cron qui lance la commande qui redémarre tous les containers à 6AM UTC, seulement si la variable d'ENV `RESTARTER_BOT_API_TOKEN` est non vide.