### PR TITLE
Corrige une flaky spec (rdv_plans_spec.rb)

### DIFF
--- a/spec/mailers/agents/webhook_mailer_spec.rb
+++ b/spec/mailers/agents/webhook_mailer_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe Agents::WebhookMailer, type: :mailer do
       mail = described_class.new_webhook_url(webhook_endpoint_id: create(:webhook_endpoint).id, notified_agent_id: notified_agent.id)
 
       expect(mail.subject).to eq("Un webhook vient d'être ajouté par API")
-      puts mail.body.encoded
       expect(mail.body.encoded).to include("Une nouvelle URL de webhook vient d'être introduite par Amine DESPACE (via API) :")
     end
   end

--- a/spec/requests/api/v1/swagger_doc/absences_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/absences_request_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Absence authentified API", swagger_doc: "v1/api.json" do
       let(:client) { auth_headers["client"].to_s }
 
       response 200, "Crée et renvoie une absence" do
-        let(:agent_id) { 12 }
+        let(:agent_id) { agent.id }
         let(:title) { "Super absence" }
         let(:first_day) { "2023-11-20" }
         let(:start_time) { "08:00" }

--- a/spec/requests/api/v1/swagger_doc/absences_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/absences_request_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Absence authentified API", swagger_doc: "v1/api.json" do
       parameter name: "end_time", in: :query, type: :string, description: "Heure de fin de l'absence", example: "15:00"
 
       let(:organisation) { create(:organisation) }
-      let!(:agent) { create(:agent, id: 12, email: "agent@example.com", basic_role_in_organisations: [organisation]) }
+      let!(:agent) { create(:agent, email: "agent@example.com", basic_role_in_organisations: [organisation]) }
       let(:auth_headers) { api_auth_headers_for_agent(agent) }
       let(:"access-token") { auth_headers["access-token"].to_s }
       let(:uid) { auth_headers["uid"].to_s }

--- a/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
       consumes "application/json"
 
       let(:organisation) { create(:organisation) }
-      let!(:agent) { create(:agent, id: 12, email: "agent@example.com", basic_role_in_organisations: [organisation]) }
+      let!(:agent) { create(:agent, email: "agent@example.com", basic_role_in_organisations: [organisation]) }
       let(:auth_headers) { api_auth_headers_for_agent(agent) }
       let(:"access-token") { auth_headers["access-token"].to_s }
       let(:uid) { auth_headers["uid"].to_s }
@@ -102,7 +102,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
       parameter name: :rdv_plan_id, in: :path, type: :integer, example: 123
 
       let(:organisation) { create(:organisation) }
-      let!(:agent) { create(:agent, id: 12, email: "agent@example.com", basic_role_in_organisations: [organisation]) }
+      let!(:agent) { create(:agent, email: "agent@example.com", basic_role_in_organisations: [organisation]) }
       let(:auth_headers) { api_auth_headers_for_agent(agent) }
       let(:"access-token") { auth_headers["access-token"].to_s }
       let(:uid) { auth_headers["uid"].to_s }


### PR DESCRIPTION
On a ce genre d'échec car on spécifie l'ID explicitement et que la séquence d'ID n'est plus remise à 0 depuis qu'on a viré DatabaseCleaner : 

https://github.com/betagouv/rdv-service-public/actions/runs/20519083452/job/58951398671

```
          ActiveRecord::RecordNotUnique:
            PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "agents_pkey"
            DETAIL:  Key (id)=(12) already exists.
          # ./spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb:118:in 'block (5 levels) in <main>'
          # ./spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb:116:in 'block (5 levels) in <main>'
          # ./spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb:114:in 'block (5 levels) in <main>'
          # ./spec/rails_helper.rb:100:in 'block (2 levels) in <top (required)>'
          # ------------------
          # --- Caused by: ---
          # PG::UniqueViolation:
          #   ERROR:  duplicate key value violates unique constraint "agents_pkey"
          #   DETAIL:  Key (id)=(12) already exists.
          #   ./spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb:118:in 'block (5 levels) in <main>'
```

Mais pourquoi spécifier un ID ? :thinking: 