### PR TITLE
Autoriser les adresses e-mail à une seule lettre (a@exemple.fr)

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -224,7 +224,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats.
   config.email_regexp = /\A
     [A-Za-z0-9_%+-]     # the first letter cannot be a dot
-    [A-Za-z0-9._%+-]+   # the rest can include dots
+    [A-Za-z0-9._%+-]*   # the rest can include dots
     @
     [A-Za-z0-9-]+
     (\.[A-Za-z0-9-]+)*  # subdomains


### PR DESCRIPTION
On a le cas d'une personne que l'on empêche de se FranceConnect car son email est en `f@nom-de-famille.fr`.

je ne vois pas trop de raison d'autoriser des mails à deux caractères et pas à un seul. :shrug: 

Autre possibilité de solution : ne pas valider l'e-mail quand il provient de ProConnect (puisqu'il est déjà validé normalement), mais ça fait entrer dans notre base un e-mail qui sera ensuite considéré invalide, donc bof.