### PR TITLE
Toujours répondre en JSON via API + fail early migration conum

### DIFF
--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -22,10 +22,19 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
 
   # Rescuable exceptions
 
+  rescue_from StandardError, with: :unexpected_error
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
   rescue_from ActionController::ParameterMissing, with: :parameter_missing
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
   rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
+
+  def unexpected_error(exception)
+    Sentry.capture_exception(exception)
+    render(
+      status: :internal_server_error,
+      json: { errors: ["Unexpected internal error"] }
+    )
+  end
 
   def not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -21,27 +21,22 @@ class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
   end
 
   def create
-    if params[:external_reference].present?
-      @external_reference = ExternalReference.find_or_initialize_by(
-        params.require(:external_reference).permit(:external_id, :external_url).merge(
-          oauth_application: doorkeeper_token&.application,
-          item_type: "Motif",
-          territory_id: Organisation.find(params[:organisation_id]).territory_id
-        )
-      )
-
-      if @external_reference
-        render(json: { object: MotifBlueprint.render_as_hash(@external_reference.item), warning: "Un objet existe déjà pour cet external_id." }) and return
-      end
-    end
-
     motif = Motif.new(params.permit(*motif_attribute_names))
 
     authorize(motif, policy_class: Agent::MotifPolicy)
 
     motif.transaction do
       motif.save!
-      @external_reference&.update!(item: motif)
+
+      if params[:external_reference].present?
+        ExternalReference.create!(
+          params.require(:external_reference).permit(:external_id, :external_url).merge(
+            item: motif,
+            oauth_application: doorkeeper_token&.application,
+            territory_id: motif.organisation.territory_id
+          )
+        )
+      end
     end
 
     if motif.persisted?

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -21,22 +21,27 @@ class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
   end
 
   def create
+    if params[:external_reference].present?
+      @external_reference = ExternalReference.find_or_initialize_by(
+        params.require(:external_reference).permit(:external_id, :external_url).merge(
+          oauth_application: doorkeeper_token&.application,
+          item_type: "Motif",
+          territory_id: Organisation.find(params[:organisation_id]).territory_id
+        )
+      )
+
+      if @external_reference
+        render(json: { object: MotifBlueprint.render_as_hash(@external_reference.item), warning: "Un objet existe déjà pour cet external_id." }) and return
+      end
+    end
+
     motif = Motif.new(params.permit(*motif_attribute_names))
 
     authorize(motif, policy_class: Agent::MotifPolicy)
 
     motif.transaction do
       motif.save!
-
-      if params[:external_reference].present?
-        ExternalReference.create!(
-          params.require(:external_reference).permit(:external_id, :external_url).merge(
-            item: motif,
-            oauth_application: doorkeeper_token&.application,
-            territory_id: motif.organisation.territory_id
-          )
-        )
-      end
+      @external_reference&.update!(item: motif)
     end
 
     if motif.persisted?

--- a/app/lib/rdv_service_public_api_client.rb
+++ b/app/lib/rdv_service_public_api_client.rb
@@ -13,17 +13,6 @@ class RdvServicePublicApiClient
 
   private
 
-  def base_url
-    ENV.fetch("RDV_SERVICE_PUBLIC_OAUTH_BASE_URL")
-  end
-
-  def request_headers
-    {
-      "Authorization" => "Bearer #{@api_token}",
-      "Content-Type" => "application/json",
-    }
-  end
-
   def connection
     url = ENV.fetch("RDV_SERVICE_PUBLIC_OAUTH_BASE_URL")
     headers = {

--- a/app/lib/rdv_service_public_api_client.rb
+++ b/app/lib/rdv_service_public_api_client.rb
@@ -1,10 +1,28 @@
 class RdvServicePublicApiClient
+  class RequestError < StandardError; end
+
   def initialize(api_token)
     @api_token = api_token
   end
 
   def post(path, params)
-    connection.post("/api/v1/#{path}", params).body
+    response = connection.post("/api/v1/#{path}", params)
+
+    return response.body if response.success?
+
+    if response.status == 422
+      external_id_errors = response.body.dig("errors", "external_id")
+      external_id_taken = external_id_errors&.find do |error_hash|
+        error_hash["error"] == "taken"
+      end
+
+      if external_id_taken # L'appel a échoué parce que la ressource a déjà été créée sur le serveur distant
+        # On ne considère pas que c'est une erreur, parce que ça nous permet de faire des créations idempotentes
+        return response.body
+      end
+    end
+
+    raise(RequestError, "échec de la requête sur #{path} (status #{response.status}). Voir les breadcrumbs Sentry pour plus d'infos")
   end
 
   def get(path, params = {})
@@ -23,7 +41,6 @@ class RdvServicePublicApiClient
     @connection ||= Faraday.new(url:, headers:) do |builder|
       builder.request :json
       builder.response :json
-      builder.response :raise_error # raise an error on 4xx and 5xx responses
       builder.use :sentry_breadcrumbs
     end
   end

--- a/app/lib/rdv_service_public_api_client.rb
+++ b/app/lib/rdv_service_public_api_client.rb
@@ -4,38 +4,38 @@ class RdvServicePublicApiClient
   end
 
   def post(path, params)
-    response = Typhoeus.post(
-      "#{ENV['RDV_SERVICE_PUBLIC_OAUTH_BASE_URL']}/api/v1/#{path}",
-      body: params.to_json,
-      headers: request_headers
-    )
-    if response.failure?
-      Sentry.capture_message("Erreur lors de l'appel à l'api de RDV Service Public")
-    end
-
-    JSON.parse(response.body)
+    connection.post("/api/v1/#{path}", params).body
   end
 
   def get(path, params = {})
-    response = Typhoeus.get(
-      "#{ENV['RDV_SERVICE_PUBLIC_OAUTH_BASE_URL']}/api/v1/#{path}",
-      params:,
-      headers: request_headers
-    )
-
-    if response.failure?
-      Sentry.capture_message("Erreur lors de l'appel à l'api de RDV Service Public")
-    end
-
-    JSON.parse(response.body)
+    connection.get("/api/v1/#{path}", params).body
   end
 
   private
+
+  def base_url
+    ENV.fetch("RDV_SERVICE_PUBLIC_OAUTH_BASE_URL")
+  end
 
   def request_headers
     {
       "Authorization" => "Bearer #{@api_token}",
       "Content-Type" => "application/json",
     }
+  end
+
+  def connection
+    url = ENV.fetch("RDV_SERVICE_PUBLIC_OAUTH_BASE_URL")
+    headers = {
+      "Authorization" => "Bearer #{@api_token}",
+      "Content-Type" => "application/json",
+    }
+
+    @connection ||= Faraday.new(url:, headers:) do |builder|
+      builder.request :json
+      builder.response :json
+      builder.response :raise_error # raise an error on 4xx and 5xx responses
+      builder.use :sentry_breadcrumbs
+    end
   end
 end

--- a/spec/lib/rdv_service_public_api_client_spec.rb
+++ b/spec/lib/rdv_service_public_api_client_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RdvServicePublicApiClient do
     it "ajoute la requête et la réponse HTTP en breadcrumb Sentry et lève une exception" do
       expect do
         described_class.new("123456").post("plage_ouvertures", { lieu_external_ids: "asdf" })
-      end.to raise_error(Faraday::ResourceNotFound) do |e|
+      end.to raise_error(RdvServicePublicApiClient::RequestError) do |e|
         Sentry.capture_exception(e)
         request_breadcrumb, response_breadcrumb = sentry_events.last.breadcrumbs.compact
         expect(request_breadcrumb.data[:body]).to eq({ lieu_external_ids: "asdf" }.to_json)
@@ -36,7 +36,7 @@ RSpec.describe RdvServicePublicApiClient do
     it "ajoute la requête et la réponse HTTP en breadcrumb Sentry et lève une exception" do
       expect do
         described_class.new("123456").post("motifs", {}) # Les paramètres ne sont pas utilisés pas le stub, donc on ne les précise pas
-      end.to raise_error(Faraday::UnprocessableEntityError) do |e|
+      end.to raise_error(RdvServicePublicApiClient::RequestError) do |e|
         Sentry.capture_exception(e)
         request_breadcrumb, response_breadcrumb = sentry_events.last.breadcrumbs.compact
         expect(request_breadcrumb.data[:body]).to be_present

--- a/spec/lib/rdv_service_public_api_client_spec.rb
+++ b/spec/lib/rdv_service_public_api_client_spec.rb
@@ -12,15 +12,51 @@ RSpec.describe RdvServicePublicApiClient do
     end
 
     it "ajoute la requête et la réponse HTTP en breadcrumb Sentry et lève une exception" do
-      client = described_class.new("123456")
       expect do
-        client.post("plage_ouvertures", { lieu_external_ids: "asdf" })
+        described_class.new("123456").post("plage_ouvertures", { lieu_external_ids: "asdf" })
       end.to raise_error(Faraday::ResourceNotFound) do |e|
         Sentry.capture_exception(e)
         request_breadcrumb, response_breadcrumb = sentry_events.last.breadcrumbs.compact
         expect(request_breadcrumb.data[:body]).to eq({ lieu_external_ids: "asdf" }.to_json)
         expect(response_breadcrumb.data[:body]).to eq({ error_message: ["Aucun lieu trouvé pour le lieu_external_id 123456"] }.to_json)
       end
+    end
+  end
+
+  context "pour une requête qui échoue à cause d'une erreur métier" do
+    before do
+      stub_request(:post, "http://rdv.localhost/api/v1/motifs")
+        .to_return(
+          status: 422,
+          headers: { "Content-Type": "application/json" },
+          body: ApiSpecHelper.invalid_motif_response.to_json
+        )
+    end
+
+    it "ajoute la requête et la réponse HTTP en breadcrumb Sentry et lève une exception" do
+      expect do
+        described_class.new("123456").post("motifs", {}) # Les paramètres ne sont pas utilisés pas le stub, donc on ne les précise pas
+      end.to raise_error(Faraday::UnprocessableEntityError) do |e|
+        Sentry.capture_exception(e)
+        request_breadcrumb, response_breadcrumb = sentry_events.last.breadcrumbs.compact
+        expect(request_breadcrumb.data[:body]).to be_present
+        expect(response_breadcrumb.data[:body]).to be_present
+      end
+    end
+  end
+
+  context "pour une requête qui échoue parce que la ressource existe déjà" do
+    before do
+      stub_request(:post, "http://rdv.localhost/api/v1/motifs")
+        .to_return(
+          status: 422,
+          headers: { "Content-Type": "application/json" },
+          body: ApiSpecHelper.external_id_error_response.to_json
+        )
+    end
+
+    it "n'échoue pas, parce qu'on veut permettre de faire plusieurs fois des copies de données inter-instances sans doublons et sans lever d'erreur" do
+      described_class.new("123456").post("motifs", {}) # Les paramètres ne sont pas utilisés pas le stub, donc on ne les précise pas
     end
   end
 end

--- a/spec/lib/rdv_service_public_api_client_spec.rb
+++ b/spec/lib/rdv_service_public_api_client_spec.rb
@@ -11,12 +11,16 @@ RSpec.describe RdvServicePublicApiClient do
         )
     end
 
-    it "envoie un message dans Sentry avec des breadcrumbs qui indiquent les valeurs de l'appel HTTP" do
+    it "ajoute la requête et la réponse HTTP en breadcrumb Sentry et lève une exception" do
       client = described_class.new("123456")
-      client.post("plage_ouvertures", { lieu_external_ids: "asdf" })
-
-      expect(sentry_events.last.message).to eq("Erreur lors de l'appel à l'api de RDV Service Public")
-      expect(sentry_events.last.breadcrumbs.first.data[:body]).to include("lieu_external_id")
+      expect do
+        client.post("plage_ouvertures", { lieu_external_ids: "asdf" })
+      end.to raise_error(Faraday::ResourceNotFound) do |e|
+        Sentry.capture_exception(e)
+        request_breadcrumb, response_breadcrumb = sentry_events.last.breadcrumbs.compact
+        expect(request_breadcrumb.data[:body]).to eq({ lieu_external_ids: "asdf" }.to_json)
+        expect(response_breadcrumb.data[:body]).to eq({ error_message: ["Aucun lieu trouvé pour le lieu_external_id 123456"] }.to_json)
+      end
     end
   end
 end

--- a/spec/requests/api/v1/motifs_spec.rb
+++ b/spec/requests/api/v1/motifs_spec.rb
@@ -56,8 +56,9 @@ RSpec.describe "Motifs API" do
       it "doesn't create the motif and returns an error message" do
         expect { post "/api/v1/motifs", headers:, params:, as: :json }.not_to change(Motif, :count)
 
-        expect(response.status).to eq 422
-        expect(parsed_response_body["error_messages"]).to eq ["external_id est déjà utilisé"]
+        expect(response.status).to eq 200
+        expect(parsed_response_body["warning"]).to eq "Un objet existe déjà pour cet external_id."
+        expect(parsed_response_body["object"]["id"]).to eq existing_motif.id
       end
     end
   end

--- a/spec/requests/api/v1/motifs_spec.rb
+++ b/spec/requests/api/v1/motifs_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Motifs API" do
         expect { post "/api/v1/motifs", headers:, params:, as: :json }.not_to change(Motif, :count)
 
         expect(response.status).to eq 422
-        expect(parsed_response_body).to eq ApiSpecHelper.invalid_motif_response(orgnisation.id)
+        expect(parsed_response_body).to eq ApiSpecHelper.invalid_motif_response(organisation.name)
       end
     end
   end

--- a/spec/requests/api/v1/motifs_spec.rb
+++ b/spec/requests/api/v1/motifs_spec.rb
@@ -56,9 +56,8 @@ RSpec.describe "Motifs API" do
       it "doesn't create the motif and returns an error message" do
         expect { post "/api/v1/motifs", headers:, params:, as: :json }.not_to change(Motif, :count)
 
-        expect(response.status).to eq 200
-        expect(parsed_response_body["warning"]).to eq "Un objet existe déjà pour cet external_id."
-        expect(parsed_response_body["object"]["id"]).to eq existing_motif.id
+        expect(response.status).to eq 422
+        expect(parsed_response_body["error_messages"]).to eq ["external_id est déjà utilisé"]
       end
     end
   end

--- a/spec/requests/api/v1/motifs_spec.rb
+++ b/spec/requests/api/v1/motifs_spec.rb
@@ -57,7 +57,34 @@ RSpec.describe "Motifs API" do
         expect { post "/api/v1/motifs", headers:, params:, as: :json }.not_to change(Motif, :count)
 
         expect(response.status).to eq 422
-        expect(parsed_response_body["error_messages"]).to eq ["external_id est déjà utilisé"]
+        expect(parsed_response_body).to eq ApiSpecHelper.external_id_error_response
+      end
+    end
+
+    context "when the motif is not valid for another reason" do
+      let(:params) do
+        {
+          name: "Suivi de dossier",
+          organisation_id: organisation.id,
+          color: "#000000",
+          default_duration_in_min: 30,
+          min_public_booking_delay: 1800,
+          max_public_booking_delay: 7889238,
+          collectif: false,
+          bookable_by: "everyone",
+          external_reference: { external_id: "123ABC" },
+        }
+      end
+
+      let!(:existing_motif) do
+        create(:motif, organisation_id: organisation.id, name: "Suivi de dossier")
+      end
+
+      it "doesn't create the motif and returns an error message" do
+        expect { post "/api/v1/motifs", headers:, params:, as: :json }.not_to change(Motif, :count)
+
+        expect(response.status).to eq 422
+        expect(parsed_response_body).to eq ApiSpecHelper.invalid_motif_response(orgnisation.id)
       end
     end
   end

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -105,5 +105,13 @@ RSpec.describe "RDV API" do
         expect(Rdv.last.created_by).to eq user_on_new_instance
       end
     end
+
+    it "returns a JSON response and warns sentry in case of unexpected error" do
+      allow(Rdv).to receive(:new).and_raise("boom")
+      post "/api/v1/rdvs", headers:, params: {}, as: :json
+
+      expect(response.parsed_body["errors"]).to include("Unexpected internal error")
+      expect(sentry_events.last.exception.values.first.value).to eq("boom (RuntimeError)")
+    end
   end
 end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -33,4 +33,18 @@ module ApiSpecHelper
     AgentRole.set_callback(:validate, :organisation_have_at_least_one_admin)
     agent.save!
   end
+
+  def self.external_id_error_response
+    {
+      "errors" => { "external_id" => [{ "error" => "taken", "value" => "123ABC" }] },
+      "error_messages" => ["external_id est déjà utilisé"],
+    }
+  end
+
+  def self.invalid_motif_response(organisation_id = 1)
+    {
+      "error_messages" => ["base Il existe déjà dans Organisation n°#{organisation_id} un motif Sur place nommé \"Suivi de dossier\" ouvert à tous les agents"],
+      "errors" => { "base" => [{ "error" => "duplicate_detected" }] },
+    }
+  end
 end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -41,9 +41,9 @@ module ApiSpecHelper
     }
   end
 
-  def self.invalid_motif_response(organisation_id = 1)
+  def self.invalid_motif_response(organisation_name = "Mon Organisation")
     {
-      "error_messages" => ["base Il existe déjà dans Organisation n°#{organisation_id} un motif Sur place nommé \"Suivi de dossier\" ouvert à tous les agents"],
+      "error_messages" => ["base Il existe déjà dans #{organisation_name} un motif Sur place nommé \"Suivi de dossier\" ouvert à tous les agents"],
       "errors" => { "base" => [{ "error" => "duplicate_detected" }] },
     }
   end


### PR DESCRIPTION
# Contexte

## Format de réponse API

Notre API a actuellement cette  fâcheuse tendance à renvoyer du HTML lors d'une erreur inattendue (500). 

Ce comportement est aussi répandu que désagréable pour les utilisateurs de l'API. Et quand nous sommes nous-mêmes utilisateurs de notre API, nous sommes les premières victimes d'erreurs pas claires : 

<img width="738" height="309" alt="image" src="https://github.com/user-attachments/assets/492495be-26fa-457a-8af9-981703f5e1dd" />

https://sentry.incubateur.net/organizations/betagouv/issues/220373/?project=74&referrer=webhooks_plugin

## Véritable contexte

Au delà de ces considérations de principe, nous avons eu ce matin le problème suivant : 

Lors de la migration d'un CoNum, un motif n'a pas été copié car il était invalide (`cant_be_enabled_if_follow_up`). Cet échec de copie n'a pas été bloquant pour le job, car **le client `RdvServicePublicApiClient` ne lève aucune exception si la requête a un statut d'erreur (!)** mais informe seulement Sentry. Cela signifie que si l'on échoue à créer un élément, le job réussit silencieusement et ne retry pas.

On a donc silencieusement échoué à copier un motif, puis lancé la copie de tous les RDV qui utilisaient ce motif, avec comme résultat des milliers d'erreurs côté API RDV-SP et des jobs congestionnés côté RDV-S :

<img width="1722" height="830" alt="image" src="https://github.com/user-attachments/assets/e5f91861-a381-4e68-8d01-41415379de63" />
 
La raison pour laquelle les jobs de copie de RDV ont bien retry, c'est qu'il ont reçu une erreur 500 avec du HTML, et donc le `JSON.parse` a échoué. 

# Solution

## Retourner du JSON

J'ajoute donc ici un `rescue_from StandardError` dans notre controller d'API de base, qui render un erreur générique pour les 500 (j'ai choisi de ne pas renvoyer le message de l'exception via API par souci de sécurité, mais on pourrait).

## Migration CoNum

J'ai ajouté une gestion d'erreur correcte dans `RdvServicePublicApiClient`, qui lève désormais une exception en cas de réponse 4xx ou 5xx (middleware Faraday `:raise_error`).