### PR TITLE
Amélioration de l’ordre d’affichage des RDV côté usager

### DIFF
--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -14,8 +14,11 @@ class Users::RdvsController < UserAuthController
   def index
     authorize(Rdv, policy_class: User::RdvPolicy)
     @rdvs = policy_scope(Rdv, policy_scope_class: User::RdvPolicy::Scope).includes(:motif, :participations, :users).user_with_relatives(current_user.id).for_domain(current_domain)
-    @rdvs = params[:past].present? ? @rdvs.past : @rdvs.future
-    @rdvs = @rdvs.order(starts_at: :desc).page(page_number)
+    @rdvs = if params[:past].present?
+              @rdvs.past.order(starts_at: :desc).page(page_number)
+            else
+              @rdvs.future.order(:starts_at).page(page_number)
+            end
   end
 
   def create

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -17,7 +17,7 @@ class Users::RdvsController < UserAuthController
     @rdvs = if params[:past].present?
               @rdvs.past.order(starts_at: :desc).page(page_number)
             else
-              @rdvs.future.order(:starts_at).page(page_number)
+              @rdvs.future.order(starts_at: :asc).page(page_number)
             end
   end
 


### PR DESCRIPTION
# Contexte

Suite à un retour d’un agent, je change l’ordre d’apparition des rendez-vous côté usager.
En effet, nous affichions le rendez-vous le plus loin dans le temps en premier, ce qui ne partait pas cohérent pour les rendez-vous futurs.

# Solution

Pour les rendez-vous passés : pas de changement
Pour les rendez-vous futurs : on met le rendez-vous le plus proche en premier
