### PR TITLE
Stocker en base le fait que les agents ont le 2FA activé

### DIFF
--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -187,6 +187,7 @@ class ProConnectController < ApplicationController
       first_name: callback_client.user_first_name,
       last_name: callback_client.user_last_name,
       proconnect_siret: callback_client.user_siret,
+      pro_connect_2fa_active: callback_client.went_through_2fa?,
       invitation_token: nil, # Pour désactiver les anciens liens d'invitation
       invitation_accepted_at: agent.invitation_accepted_at || Time.zone.now,
       confirmed_at: agent.confirmed_at || Time.zone.now,

--- a/app/dashboards/agent_dashboard.rb
+++ b/app/dashboards/agent_dashboard.rb
@@ -22,6 +22,7 @@ class AgentDashboard < Administrate::BaseDashboard
     rdvs: Field::HasMany.with_options(sort_by: :starts_at, direction: :desc),
     invitation_sent_at: Field::DateTime,
     pro_connect_openid_sub: Field::String,
+    pro_connect_2fa_active: Field::Boolean,
     deleted_at: Field::DateTime,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -53,6 +54,7 @@ class AgentDashboard < Administrate::BaseDashboard
     rdvs
     invitation_sent_at
     pro_connect_openid_sub
+    pro_connect_2fa_active
     created_at
     deleted_at
     updated_at

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -12,7 +12,7 @@ class Agent < ApplicationRecord
     only: %w[
       email unconfirmed_email
       first_name last_name
-      pro_connect_openid_sub proconnect_siret
+      pro_connect_openid_sub proconnect_siret pro_connect_2fa_active
       invitation_sent_at invitation_accepted_at deleted_at
     ]
   )

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -103,6 +103,7 @@ tables:
       - refresh_microsoft_graph_token
       - remember_created_at
       - pro_connect_openid_sub
+      - pro_connect_2fa_active
     non_anonymized_column_names:
       - reset_password_sent_at
       - last_sign_in_at

--- a/db/migrate/20251230134819_add_proconnect2fa_active_to_agents.rb
+++ b/db/migrate/20251230134819_add_proconnect2fa_active_to_agents.rb
@@ -1,0 +1,5 @@
+class AddProconnect2faActiveToAgents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :agents, :pro_connect_2fa_active, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_01_130457) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_30_134819) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -153,6 +153,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_01_130457) do
     t.datetime "blog_read_at"
     t.string "pro_connect_openid_sub"
     t.string "caldav_sync_token"
+    t.boolean "pro_connect_2fa_active"
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -120,12 +120,13 @@ RSpec.describe ProConnectController do
     end
 
     describe "agent login" do
-      def expect_agent_to_be_updated_and_logged_in(agent)
+      def expect_agent_to_be_updated_and_logged_in(agent, with_2fa: false)
         expected_attrs = {
           pro_connect_openid_sub: user_info["sub"],
           email: user_info["email"],
           first_name: "Francis",
           last_name: "Factice",
+          pro_connect_2fa_active: with_2fa,
         }
         expect(agent).to have_attributes(expected_attrs)
         expect(current_agent_id).to eq(agent.id)
@@ -219,6 +220,18 @@ RSpec.describe ProConnectController do
           expect(sentry_events.last.extra).to eq({ user_info: })
           expect(sentry_events.last.user[:email]).to eq(user_info["email"])
           expect(current_agent_id).to be_nil
+        end
+      end
+
+      context "when logging in with 2FA enabled" do
+        before do
+          ProConnectStubs.stub_callback_requests(code, user_info, with_2fa: true)
+        end
+
+        it "sets pro_connect_2fa_active to true" do
+          agent = create(:agent, email: user_info["email"])
+          get :callback, params: { state:, code: }
+          expect_agent_to_be_updated_and_logged_in(agent.reload, with_2fa: true)
         end
       end
     end


### PR DESCRIPTION
# Contexte

Afin de renforcer la sécurité, nous souhaitons sensibiliser/inciter les agents à activer voir la double authentification sur leur compte ProConnect. 
On commence donc par récupérer l’information au moment de la connexion.

Dans des futurs PR, nous pourrons mettre en place des mesures pour les agents sans 2FA (notamment les admins).


