### PR TITLE
Correction de l’affichage des listes à item uniques avec le DSFR

### DIFF
--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -186,3 +186,8 @@
 .rdv-border-color-blue-france {
   border-color: var(--blue-france-main-525);
 }
+
+.rdv-list-unstyled {
+  list-style: none;
+  padding-left: 0 !important;
+}

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -186,8 +186,3 @@
 .rdv-border-color-blue-france {
   border-color: var(--blue-france-main-525);
 }
-
-.rdv-list-unstyled {
-  list-style: none;
-  padding-left: 0 !important;
-}

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -1,10 +1,12 @@
 - if model.respond_to?(:errors_are_all_benign?) && model.errors_are_all_benign?
   / warnings only appear if there are no other errors
   .fr-alert.fr-alert--warning.fr-mb-2w
-    ul.fr-mb-0[class="#{"list-unstyled rdv-list-unstyled" if model.benign_errors&.count == 1}"]
-      - model.benign_errors.each do |msg|
-        li
-          = msg
+    - if model.benign_errors&.count == 1
+      = model.benign_errors.first
+    - else
+      ul.fr-mb-0
+        - model.benign_errors.each do |msg|
+          li= msg
 
   - if local_assigns[:f]
     .collapse.show.js-collapse-warning-confirmation
@@ -23,6 +25,9 @@
 - elsif model.errors.any?
   .fr-alert.fr-alert--error.fr-mb-1w
     - error_messages = errors_full_messages(model).uniq
-    ul.fr-m-0.fr-pl-2w[class="#{"list-unstyled rdv-list-unstyled" if error_messages.count == 1}"]
-      - error_messages.each do |msg|
-        li= msg
+    - if error_messages.count == 1
+      = error_messages.first
+    - else
+      ul.fr-m-0.fr-pl-2w
+        - error_messages.each do |msg|
+          li= msg

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -1,7 +1,7 @@
 - if model.respond_to?(:errors_are_all_benign?) && model.errors_are_all_benign?
   / warnings only appear if there are no other errors
   .fr-alert.fr-alert--warning.fr-mb-2w
-    ul.fr-mb-0[class="#{"list-unstyled" if model.benign_errors&.count == 1}"]
+    ul.fr-mb-0[class="#{"list-unstyled rdv-list-unstyled" if model.benign_errors&.count == 1}"]
       - model.benign_errors.each do |msg|
         li
           = msg
@@ -23,6 +23,6 @@
 - elsif model.errors.any?
   .fr-alert.fr-alert--error.fr-mb-1w
     - error_messages = errors_full_messages(model).uniq
-    ul.fr-m-0.fr-pl-2w[class="#{"list-unstyled" if error_messages.count == 1}"]
+    ul.fr-m-0.fr-pl-2w[class="#{"list-unstyled rdv-list-unstyled" if error_messages.count == 1}"]
       - error_messages.each do |msg|
         li= msg


### PR DESCRIPTION
# Contexte

J’aimerais réutiliser le partial `model_errors` côté usager dans #5962 et il s’affiche bizarrement quand il y a une seul erreur.

# Solution

J’ai d’abord ré-implémenté list-unstyled pour fonctionner sans bootstrap / avec le DSFR

puis je me suis dit qu’en fait ça n’avait pas de sens d’afficher une liste avec un unique point donc j’ai plutôt changé l’affichage complètement.

J’ai fait un tour sur des formulaires côté agent et côté usagers, ça a l’air OK 

## Captures d'écran

<img width="1799" height="655" alt="image" src="https://github.com/user-attachments/assets/c357dd29-3d73-43b3-aa6d-58101fe33792" />
