### PR TITLE
Ajout de specs pour AgendaChannel

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -96,7 +96,7 @@ class Rdv < ApplicationRecord
     refresh_periods = [[starts_at, ends_at]]
     refresh_periods.push([starts_at_previously_was, ends_at_previously_was]) if starts_at_previously_changed? || ends_at_previously_changed?
 
-    (agent_ids + (@agent_ids_before_change || [])).uniq.each do |agent_id|
+    (agent_ids_from_db + (@agent_ids_before_change || [])).uniq.each do |agent_id|
       AgendaChannel.broadcast_to(agent_id, model: "Rdv", refresh_periods:)
     end
   end
@@ -396,6 +396,10 @@ class Rdv < ApplicationRecord
 
   private
 
+  def agent_ids_from_db
+    AgentsRdv.where(rdv_id: id).pluck(:agent_id).uniq
+  end
+
   def update_collective_rdv_status
     revoked! if participations.none?(&:unknown?) && in_the_past?
   end
@@ -430,8 +434,8 @@ class Rdv < ApplicationRecord
 
   def virtual_attributes_for_paper_trail
     {
-      user_ids: users.ids,
-      agent_ids: agents.ids,
+      user_ids: participations.load.map(&:user_id),
+      agent_ids: agent_ids,
       participations: participations.map do |participation|
         participation.slice(
           :user_id,

--- a/spec/channels/application_cable/agenda_channel_spec.rb
+++ b/spec/channels/application_cable/agenda_channel_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe AgendaChannel do
     expect(subscription).to be_rejected
   end
 
-  it "rejects subscription and warsn Sentry on unexpected error" do
+  it "rejects subscription and warns Sentry on unexpected error" do
     allow(Agent::AgentPolicy::Scope).to receive(:new).and_raise("woops")
     subscribe
     expect(subscription).to be_rejected

--- a/spec/channels/application_cable/agenda_channel_spec.rb
+++ b/spec/channels/application_cable/agenda_channel_spec.rb
@@ -30,4 +30,62 @@ RSpec.describe AgendaChannel do
     expect(subscription).to be_rejected
     expect(sentry_events.last.exception.values.first.value).to eq("woops (RuntimeError)")
   end
+
+  describe "broadcasts" do
+    it "fires on Rdv creation, update and deletion" do
+      rdv_agent = create(:agent)
+      rdv = nil
+      expect do
+        rdv = create(:rdv, agents: [rdv_agent])
+      end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class)
+
+      expect do
+        rdv.update!(starts_at: 4.days.from_now)
+      end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class)
+
+      expect do
+        rdv.destroy!
+      end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class)
+    end
+
+    it "fires when adding, updating or removing a participation" do
+      rdv_agent = create(:agent)
+      rdv = create(:rdv, agents: [rdv_agent])
+
+      expect do
+        create(:participation, rdv:)
+      end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class)
+
+      expect do
+        rdv.participations.last.update!(status: "seen")
+      end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class)
+
+      expect do
+        rdv.participations.last.destroy!
+      end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class)
+    end
+
+    it "fires when adding, updating or removing an AgentsRdv" do
+      org = create(:organisation)
+      rdv_agent = create(:agent, organisations: [org])
+      colleague = create(:agent, organisations: [org])
+      rdv = create(:rdv, agents: [rdv_agent])
+
+      expect do
+        create(:agents_rdv, rdv:, agent: colleague)
+      end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class).and(
+        have_broadcasted_to(colleague.id).from_channel(described_class)
+      )
+
+      expect do
+        rdv.agents_rdvs.last.update!(agent_id: current_agent.id)
+      end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class).and(
+        have_broadcasted_to(colleague.id).from_channel(described_class)
+      )
+
+      expect do
+        rdv.agents_rdvs.last.destroy!
+      end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class)
+    end
+  end
 end

--- a/spec/channels/application_cable/agenda_channel_spec.rb
+++ b/spec/channels/application_cable/agenda_channel_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe AgendaChannel, action_cable: :test do
+  let!(:current_agent) { create(:agent) }
+
+  before do
+    # initialize connection with identifiers
+    stub_connection current_agent:
+  end
+
+  it "subscribes when passing the ID of an agent within scope" do
+    colleague = create(:agent, organisations: [create(:organisation, agents: [current_agent])])
+    subscribe(agent_id: colleague.id)
+    expect(subscription).to be_confirmed
+    expect(subscription).to have_stream_from("agenda:#{colleague.id}")
+  end
+
+  it "rejects subscription when passing the ID of an agent outside scope" do
+    not_a_colleague = create(:agent, organisations: [create(:organisation)])
+    subscribe(agent_id: not_a_colleague.id)
+    expect(subscription).to be_rejected
+  end
+
+  it "rejects subscription when passing no agent_id" do
+    subscribe
+    expect(subscription).to be_rejected
+  end
+
+  it "rejects subscription and warsn Sentry on unexpected error" do
+    allow(Agent::AgentPolicy::Scope).to receive(:new).and_raise("woops")
+    subscribe
+    expect(subscription).to be_rejected
+    expect(sentry_events.last.exception.values.first.value).to eq("woops (RuntimeError)")
+  end
+end

--- a/spec/channels/application_cable/agenda_channel_spec.rb
+++ b/spec/channels/application_cable/agenda_channel_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe AgendaChannel, action_cable: :test do
+RSpec.describe AgendaChannel do
   let!(:current_agent) { create(:agent) }
 
   before do


### PR DESCRIPTION
Je n'avais pas pris le temps de rédiger des specs pour couvrir `AgendaChannel` dans #5873.

Je le fais donc ici en m'aidant de ce beau guide : 
https://github.com/palkan/action-cable-testing?tab=readme-ov-file#rspec-usage