### PR TITLE
Empêcher que plusieurs jobs à haute consommation de RAM ne s'exécutent en même temps

### DIFF
--- a/app/jobs/participations_export_send_email_job.rb
+++ b/app/jobs/participations_export_send_email_job.rb
@@ -1,4 +1,11 @@
 class ParticipationsExportSendEmailJob < ExportJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    perform_limit: 1,
+    key: -> { "high_ram_usage_export" }
+  )
+
   def perform(batch, _params)
     export = Export.find(batch.properties[:export_id])
 

--- a/app/jobs/rdvs_export_send_email_job.rb
+++ b/app/jobs/rdvs_export_send_email_job.rb
@@ -1,4 +1,11 @@
 class RdvsExportSendEmailJob < ExportJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(
+    perform_limit: 1,
+    key: -> { "high_ram_usage_export" }
+  )
+
   def perform(batch, _params)
     export = Export.find(batch.properties[:export_id])
 


### PR DESCRIPTION
Contexte : Nous avons eu il y a deux semaines de gros soucis de swap sur des exports de 350 000 à 400 000 RDV. 

Un problème était qu'un worker prenait deux gros jobs à la fois et donc il n'avais pas assez de RAM. Je propose de mettre une limite d'exécution concurrente du job en place en complément des optimisations de #5968.