### PR TITLE
[API] Ajouter la durée du motif dans le blueprint des motifs

### DIFF
--- a/app/blueprints/motif_blueprint.rb
+++ b/app/blueprints/motif_blueprint.rb
@@ -1,6 +1,6 @@
 class MotifBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :location_type, :deleted_at, :bookable_publicly, :service_id, :organisation_id, :collectif, :follow_up, :instruction_for_rdv, :bookable_by
+  fields :name, :location_type, :deleted_at, :bookable_publicly, :service_id, :organisation_id, :collectif, :follow_up, :instruction_for_rdv, :bookable_by, :default_duration_in_minutes
   association :motif_category, blueprint: MotifCategoryBlueprint
 end

--- a/app/blueprints/motif_blueprint.rb
+++ b/app/blueprints/motif_blueprint.rb
@@ -1,6 +1,6 @@
 class MotifBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :location_type, :deleted_at, :bookable_publicly, :service_id, :organisation_id, :collectif, :follow_up, :instruction_for_rdv, :bookable_by, :default_duration_in_minutes
+  fields :name, :location_type, :deleted_at, :bookable_publicly, :service_id, :organisation_id, :collectif, :follow_up, :instruction_for_rdv, :bookable_by, :default_duration_in_min
   association :motif_category, blueprint: MotifCategoryBlueprint
 end

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -1291,20 +1291,20 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 14,
+                        "id": 12,
                         "agent": {
-                          "id": 300,
+                          "id": 15,
                           "email": "agent@example.com",
-                          "first_name": "Briac",
-                          "last_name": "Schmitt"
+                          "first_name": "Althée",
+                          "last_name": "Guillot"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T135606Z\r\nUID:absence_14@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/194/planning/absences/14/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Super absence\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_14@RDV Solidarités",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142249Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/12/planning/absences/12/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Super absence\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_12@RDV Solidarités",
                         "organisation": {
-                          "id": 194,
+                          "id": 12,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1476,20 +1476,20 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 23,
+                        "id": 21,
                         "agent": {
-                          "id": 318,
+                          "id": 33,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Léopold",
-                          "last_name": "Nicolas"
+                          "first_name": "Amaranthe",
+                          "last_name": "Nguyen"
                         },
-                        "end_day": "2026-01-08",
+                        "end_day": "2026-01-07",
                         "end_time": "15:30:00",
-                        "first_day": "2026-01-08",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T135607Z\r\nUID:absence_23@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260108T100000\r\nDTEND;TZID=Europe/Paris:20260108T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/208/planning/absences/23/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Indisponibilité 1\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_23@RDV Solidarités",
+                        "first_day": "2026-01-07",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142249Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/26/planning/absences/21/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Indisponibilité 1\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_21@RDV Solidarités",
                         "organisation": {
-                          "id": 208,
+                          "id": 26,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1683,20 +1683,20 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 35,
+                        "id": 33,
                         "agent": {
-                          "id": 330,
+                          "id": 45,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Léopold",
-                          "last_name": "Dvnis"
+                          "first_name": "Coralie",
+                          "last_name": "Chevallier"
                         },
-                        "end_day": "2026-01-08",
+                        "end_day": "2026-01-07",
                         "end_time": "15:30:00",
-                        "first_day": "2026-01-08",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T135608Z\r\nUID:absence_35@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260108T100000\r\nDTEND;TZID=Europe/Paris:20260108T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/220/planning/absences/35/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Nouveau titre\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_35@RDV Solidarités",
+                        "first_day": "2026-01-07",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142250Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/38/planning/absences/33/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Nouveau titre\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_33@RDV Solidarités",
                         "organisation": {
-                          "id": 220,
+                          "id": 38,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1981,10 +1981,10 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 354,
+                          "id": 69,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Ulrich",
-                          "last_name": "Bailly"
+                          "first_name": "Régine",
+                          "last_name": "Renault"
                         }
                       ],
                       "meta": {
@@ -2203,12 +2203,12 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 138,
+                      "id": 2,
                       "address": "77 avenue de Ségur, 75015 Paris",
                       "latitude": 44.5569244,
                       "longitude": 4.7521632,
                       "name": "Maison France Service de Montreuil",
-                      "organisation_id": 258,
+                      "organisation_id": 76,
                       "phone_number": "01 22 33 44 55",
                       "single_use": false
                     }
@@ -2325,42 +2325,40 @@
                     "value": {
                       "motifs": [
                         {
-                          "id": 136,
+                          "id": 7,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
-                          "default_duration_in_min": 45,
                           "deleted_at": null,
                           "follow_up": false,
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 109,
+                            "id": 7,
                             "name": "Catégorie de motif n°1",
                             "short_name": "1_motif_cat"
                           },
                           "name": "Motif 1",
-                          "organisation_id": 264,
-                          "service_id": 39
+                          "organisation_id": 82,
+                          "service_id": 19
                         },
                         {
-                          "id": 137,
+                          "id": 8,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
-                          "default_duration_in_min": 45,
                           "deleted_at": null,
                           "follow_up": false,
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 110,
+                            "id": 8,
                             "name": "Catégorie de motif n°2",
                             "short_name": "2_motif_cat"
                           },
                           "name": "Motif 2",
-                          "organisation_id": 264,
-                          "service_id": 39
+                          "organisation_id": 82,
+                          "service_id": 19
                         }
                       ],
                       "meta": {
@@ -2485,7 +2483,7 @@
                     "value": {
                       "organisations": [
                         {
-                          "id": 299,
+                          "id": 117,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -2493,7 +2491,7 @@
                           "website": null
                         },
                         {
-                          "id": 300,
+                          "id": 118,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
@@ -2501,7 +2499,7 @@
                           "website": null
                         },
                         {
-                          "id": 301,
+                          "id": 119,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
@@ -2509,7 +2507,7 @@
                           "website": null
                         },
                         {
-                          "id": 302,
+                          "id": 120,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
@@ -2517,7 +2515,7 @@
                           "website": null
                         },
                         {
-                          "id": 303,
+                          "id": 121,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
@@ -2636,7 +2634,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 310,
+                        "id": 128,
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
@@ -2746,7 +2744,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 314,
+                        "id": 132,
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
@@ -2857,12 +2855,12 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 11,
-                        "created_at": "2026-01-07 14:56:14 +0100",
+                        "id": 2,
+                        "created_at": "2026-01-06 15:22:54 +0100",
                         "rdv": null,
-                        "updated_at": "2026-01-07 14:56:14 +0100",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/11",
-                        "user_id": 92
+                        "updated_at": "2026-01-06 15:22:54 +0100",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/2",
+                        "user_id": 8
                       }
                     }
                   }
@@ -2971,17 +2969,17 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 13,
-                        "created_at": "2026-01-07 14:56:14 +0100",
+                        "id": 4,
+                        "created_at": "2026-01-06 15:22:54 +0100",
                         "rdv": {
-                          "id": 29,
+                          "id": 5,
                           "status": "unknown",
-                          "starts_at": "2026-01-10 14:56:00 +0100",
+                          "starts_at": "2026-01-09 15:22:00 +0100",
                           "location_type": "public_office"
                         },
-                        "updated_at": "2026-01-07 14:56:14 +0100",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/13",
-                        "user_id": 96
+                        "updated_at": "2026-01-06 15:22:54 +0100",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/4",
+                        "user_id": 12
                       }
                     }
                   }
@@ -3063,15 +3061,15 @@
           {
             "name": "status",
             "in": "query",
-            "description": "Filtre les rendez-vous par statut.\nVous pouvez passer soit une seule chaine de caractères, soit un tableau de chaines de caractères.\nLes différentes valeurs possibles sont [\"unknown\", \"seen\", \"excused\", \"revoked\", \"noshow\"].\nSi vous passez un tableau, le format attendu est status[]=excused&status[]=revoked\n",
-            "example": "seen ou status[]=excused&status[]=revoked",
+            "description": "Filtre les rendez-vous par statut.\nVous pouvez passer soit une seule chaine de caractères, soit un tableau de chaines de caractères.\nLes différentes valeurs possibles sont [\"unknown\", \"seen\", \"excused\", \"revoked\", \"noshow\"].\nSi vous passez un tableau, vous pouvez utiliser le format `status[]=excused&status[]=revoked` ou `status=excused,revoked`.\n",
+            "example": "seen ou status[]=excused&status[]=revoked ou status=excused,revoked",
             "required": false
           },
           {
             "name": "id",
             "in": "query",
-            "description": "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.\nVous pouvez passer soit un tableau d'entier pour obtenir plusieurs rdvs, soit un seul entier pour obtenir un seul rdv.\nSi vous passez un tableau d'entier, le format attendu est id[]=1234&id[]=5678\n",
-            "example": "789 ou id[]=1234&id[]=5678",
+            "description": "Filtre pour obtenir uniquement les rendez-vous dont l'id est dans cette liste.\nVous pouvez passer soit un tableau d'entier pour obtenir plusieurs rdvs, soit un seul entier pour obtenir un seul rdv.\nSi vous passez un tableau d'entier, le format attendu est\nSi vous passez un tableau, vous pouvez utiliser le format id[]=1234&id[]=5678 ou id=1234,5678.\n",
+            "example": "789 ou id[]=1234&id[]=5678 id=1234,5678",
             "required": false
           },
           {
@@ -3099,7 +3097,7 @@
           "RDV"
         ],
         "operationId": "getRdvs",
-        "description": "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres facultatifs passés en paramètre",
+        "description": "Renvoie les RDVs visibles pour l'agent authentifié, en appliquant les filtres facultatifs passés en paramètre. <br /> Par défaut, toutes les associations disponibles sont renvoyées (participants, agents, motif, etc...), ce qui peut considérablement ralentir le temps de réponse. Vous pouvez passer le paramètre `include` pour choisir quelles associations inclure dans la réponse. Il prend un tableau de chaines de caractères, et les valeurs possibles sont : <ul> <li>organisation</li> <li>lieu</li> <li>motifs</li> <li>agents</li> <li>users</li> <li>participations</li> </ul> Par exemple, vous pouvez passer `include[]=agents&include[]=users` ou `include=agents,users` en query params.",
         "responses": {
           "200": {
             "description": "Appel API réussi",
@@ -3110,58 +3108,57 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 30,
+                          "id": 6,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 426,
+                              "id": 141,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Andrée",
-                              "last_name": "Petit"
+                              "first_name": "Florent",
+                              "last_name": "Mercier"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-07 14:56:15 +0100",
+                          "created_at": "2026-01-06 15:22:54 +0100",
                           "created_by": "agent",
-                          "created_by_id": 426,
+                          "created_by_id": 141,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 144,
+                            "id": 8,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 352,
+                            "organisation_id": 170,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 179,
+                            "id": 50,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
-                            "default_duration_in_min": 45,
                             "deleted_at": null,
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 152,
+                              "id": 50,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 352,
-                            "service_id": 60
+                            "organisation_id": 170,
+                            "service_id": 40
                           },
                           "name": null,
                           "organisation": {
-                            "id": 352,
+                            "id": 170,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3170,32 +3167,32 @@
                           },
                           "participations": [
                             {
-                              "id": 33,
+                              "id": 9,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 426,
+                              "created_by_id": 141,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 97,
+                                "id": 13,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-07 14:56:15 +0100",
+                                "created_at": "2026-01-06 15:22:54 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Patrice",
+                                "first_name": "Chrysole",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "JOLY",
+                                "last_name": "LE GALL",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "623459591",
-                                "phone_number_formatted": "+33623459591",
+                                "phone_number": "7 70 91 44 97",
+                                "phone_number_formatted": "+33770914497",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3204,33 +3201,33 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/30",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/6",
                           "users": [
                             {
-                              "id": 97,
+                              "id": 13,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-07 14:56:15 +0100",
+                              "created_at": "2026-01-06 15:22:54 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Patrice",
+                              "first_name": "Chrysole",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "JOLY",
+                              "last_name": "LE GALL",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "623459591",
-                              "phone_number_formatted": "+33623459591",
+                              "phone_number": "7 70 91 44 97",
+                              "phone_number_formatted": "+33770914497",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "38397589-0c51-481b-9bc5-5fdfa0e9dd1d"
+                          "uuid": "6383d3b9-98f3-4ec5-9279-aeef43b74079"
                         }
                       ],
                       "meta": {
@@ -3356,58 +3353,57 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 35,
+                          "id": 11,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 433,
+                              "id": 148,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Chrysostome",
-                              "last_name": "Dufour"
+                              "first_name": "Gédéon",
+                              "last_name": "Mallet"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-07 14:56:15 +0100",
+                          "created_at": "2026-01-06 15:22:55 +0100",
                           "created_by": "agent",
-                          "created_by_id": 433,
+                          "created_by_id": 148,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 149,
+                            "id": 13,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 355,
+                            "organisation_id": 173,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 185,
+                            "id": 56,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
-                            "default_duration_in_min": 45,
                             "deleted_at": null,
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 158,
+                              "id": 56,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 355,
-                            "service_id": 63
+                            "organisation_id": 173,
+                            "service_id": 43
                           },
                           "name": null,
                           "organisation": {
-                            "id": 355,
+                            "id": 173,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3416,32 +3412,32 @@
                           },
                           "participations": [
                             {
-                              "id": 38,
+                              "id": 14,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 433,
+                              "created_by_id": 148,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 102,
+                                "id": 18,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-07 14:56:15 +0100",
+                                "created_at": "2026-01-06 15:22:55 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Bastien",
+                                "first_name": "Armandine",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "LUCAS",
+                                "last_name": "ROUSSEL",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "7 43 28 83 36",
-                                "phone_number_formatted": "+33743288336",
+                                "phone_number": "6 60 77 38 60",
+                                "phone_number_formatted": "+33660773860",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3450,87 +3446,86 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/35",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/11",
                           "users": [
                             {
-                              "id": 102,
+                              "id": 18,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-07 14:56:15 +0100",
+                              "created_at": "2026-01-06 15:22:55 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Bastien",
+                              "first_name": "Armandine",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "LUCAS",
+                              "last_name": "ROUSSEL",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "7 43 28 83 36",
-                              "phone_number_formatted": "+33743288336",
+                              "phone_number": "6 60 77 38 60",
+                              "phone_number_formatted": "+33660773860",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "301d34c1-893c-428d-af5a-b1723f52c6ec"
+                          "uuid": "97a3de97-1822-4d4a-b42b-8dde8a597b9a"
                         },
                         {
-                          "id": 38,
+                          "id": 14,
                           "address": "4 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 436,
+                              "id": 151,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Alain",
-                              "last_name": "Marchal"
+                              "first_name": "Emmelie",
+                              "last_name": "David"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-07 14:56:15 +0100",
+                          "created_at": "2026-01-06 15:22:55 +0100",
                           "created_by": "agent",
-                          "created_by_id": 436,
+                          "created_by_id": 151,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2024-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 152,
+                            "id": 16,
                             "address": "4 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°4",
-                            "organisation_id": 355,
+                            "organisation_id": 173,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 189,
+                            "id": 60,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
-                            "default_duration_in_min": 45,
                             "deleted_at": null,
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 162,
+                              "id": 60,
                               "name": "Catégorie de motif n°5",
                               "short_name": "5_motif_cat"
                             },
                             "name": "Motif 5",
-                            "organisation_id": 355,
+                            "organisation_id": 173,
                             "service_id": null
                           },
                           "name": null,
                           "organisation": {
-                            "id": 355,
+                            "id": 173,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3539,32 +3534,32 @@
                           },
                           "participations": [
                             {
-                              "id": 41,
+                              "id": 17,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 436,
+                              "created_by_id": 151,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 105,
+                                "id": 21,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-07 14:56:15 +0100",
+                                "created_at": "2026-01-06 15:22:55 +0100",
                                 "email": "usager_4@lapin.fr",
-                                "first_name": "Laurine",
+                                "first_name": "Narcisse",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "ROCHE",
+                                "last_name": "REYNAUD",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "0655044431",
-                                "phone_number_formatted": "+33655044431",
+                                "phone_number": "651303455",
+                                "phone_number_formatted": "+33651303455",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3573,33 +3568,33 @@
                           ],
                           "starts_at": "2024-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/38",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/14",
                           "users": [
                             {
-                              "id": 105,
+                              "id": 21,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-07 14:56:15 +0100",
+                              "created_at": "2026-01-06 15:22:55 +0100",
                               "email": "usager_4@lapin.fr",
-                              "first_name": "Laurine",
+                              "first_name": "Narcisse",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "ROCHE",
+                              "last_name": "REYNAUD",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "0655044431",
-                              "phone_number_formatted": "+33655044431",
+                              "phone_number": "651303455",
+                              "phone_number_formatted": "+33651303455",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "ae86bb78-719b-44ba-99bb-1dc3bf3d180f"
+                          "uuid": "b682efe9-b19a-412d-9c67-f6e3db780bb9"
                         }
                       ],
                       "meta": {
@@ -3816,29 +3811,29 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 555,
+                          "id": 270,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Noëlle",
-                          "last_name": "Moreau"
+                          "first_name": "Guérin",
+                          "last_name": "Legrand"
                         },
                         "user": {
-                          "id": 197,
+                          "id": 113,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 14:56:25 +0100",
+                          "created_at": "2026-01-06 15:23:00 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Anceline",
+                          "first_name": "Ombline",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MORIN",
+                          "last_name": "LEVEQUE",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "7 91 25 30 09",
-                          "phone_number_formatted": "+33791253009",
+                          "phone_number": "07 49 59 08 84",
+                          "phone_number_formatted": "+33749590884",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4091,27 +4086,27 @@
                           "id": 5,
                           "agents": [
                             {
-                              "id": 587,
+                              "id": 302,
                               "email": "agent_2@lapin.fr",
-                              "first_name": "Artémis",
-                              "last_name": "Lemaire"
+                              "first_name": "Maguelone",
+                              "last_name": "Weber"
                             },
                             {
-                              "id": 588,
+                              "id": 303,
                               "email": "agent_3@lapin.fr",
-                              "first_name": "Savinien",
-                              "last_name": "Gauthier"
+                              "first_name": "Mathilde",
+                              "last_name": "Collin"
                             },
                             {
-                              "id": 589,
+                              "id": 304,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Ambroisie",
-                              "last_name": "Robin"
+                              "first_name": "Zénobe",
+                              "last_name": "Fontaine"
                             }
                           ],
-                          "name": "Martinique lycanthropes ee10aab3",
+                          "name": "Champagne-Ardenne buffalo b681b280",
                           "territory": {
-                            "id": 375,
+                            "id": 234,
                             "departement_number": "01",
                             "motif_categories": [],
                             "name": "Espace n°1"
@@ -4228,7 +4223,7 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 420,
+                          "id": 238,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -4236,23 +4231,23 @@
                           "website": null
                         },
                         "user": {
-                          "id": 213,
+                          "id": 129,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 14:56:27 +0100",
+                          "created_at": "2026-01-06 15:23:02 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Eugénie",
+                          "first_name": "Philibert",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "BLANCHARD",
+                          "last_name": "GUILLOT",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "07 60 04 08 76",
-                          "phone_number_formatted": "+33760040876",
+                          "phone_number": "649074046",
+                          "phone_number_formatted": "+33649074046",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4537,13 +4532,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 230,
+                        "id": 146,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2026-01-07 14:56:29 +0100",
+                        "created_at": "2026-01-06 15:23:03 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -4552,14 +4547,14 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "0623172447",
-                        "phone_number_formatted": "+33623172447",
+                        "phone_number": "6 18 69 74 08",
+                        "phone_number_formatted": "+33618697408",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 441,
+                              "id": 259,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -4848,13 +4843,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 237,
+                        "id": 153,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2026-01-07 14:56:30 +0100",
+                        "created_at": "2026-01-06 15:23:03 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Alain",
                         "invitation_accepted_at": null,
@@ -4866,28 +4861,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 236,
+                          "id": 152,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 14:56:30 +0100",
+                          "created_at": "2026-01-06 15:23:03 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Tim",
+                          "first_name": "Amaryllis",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LANGLOIS",
+                          "last_name": "LEMAITRE",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "7 30 97 72 78",
-                          "phone_number_formatted": "+33730977278",
+                          "phone_number": "0730968393",
+                          "phone_number_formatted": "+33730968393",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 236,
+                        "responsible_id": 152,
                         "user_profiles": null
                       }
                     }
@@ -5016,7 +5011,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "JIXI4H8L"
+                      "invitation_token": "5RBQLEW7"
                     }
                   }
                 },
@@ -5149,23 +5144,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 264,
+                          "id": 180,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 14:56:31 +0100",
+                          "created_at": "2026-01-06 15:23:04 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Virgile",
+                          "first_name": "Fabien",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MEUNIER",
+                          "last_name": "ANDRÉ",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0788093804",
-                          "phone_number_formatted": "+33788093804",
+                          "phone_number": "0686706215",
+                          "phone_number_formatted": "+33686706215",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5422,13 +5417,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 275,
+                        "id": 191,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2026-01-07 14:56:32 +0100",
+                        "created_at": "2026-01-06 15:23:04 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Johnny",
                         "invitation_accepted_at": null,
@@ -5440,28 +5435,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 274,
+                          "id": 190,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 14:56:32 +0100",
+                          "created_at": "2026-01-06 15:23:04 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Aloïs",
+                          "first_name": "Sylviane",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MICHAUD",
+                          "last_name": "ANTOINE",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "616021139",
-                          "phone_number_formatted": "+33616021139",
+                          "phone_number": "6 72 78 90 58",
+                          "phone_number_formatted": "+33672789058",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 274,
+                        "responsible_id": 190,
                         "user_profiles": null
                       }
                     }
@@ -5601,23 +5596,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 284,
+                          "id": 200,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 14:56:33 +0100",
+                          "created_at": "2026-01-06 15:23:05 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Archibald",
+                          "first_name": "Eubert",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "PONS",
+                          "last_name": "REYNAUD",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "7 77 58 08 91",
-                          "phone_number_formatted": "+33777580891",
+                          "phone_number": "07 98 65 29 65",
+                          "phone_number_formatted": "+33798652965",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5734,13 +5729,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 289,
+                        "id": 205,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2026-01-07 14:56:33 +0100",
+                        "created_at": "2026-01-06 15:23:05 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -5749,14 +5744,14 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "7 37 48 58 97",
-                        "phone_number_formatted": "+33737485897",
+                        "phone_number": "07 87 23 05 13",
+                        "phone_number_formatted": "+33787230513",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 506,
+                              "id": 324,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -6063,8 +6058,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 27,
-                        "organisation_id": 526,
+                        "id": 26,
+                        "organisation_id": 344,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -6260,8 +6255,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 29,
-                        "organisation_id": 533,
+                        "id": 28,
+                        "organisation_id": 351,
                         "subscriptions": [
                           "rdv",
                           "user",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -1291,20 +1291,20 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 66,
+                        "id": 12,
                         "agent": {
-                          "id": 2284,
+                          "id": 15,
                           "email": "agent@example.com",
-                          "first_name": "Lambert",
-                          "last_name": "Reynaud"
+                          "first_name": "Althée",
+                          "last_name": "Guillot"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T140314Z\r\nUID:absence_66@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/793/planning/absences/66/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Super absence\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_66@RDV Solidarités",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142249Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/12/planning/absences/12/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Super absence\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_12@RDV Solidarités",
                         "organisation": {
-                          "id": 793,
+                          "id": 12,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1476,20 +1476,20 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 75,
+                        "id": 21,
                         "agent": {
-                          "id": 2302,
+                          "id": 33,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Brune",
-                          "last_name": "Lejeune"
+                          "first_name": "Amaranthe",
+                          "last_name": "Nguyen"
                         },
-                        "end_day": "2026-01-08",
+                        "end_day": "2026-01-07",
                         "end_time": "15:30:00",
-                        "first_day": "2026-01-08",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T140315Z\r\nUID:absence_75@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260108T100000\r\nDTEND;TZID=Europe/Paris:20260108T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/807/planning/absences/75/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Indisponibilité 1\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_75@RDV Solidarités",
+                        "first_day": "2026-01-07",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142249Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/26/planning/absences/21/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Indisponibilité 1\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_21@RDV Solidarités",
                         "organisation": {
-                          "id": 807,
+                          "id": 26,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1683,20 +1683,20 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 87,
+                        "id": 33,
                         "agent": {
-                          "id": 2314,
+                          "id": 45,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Amiel",
-                          "last_name": "Caron"
+                          "first_name": "Coralie",
+                          "last_name": "Chevallier"
                         },
-                        "end_day": "2026-01-08",
+                        "end_day": "2026-01-07",
                         "end_time": "15:30:00",
-                        "first_day": "2026-01-08",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T140316Z\r\nUID:absence_87@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260108T100000\r\nDTEND;TZID=Europe/Paris:20260108T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/819/planning/absences/87/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Nouveau titre\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_87@RDV Solidarités",
+                        "first_day": "2026-01-07",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142250Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/38/planning/absences/33/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Nouveau titre\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_33@RDV Solidarités",
                         "organisation": {
-                          "id": 819,
+                          "id": 38,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1981,10 +1981,10 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 2338,
+                          "id": 69,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Andy",
-                          "last_name": "Nguyen"
+                          "first_name": "Régine",
+                          "last_name": "Renault"
                         }
                       ],
                       "meta": {
@@ -2203,12 +2203,12 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 417,
+                      "id": 2,
                       "address": "77 avenue de Ségur, 75015 Paris",
                       "latitude": 44.5569244,
                       "longitude": 4.7521632,
                       "name": "Maison France Service de Montreuil",
-                      "organisation_id": 857,
+                      "organisation_id": 76,
                       "phone_number": "01 22 33 44 55",
                       "single_use": false
                     }
@@ -2325,7 +2325,7 @@
                     "value": {
                       "motifs": [
                         {
-                          "id": 458,
+                          "id": 7,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
@@ -2335,16 +2335,16 @@
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 363,
+                            "id": 7,
                             "name": "Catégorie de motif n°1",
                             "short_name": "1_motif_cat"
                           },
                           "name": "Motif 1",
-                          "organisation_id": 863,
-                          "service_id": 177
+                          "organisation_id": 82,
+                          "service_id": 19
                         },
                         {
-                          "id": 459,
+                          "id": 8,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
@@ -2354,13 +2354,13 @@
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 364,
+                            "id": 8,
                             "name": "Catégorie de motif n°2",
                             "short_name": "2_motif_cat"
                           },
                           "name": "Motif 2",
-                          "organisation_id": 863,
-                          "service_id": 177
+                          "organisation_id": 82,
+                          "service_id": 19
                         }
                       ],
                       "meta": {
@@ -2485,7 +2485,7 @@
                     "value": {
                       "organisations": [
                         {
-                          "id": 898,
+                          "id": 117,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -2493,7 +2493,7 @@
                           "website": null
                         },
                         {
-                          "id": 899,
+                          "id": 118,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
@@ -2501,7 +2501,7 @@
                           "website": null
                         },
                         {
-                          "id": 900,
+                          "id": 119,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
@@ -2509,7 +2509,7 @@
                           "website": null
                         },
                         {
-                          "id": 901,
+                          "id": 120,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
@@ -2517,7 +2517,7 @@
                           "website": null
                         },
                         {
-                          "id": 902,
+                          "id": 121,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
@@ -2636,7 +2636,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 909,
+                        "id": 128,
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
@@ -2746,7 +2746,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 913,
+                        "id": 132,
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
@@ -2857,12 +2857,12 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 24,
-                        "created_at": "2026-01-07 15:03:22 +0100",
+                        "id": 2,
+                        "created_at": "2026-01-06 15:22:54 +0100",
                         "rdv": null,
-                        "updated_at": "2026-01-07 15:03:22 +0100",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/24",
-                        "user_id": 421
+                        "updated_at": "2026-01-06 15:22:54 +0100",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/2",
+                        "user_id": 8
                       }
                     }
                   }
@@ -2971,17 +2971,17 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 26,
-                        "created_at": "2026-01-07 15:03:22 +0100",
+                        "id": 4,
+                        "created_at": "2026-01-06 15:22:54 +0100",
                         "rdv": {
-                          "id": 186,
+                          "id": 5,
                           "status": "unknown",
-                          "starts_at": "2026-01-10 15:03:00 +0100",
+                          "starts_at": "2026-01-09 15:22:00 +0100",
                           "location_type": "public_office"
                         },
-                        "updated_at": "2026-01-07 15:03:22 +0100",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/26",
-                        "user_id": 425
+                        "updated_at": "2026-01-06 15:22:54 +0100",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/4",
+                        "user_id": 12
                       }
                     }
                   }
@@ -3110,38 +3110,38 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 187,
+                          "id": 6,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 2410,
+                              "id": 141,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Savinien",
-                              "last_name": "Gaillard"
+                              "first_name": "Florent",
+                              "last_name": "Mercier"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-07 15:03:23 +0100",
+                          "created_at": "2026-01-06 15:22:54 +0100",
                           "created_by": "agent",
-                          "created_by_id": 2410,
+                          "created_by_id": 141,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 423,
+                            "id": 8,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 951,
+                            "organisation_id": 170,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 501,
+                            "id": 50,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3151,17 +3151,17 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 406,
+                              "id": 50,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 951,
-                            "service_id": 198
+                            "organisation_id": 170,
+                            "service_id": 40
                           },
                           "name": null,
                           "organisation": {
-                            "id": 951,
+                            "id": 170,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3170,32 +3170,32 @@
                           },
                           "participations": [
                             {
-                              "id": 193,
+                              "id": 9,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 2410,
+                              "created_by_id": 141,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 426,
+                                "id": 13,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-07 15:03:23 +0100",
+                                "created_at": "2026-01-06 15:22:54 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Louis",
+                                "first_name": "Chrysole",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "CHARLES",
+                                "last_name": "LE GALL",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "0679993072",
-                                "phone_number_formatted": "+33679993072",
+                                "phone_number": "7 70 91 44 97",
+                                "phone_number_formatted": "+33770914497",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3204,33 +3204,33 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/187",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/6",
                           "users": [
                             {
-                              "id": 426,
+                              "id": 13,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-07 15:03:23 +0100",
+                              "created_at": "2026-01-06 15:22:54 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Louis",
+                              "first_name": "Chrysole",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "CHARLES",
+                              "last_name": "LE GALL",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "0679993072",
-                              "phone_number_formatted": "+33679993072",
+                              "phone_number": "7 70 91 44 97",
+                              "phone_number_formatted": "+33770914497",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "5ecb9821-6ec3-4cf2-bc82-fcafd9f7e92a"
+                          "uuid": "6383d3b9-98f3-4ec5-9279-aeef43b74079"
                         }
                       ],
                       "meta": {
@@ -3356,38 +3356,38 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 192,
+                          "id": 11,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 2417,
+                              "id": 148,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Cléandre",
-                              "last_name": "Remy"
+                              "first_name": "Gédéon",
+                              "last_name": "Mallet"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-07 15:03:23 +0100",
+                          "created_at": "2026-01-06 15:22:55 +0100",
                           "created_by": "agent",
-                          "created_by_id": 2417,
+                          "created_by_id": 148,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 428,
+                            "id": 13,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 954,
+                            "organisation_id": 173,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 507,
+                            "id": 56,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3397,17 +3397,17 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 412,
+                              "id": 56,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 954,
-                            "service_id": 201
+                            "organisation_id": 173,
+                            "service_id": 43
                           },
                           "name": null,
                           "organisation": {
-                            "id": 954,
+                            "id": 173,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3416,32 +3416,32 @@
                           },
                           "participations": [
                             {
-                              "id": 198,
+                              "id": 14,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 2417,
+                              "created_by_id": 148,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 431,
+                                "id": 18,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-07 15:03:23 +0100",
+                                "created_at": "2026-01-06 15:22:55 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Zaché",
+                                "first_name": "Armandine",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "BONNET",
+                                "last_name": "ROUSSEL",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "6 44 86 97 33",
-                                "phone_number_formatted": "+33644869733",
+                                "phone_number": "6 60 77 38 60",
+                                "phone_number_formatted": "+33660773860",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3450,67 +3450,67 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/192",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/11",
                           "users": [
                             {
-                              "id": 431,
+                              "id": 18,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-07 15:03:23 +0100",
+                              "created_at": "2026-01-06 15:22:55 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Zaché",
+                              "first_name": "Armandine",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "BONNET",
+                              "last_name": "ROUSSEL",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "6 44 86 97 33",
-                              "phone_number_formatted": "+33644869733",
+                              "phone_number": "6 60 77 38 60",
+                              "phone_number_formatted": "+33660773860",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "4a5acb4c-740f-404a-bc69-9311b933a95b"
+                          "uuid": "97a3de97-1822-4d4a-b42b-8dde8a597b9a"
                         },
                         {
-                          "id": 195,
+                          "id": 14,
                           "address": "4 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 2420,
+                              "id": 151,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Gui",
-                              "last_name": "Boulanger"
+                              "first_name": "Emmelie",
+                              "last_name": "David"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-07 15:03:23 +0100",
+                          "created_at": "2026-01-06 15:22:55 +0100",
                           "created_by": "agent",
-                          "created_by_id": 2420,
+                          "created_by_id": 151,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2024-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 431,
+                            "id": 16,
                             "address": "4 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°4",
-                            "organisation_id": 954,
+                            "organisation_id": 173,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 511,
+                            "id": 60,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3520,17 +3520,17 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 416,
+                              "id": 60,
                               "name": "Catégorie de motif n°5",
                               "short_name": "5_motif_cat"
                             },
                             "name": "Motif 5",
-                            "organisation_id": 954,
+                            "organisation_id": 173,
                             "service_id": null
                           },
                           "name": null,
                           "organisation": {
-                            "id": 954,
+                            "id": 173,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3539,32 +3539,32 @@
                           },
                           "participations": [
                             {
-                              "id": 201,
+                              "id": 17,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 2420,
+                              "created_by_id": 151,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 434,
+                                "id": 21,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-07 15:03:23 +0100",
+                                "created_at": "2026-01-06 15:22:55 +0100",
                                 "email": "usager_4@lapin.fr",
-                                "first_name": "Olive",
+                                "first_name": "Narcisse",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "VIDAL",
+                                "last_name": "REYNAUD",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "7 35 54 44 50",
-                                "phone_number_formatted": "+33735544450",
+                                "phone_number": "651303455",
+                                "phone_number_formatted": "+33651303455",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3573,33 +3573,33 @@
                           ],
                           "starts_at": "2024-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/195",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/14",
                           "users": [
                             {
-                              "id": 434,
+                              "id": 21,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-07 15:03:23 +0100",
+                              "created_at": "2026-01-06 15:22:55 +0100",
                               "email": "usager_4@lapin.fr",
-                              "first_name": "Olive",
+                              "first_name": "Narcisse",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "VIDAL",
+                              "last_name": "REYNAUD",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "7 35 54 44 50",
-                              "phone_number_formatted": "+33735544450",
+                              "phone_number": "651303455",
+                              "phone_number_formatted": "+33651303455",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "f877df81-1c48-43c2-ab17-e25023a41b56"
+                          "uuid": "b682efe9-b19a-412d-9c67-f6e3db780bb9"
                         }
                       ],
                       "meta": {
@@ -3816,29 +3816,29 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 2539,
+                          "id": 270,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Briac",
+                          "first_name": "Guérin",
                           "last_name": "Legrand"
                         },
                         "user": {
-                          "id": 526,
+                          "id": 113,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 15:03:33 +0100",
+                          "created_at": "2026-01-06 15:23:00 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Aloïse",
+                          "first_name": "Ombline",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "SCHMITT",
+                          "last_name": "LEVEQUE",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "06 42 12 99 33",
-                          "phone_number_formatted": "+33642129933",
+                          "phone_number": "07 49 59 08 84",
+                          "phone_number_formatted": "+33749590884",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4088,30 +4088,30 @@
                     "value": {
                       "teams": [
                         {
-                          "id": 13,
+                          "id": 5,
                           "agents": [
                             {
-                              "id": 2571,
+                              "id": 302,
                               "email": "agent_2@lapin.fr",
-                              "first_name": "Ozanne",
-                              "last_name": "Arnaud"
+                              "first_name": "Maguelone",
+                              "last_name": "Weber"
                             },
                             {
-                              "id": 2572,
+                              "id": 303,
                               "email": "agent_3@lapin.fr",
-                              "first_name": "Sabine",
-                              "last_name": "Marchal"
+                              "first_name": "Mathilde",
+                              "last_name": "Collin"
                             },
                             {
-                              "id": 2573,
+                              "id": 304,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Alexine",
-                              "last_name": "Germain"
+                              "first_name": "Zénobe",
+                              "last_name": "Fontaine"
                             }
                           ],
-                          "name": "Centre bees cb0d9fc4",
+                          "name": "Champagne-Ardenne buffalo b681b280",
                           "territory": {
-                            "id": 935,
+                            "id": 234,
                             "departement_number": "01",
                             "motif_categories": [],
                             "name": "Espace n°1"
@@ -4228,7 +4228,7 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 1019,
+                          "id": 238,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -4236,23 +4236,23 @@
                           "website": null
                         },
                         "user": {
-                          "id": 542,
+                          "id": 129,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 15:03:35 +0100",
+                          "created_at": "2026-01-06 15:23:02 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "René",
+                          "first_name": "Philibert",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "GAILLARD",
+                          "last_name": "GUILLOT",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "614233158",
-                          "phone_number_formatted": "+33614233158",
+                          "phone_number": "649074046",
+                          "phone_number_formatted": "+33649074046",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4537,13 +4537,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 559,
+                        "id": 146,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2026-01-07 15:03:37 +0100",
+                        "created_at": "2026-01-06 15:23:03 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -4552,14 +4552,14 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "07 84 04 02 51",
-                        "phone_number_formatted": "+33784040251",
+                        "phone_number": "6 18 69 74 08",
+                        "phone_number_formatted": "+33618697408",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 1040,
+                              "id": 259,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -4848,13 +4848,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 566,
+                        "id": 153,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2026-01-07 15:03:37 +0100",
+                        "created_at": "2026-01-06 15:23:03 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Alain",
                         "invitation_accepted_at": null,
@@ -4866,28 +4866,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 565,
+                          "id": 152,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 15:03:37 +0100",
+                          "created_at": "2026-01-06 15:23:03 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Francette",
+                          "first_name": "Amaryllis",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "DELAUNAY",
+                          "last_name": "LEMAITRE",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0669472546",
-                          "phone_number_formatted": "+33669472546",
+                          "phone_number": "0730968393",
+                          "phone_number_formatted": "+33730968393",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 565,
+                        "responsible_id": 152,
                         "user_profiles": null
                       }
                     }
@@ -5016,7 +5016,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "P79V6E7X"
+                      "invitation_token": "5RBQLEW7"
                     }
                   }
                 },
@@ -5149,23 +5149,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 593,
+                          "id": 180,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 15:03:39 +0100",
+                          "created_at": "2026-01-06 15:23:04 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Gwenaëlle",
+                          "first_name": "Fabien",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "TESSIER",
+                          "last_name": "ANDRÉ",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0756257706",
-                          "phone_number_formatted": "+33756257706",
+                          "phone_number": "0686706215",
+                          "phone_number_formatted": "+33686706215",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5422,13 +5422,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 604,
+                        "id": 191,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2026-01-07 15:03:40 +0100",
+                        "created_at": "2026-01-06 15:23:04 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Johnny",
                         "invitation_accepted_at": null,
@@ -5440,28 +5440,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 603,
+                          "id": 190,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 15:03:40 +0100",
+                          "created_at": "2026-01-06 15:23:04 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Conception",
+                          "first_name": "Sylviane",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "AUBERT",
+                          "last_name": "ANTOINE",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "783212543",
-                          "phone_number_formatted": "+33783212543",
+                          "phone_number": "6 72 78 90 58",
+                          "phone_number_formatted": "+33672789058",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 603,
+                        "responsible_id": 190,
                         "user_profiles": null
                       }
                     }
@@ -5601,23 +5601,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 613,
+                          "id": 200,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-07 15:03:41 +0100",
+                          "created_at": "2026-01-06 15:23:05 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Almine",
+                          "first_name": "Eubert",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "HAMON",
+                          "last_name": "REYNAUD",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "6 47 05 22 14",
-                          "phone_number_formatted": "+33647052214",
+                          "phone_number": "07 98 65 29 65",
+                          "phone_number_formatted": "+33798652965",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5734,13 +5734,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 618,
+                        "id": 205,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2026-01-07 15:03:41 +0100",
+                        "created_at": "2026-01-06 15:23:05 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -5749,14 +5749,14 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "644859877",
-                        "phone_number_formatted": "+33644859877",
+                        "phone_number": "07 87 23 05 13",
+                        "phone_number_formatted": "+33787230513",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 1105,
+                              "id": 324,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -6063,8 +6063,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 58,
-                        "organisation_id": 1125,
+                        "id": 26,
+                        "organisation_id": 344,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -6260,8 +6260,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 60,
-                        "organisation_id": 1132,
+                        "id": 28,
+                        "organisation_id": 351,
                         "subscriptions": [
                           "rdv",
                           "user",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -1291,20 +1291,20 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 12,
+                        "id": 66,
                         "agent": {
-                          "id": 15,
+                          "id": 2284,
                           "email": "agent@example.com",
-                          "first_name": "Althée",
-                          "last_name": "Guillot"
+                          "first_name": "Lambert",
+                          "last_name": "Reynaud"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142249Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/12/planning/absences/12/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Super absence\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_12@RDV Solidarités",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T140314Z\r\nUID:absence_66@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/793/planning/absences/66/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Super absence\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_66@RDV Solidarités",
                         "organisation": {
-                          "id": 12,
+                          "id": 793,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1476,20 +1476,20 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 21,
+                        "id": 75,
                         "agent": {
-                          "id": 33,
+                          "id": 2302,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Amaranthe",
-                          "last_name": "Nguyen"
+                          "first_name": "Brune",
+                          "last_name": "Lejeune"
                         },
-                        "end_day": "2026-01-07",
+                        "end_day": "2026-01-08",
                         "end_time": "15:30:00",
-                        "first_day": "2026-01-07",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142249Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/26/planning/absences/21/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Indisponibilité 1\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_21@RDV Solidarités",
+                        "first_day": "2026-01-08",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T140315Z\r\nUID:absence_75@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260108T100000\r\nDTEND;TZID=Europe/Paris:20260108T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/807/planning/absences/75/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Indisponibilité 1\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_75@RDV Solidarités",
                         "organisation": {
-                          "id": 26,
+                          "id": 807,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1683,20 +1683,20 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 33,
+                        "id": 87,
                         "agent": {
-                          "id": 45,
+                          "id": 2314,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Coralie",
-                          "last_name": "Chevallier"
+                          "first_name": "Amiel",
+                          "last_name": "Caron"
                         },
-                        "end_day": "2026-01-07",
+                        "end_day": "2026-01-08",
                         "end_time": "15:30:00",
-                        "first_day": "2026-01-07",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260106T142250Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260107T100000\r\nDTEND;TZID=Europe/Paris:20260107T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/38/planning/absences/33/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Nouveau titre\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_33@RDV Solidarités",
+                        "first_day": "2026-01-08",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T140316Z\r\nUID:absence_87@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260108T100000\r\nDTEND;TZID=Europe/Paris:20260108T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/819/planning/absences/87/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Nouveau titre\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_87@RDV Solidarités",
                         "organisation": {
-                          "id": 38,
+                          "id": 819,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1981,10 +1981,10 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 69,
+                          "id": 2338,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Régine",
-                          "last_name": "Renault"
+                          "first_name": "Andy",
+                          "last_name": "Nguyen"
                         }
                       ],
                       "meta": {
@@ -2203,12 +2203,12 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 2,
+                      "id": 417,
                       "address": "77 avenue de Ségur, 75015 Paris",
                       "latitude": 44.5569244,
                       "longitude": 4.7521632,
                       "name": "Maison France Service de Montreuil",
-                      "organisation_id": 76,
+                      "organisation_id": 857,
                       "phone_number": "01 22 33 44 55",
                       "single_use": false
                     }
@@ -2325,40 +2325,42 @@
                     "value": {
                       "motifs": [
                         {
-                          "id": 7,
+                          "id": 458,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
+                          "default_duration_in_min": 45,
                           "deleted_at": null,
                           "follow_up": false,
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 7,
+                            "id": 363,
                             "name": "Catégorie de motif n°1",
                             "short_name": "1_motif_cat"
                           },
                           "name": "Motif 1",
-                          "organisation_id": 82,
-                          "service_id": 19
+                          "organisation_id": 863,
+                          "service_id": 177
                         },
                         {
-                          "id": 8,
+                          "id": 459,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
+                          "default_duration_in_min": 45,
                           "deleted_at": null,
                           "follow_up": false,
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 8,
+                            "id": 364,
                             "name": "Catégorie de motif n°2",
                             "short_name": "2_motif_cat"
                           },
                           "name": "Motif 2",
-                          "organisation_id": 82,
-                          "service_id": 19
+                          "organisation_id": 863,
+                          "service_id": 177
                         }
                       ],
                       "meta": {
@@ -2483,7 +2485,7 @@
                     "value": {
                       "organisations": [
                         {
-                          "id": 117,
+                          "id": 898,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -2491,7 +2493,7 @@
                           "website": null
                         },
                         {
-                          "id": 118,
+                          "id": 899,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
@@ -2499,7 +2501,7 @@
                           "website": null
                         },
                         {
-                          "id": 119,
+                          "id": 900,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
@@ -2507,7 +2509,7 @@
                           "website": null
                         },
                         {
-                          "id": 120,
+                          "id": 901,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
@@ -2515,7 +2517,7 @@
                           "website": null
                         },
                         {
-                          "id": 121,
+                          "id": 902,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
@@ -2634,7 +2636,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 128,
+                        "id": 909,
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
@@ -2744,7 +2746,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 132,
+                        "id": 913,
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
@@ -2855,12 +2857,12 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 2,
-                        "created_at": "2026-01-06 15:22:54 +0100",
+                        "id": 24,
+                        "created_at": "2026-01-07 15:03:22 +0100",
                         "rdv": null,
-                        "updated_at": "2026-01-06 15:22:54 +0100",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/2",
-                        "user_id": 8
+                        "updated_at": "2026-01-07 15:03:22 +0100",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/24",
+                        "user_id": 421
                       }
                     }
                   }
@@ -2969,17 +2971,17 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 4,
-                        "created_at": "2026-01-06 15:22:54 +0100",
+                        "id": 26,
+                        "created_at": "2026-01-07 15:03:22 +0100",
                         "rdv": {
-                          "id": 5,
+                          "id": 186,
                           "status": "unknown",
-                          "starts_at": "2026-01-09 15:22:00 +0100",
+                          "starts_at": "2026-01-10 15:03:00 +0100",
                           "location_type": "public_office"
                         },
-                        "updated_at": "2026-01-06 15:22:54 +0100",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/4",
-                        "user_id": 12
+                        "updated_at": "2026-01-07 15:03:22 +0100",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/26",
+                        "user_id": 425
                       }
                     }
                   }
@@ -3108,57 +3110,58 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 6,
+                          "id": 187,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 141,
+                              "id": 2410,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Florent",
-                              "last_name": "Mercier"
+                              "first_name": "Savinien",
+                              "last_name": "Gaillard"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-06 15:22:54 +0100",
+                          "created_at": "2026-01-07 15:03:23 +0100",
                           "created_by": "agent",
-                          "created_by_id": 141,
+                          "created_by_id": 2410,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 8,
+                            "id": 423,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 170,
+                            "organisation_id": 951,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 50,
+                            "id": 501,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
+                            "default_duration_in_min": 45,
                             "deleted_at": null,
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 50,
+                              "id": 406,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 170,
-                            "service_id": 40
+                            "organisation_id": 951,
+                            "service_id": 198
                           },
                           "name": null,
                           "organisation": {
-                            "id": 170,
+                            "id": 951,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3167,32 +3170,32 @@
                           },
                           "participations": [
                             {
-                              "id": 9,
+                              "id": 193,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 141,
+                              "created_by_id": 2410,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 13,
+                                "id": 426,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-06 15:22:54 +0100",
+                                "created_at": "2026-01-07 15:03:23 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Chrysole",
+                                "first_name": "Louis",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "LE GALL",
+                                "last_name": "CHARLES",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "7 70 91 44 97",
-                                "phone_number_formatted": "+33770914497",
+                                "phone_number": "0679993072",
+                                "phone_number_formatted": "+33679993072",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3201,33 +3204,33 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/6",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/187",
                           "users": [
                             {
-                              "id": 13,
+                              "id": 426,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-06 15:22:54 +0100",
+                              "created_at": "2026-01-07 15:03:23 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Chrysole",
+                              "first_name": "Louis",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "LE GALL",
+                              "last_name": "CHARLES",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "7 70 91 44 97",
-                              "phone_number_formatted": "+33770914497",
+                              "phone_number": "0679993072",
+                              "phone_number_formatted": "+33679993072",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "6383d3b9-98f3-4ec5-9279-aeef43b74079"
+                          "uuid": "5ecb9821-6ec3-4cf2-bc82-fcafd9f7e92a"
                         }
                       ],
                       "meta": {
@@ -3353,57 +3356,58 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 11,
+                          "id": 192,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 148,
+                              "id": 2417,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Gédéon",
-                              "last_name": "Mallet"
+                              "first_name": "Cléandre",
+                              "last_name": "Remy"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-06 15:22:55 +0100",
+                          "created_at": "2026-01-07 15:03:23 +0100",
                           "created_by": "agent",
-                          "created_by_id": 148,
+                          "created_by_id": 2417,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 13,
+                            "id": 428,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 173,
+                            "organisation_id": 954,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 56,
+                            "id": 507,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
+                            "default_duration_in_min": 45,
                             "deleted_at": null,
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 56,
+                              "id": 412,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 173,
-                            "service_id": 43
+                            "organisation_id": 954,
+                            "service_id": 201
                           },
                           "name": null,
                           "organisation": {
-                            "id": 173,
+                            "id": 954,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3412,32 +3416,32 @@
                           },
                           "participations": [
                             {
-                              "id": 14,
+                              "id": 198,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 148,
+                              "created_by_id": 2417,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 18,
+                                "id": 431,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-06 15:22:55 +0100",
+                                "created_at": "2026-01-07 15:03:23 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Armandine",
+                                "first_name": "Zaché",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "ROUSSEL",
+                                "last_name": "BONNET",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "6 60 77 38 60",
-                                "phone_number_formatted": "+33660773860",
+                                "phone_number": "6 44 86 97 33",
+                                "phone_number_formatted": "+33644869733",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3446,86 +3450,87 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/11",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/192",
                           "users": [
                             {
-                              "id": 18,
+                              "id": 431,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-06 15:22:55 +0100",
+                              "created_at": "2026-01-07 15:03:23 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Armandine",
+                              "first_name": "Zaché",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "ROUSSEL",
+                              "last_name": "BONNET",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "6 60 77 38 60",
-                              "phone_number_formatted": "+33660773860",
+                              "phone_number": "6 44 86 97 33",
+                              "phone_number_formatted": "+33644869733",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "97a3de97-1822-4d4a-b42b-8dde8a597b9a"
+                          "uuid": "4a5acb4c-740f-404a-bc69-9311b933a95b"
                         },
                         {
-                          "id": 14,
+                          "id": 195,
                           "address": "4 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 151,
+                              "id": 2420,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Emmelie",
-                              "last_name": "David"
+                              "first_name": "Gui",
+                              "last_name": "Boulanger"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2026-01-06 15:22:55 +0100",
+                          "created_at": "2026-01-07 15:03:23 +0100",
                           "created_by": "agent",
-                          "created_by_id": 151,
+                          "created_by_id": 2420,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2024-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 16,
+                            "id": 431,
                             "address": "4 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°4",
-                            "organisation_id": 173,
+                            "organisation_id": 954,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 60,
+                            "id": 511,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
+                            "default_duration_in_min": 45,
                             "deleted_at": null,
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 60,
+                              "id": 416,
                               "name": "Catégorie de motif n°5",
                               "short_name": "5_motif_cat"
                             },
                             "name": "Motif 5",
-                            "organisation_id": 173,
+                            "organisation_id": 954,
                             "service_id": null
                           },
                           "name": null,
                           "organisation": {
-                            "id": 173,
+                            "id": 954,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3534,32 +3539,32 @@
                           },
                           "participations": [
                             {
-                              "id": 17,
+                              "id": 201,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 151,
+                              "created_by_id": 2420,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 21,
+                                "id": 434,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2026-01-06 15:22:55 +0100",
+                                "created_at": "2026-01-07 15:03:23 +0100",
                                 "email": "usager_4@lapin.fr",
-                                "first_name": "Narcisse",
+                                "first_name": "Olive",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "REYNAUD",
+                                "last_name": "VIDAL",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "651303455",
-                                "phone_number_formatted": "+33651303455",
+                                "phone_number": "7 35 54 44 50",
+                                "phone_number_formatted": "+33735544450",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3568,33 +3573,33 @@
                           ],
                           "starts_at": "2024-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/14",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/195",
                           "users": [
                             {
-                              "id": 21,
+                              "id": 434,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2026-01-06 15:22:55 +0100",
+                              "created_at": "2026-01-07 15:03:23 +0100",
                               "email": "usager_4@lapin.fr",
-                              "first_name": "Narcisse",
+                              "first_name": "Olive",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "REYNAUD",
+                              "last_name": "VIDAL",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "651303455",
-                              "phone_number_formatted": "+33651303455",
+                              "phone_number": "7 35 54 44 50",
+                              "phone_number_formatted": "+33735544450",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "b682efe9-b19a-412d-9c67-f6e3db780bb9"
+                          "uuid": "f877df81-1c48-43c2-ab17-e25023a41b56"
                         }
                       ],
                       "meta": {
@@ -3811,29 +3816,29 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 270,
+                          "id": 2539,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Guérin",
+                          "first_name": "Briac",
                           "last_name": "Legrand"
                         },
                         "user": {
-                          "id": 113,
+                          "id": 526,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 15:23:00 +0100",
+                          "created_at": "2026-01-07 15:03:33 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Ombline",
+                          "first_name": "Aloïse",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LEVEQUE",
+                          "last_name": "SCHMITT",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "07 49 59 08 84",
-                          "phone_number_formatted": "+33749590884",
+                          "phone_number": "06 42 12 99 33",
+                          "phone_number_formatted": "+33642129933",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4083,30 +4088,30 @@
                     "value": {
                       "teams": [
                         {
-                          "id": 5,
+                          "id": 13,
                           "agents": [
                             {
-                              "id": 302,
+                              "id": 2571,
                               "email": "agent_2@lapin.fr",
-                              "first_name": "Maguelone",
-                              "last_name": "Weber"
+                              "first_name": "Ozanne",
+                              "last_name": "Arnaud"
                             },
                             {
-                              "id": 303,
+                              "id": 2572,
                               "email": "agent_3@lapin.fr",
-                              "first_name": "Mathilde",
-                              "last_name": "Collin"
+                              "first_name": "Sabine",
+                              "last_name": "Marchal"
                             },
                             {
-                              "id": 304,
+                              "id": 2573,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Zénobe",
-                              "last_name": "Fontaine"
+                              "first_name": "Alexine",
+                              "last_name": "Germain"
                             }
                           ],
-                          "name": "Champagne-Ardenne buffalo b681b280",
+                          "name": "Centre bees cb0d9fc4",
                           "territory": {
-                            "id": 234,
+                            "id": 935,
                             "departement_number": "01",
                             "motif_categories": [],
                             "name": "Espace n°1"
@@ -4223,7 +4228,7 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 238,
+                          "id": 1019,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -4231,23 +4236,23 @@
                           "website": null
                         },
                         "user": {
-                          "id": 129,
+                          "id": 542,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 15:23:02 +0100",
+                          "created_at": "2026-01-07 15:03:35 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Philibert",
+                          "first_name": "René",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "GUILLOT",
+                          "last_name": "GAILLARD",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "649074046",
-                          "phone_number_formatted": "+33649074046",
+                          "phone_number": "614233158",
+                          "phone_number_formatted": "+33614233158",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4532,13 +4537,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 146,
+                        "id": 559,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2026-01-06 15:23:03 +0100",
+                        "created_at": "2026-01-07 15:03:37 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -4547,14 +4552,14 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "6 18 69 74 08",
-                        "phone_number_formatted": "+33618697408",
+                        "phone_number": "07 84 04 02 51",
+                        "phone_number_formatted": "+33784040251",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 259,
+                              "id": 1040,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -4843,13 +4848,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 153,
+                        "id": 566,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2026-01-06 15:23:03 +0100",
+                        "created_at": "2026-01-07 15:03:37 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Alain",
                         "invitation_accepted_at": null,
@@ -4861,28 +4866,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 152,
+                          "id": 565,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 15:23:03 +0100",
+                          "created_at": "2026-01-07 15:03:37 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Amaryllis",
+                          "first_name": "Francette",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LEMAITRE",
+                          "last_name": "DELAUNAY",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0730968393",
-                          "phone_number_formatted": "+33730968393",
+                          "phone_number": "0669472546",
+                          "phone_number_formatted": "+33669472546",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 152,
+                        "responsible_id": 565,
                         "user_profiles": null
                       }
                     }
@@ -5011,7 +5016,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "5RBQLEW7"
+                      "invitation_token": "P79V6E7X"
                     }
                   }
                 },
@@ -5144,23 +5149,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 180,
+                          "id": 593,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 15:23:04 +0100",
+                          "created_at": "2026-01-07 15:03:39 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Fabien",
+                          "first_name": "Gwenaëlle",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "ANDRÉ",
+                          "last_name": "TESSIER",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0686706215",
-                          "phone_number_formatted": "+33686706215",
+                          "phone_number": "0756257706",
+                          "phone_number_formatted": "+33756257706",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5417,13 +5422,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 191,
+                        "id": 604,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2026-01-06 15:23:04 +0100",
+                        "created_at": "2026-01-07 15:03:40 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Johnny",
                         "invitation_accepted_at": null,
@@ -5435,28 +5440,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 190,
+                          "id": 603,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 15:23:04 +0100",
+                          "created_at": "2026-01-07 15:03:40 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Sylviane",
+                          "first_name": "Conception",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "ANTOINE",
+                          "last_name": "AUBERT",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "6 72 78 90 58",
-                          "phone_number_formatted": "+33672789058",
+                          "phone_number": "783212543",
+                          "phone_number_formatted": "+33783212543",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 190,
+                        "responsible_id": 603,
                         "user_profiles": null
                       }
                     }
@@ -5596,23 +5601,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 200,
+                          "id": 613,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2026-01-06 15:23:05 +0100",
+                          "created_at": "2026-01-07 15:03:41 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Eubert",
+                          "first_name": "Almine",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "REYNAUD",
+                          "last_name": "HAMON",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "07 98 65 29 65",
-                          "phone_number_formatted": "+33798652965",
+                          "phone_number": "6 47 05 22 14",
+                          "phone_number_formatted": "+33647052214",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5729,13 +5734,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 205,
+                        "id": 618,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2026-01-06 15:23:05 +0100",
+                        "created_at": "2026-01-07 15:03:41 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -5744,14 +5749,14 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "07 87 23 05 13",
-                        "phone_number_formatted": "+33787230513",
+                        "phone_number": "644859877",
+                        "phone_number_formatted": "+33644859877",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 324,
+                              "id": 1105,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -6058,8 +6063,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 26,
-                        "organisation_id": 344,
+                        "id": 58,
+                        "organisation_id": 1125,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -6255,8 +6260,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 28,
-                        "organisation_id": 351,
+                        "id": 60,
+                        "organisation_id": 1132,
                         "subscriptions": [
                           "rdv",
                           "user",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -1291,24 +1291,25 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 12,
+                        "id": 14,
                         "agent": {
-                          "id": 12,
+                          "id": 300,
                           "email": "agent@example.com",
-                          "first_name": "Barbe",
-                          "last_name": "Colin"
+                          "first_name": "Briac",
+                          "last_name": "Schmitt"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113628Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_12@RDV Solidarités",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T135606Z\r\nUID:absence_14@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/194/planning/absences/14/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Super absence\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_14@RDV Solidarités",
                         "organisation": {
-                          "id": 12,
+                          "id": 194,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "rrule": null,
                         "start_time": "08:00:00",
@@ -1475,24 +1476,25 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 21,
+                        "id": 23,
                         "agent": {
-                          "id": 23,
+                          "id": 318,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Adeline",
-                          "last_name": "Paul"
+                          "first_name": "Léopold",
+                          "last_name": "Nicolas"
                         },
-                        "end_day": "2025-10-07",
+                        "end_day": "2026-01-08",
                         "end_time": "15:30:00",
-                        "first_day": "2025-10-07",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113629Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20251007T100000\r\nDTEND;TZID=Europe/Paris:20251007T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_21@RDV Solidarités",
+                        "first_day": "2026-01-08",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T135607Z\r\nUID:absence_23@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260108T100000\r\nDTEND;TZID=Europe/Paris:20260108T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/208/planning/absences/23/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Indisponibilité 1\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_23@RDV Solidarités",
                         "organisation": {
-                          "id": 26,
+                          "id": 208,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "rrule": null,
                         "start_time": "10:00:00",
@@ -1681,24 +1683,25 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 33,
+                        "id": 35,
                         "agent": {
-                          "id": 35,
+                          "id": 330,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Gérard",
-                          "last_name": "Fabre"
+                          "first_name": "Léopold",
+                          "last_name": "Dvnis"
                         },
-                        "end_day": "2025-10-07",
+                        "end_day": "2026-01-08",
                         "end_time": "15:30:00",
-                        "first_day": "2025-10-07",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20251006T113629Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20251007T100000\r\nDTEND;TZID=Europe/Paris:20251007T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_33@RDV Solidarités",
+                        "first_day": "2026-01-08",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20260329T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20251026T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20260107T135608Z\r\nUID:absence_35@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20260108T100000\r\nDTEND;TZID=Europe/Paris:20260108T153000\r\nDESCRIPTION:Voir sur RDV Service Public : http://www.rdv-service-public-tes\r\n t.localhost/admin/organisations/220/planning/absences/35/edit\r\nORGANIZER:mailto:secretariat-auto@rdv-service-public.fr\r\nSEQUENCE:0\r\nSTATUS:CONFIRMED\r\nSUMMARY:Nouveau titre\r\nCATEGORIES:RDV Service Public\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_35@RDV Solidarités",
                         "organisation": {
-                          "id": 38,
+                          "id": 220,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "rrule": null,
                         "start_time": "10:00:00",
@@ -1978,10 +1981,10 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 59,
+                          "id": 354,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Suzanne",
-                          "last_name": "Pasquier"
+                          "first_name": "Ulrich",
+                          "last_name": "Bailly"
                         }
                       ],
                       "meta": {
@@ -2200,12 +2203,12 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 2,
+                      "id": 138,
                       "address": "77 avenue de Ségur, 75015 Paris",
                       "latitude": 44.5569244,
                       "longitude": 4.7521632,
                       "name": "Maison France Service de Montreuil",
-                      "organisation_id": 76,
+                      "organisation_id": 258,
                       "phone_number": "01 22 33 44 55",
                       "single_use": false
                     }
@@ -2322,40 +2325,42 @@
                     "value": {
                       "motifs": [
                         {
-                          "id": 7,
+                          "id": 136,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
+                          "default_duration_in_min": 45,
                           "deleted_at": null,
                           "follow_up": false,
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 7,
+                            "id": 109,
                             "name": "Catégorie de motif n°1",
                             "short_name": "1_motif_cat"
                           },
                           "name": "Motif 1",
-                          "organisation_id": 82,
-                          "service_id": 19
+                          "organisation_id": 264,
+                          "service_id": 39
                         },
                         {
-                          "id": 8,
+                          "id": 137,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
+                          "default_duration_in_min": 45,
                           "deleted_at": null,
                           "follow_up": false,
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 8,
+                            "id": 110,
                             "name": "Catégorie de motif n°2",
                             "short_name": "2_motif_cat"
                           },
                           "name": "Motif 2",
-                          "organisation_id": 82,
-                          "service_id": 19
+                          "organisation_id": 264,
+                          "service_id": 39
                         }
                       ],
                       "meta": {
@@ -2480,39 +2485,44 @@
                     "value": {
                       "organisations": [
                         {
-                          "id": 117,
+                          "id": 299,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
-                          "id": 118,
+                          "id": 300,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
-                          "id": 119,
+                          "id": 301,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
-                          "id": 120,
+                          "id": 302,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         {
-                          "id": 121,
+                          "id": 303,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         }
                       ],
                       "meta": {
@@ -2626,11 +2636,12 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 128,
+                        "id": 310,
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
-                        "verticale": "rdv_solidarites"
+                        "verticale": "rdv_solidarites",
+                        "website": null
                       }
                     }
                   }
@@ -2735,11 +2746,12 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 132,
+                        "id": 314,
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
-                        "verticale": "rdv_solidarites"
+                        "verticale": "rdv_solidarites",
+                        "website": null
                       }
                     }
                   }
@@ -2845,12 +2857,12 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 2,
-                        "created_at": "2025-10-06 13:36:33 +0200",
+                        "id": 11,
+                        "created_at": "2026-01-07 14:56:14 +0100",
                         "rdv": null,
-                        "updated_at": "2025-10-06 13:36:33 +0200",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/2",
-                        "user_id": 8
+                        "updated_at": "2026-01-07 14:56:14 +0100",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/11",
+                        "user_id": 92
                       }
                     }
                   }
@@ -2959,17 +2971,17 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 4,
-                        "created_at": "2025-10-06 13:36:34 +0200",
+                        "id": 13,
+                        "created_at": "2026-01-07 14:56:14 +0100",
                         "rdv": {
-                          "id": 5,
+                          "id": 29,
                           "status": "unknown",
-                          "starts_at": "2025-10-09 13:36:00 +0200",
+                          "starts_at": "2026-01-10 14:56:00 +0100",
                           "location_type": "public_office"
                         },
-                        "updated_at": "2025-10-06 13:36:34 +0200",
-                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/4",
-                        "user_id": 12
+                        "updated_at": "2026-01-07 14:56:14 +0100",
+                        "url": "http://www.rdv-service-public-test.localhost/agents/rdv_plans/13",
+                        "user_id": 96
                       }
                     }
                   }
@@ -3098,90 +3110,92 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 6,
+                          "id": 30,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 127,
+                              "id": 426,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Clodion",
-                              "last_name": "Leclercq"
+                              "first_name": "Andrée",
+                              "last_name": "Petit"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-10-06 13:36:34 +0200",
+                          "created_at": "2026-01-07 14:56:15 +0100",
                           "created_by": "agent",
-                          "created_by_id": 127,
+                          "created_by_id": 426,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 8,
+                            "id": 144,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 170,
+                            "organisation_id": 352,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 50,
+                            "id": 179,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
+                            "default_duration_in_min": 45,
                             "deleted_at": null,
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 50,
+                              "id": 152,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 170,
-                            "service_id": 40
+                            "organisation_id": 352,
+                            "service_id": 60
                           },
                           "name": null,
                           "organisation": {
-                            "id": 170,
+                            "id": 352,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites"
+                            "verticale": "rdv_solidarites",
+                            "website": null
                           },
                           "participations": [
                             {
-                              "id": 9,
+                              "id": 33,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 127,
+                              "created_by_id": 426,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 13,
+                                "id": 97,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2025-10-06 13:36:34 +0200",
+                                "created_at": "2026-01-07 14:56:15 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Florian",
+                                "first_name": "Patrice",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "PICHON",
+                                "last_name": "JOLY",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "6 19 21 39 36",
-                                "phone_number_formatted": "+33619213936",
+                                "phone_number": "623459591",
+                                "phone_number_formatted": "+33623459591",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3190,33 +3204,33 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/6",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/30",
                           "users": [
                             {
-                              "id": 13,
+                              "id": 97,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2025-10-06 13:36:34 +0200",
+                              "created_at": "2026-01-07 14:56:15 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Florian",
+                              "first_name": "Patrice",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "PICHON",
+                              "last_name": "JOLY",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "6 19 21 39 36",
-                              "phone_number_formatted": "+33619213936",
+                              "phone_number": "623459591",
+                              "phone_number_formatted": "+33623459591",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "c72fa749-69a2-49b6-a28a-4bbae50df1d8"
+                          "uuid": "38397589-0c51-481b-9bc5-5fdfa0e9dd1d"
                         }
                       ],
                       "meta": {
@@ -3342,90 +3356,92 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 11,
+                          "id": 35,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 134,
+                              "id": 433,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Annibal",
-                              "last_name": "Meyer"
+                              "first_name": "Chrysostome",
+                              "last_name": "Dufour"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-10-06 13:36:34 +0200",
+                          "created_at": "2026-01-07 14:56:15 +0100",
                           "created_by": "agent",
-                          "created_by_id": 134,
+                          "created_by_id": 433,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 13,
+                            "id": 149,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°1",
-                            "organisation_id": 173,
+                            "organisation_id": 355,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 56,
+                            "id": 185,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
+                            "default_duration_in_min": 45,
                             "deleted_at": null,
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 56,
+                              "id": 158,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 173,
-                            "service_id": 43
+                            "organisation_id": 355,
+                            "service_id": 63
                           },
                           "name": null,
                           "organisation": {
-                            "id": 173,
+                            "id": 355,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites"
+                            "verticale": "rdv_solidarites",
+                            "website": null
                           },
                           "participations": [
                             {
-                              "id": 14,
+                              "id": 38,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 134,
+                              "created_by_id": 433,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 18,
+                                "id": 102,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2025-10-06 13:36:34 +0200",
+                                "created_at": "2026-01-07 14:56:15 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "first_name": "Julien",
+                                "first_name": "Bastien",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "DUPUY",
+                                "last_name": "LUCAS",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "0686864704",
-                                "phone_number_formatted": "+33686864704",
+                                "phone_number": "7 43 28 83 36",
+                                "phone_number_formatted": "+33743288336",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3434,119 +3450,121 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/11",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/35",
                           "users": [
                             {
-                              "id": 18,
+                              "id": 102,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2025-10-06 13:36:34 +0200",
+                              "created_at": "2026-01-07 14:56:15 +0100",
                               "email": "usager_1@lapin.fr",
-                              "first_name": "Julien",
+                              "first_name": "Bastien",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "DUPUY",
+                              "last_name": "LUCAS",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "0686864704",
-                              "phone_number_formatted": "+33686864704",
+                              "phone_number": "7 43 28 83 36",
+                              "phone_number_formatted": "+33743288336",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "cd32d504-532f-428a-b4fb-163e87de7dbc"
+                          "uuid": "301d34c1-893c-428d-af5a-b1723f52c6ec"
                         },
                         {
-                          "id": 14,
+                          "id": 38,
                           "address": "4 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 137,
+                              "id": 436,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Romain",
-                              "last_name": "Pichon"
+                              "first_name": "Alain",
+                              "last_name": "Marchal"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-10-06 13:36:34 +0200",
+                          "created_at": "2026-01-07 14:56:15 +0100",
                           "created_by": "agent",
-                          "created_by_id": 137,
+                          "created_by_id": 436,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2024-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 16,
+                            "id": 152,
                             "address": "4 rue de l'adresse, Ville, 12345",
                             "latitude": 38.8951,
                             "longitude": -77.0364,
                             "name": "Lieu n°4",
-                            "organisation_id": 173,
+                            "organisation_id": 355,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 60,
+                            "id": 189,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
+                            "default_duration_in_min": 45,
                             "deleted_at": null,
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 60,
+                              "id": 162,
                               "name": "Catégorie de motif n°5",
                               "short_name": "5_motif_cat"
                             },
                             "name": "Motif 5",
-                            "organisation_id": 173,
+                            "organisation_id": 355,
                             "service_id": null
                           },
                           "name": null,
                           "organisation": {
-                            "id": 173,
+                            "id": 355,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
-                            "verticale": "rdv_solidarites"
+                            "verticale": "rdv_solidarites",
+                            "website": null
                           },
                           "participations": [
                             {
-                              "id": 17,
+                              "id": 41,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 137,
+                              "created_by_id": 436,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 21,
+                                "id": 105,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "created_at": "2025-10-06 13:36:34 +0200",
+                                "created_at": "2026-01-07 14:56:15 +0100",
                                 "email": "usager_4@lapin.fr",
-                                "first_name": "Édouard",
+                                "first_name": "Laurine",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "DUMONT",
+                                "last_name": "ROCHE",
                                 "notification_email": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "phone_number": "0622502309",
-                                "phone_number_formatted": "+33622502309",
+                                "phone_number": "0655044431",
+                                "phone_number_formatted": "+33655044431",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3555,33 +3573,33 @@
                           ],
                           "starts_at": "2024-01-01 08:00:00 +0100",
                           "status": "unknown",
-                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/14",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/38",
                           "users": [
                             {
-                              "id": 21,
+                              "id": 105,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "created_at": "2025-10-06 13:36:34 +0200",
+                              "created_at": "2026-01-07 14:56:15 +0100",
                               "email": "usager_4@lapin.fr",
-                              "first_name": "Édouard",
+                              "first_name": "Laurine",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "DUMONT",
+                              "last_name": "ROCHE",
                               "notification_email": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "phone_number": "0622502309",
-                              "phone_number_formatted": "+33622502309",
+                              "phone_number": "0655044431",
+                              "phone_number_formatted": "+33655044431",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "59021b59-15f5-4ec5-b0da-c81987f1270e"
+                          "uuid": "ae86bb78-719b-44ba-99bb-1dc3bf3d180f"
                         }
                       ],
                       "meta": {
@@ -3694,7 +3712,7 @@
                         ]
                       },
                       "error_messages": [
-                        "status doit être rempli(e)"
+                        "status doit être rempli·e"
                       ]
                     }
                   }
@@ -3798,29 +3816,29 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 252,
+                          "id": 555,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Aurélie",
-                          "last_name": "Perez"
+                          "first_name": "Noëlle",
+                          "last_name": "Moreau"
                         },
                         "user": {
-                          "id": 111,
+                          "id": 197,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:39 +0200",
+                          "created_at": "2026-01-07 14:56:25 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Aimable",
+                          "first_name": "Anceline",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "ARNAUD",
+                          "last_name": "MORIN",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0642890191",
-                          "phone_number_formatted": "+33642890191",
+                          "phone_number": "7 91 25 30 09",
+                          "phone_number_formatted": "+33791253009",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4073,27 +4091,27 @@
                           "id": 5,
                           "agents": [
                             {
-                              "id": 284,
+                              "id": 587,
                               "email": "agent_2@lapin.fr",
-                              "first_name": "Arian",
-                              "last_name": "Le Goff"
+                              "first_name": "Artémis",
+                              "last_name": "Lemaire"
                             },
                             {
-                              "id": 285,
+                              "id": 588,
                               "email": "agent_3@lapin.fr",
-                              "first_name": "Arielle",
-                              "last_name": "Morel"
+                              "first_name": "Savinien",
+                              "last_name": "Gauthier"
                             },
                             {
-                              "id": 286,
+                              "id": 589,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Armelle",
-                              "last_name": "Guérin"
+                              "first_name": "Ambroisie",
+                              "last_name": "Robin"
                             }
                           ],
-                          "name": "Aquitaine ghosts 799285ed",
+                          "name": "Martinique lycanthropes ee10aab3",
                           "territory": {
-                            "id": 232,
+                            "id": 375,
                             "departement_number": "01",
                             "motif_categories": [],
                             "name": "Espace n°1"
@@ -4210,30 +4228,31 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 236,
+                          "id": 420,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
-                          "verticale": "rdv_solidarites"
+                          "verticale": "rdv_solidarites",
+                          "website": null
                         },
                         "user": {
-                          "id": 127,
+                          "id": 213,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:41 +0200",
+                          "created_at": "2026-01-07 14:56:27 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Agilberte",
+                          "first_name": "Eugénie",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "DENIS",
+                          "last_name": "BLANCHARD",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "0631339353",
-                          "phone_number_formatted": "+33631339353",
+                          "phone_number": "07 60 04 08 76",
+                          "phone_number_formatted": "+33760040876",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4292,7 +4311,7 @@
             }
           },
           "422": {
-            "description": "Renvoie 'unprocessable_entity' quand l'utilisateur ou l'organisation est inconnu(e) ou ce profil existe déjà",
+            "description": "Renvoie 'unprocessable_entity' quand l'utilisateur ou l'organisation est inconnu·e ou ce profil existe déjà",
             "content": {
               "application/json": {
                 "examples": {
@@ -4518,13 +4537,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 144,
+                        "id": 230,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2025-10-06 13:36:42 +0200",
+                        "created_at": "2026-01-07 14:56:29 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -4533,18 +4552,19 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "666609679",
-                        "phone_number_formatted": "+33666609679",
+                        "phone_number": "0623172447",
+                        "phone_number_formatted": "+33623172447",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 257,
+                              "id": 441,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
-                              "verticale": "rdv_solidarites"
+                              "verticale": "rdv_solidarites",
+                              "website": null
                             }
                           }
                         ]
@@ -4828,13 +4848,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 151,
+                        "id": 237,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2025-10-06 13:36:42 +0200",
+                        "created_at": "2026-01-07 14:56:30 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Alain",
                         "invitation_accepted_at": null,
@@ -4846,28 +4866,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 150,
+                          "id": 236,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:42 +0200",
+                          "created_at": "2026-01-07 14:56:30 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Huguette",
+                          "first_name": "Tim",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MARCHAND",
+                          "last_name": "LANGLOIS",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "07 73 48 85 78",
-                          "phone_number_formatted": "+33773488578",
+                          "phone_number": "7 30 97 72 78",
+                          "phone_number_formatted": "+33730977278",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 150,
+                        "responsible_id": 236,
                         "user_profiles": null
                       }
                     }
@@ -4899,8 +4919,8 @@
                         ]
                       },
                       "error_messages": [
-                        "last_name doit être rempli(e)",
-                        "first_name doit être rempli(e)"
+                        "last_name doit être rempli·e",
+                        "first_name doit être rempli·e"
                       ]
                     }
                   }
@@ -4996,7 +5016,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "793HRDC6"
+                      "invitation_token": "JIXI4H8L"
                     }
                   }
                 },
@@ -5129,23 +5149,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 178,
+                          "id": 264,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:43 +0200",
+                          "created_at": "2026-01-07 14:56:31 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Maxime",
+                          "first_name": "Virgile",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "GRONDIN",
+                          "last_name": "MEUNIER",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "7 39 50 85 46",
-                          "phone_number_formatted": "+33739508546",
+                          "phone_number": "0788093804",
+                          "phone_number_formatted": "+33788093804",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5402,13 +5422,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 189,
+                        "id": 275,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "created_at": "2025-10-06 13:36:43 +0200",
+                        "created_at": "2026-01-07 14:56:32 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Johnny",
                         "invitation_accepted_at": null,
@@ -5420,28 +5440,28 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 188,
+                          "id": 274,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:43 +0200",
+                          "created_at": "2026-01-07 14:56:32 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Argine",
+                          "first_name": "Aloïs",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LE GOFF",
+                          "last_name": "MICHAUD",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "06 86 16 99 55",
-                          "phone_number_formatted": "+33686169955",
+                          "phone_number": "616021139",
+                          "phone_number_formatted": "+33616021139",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 188,
+                        "responsible_id": 274,
                         "user_profiles": null
                       }
                     }
@@ -5492,8 +5512,8 @@
                         ]
                       },
                       "error_messages": [
-                        "last_name doit être rempli(e)",
-                        "first_name doit être rempli(e)"
+                        "last_name doit être rempli·e",
+                        "first_name doit être rempli·e"
                       ]
                     }
                   }
@@ -5581,23 +5601,23 @@
                     "value": {
                       "users": [
                         {
-                          "id": 198,
+                          "id": 284,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "created_at": "2025-10-06 13:36:44 +0200",
+                          "created_at": "2026-01-07 14:56:33 +0100",
                           "email": "usager_1@lapin.fr",
-                          "first_name": "Eusèbe",
+                          "first_name": "Archibald",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "PERRIER",
+                          "last_name": "PONS",
                           "notification_email": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "phone_number": "736258265",
-                          "phone_number_formatted": "+33736258265",
+                          "phone_number": "7 77 58 08 91",
+                          "phone_number_formatted": "+33777580891",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5714,13 +5734,13 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 203,
+                        "id": 289,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "created_at": "2025-10-06 13:36:44 +0200",
+                        "created_at": "2026-01-07 14:56:33 +0100",
                         "email": "jean@jacques.fr",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
@@ -5729,18 +5749,19 @@
                         "notification_email": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "phone_number": "06 33 09 76 25",
-                        "phone_number_formatted": "+33633097625",
+                        "phone_number": "7 37 48 58 97",
+                        "phone_number_formatted": "+33737485897",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 322,
+                              "id": 506,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
-                              "verticale": "rdv_solidarites"
+                              "verticale": "rdv_solidarites",
+                              "website": null
                             }
                           }
                         ]
@@ -6042,8 +6063,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 26,
-                        "organisation_id": 342,
+                        "id": 27,
+                        "organisation_id": 526,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -6239,8 +6260,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 28,
-                        "organisation_id": 349,
+                        "id": 29,
+                        "organisation_id": 533,
                         "subscriptions": [
                           "rdv",
                           "user",


### PR DESCRIPTION
# Contexte

Nous sommes en train de revoir l'interface de configuration des organisations dans RDVI et nous avons besoin (pour de la lecture uniquement) de la durée des motifs pour l'afficher dans la nouvelle interface.
PI les liens permettant d'éditer le motifs, le consulter pointent vers rdvsp.

<img width="1145" height="877" alt="Capture d’écran 2026-01-06 à 13 57 40" src="https://github.com/user-attachments/assets/bb161957-9004-483c-9c2d-5dc94eb4152a" />

# Solution

Ajouter le champ `default_duration_in_min` dans le blueprint des motifs.