### PR TITLE
Correction de la création idempotente de motifs lors d'une migration inter-instance

### DIFF
--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -25,17 +25,31 @@ class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
 
     authorize(motif, policy_class: Agent::MotifPolicy)
 
+    external_reference_scope = ExternalReference.where(
+      params.require(:external_reference).permit(:external_id, :external_url).merge(
+        oauth_application: doorkeeper_token&.application,
+        territory_id: motif.organisation.territory_id
+      )
+    )
+
+    if params[:external_reference].present?
+      existing_external_reference = external_reference_scope.find_by({})
+
+      if existing_external_reference
+        error_response = {
+          error_messages: ["external_id est déjà utilisé"],
+          errors: { external_id: [{ error: :taken, value: params.dig(:external_reference, :external_id) }] },
+        }
+
+        render(status: :unprocessable_entity, json: error_response) and return
+      end
+    end
+
     motif.transaction do
       motif.save!
 
       if params[:external_reference].present?
-        ExternalReference.create!(
-          params.require(:external_reference).permit(:external_id, :external_url).merge(
-            item: motif,
-            oauth_application: doorkeeper_token&.application,
-            territory_id: motif.organisation.territory_id
-          )
-        )
+        external_reference_scope.create!(item: motif)
       end
     end
 

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
         )
       )
 
-      existing_external_reference = external_reference_scope.find_by({})
+      existing_external_reference = external_reference_scope.first
 
       if existing_external_reference
         error_response = {

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -25,14 +25,14 @@ class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
 
     authorize(motif, policy_class: Agent::MotifPolicy)
 
-    external_reference_scope = ExternalReference.where(
-      params.require(:external_reference).permit(:external_id, :external_url).merge(
-        oauth_application: doorkeeper_token&.application,
-        territory_id: motif.organisation.territory_id
-      )
-    )
-
     if params[:external_reference].present?
+      external_reference_scope = ExternalReference.where(
+        params.require(:external_reference).permit(:external_id, :external_url).merge(
+          oauth_application: doorkeeper_token&.application,
+          territory_id: motif.organisation.territory_id
+        )
+      )
+
       existing_external_reference = external_reference_scope.find_by({})
 
       if existing_external_reference

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,21 +3,21 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "5e49c97564dd5bd05b5bc9a38faaf23c0c404cc707b798d4632845745720d0a4",
+      "fingerprint": "ceb24ff5fe91c83981f6f59fcdd75d599917cd60bdb5f6c3367305bb3c0bb4cb",
       "check_name": "SQL",
       "message": "Possible SQL injection",
-      "file": "scripts/clean_crisp_tickets.rb",
-      "line": 42,
+      "file": "app/controllers/api/v1/motifs_controller.rb",
+      "line": 30,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "connection.delete(\"/v1/website/#{WEBSITE_ID}/conversation/#{conversation[\"session_id\"]}\")",
+      "code": "ExternalReference.where(params.require(:external_reference).permit(:external_id, :external_url).merge(:oauth_application => doorkeeper_token.application, :territory_id => Motif.new(params.permit(*motif_attribute_names)).organisation.territory_id))",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "Cleaner",
-        "method": "fetch_conversations_and_delete"
+        "class": "Api::V1::MotifsController",
+        "method": "create"
       },
-      "user_input": "conversation[\"session_id\"]",
-      "confidence": "Medium",
+      "user_input": "params.require(:external_reference).permit(:external_id, :external_url).merge(:oauth_application => doorkeeper_token.application, :territory_id => Motif.new(params.permit(*motif_attribute_names)).organisation.territory_id)",
+      "confidence": "High",
       "cwe_id": [
         89
       ],
@@ -30,7 +30,7 @@
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/agents/rdv_plans/rdv.html.slim",
-      "line": 33,
+      "line": 39,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(\"Retour sur #{RdvPlan.find(params[:id]).oauth_application.name}\", RdvPlan.find(params[:id]).return_url, :class => \"float-right fr-btn\")",
       "render_path": [
@@ -38,7 +38,7 @@
           "type": "controller",
           "class": "Agents::RdvPlansController",
           "method": "rdv",
-          "line": 86,
+          "line": 107,
           "file": "app/controllers/agents/rdv_plans_controller.rb",
           "rendered": {
             "name": "agents/rdv_plans/rdv",
@@ -64,7 +64,7 @@
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/agents/rdv_plans/edit_starts_at.html.slim",
-      "line": 9,
+      "line": 21,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(RdvPlan.find(params[:id]).return_url)",
       "render_path": [
@@ -72,7 +72,7 @@
           "type": "controller",
           "class": "Agents::RdvPlansController",
           "method": "edit_starts_at",
-          "line": 16,
+          "line": 31,
           "file": "app/controllers/agents/rdv_plans_controller.rb",
           "rendered": {
             "name": "agents/rdv_plans/edit_starts_at",

--- a/spec/requests/api/v1/motifs_spec.rb
+++ b/spec/requests/api/v1/motifs_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Motifs API" do
       end
     end
 
-    context "when a motif already exists for the given external reference" do
+    context "when calling the endpoint twice with the same external reference" do
       let(:params) do
         {
           name: "Suivi de dossier",
@@ -46,14 +46,9 @@ RSpec.describe "Motifs API" do
         }
       end
 
-      let!(:existing_motif) do
-        create(:motif, organisation_id: organisation.id)
-      end
-      let!(:external_reference) do
-        create(:external_reference, oauth_application: application, item: existing_motif, territory_id: organisation.territory_id, external_id: "123ABC")
-      end
+      it "creates only one motif and returns an error message on the second call" do
+        expect { post "/api/v1/motifs", headers:, params:, as: :json }.to change(Motif, :count)
 
-      it "doesn't create the motif and returns an error message" do
         expect { post "/api/v1/motifs", headers:, params:, as: :json }.not_to change(Motif, :count)
 
         expect(response.status).to eq 422


### PR DESCRIPTION
Correctif complémentaire pour : https://sentry.incubateur.net/organizations/betagouv/issues/233925/?project=74&referrer=webhooks_plugin

Si on fait une création de motif une deuxième fois, vu qu'on vérifie l'external reference après la création du motif, on a l'erreur de validation sur l'unicité du motif qui se lève avant celle sur l'unicité de l'external reference.

Par la suite, notre code client considère que c'est une véritable erreur, et pas un cas d'idempotence à ignorer, et donc le job échoue de manière répétée.