### PR TITLE
Motif direct link

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -132,7 +132,7 @@ class SearchController < ApplicationController
       redirect_to prendre_rdv_path({
         public_link_organisation_id: organisation.id,
         departement: organisation.territory.departement_number,
-        motif_id: motif.id,
+        motif_id: motif&.id,
       }.compact)
     else
       flash[:alert] = "Organisation non trouvée"

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -60,7 +60,16 @@ class SearchController < ApplicationController
 
   def public_link_with_internal_organisation_id
     organisation = Organisation.find(params[:organisation_id])
-    redirect_to_organisation_search(organisation, params[:motif_id])
+    redirect_to_organisation_search(organisation)
+  end
+
+  def public_link_with_public_motif_id
+    motif = Motif.find_by(public_link_id: params[:public_link_id])
+    if motif
+      redirect_to_organisation_search(motif.organisation, motif:)
+    else
+      redirect_to root_path, flash: { error: "Motif introuvable" }
+    end
   end
 
   def public_link_with_external_organisation_id
@@ -118,11 +127,12 @@ class SearchController < ApplicationController
     public_link_to_org_url(organisation_id: export.destination_organisation_id, org_slug: organisation.slug, host: ENV["RDV_SERVICE_PUBLIC_OAUTH_BASE_URL"])
   end
 
-  def redirect_to_organisation_search(organisation, motif_id = nil)
+  def redirect_to_organisation_search(organisation, motif: nil)
     if organisation
       redirect_to prendre_rdv_path({
-        public_link_organisation_id: organisation.id, departement: organisation.territory.departement_number,
-        motif_id:,
+        public_link_organisation_id: organisation.id,
+        departement: organisation.territory.departement_number,
+        motif_id: motif.id,
       }.compact)
     else
       flash[:alert] = "Organisation non trouvée"

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -60,7 +60,7 @@ class SearchController < ApplicationController
 
   def public_link_with_internal_organisation_id
     organisation = Organisation.find(params[:organisation_id])
-    redirect_to_organisation_search(organisation)
+    redirect_to_organisation_search(organisation, params[:motif_id])
   end
 
   def public_link_with_external_organisation_id
@@ -118,11 +118,12 @@ class SearchController < ApplicationController
     public_link_to_org_url(organisation_id: export.destination_organisation_id, org_slug: organisation.slug, host: ENV["RDV_SERVICE_PUBLIC_OAUTH_BASE_URL"])
   end
 
-  def redirect_to_organisation_search(organisation)
+  def redirect_to_organisation_search(organisation, motif_id = nil)
     if organisation
-      redirect_to prendre_rdv_path(
-        public_link_organisation_id: organisation.id, departement: organisation.territory.departement_number
-      )
+      redirect_to prendre_rdv_path({
+        public_link_organisation_id: organisation.id, departement: organisation.territory.departement_number,
+        motif_id:,
+      }.compact)
     else
       flash[:alert] = "Organisation non trouvée"
       redirect_to root_path

--- a/app/controllers/super_admins/migrations_controller.rb
+++ b/app/controllers/super_admins/migrations_controller.rb
@@ -45,6 +45,7 @@ module SuperAdmins
         Motif.joins(rdvs: :agents_rdvs).where(agents_rdvs: { agent_id: agent.id }).distinct.find_each do |old_motif|
           new_motif = old_motif.dup
           new_motif.organisation = new_organisation
+          new_motif.public_link_id = SecureRandom.base58(8)
           new_motif.save!
 
           MotifsPlageOuverture.where(motif_id: old_motif, plage_ouverture_id: plage_ouvertures_for_organisation).update_all(motif_id: new_motif.id)

--- a/app/form_models/admin/create_motifs.rb
+++ b/app/form_models/admin/create_motifs.rb
@@ -18,7 +18,7 @@ class Admin::CreateMotifs
   end
 
   def motifs
-    @motifs ||= @organisations.map { |org| Motif.new(@motif_params.merge(organisation: org)) }
+    @motifs ||= @organisations.map { |org| Motif.new(@motif_params.merge(organisation: org, public_link_id: SecureRandom.base58(8))) }
   end
 
   def motif_for_form

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -71,6 +71,10 @@ class Motif < ApplicationRecord
   validate :cant_be_for_secretariat_and_follow_up
   validate :unique_in_org
 
+  # Hooks
+
+  after_initialize { self.public_link_id ||= SecureRandom.base58(8) }
+
   # Scopes
   scope :active, lambda { |active = true|
     active ? where(deleted_at: nil) : where.not(deleted_at: nil)

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -135,6 +135,10 @@ class Motif < ApplicationRecord
     name
   end
 
+  def slug
+    name.parameterize[..60]
+  end
+
   def soft_delete
     rdvs.any? ? update_attribute(:deleted_at, Time.zone.now) : destroy
   end

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -33,7 +33,7 @@
     - if @motif.bookable_by_everyone? && !current_organisation.sectorized?
       .card
         .card-body
-          h2.fr-h4 Lien de réservation
+          h2.fr-h4 Lien de réservation direct
           - motif_booking_link = public_link_to_org_url(organisation_id: current_organisation.id, org_slug: current_organisation.slug, motif_id: @motif.id)
           = render partial: "admin/organisations/online_bookings/booking_link", locals: { booking_link: motif_booking_link }
 

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -34,7 +34,7 @@
       .card
         .card-body
           h2.fr-h4 Lien de réservation direct
-          - motif_booking_link = public_link_to_org_url(organisation_id: current_organisation.id, org_slug: current_organisation.slug, motif_id: @motif.id)
+          - motif_booking_link = public_link_to_motif_url(public_link_id: @motif.public_link_id, motif_slug: @motif.slug)
           = render partial: "admin/organisations/online_bookings/booking_link", locals: { booking_link: motif_booking_link }
 
           p.fr-mt-2w Ce lien permet de prendre rendez-vous pour ce motif.

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -30,6 +30,15 @@
           p Ce motif n'est pas ouvert à la réservation en ligne
           = button_to "Ouvrir à la réservation en ligne", open_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn", method: :post
 
+    - if @motif.bookable_by_everyone? && !current_organisation.sectorized?
+      .card
+        .card-body
+          h2.fr-h4 Lien de réservation
+          - motif_booking_link = public_link_to_org_url(organisation_id: current_organisation.id, org_slug: current_organisation.slug, motif_id: @motif.id)
+          = render partial: "admin/organisations/online_bookings/booking_link", locals: { booking_link: motif_booking_link }
+
+          p.fr-mt-2w Ce lien permet de prendre rendez-vous pour ce motif.
+
     - if @motif.bookable_outside_of_organisation?
       .card
         .card-body

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -62,9 +62,9 @@
     .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
       h3.fr-h4 Motifs ouverts à la réservation en ligne
       = link_to "Modifier", edit_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
-    ul.list-group.my-1
+    ul.list-unstyled.my-1
       - @open_motifs.each do |motif|
-        = render "motif_card", motif:
+        li = render "motif_card", motif:
 
 - if @closed_motifs.present?
   .card
@@ -72,6 +72,6 @@
       .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
         h3.fr-h4 Motifs fermés à la réservation en ligne
         = link_to "Modifier", edit_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
-      ul.list-group.my-1
+      ul.list-unstyled.my-1
         - @closed_motifs.each do |motif|
-          = render "motif_card", motif:
+          li = render "motif_card", motif:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -418,6 +418,7 @@ Rails.application.routes.draw do
   # short public link
   get "org/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id", as: :public_link_to_org
   get "org/ext/:territory/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
+  get "motif/:public_link_id(/:motif_slug)" => "search#public_link_with_public_motif_id", as: :public_link_to_motif
   get "/creneaux", to: "search#public_link_to_creneaux"
 
   # resin public link

--- a/db/migrate/20260108100544_add_public_link_id_to_motifs.rb
+++ b/db/migrate/20260108100544_add_public_link_id_to_motifs.rb
@@ -4,12 +4,12 @@ class AddPublicLinkIdToMotifs < ActiveRecord::Migration[8.0]
 
     up_only do
       Motif.find_each do |motif|
-        motif.update_columns(public_link_id: SecureRandom.base58(8)) # rubocop:disable Rails/SkipsModelValidations
+        motif.update_columns(public_link_id: SecureRandom.base58(8))
       end
 
       # On fait une seconde passe au cas où de nouveaux motifs seraient ajoutés pendant la première boucle.
       Motif.where(public_link_id: nil).find_each do |motif|
-        motif.update_columns(public_link_id: SecureRandom.base58(8)) # rubocop:disable Rails/SkipsModelValidations
+        motif.update_columns(public_link_id: SecureRandom.base58(8))
       end
     end
 

--- a/db/migrate/20260108100544_add_public_link_id_to_motifs.rb
+++ b/db/migrate/20260108100544_add_public_link_id_to_motifs.rb
@@ -6,6 +6,11 @@ class AddPublicLinkIdToMotifs < ActiveRecord::Migration[8.0]
       Motif.find_each do |motif|
         motif.update_columns(public_link_id: SecureRandom.base58(8)) # rubocop:disable Rails/SkipsModelValidations
       end
+
+      # On fait une seconde passe au cas où de nouveaux motifs seraient ajoutés pendant la première boucle.
+      Motif.where(public_link_id: nil).find_each do |motif|
+        motif.update_columns(public_link_id: SecureRandom.base58(8)) # rubocop:disable Rails/SkipsModelValidations
+      end
     end
 
     add_check_constraint :motifs, "public_link_id IS NOT NULL", name: "motifs_public_link_id_null", validate: false

--- a/db/migrate/20260108100544_add_public_link_id_to_motifs.rb
+++ b/db/migrate/20260108100544_add_public_link_id_to_motifs.rb
@@ -1,0 +1,13 @@
+class AddPublicLinkIdToMotifs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :motifs, :public_link_id, :string
+
+    up_only do
+      Motif.find_each do |motif|
+        motif.update_columns(public_link_id: SecureRandom.base58(8)) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+
+    add_check_constraint :motifs, "public_link_id IS NOT NULL", name: "motifs_public_link_id_null", validate: false
+  end
+end

--- a/db/migrate/20260108101300_validate_add_public_link_id_to_motifs.rb
+++ b/db/migrate/20260108101300_validate_add_public_link_id_to_motifs.rb
@@ -1,0 +1,12 @@
+class ValidateAddPublicLinkIdToMotifs < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :motifs, name: "motifs_public_link_id_null"
+    change_column_null :motifs, :public_link_id, false
+    remove_check_constraint :motifs, name: "motifs_public_link_id_null"
+  end
+
+  def down
+    add_check_constraint :motifs, "public_link_id IS NOT NULL", name: "motifs_public_link_id_null", validate: false
+    change_column_null :motifs, :public_link_id, true
+  end
+end

--- a/db/migrate/20260108101447_add_index_to_motifs_public_link_id.rb
+++ b/db/migrate/20260108101447_add_index_to_motifs_public_link_id.rb
@@ -1,0 +1,7 @@
+class AddIndexToMotifsPublicLinkId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :motifs, :public_link_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_30_134819) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_08_101447) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -407,6 +407,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_30_134819) do
     t.boolean "rdvs_cancellable_by_user", default: true, comment: "Option invisible dans l’interface agents, utilisée par RDV Insertion pour des motifs de convocations"
     t.bigint "motif_category_id"
     t.enum "bookable_by", default: "agents", null: false, enum_type: "bookable_by"
+    t.string "public_link_id", null: false
     t.index "to_tsvector('simple'::regconfig, (COALESCE(name, (''::text)::character varying))::text)", name: "index_motifs_name_vector", using: :gin
     t.index ["collectif"], name: "index_motifs_on_collectif"
     t.index ["deleted_at"], name: "index_motifs_on_deleted_at"
@@ -415,6 +416,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_30_134819) do
     t.index ["name", "organisation_id", "location_type", "service_id"], name: "index_motifs_on_name_scoped", unique: true, where: "(deleted_at IS NULL)"
     t.index ["name"], name: "index_motifs_on_name"
     t.index ["organisation_id"], name: "index_motifs_on_organisation_id"
+    t.index ["public_link_id"], name: "index_motifs_on_public_link_id", unique: true
     t.index ["service_id"], name: "index_motifs_on_service_id"
     t.index ["visibility_type"], name: "index_motifs_on_visibility_type"
   end

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -213,7 +213,7 @@ motifs_attributes = 1000.times.map do |i|
     service_id: service_pmi.id,
     bookable_by: :everyone,
     location_type: :public_office,
-    public_link_id: SecureRandom.base58(8)
+    public_link_id: SecureRandom.base58(8),
   }
 end
 Motif.insert_all!(motifs_attributes) # rubocop:disable Rails/SkipsModelValidations

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -213,6 +213,7 @@ motifs_attributes = 1000.times.map do |i|
     service_id: service_pmi.id,
     bookable_by: :everyone,
     location_type: :public_office,
+    public_link_id: SecureRandom.base58(8)
   }
 end
 Motif.insert_all!(motifs_attributes) # rubocop:disable Rails/SkipsModelValidations

--- a/spec/features/agents/motifs/crud_spec.rb
+++ b/spec/features/agents/motifs/crud_spec.rb
@@ -237,6 +237,7 @@ RSpec.describe "Agent can CRUD motifs" do
       before do
         duplicate = motif.dup
         duplicate.deleted_at = nil
+        duplicate.public_link_id = SecureRandom.base58(8)
         duplicate.save!
       end
 

--- a/spec/features/agents/motifs/duplicate_spec.rb
+++ b/spec/features/agents/motifs/duplicate_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe "agent can duplicate motif" do
       id: be_a(Integer),
       created_at: be_within(1.second).of(Time.zone.now),
       updated_at: be_within(1.second).of(Time.zone.now),
-      location_type: "home"
+      location_type: "home",
+      public_link_id: be_present
     )
     expect(Motif.last).to have_attributes(expected_attributes)
   end
@@ -73,7 +74,8 @@ RSpec.describe "agent can duplicate motif" do
         created_at: be_within(1.second).of(Time.zone.now),
         updated_at: be_within(1.second).of(Time.zone.now),
         name: "Suivi de dossier",
-        organisation_id: other_organisation.id
+        organisation_id: other_organisation.id,
+        public_link_id: be_present
       )
       expect(Motif.last).to have_attributes(expected_attributes)
 

--- a/spec/features/autodoc/reservation_en_ligne_sur_un_motif_spec.rb
+++ b/spec/features/autodoc/reservation_en_ligne_sur_un_motif_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe "Lien de réservation direct pour un motif", js: true do
+  let!(:motif) { create(:motif, name: "Suivi de dossier") }
+  let(:lieu) { create(:lieu, organisation: motif.organisation) }
+  let(:agent) { create(:agent, admin_role_in_organisations: [motif.organisation]) }
+
+  before do
+    create(:plage_ouverture, motifs: [motif], lieu:)
+    login_as(agent, scope: :agent)
+  end
+
+  specify do
+    doc = Autodoc.start_scenario("Lien de prise de rendez-vous pour un motif spécifique", self, category: "3) Produit")
+
+    doc.start_section("Pour un motif ouvert à la réservation en ligne, avec des créneaux disponible")
+    visit admin_organisation_online_booking_path(motif.organisation)
+
+    Capybara.page.current_window.resize_to(1280, 1000)
+
+    doc.add_screenshot(page, text: "J'ouvre la page de configuration de la réservation en ligne.",
+                             wait_for: "Réservation en ligne")
+
+    click_on "Suivi de dossier"
+    doc.add_screenshot(page, text: "J'ouvre les détails de ce motif.",
+                             wait_for: "Ce lien permet de prendre rendez-vous pour ce motif.")
+
+    Capybara.page.current_window.resize_to(1280, 720)
+
+    within(".card-body", match: :first) do
+      visit find("a[target='_blank']").text # On fait un visit plutôt que d'ouvrir le lien dans un nouvel onglet
+    end
+
+    doc.add_screenshot(
+      page,
+      text: "En cliquant sur le lien, j'arrive sur la prise de rendez-vous pour ce motif. Si d'autres motifs sont ouverts, l'usager pourra quand même revenir en arrière et choisir un autre motif.",
+      wait_for: "Sélectionnez un lieu de RDV"
+    )
+  end
+end

--- a/spec/features/super_admin/migrating_an_agent_spec.rb
+++ b/spec/features/super_admin/migrating_an_agent_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe "Migrating an agent from one organisation to another" do
     expect(rdv3.reload.organisation).to eq(new_organisation)
 
     # Motifs a copied to new org
-    expect(rdv1.motif).to have_attributes(motif1.attributes.except("id", "organisation_id", "created_at", "updated_at"))
-    expect(rdv2.motif).to have_attributes(motif1.attributes.except("id", "organisation_id", "created_at", "updated_at"))
-    expect(rdv3.motif).to have_attributes(motif2.attributes.except("id", "organisation_id", "created_at", "updated_at"))
+    expect(rdv1.motif).to have_attributes(motif1.attributes.except("id", "organisation_id", "created_at", "updated_at", "public_link_id"))
+    expect(rdv2.motif).to have_attributes(motif1.attributes.except("id", "organisation_id", "created_at", "updated_at", "public_link_id"))
+    expect(rdv3.motif).to have_attributes(motif2.attributes.except("id", "organisation_id", "created_at", "updated_at", "public_link_id"))
     expect([rdv1.motif, rdv3.reload.motif]).to match_array(new_organisation.motifs)
 
     # RVS users are present in the new org

--- a/spec/features/territory_admins/territory_admin_can_manage_motifs_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_motifs_spec.rb
@@ -353,6 +353,7 @@ RSpec.describe "territory admin can manage motifs", type: :feature do
       before do
         duplicate = motif.dup
         duplicate.deleted_at = nil
+        duplicate.public_link_id = SecureRandom.base58(8)
         duplicate.save!
       end
 

--- a/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
     before { create(:plage_ouverture, motifs: [motif], lieu:) }
 
     it "still works for links that have been copied before" do
-      visit "/org/#{motif.organisation_id}/mds-paris-nord?motif_id=#{motif.id}"
+      visit "/motif/#{motif.public_link_id}/any-slug"
       expect(page).to have_content "Motif : #{motif.name}"
       expect(page).to have_content "Sélectionnez un lieu de RDV"
     end

--- a/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
@@ -106,4 +106,21 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
       expect(page).to have_content("Sélectionnez le motif de votre RDV")
     end
   end
+
+  describe "links to a specific motif" do
+    # On a actuellement des liens qui peuvent être sur les sites des organisations.
+    #
+    # Cette spec échouera si on change les routes d'une manière qui n'est pas rétro-compatible avec les
+    # liens de réservation qui sont actuellement proposés.
+    let!(:motif) { create(:motif, name: "Suivi de dossier") }
+    let(:lieu) { create(:lieu, organisation: motif.organisation) }
+    let(:agent) { create(:agent, admin_role_in_organisations: [motif.organisation]) }
+
+    before { create(:plage_ouverture, motifs: [motif], lieu:) }
+
+    it "still works for links that have been copied before" do
+      visit "/org/#{motif.organisation_id}/mds-paris-nord?motif_id=#{motif.id}"
+      expect(page).to have_content "Sélectionnez un lieu de RDV"
+    end
+  end
 end

--- a/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
 
     it "still works for links that have been copied before" do
       visit "/org/#{motif.organisation_id}/mds-paris-nord?motif_id=#{motif.id}"
+      expect(page).to have_content "Motif : #{motif.name}"
       expect(page).to have_content "Sélectionnez un lieu de RDV"
     end
   end

--- a/spec/form_models/admin/create_motifs_spec.rb
+++ b/spec/form_models/admin/create_motifs_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Admin::CreateMotifs do
   context "when the motif already exists in one of the orgs" do
     let!(:organisations) do
       [
-        create(:organisation, name: "Ma première orga").tap { Motif.create!(valid_motif.attributes.merge(organisation: _1, public_link_id: "123")) },
-        create(:organisation, name: "Ma seconde orga").tap { Motif.create!(valid_motif.attributes.merge(organisation: _1, public_link_id: "456")) },
+        create(:organisation, name: "Ma première orga").tap { Motif.create!(valid_motif.attributes.merge(organisation: _1, public_link_id: SecureRandom.base58(8))) },
+        create(:organisation, name: "Ma seconde orga").tap { Motif.create!(valid_motif.attributes.merge(organisation: _1, public_link_id: SecureRandom.base58(8))) },
         create(:organisation, name: "Ma troisième orga"),
       ]
     end

--- a/spec/form_models/admin/create_motifs_spec.rb
+++ b/spec/form_models/admin/create_motifs_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Admin::CreateMotifs do
   context "when the motif already exists in one of the orgs" do
     let!(:organisations) do
       [
-        create(:organisation, name: "Ma première orga").tap { |org| valid_motif.dup.tap { |motif| motif.assign_attributes(organisation: org) }.save! },
-        create(:organisation, name: "Ma seconde orga").tap { |org| valid_motif.dup.tap { |motif| motif.assign_attributes(organisation: org) }.save! },
+        create(:organisation, name: "Ma première orga").tap { Motif.create!(valid_motif.attributes.merge(organisation: _1, public_link_id: "123")) },
+        create(:organisation, name: "Ma seconde orga").tap { Motif.create!(valid_motif.attributes.merge(organisation: _1, public_link_id: "456")) },
         create(:organisation, name: "Ma troisième orga"),
       ]
     end


### PR DESCRIPTION

<img width="1280" height="1000" alt="scenario_de145c5fb_section_1_step_1" src="https://github.com/user-attachments/assets/82b287e1-09fc-4c7d-9094-c9c036f8086c" />


# Contexte

On voudrait arrêter d'utiliser Cal.com, mais pour ça, ça serait pratique d'avoir des liens de réservation direct qui pré-sélectionnent des motifs.
Ça tombe bien, c'était demandé par pas mal d'agents.

# Solution

On fait une première version raisonnable (mais qui pourra être améliorée plus tard, par exemple en fusionnant la card du lien et la dernière de la page).
Le titre de la nouvelle card est légèrement différent de celui pour la page principale pour permettre de distinguer les deux pages.

Je mets aussi une spec qui échouera si on change la route d'une manière qui n'est pas compatible avec les liens que les gens pourront copier.


