### PR TITLE
Utiliser un ID non énumérable dans le lien public vers une orga

### DIFF
--- a/app/blueprints/organisation_blueprint.rb
+++ b/app/blueprints/organisation_blueprint.rb
@@ -1,5 +1,5 @@
 class OrganisationBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :phone_number, :email, :website, :verticale, :public_link_id
+  fields :name, :phone_number, :email, :website, :verticale
 end

--- a/app/blueprints/organisation_blueprint.rb
+++ b/app/blueprints/organisation_blueprint.rb
@@ -1,5 +1,5 @@
 class OrganisationBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :phone_number, :email, :website, :verticale
+  fields :name, :phone_number, :email, :website, :verticale, :public_link_id
 end

--- a/app/controllers/api/justice/lieux_controller.rb
+++ b/app/controllers/api/justice/lieux_controller.rb
@@ -48,7 +48,7 @@ class Api::Justice::LieuxController < ActionController::Base # rubocop:disable R
 
   def url(lieu)
     Rails.application.routes.url_helpers.public_link_to_org_url(
-      organisation_id: lieu.organisation_id,
+      organisation_id: lieu.organisation.public_link_id,
       org_slug: lieu.organisation.slug,
       host: "rdv.anct.gouv.fr"
     )

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -124,7 +124,7 @@ class SearchController < ApplicationController
 
     export = InstanceExport.finished_exports_for_organisation(organisation.id).first
 
-    public_link_to_org_url(organisation_id: export.destination_organisation.public_link_id, org_slug: organisation.slug, host: ENV["RDV_SERVICE_PUBLIC_OAUTH_BASE_URL"])
+    public_link_to_org_url(organisation_id: export.destination_organisation_id, org_slug: organisation.slug, host: ENV["RDV_SERVICE_PUBLIC_OAUTH_BASE_URL"])
   end
 
   def redirect_to_organisation_search(organisation, motif: nil)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -59,7 +59,7 @@ class SearchController < ApplicationController
   end
 
   def public_link_with_internal_organisation_id
-    organisation = Organisation.find(params[:organisation_id])
+    organisation = Organisation.find_by(public_link_id: params[:organisation_id]) || Organisation.find(params[:organisation_id])
     redirect_to_organisation_search(organisation)
   end
 
@@ -124,7 +124,7 @@ class SearchController < ApplicationController
 
     export = InstanceExport.finished_exports_for_organisation(organisation.id).first
 
-    public_link_to_org_url(organisation_id: export.destination_organisation_id, org_slug: organisation.slug, host: ENV["RDV_SERVICE_PUBLIC_OAUTH_BASE_URL"])
+    public_link_to_org_url(organisation_id: export.destination_organisation.public_link_id, org_slug: organisation.slug, host: ENV["RDV_SERVICE_PUBLIC_OAUTH_BASE_URL"])
   end
 
   def redirect_to_organisation_search(organisation, motif: nil)

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -27,10 +27,6 @@ class InstanceExport < ApplicationRecord
     super || agent.organisations.first
   end
 
-  def destination_organisation
-    @destination_organisation ||= Organisation.new(new_instance_organisations.first).tap(&:readonly!)
-  end
-
   def api_client
     @api_client ||= RdvServicePublicApiClient.new(api_token)
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -52,7 +52,7 @@ class Organisation < ApplicationRecord
 
   # Hooks
 
-  after_initialize { self.public_link_id ||= SecureRandom.base58(6) }
+  before_save { self.public_link_id ||= SecureRandom.base58(6) }
 
   # Scopes
   scope :attributed_to_sectors, lambda { |sectors:, most_relevant: false|

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -50,6 +50,10 @@ class Organisation < ApplicationRecord
               in: TZInfo::Timezone.all_identifiers, # on utilise all_identifiers car nous souhaitons afficher les timezones et leurs alias
             }
 
+  # Hooks
+
+  after_initialize { self.public_link_id ||= SecureRandom.base58(8) }
+
   # Scopes
   scope :attributed_to_sectors, lambda { |sectors:, most_relevant: false|
     attributions = SectorAttribution

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -52,7 +52,7 @@ class Organisation < ApplicationRecord
 
   # Hooks
 
-  after_initialize { self.public_link_id ||= SecureRandom.base58(8) }
+  after_initialize { self.public_link_id ||= SecureRandom.base58(6) }
 
   # Scopes
   scope :attributed_to_sectors, lambda { |sectors:, most_relevant: false|

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -38,7 +38,7 @@
       p Cette organisation est sectorisée, les usagers peuvent prendre rendez-vous en saisissant leur adresse sur la page d'accueil&nbsp;:
       = render partial: "admin/organisations/online_bookings/booking_link", locals: { booking_link: prendre_rdv_url }
     - else
-      - org_booking_link = public_link_to_org_url(organisation_id: current_organisation.id, org_slug: current_organisation.slug)
+      - org_booking_link = public_link_to_org_url(organisation_id: current_organisation.public_link_id, org_slug: current_organisation.slug)
       = render partial: "admin/organisations/online_bookings/booking_link", locals: { booking_link: org_booking_link }
 
     p.fr-mt-2w Ce lien permet de  prendre rendez-vous avec votre organisation sur les plages d'ouverture disponibles.

--- a/db/migrate/20260108161716_add_public_link_id_to_organisations.rb
+++ b/db/migrate/20260108161716_add_public_link_id_to_organisations.rb
@@ -1,0 +1,13 @@
+class AddPublicLinkIdToOrganisations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :organisations, :public_link_id, :string
+
+    up_only do
+      Organisation.find_each do |org|
+        org.update_columns(public_link_id: SecureRandom.base58(8))
+      end
+    end
+
+    add_check_constraint :organisations, "public_link_id IS NOT NULL", name: "organisations_public_link_id_null", validate: false
+  end
+end

--- a/db/migrate/20260108161716_add_public_link_id_to_organisations.rb
+++ b/db/migrate/20260108161716_add_public_link_id_to_organisations.rb
@@ -4,7 +4,7 @@ class AddPublicLinkIdToOrganisations < ActiveRecord::Migration[8.0]
 
     up_only do
       Organisation.find_each do |org|
-        org.update_columns(public_link_id: SecureRandom.base58(8))
+        org.update_columns(public_link_id: SecureRandom.base58(6))
       end
     end
 

--- a/db/migrate/20260108161837_validate_add_public_link_id_to_organisations.rb
+++ b/db/migrate/20260108161837_validate_add_public_link_id_to_organisations.rb
@@ -1,0 +1,12 @@
+class ValidateAddPublicLinkIdToOrganisations < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :organisations, name: "organisations_public_link_id_null"
+    change_column_null :organisations, :public_link_id, false
+    remove_check_constraint :organisations, name: "organisations_public_link_id_null"
+  end
+
+  def down
+    add_check_constraint :organisations, "public_link_id IS NOT NULL", name: "organisations_public_link_id_null", validate: false
+    change_column_null :organisations, :public_link_id, true
+  end
+end

--- a/db/migrate/20260108161928_add_index_to_organisations_public_link_id.rb
+++ b/db/migrate/20260108161928_add_index_to_organisations_public_link_id.rb
@@ -1,0 +1,7 @@
+class AddIndexToOrganisationsPublicLinkId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :organisations, :public_link_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_08_101447) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_08_161928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -509,8 +509,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_08_101447) do
     t.boolean "online_booking_for_professionnels", default: false, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des professionnels, et donc qu'on propose le bouton ProConnect lors de la prise de rendez-vous en ligne.\n"
     t.string "time_zone", default: "Europe/Paris", null: false
     t.datetime "disabled_at", comment: "Date de fermeture de l'organisation"
+    t.string "public_link_id", null: false
     t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["name", "territory_id"], name: "index_organisations_on_name_and_territory_id", unique: true
+    t.index ["public_link_id"], name: "index_organisations_on_public_link_id", unique: true
     t.index ["territory_id"], name: "index_organisations_on_territory_id"
   end
 

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
 
   it "shows the online booking forms, until the creneau selection" do
     login_as(agent, scope: :agent)
-    visit public_link_to_org_path(organisation_id: organisation.id)
+    visit public_link_to_org_path(organisation_id: organisation.public_link_id)
 
     expect(page).to have_content("Sélectionnez le motif de votre RDV :")
     click_link("Accompagnement Formation")
@@ -22,7 +22,7 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
 
   it "works on the RDV_SERVICE_PUBLIC domain" do
     login_as(agent, scope: :agent)
-    visit "http://www.rdv-service-public-test.localhost/#{public_link_to_org_path(organisation_id: organisation.id)}"
+    visit "http://www.rdv-service-public-test.localhost/#{public_link_to_org_path(organisation_id: organisation.public_link_id)}"
     expect(page).to have_content("Sélectionnez le motif de votre RDV :")
   end
 end

--- a/spec/features/agents/online_booking/configuration_spec.rb
+++ b/spec/features/agents/online_booking/configuration_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "Agents can configure online booking" do
     context "when organisation is not sectorized" do
       it "points to the public booking home page" do
         visit admin_organisation_online_booking_path(organisation)
-        expect(page).to have_content("http://www.rdv-solidarites-test.localhost:#{Capybara.server_port}/org/#{organisation.id}/#{organisation.slug}")
+        expect(page).to have_content("http://www.rdv-solidarites-test.localhost:#{Capybara.server_port}/org/#{organisation.public_link_id}/#{organisation.slug}")
       end
     end
   end

--- a/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/rendez_vous_entre_agents_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     doc.start_section("Côté usager")
 
-    visit public_link_to_org_url(organisation_id: Organisation.last.id, host: "http://www.rdv-service-public-test.localhost/")
+    visit public_link_to_org_url(organisation_id: Organisation.last.public_link_id, host: "http://www.rdv-service-public-test.localhost/")
 
     doc.add_screenshot(page,
                        text: "Je visite le lien de prise de rendez-vous que l'agent m'a transmis.",

--- a/spec/features/users/account/logout_spec.rb
+++ b/spec/features/users/account/logout_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Déconnexion" do
   let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: 1.month.from_now, motifs: [motif], lieu: lieu, organisation: organisation) }
 
   it "fonctionne après une prise de rdv" do
-    visit public_link_to_org_path(organisation_id: organisation.id, org_slug: organisation.slug)
+    visit public_link_to_org_path(organisation_id: organisation.public_link_id, org_slug: organisation.slug)
     click_on motif.name
     click_on lieu.name
     first(:link, "11:00").click
@@ -23,7 +23,7 @@ RSpec.describe "Déconnexion" do
 
     click_on "Déconnexion"
 
-    visit public_link_to_org_path(organisation_id: organisation.id, org_slug: organisation.slug)
+    visit public_link_to_org_path(organisation_id: organisation.public_link_id, org_slug: organisation.slug)
     click_on motif.name
     click_on lieu.name
     first(:link, "11:00").click

--- a/spec/features/users/online_booking/creneaux_selection_spec.rb
+++ b/spec/features/users/online_booking/creneaux_selection_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "User can select a creneau" do
     let!(:plage_ouverture2) { create(:plage_ouverture, first_day: Time.zone.tomorrow, motifs: [motif], lieu: lieu, organisation: organisation) }
 
     it "does not show duplicate creneaux" do
-      visit public_link_to_org_path(organisation_id: organisation.id)
+      visit public_link_to_org_path(organisation_id: organisation.public_link_id)
 
       click_on("RSA Orientation") # choix du motif
       click_on(lieu.name) # choix du lieu

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -451,7 +451,7 @@ RSpec.describe "User can search for rdvs" do
     let(:organisation) { create(:organisation) }
 
     it "permet de prendre rendez-vous" do
-      visit public_link_to_org_path(organisation_id: organisation.id)
+      visit public_link_to_org_path(organisation_id: organisation.public_link_id)
       click_on "Vaccination"
       click_on "Prochaine disponibilité"
       first(:link, "08:00").click

--- a/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
         expect(page).to have_content("Motif A")
         expect(page).not_to have_content("Motif B")
       end
+
+      it "supports both internal ID and public ID" do
+        visit "/org/#{organisation_a.public_link_id}"
+        expect(page).to have_content("Motif A")
+        url_de_prise_de_rdv = current_url
+
+        visit "/org/#{organisation_a.id}"
+        expect(current_url).to eq(url_de_prise_de_rdv)
+      end
     end
 
     context "when providing the external organisation id + territory slug" do

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
     end
 
     it "displays the organisation name for a public link" do
-      visit public_link_to_org_url(organisation_id: organisation.id)
+      visit public_link_to_org_url(organisation_id: organisation.public_link_id)
       expect(page).to have_content "Prenez rendez-vous avec Mairie de Wavignies"
     end
   end


### PR DESCRIPTION
# Contexte

Actuellement nous proposons des liens publics de réservation usager sous la forme suivante :

```
https://domaine.tld/org/$ID_ORGA/$SLUG_DÉCORATIF

Exemple : 
https://rdv.anct.gouv.fr/org/112/equipe-produit-de-rdv-service-public
```

Nous utilisons l'ID interne de l'organisation, qui est un nombre entier incrémental. Le problème c'est qu'**il est donc facile d'énumérer tous les IDs pour accéder à toues les prises de RDV publiques de toute une instance**.

## Est-ce grave ?

C'est difficile à dire car ça dépend des attentes de l'agent vis-à-vis d'un "lien public". On peut essayer de distinguer plusieurs cas :
1. En tant qu'agent, je peux considérer implicitement que le lien constitue un "sésame" d'accès, et donc supposer qu'il faut forcément connaître ce lien pour voir mes créneaux et prendre RDV.
2. En tant qu'agent, je peux considérer que le lien est juste un raccourci facile vers une ressource déjà publiquement accessible (peu d'agents pensent comme ça je crois).
3. En tant qu'agent, je peux peux ne pas me poser cette question. Je considère simplement que le lien donne accès à mes dispos, mais je ne me pose pas la question de si on peut les trouver sans le lien. Je crois que ce cas de figure est peu probable, car l'existence même du lien pousse à croire qu'il est confidentiel (on retombe donc sur le cas 1).

# Solution

Afin de ne pas avoir à trouver de réponse à la question "Est-ce grave ?", je propose ici d'introduire des IDs publics non énumérables car aléatoires.

## Et les liens déjà dans la nature ?

Nous gardons les anciens liens valables pendant encore un bon moment et réfléchirons à éventuellement les rendre invalides dans un moment lointain, peut-être lors d'éventuels ajouts de fonctionnalités de confidentialité sur les liens publics.

## Taille de l'ID

Comme dans #5992 j'ai opté pour un alphabet base58 pour permettre de taper l'ID à la main au cas où.

Il y a 4000 orgas sur RDVS et 2000 orgas sur RDVSP, donc à 6 caractères on, est pas mal : 

<img width="1012" height="480" alt="image" src="https://github.com/user-attachments/assets/1a7be26f-730e-4ec4-b74b-303f05290461" />
