### PR TITLE
correction login_hint proconnect pour les usagers

### DIFF
--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -12,7 +12,7 @@
       h2 Se connecter avec ProConnect
 
       .rdv-text-align-center
-        = render "common/proconnect_button_dsfr", login_hint: resource.email, user_type: "user"
+        = render "common/proconnect_button_dsfr", user_type: "user"
 
       p.fr-hr-or ou
     h2 Se connecter par e-mail


### PR DESCRIPTION
Corrige https://sentry.incubateur.net/organizations/betagouv/issues/235848/?project=74&referrer=webhooks_plugin

Se produit dans un cas particulier : 
- des motifs d’orgas où les usagers peuvent se ProConnect
- l’usager renseigne un email dans le champ pour recevoir un login code et le soumet
- cet email ne correspond à aucun User en db

Le lien du bouton vers ProConnect contient un `login_hint: resource.email`, or dans ce cas précis on render `users/sessions/new.html` depuis le LoginCodesController qui n’hérite pas de devise et n’instancie pas de `resource`. 

Je ne comprends pas bien dans quel cas ce login_hint est utile. Je ne vois qu’un seul cas où c’était utile : l’usager renseignait un email / mot de passe invalide puis cliquait sur proconnect. ça me parait suffisament niche comme cas pour simplement le supprimer.

Ça va aussi avec l’idée de se diriger de plus en plus pour nous extraire de devise côté usagers.

si on veut le conserver on peut tout à fait faire un truc comme `login_hint: @login_code_form_request&.email`
