### PR TITLE
Ajout de connexions DB supplémentaires via une variable d'environnement

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -33,7 +33,7 @@ default: &default
   # Pour savoir combien de connexions on utilise, on peut vérifier sur Scalingo via la page "Running queries" du dashboard postgres
   # par exemple https://dashboard.scalingo.com/apps/osc-secnum-fr1/production-rdv-solidarites/db/postgresql/running-queries
   #
-  # On pourrait même mieux utiliser le mécanisme de connection pool, et avoir moins de connexions que de threads.
+  # Sur l'instance RDV Service Public, on ajoute quelques connexions supplémentaire parce qu'on a de la marge côté DB.
   #
   # For GoodJob container, we need connections for :
   # - the max number of threads (5 by default, cf https://github.com/bensheldon/good_job/blob/main/lib/good_job/configuration.rb#L126-L134)
@@ -42,7 +42,7 @@ default: &default
   #
   # cf docs/4-notes-techniques.md pour une vue d’ensemble du nombre de threads et de connexions à
   # la base de données
-  pool: <%= $PROGRAM_NAME.include?("good_job") ? GoodJob.configuration.max_threads + 2 + 1 : (ENV.fetch("RAILS_MAX_THREADS", 4).to_i) %>
+pool: <%= $PROGRAM_NAME.include?("good_job") ? GoodJob.configuration.max_threads + 2 + 1 : ((ENV.fetch("RAILS_MAX_THREADS", 4).to_i) + (ENV.fetch("RAILS_EXTRA_DB_CONNECTIONS", 0).to_i)) %>
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -42,7 +42,7 @@ default: &default
   #
   # cf docs/4-notes-techniques.md pour une vue d’ensemble du nombre de threads et de connexions à
   # la base de données
-pool: <%= $PROGRAM_NAME.include?("good_job") ? GoodJob.configuration.max_threads + 2 + 1 : ((ENV.fetch("RAILS_MAX_THREADS", 4).to_i) + (ENV.fetch("RAILS_EXTRA_DB_CONNECTIONS", 0).to_i)) %>
+  pool: <%= $PROGRAM_NAME.include?("good_job") ? GoodJob.configuration.max_threads + 2 + 1 : (ENV.fetch("RAILS_MAX_THREADS", 4).to_i + ENV.fetch("RAILS_EXTRA_DB_CONNECTIONS", 0).to_i) %>
 
 development:
   <<: *default


### PR DESCRIPTION
mitigation pour https://sentry.incubateur.net/organizations/betagouv/issues/217642/?referrer=webhooks_plugin

# Contexte

A cause des requêtes en parallèles lors du calcul de créneaux, on a des erreurs de ce type :
```
ActiveRecord::ConnectionTimeoutError could not obtain a connection from the pool within 5.000 seconds (waited 15.011 seconds); all pooled connections were in use (ActiveRecord::ConnectionTimeoutError)
```

C'est possible que ça soit un deadlock s'il y a plusieurs calculs de créneaux en même temps.

# Solution

C'est un peu risqué de dé-paralléliser ce calcul tout de suite (on a du mal à savoir quel impact ça aurait sur les perfs), donc pour mitiger le problème pour le moment, on ajoute des connexions.
On va faire ça sur la nouvelle instance, sur laquelle on a encore beaucoup de marge en terme de nombre de connexions.

