### PR TITLE
Captures d'écran haute résolution dans l'autodoc

### DIFF
--- a/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/connexion_par_administrateur_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Connexion de Démarches Simplifiées à RDV Service Public par u
       Si j'ai déjà un compte, je peux aussi me connecter par email et mot de passe.
       Si je suis déjà connecté à RDV Service Public, cet écran ne s'affiche pas et je passe directement au suivant.
     TEXT
-    doc.add_screenshot(page, text: text, wait_for: "Vous devez vous connecter pour continuer")
+    doc.add_screenshot(page, text: text, wait_for: "Vous devez vous connecter pour continuer", disable_high_res_zoom: true)
 
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password

--- a/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe "Prise de rendez-vous par un instructeur", js: true do
     click_on "Se connecter"
 
     doc.add_screenshot(page,
-                       text: "On me demande de confirmer que j'accepte de connecter les deux applications. \
-    (Il se peut que cette capture d'écran ne s'affiche pas dans l'autodoc, vous pouvez la récupérer depuis le parcours de connexion des admins.)")
+                       text: "On me demande de confirmer que j'accepte de connecter les deux applications.",
+                       wait_for: "Validation de permissions")
 
     rdv_plan = create(:rdv_plan,
                       user: user,

--- a/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
+++ b/spec/features/autodoc/integration_demarches_simplifiees/prise_de_rdv_spec.rb
@@ -16,14 +16,11 @@ RSpec.describe "Prise de rendez-vous par un instructeur", js: true do
   let!(:lieu) { create(:lieu, address: "8 Rue Froissart, 75003 Paris", name: "DDPP de Paris", organisation:) }
   let(:organisation) { create(:organisation, name: "Préfecture de Police de Paris") }
 
-  let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application: oauth_application) }
   let!(:agent) do
     create(:agent, first_name: "Alex", last_name: "Emple",
                    email: "alex.emple@exemple.gouv.fr", password: "RdvServicePublicTest1!",
                    basic_role_in_organisations: [organisation])
   end
-
-  stub_env_for_proconnect
 
   around do |example|
     previous_host = Capybara.app_host
@@ -31,6 +28,8 @@ RSpec.describe "Prise de rendez-vous par un instructeur", js: true do
     example.run
     Capybara.app_host = previous_host
   end
+
+  stub_env_for_proconnect
 
   specify do
     doc = Autodoc.start_scenario("3) Prise de RDV par un instructeur", self, accessibility_checks: false, category: "4) Intégration à Démarches Simplifiées")
@@ -57,7 +56,7 @@ RSpec.describe "Prise de rendez-vous par un instructeur", js: true do
       response_type: :code, scope: :write, state: "fakestate"
     )
 
-    doc.add_screenshot(page, text: "Je me ProConnecte", wait_for: "Vous devez vous connecter pour continuer")
+    doc.add_screenshot(page, text: "Je me ProConnecte", wait_for: "Vous devez vous connecter pour continuer", disable_high_res_zoom: true)
 
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password
@@ -65,7 +64,7 @@ RSpec.describe "Prise de rendez-vous par un instructeur", js: true do
 
     doc.add_screenshot(page,
                        text: "On me demande de confirmer que j'accepte de connecter les deux applications.",
-                       wait_for: "Validation de permissions")
+                       wait_for: "vous allez permettre à Démarches Simplifiées")
 
     rdv_plan = create(:rdv_plan,
                       user: user,

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -69,7 +69,15 @@ class Autodoc
         if @scenario_accessibility_checks && accessibility_checks # On peut désactiver ces checks au niveau de tout le scénario ou juste pour ce screenshot
           @example.expect(page_or_email).to @example.be_axe_clean
         end
+
+        current_size = Capybara.page.current_window.size
+        Capybara.page.current_window.resize_to(current_size[0] * 2, current_size[1] * 2)
+        page_or_email.execute_script("document.body.style.zoom=2.0")
+
         page_or_email.driver.save_screenshot(path)
+
+        page_or_email.execute_script("document.body.style.zoom=1.0")
+        Capybara.page.current_window.resize_to(current_size[0], current_size[1])
       end
 
       img_src = ENV["UPLOAD_TO_GH_PAGES"] ? "/rdv-service-public/#{filename}" : path

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -55,7 +55,7 @@ class Autodoc
     # On zoome artificiellement pour avoir des captures d'écran en haute résolution, mais cela peut fausser l'affichage
     # des pages qui utilisent un layout centré verticalement.
     # Dans ce cas, il faut passer l'option `disable_high_res_zoom: true` pour avoir un affichage correct (mais une capture d'écran en basse définition)
-    def add_screenshot(page_or_email, text: nil, wait_for: nil, accessibility_checks: true, disable_high_res_zoom: false)
+    def add_screenshot(page_or_email, text: nil, wait_for: nil, accessibility_checks: true, disable_high_res_zoom: false) # rubocop:disable Metrics/PerceivedComplexity
       if wait_for
         @example.expect(page_or_email).to(@example.have_content(wait_for))
       end

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -70,14 +70,14 @@ class Autodoc
           @example.expect(page_or_email).to @example.be_axe_clean
         end
 
-        current_size = Capybara.page.current_window.size
-        Capybara.page.current_window.resize_to(current_size[0] * 2, current_size[1] * 2)
+        current_size = page_or_email.current_window.size
+        page_or_email.current_window.resize_to(current_size[0] * 2, current_size[1] * 2)
         page_or_email.execute_script("document.body.style.zoom=2.0")
 
         page_or_email.driver.save_screenshot(path)
 
         page_or_email.execute_script("document.body.style.zoom=1.0")
-        Capybara.page.current_window.resize_to(current_size[0], current_size[1])
+        page_or_email.current_window.resize_to(current_size[0], current_size[1])
       end
 
       img_src = ENV["UPLOAD_TO_GH_PAGES"] ? "/rdv-service-public/#{filename}" : path

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -52,7 +52,10 @@ class Autodoc
       @current_section.steps << { text: description }
     end
 
-    def add_screenshot(page_or_email, text: nil, wait_for: nil, accessibility_checks: true)
+    # On zoome artificiellement pour avoir des captures d'écran en haute résolution, mais cela peut fausser l'affichage
+    # des pages qui utilisent un layout centré verticalement.
+    # Dans ce cas, il faut passer l'option `disable_high_res_zoom: true` pour avoir un affichage correct (mais une capture d'écran en basse définition)
+    def add_screenshot(page_or_email, text: nil, wait_for: nil, accessibility_checks: true, disable_high_res_zoom: false)
       if wait_for
         @example.expect(page_or_email).to(@example.have_content(wait_for))
       end
@@ -70,14 +73,18 @@ class Autodoc
           @example.expect(page_or_email).to @example.be_axe_clean
         end
 
-        current_size = page_or_email.current_window.size
-        page_or_email.current_window.resize_to(current_size[0] * 2, current_size[1] * 2)
-        page_or_email.execute_script("document.body.style.zoom=2.0")
+        unless disable_high_res_zoom
+          current_size = page_or_email.current_window.size
+          page_or_email.current_window.resize_to(current_size[0] * 2, current_size[1] * 2)
+          page_or_email.execute_script("document.body.style.zoom=2.0")
+        end
 
         page_or_email.driver.save_screenshot(path)
 
-        page_or_email.execute_script("document.body.style.zoom=1.0")
-        page_or_email.current_window.resize_to(current_size[0], current_size[1])
+        unless disable_high_res_zoom
+          page_or_email.execute_script("document.body.style.zoom=1.0")
+          page_or_email.current_window.resize_to(current_size[0], current_size[1])
+        end
       end
 
       img_src = ENV["UPLOAD_TO_GH_PAGES"] ? "/rdv-service-public/#{filename}" : path


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1280" height="720" alt="low_res" src="https://github.com/user-attachments/assets/f7a9fbe3-4cff-4616-8a30-3d075077a947" />|<img width="1280" height="720" alt="high_res" src="https://github.com/user-attachments/assets/b3f84cd7-8ed3-4aea-8648-ae4b3d259fcb" />

Une petite astuce pour avoir des captures d'écran en haute résolution qui seront plus pratique à utiliser pour communiquer avec les usagers ou les partenaires.