### PR TITLE
Utiliser un input type number pour les login codes

### DIFF
--- a/app/views/users/sessions_by_code/new.html.slim
+++ b/app/views/users/sessions_by_code/new.html.slim
@@ -24,6 +24,7 @@
         = form.hidden_field :email
         = form.dsfr_text_field :code,
           label: "Code à 6 chiffres",
+          type: "number",
           maxlength: 6,
           required: true,
           autocomplete: "off"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = false
   end
 
-  config.hosts << ".ngrok.io"
+  config.hosts << ".ngrok-free.dev"
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   # config.active_storage.service = :local


### PR DESCRIPTION
Lors de la saisie du login code sur mobile, on peut forcer à afficher un clavier numérique plutôt qu’un clavier complet puisqu’on n’envoie que des codes à 6 chiffres


https://github.com/user-attachments/assets/3461df92-d7bc-47d3-986f-376856dc39be

