### PR TITLE
Bugfix : l'en-tête d'agenda mensuel affiche des numéros de jours

### DIFF
--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -12,7 +12,7 @@ import {
   classicHeaderToolbarLayout,
   betaHeaderToolbarLayout,
   betaWeekTitleFormat,
-  betaDayHeaderFormat,
+  dayHeaderContent,
   betaPlanningEnabled,
 } from './calendar/utils'
 
@@ -53,7 +53,7 @@ export class AgendaMonoAgent {
       initialView: this.getDefaultView(),
       hiddenDays: hiddenDays,
       titleFormat: betaPlanningEnabled() ? betaWeekTitleFormat : null,
-      dayHeaderFormat: betaPlanningEnabled() ? betaDayHeaderFormat : null,
+      dayHeaderContent: dayHeaderContent,
       select: this.selectEvent,
       headerToolbar: betaPlanningEnabled() ? betaHeaderToolbarLayout : classicHeaderToolbarLayout,
       customButtons: {

--- a/app/javascript/components/calendar/agenda-multi-agent.js
+++ b/app/javascript/components/calendar/agenda-multi-agent.js
@@ -7,7 +7,7 @@ import {
   setupPollingRefresh,
   setupRealtimeRefresh,
   handleAjaxError,
-  betaDayHeaderFormat,
+  dayHeaderContent,
   betaWeekTitleFormat
 } from "./utils";
 
@@ -50,7 +50,7 @@ class AgendaMultiAgent {
         right: "preferencesModalToggle",
       },
       titleFormat: betaWeekTitleFormat,
-      dayHeaderFormat: betaDayHeaderFormat,
+      dayHeaderContent: dayHeaderContent,
       customButtons: this.customButtons(),
       datesAboveResources: this.data.groupByAgent !== "true",
       datesSet: this.datesSet,

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -10,7 +10,21 @@ export const classicHeaderToolbarLayout = { center: "dayGridMonth,timeGridWeek,t
 
 export const betaWeekTitleFormat = { month: "long", year: "numeric" };
 
-export const betaDayHeaderFormat = { weekday: "short", day: "numeric", omitCommas: true };
+
+const CUSTOM_HEADER_FORMATS = {
+  timeGridWeek: { weekday: "short", day: "numeric" },
+  timeGridOneDay: { weekday: "short", day: "numeric" },
+  dayGridMonth: { weekday: "long" },
+  resourceTimeGridWeek: { weekday: "short", day: "numeric" },
+};
+export const dayHeaderContent = ({ date, view }) => {
+  if(betaPlanningEnabled()) {
+    if (CUSTOM_HEADER_FORMATS[view.type]) {
+      return new Intl.DateTimeFormat('fr-FR', CUSTOM_HEADER_FORMATS[view.type]).format(date);
+    }
+  }
+  // else : on retourne null et FullCalendar utilise le formateur par défaut
+};
 
 const defaultFullCalendarConfig = () => ({
   locale: frLocale,


### PR DESCRIPTION
# Contexte

Les en-têtes d'agenda mensuel affichent des numéros de jours alors qu'ils devraient uniquement afficher le nom des jours de la semaine. 

## Avant

<img width="1848" height="934" alt="image" src="https://github.com/user-attachments/assets/d6ab11df-43ad-4040-b250-73fd7e27545f" />

## Après

<img width="1848" height="934" alt="image" src="https://github.com/user-attachments/assets/bf7b482f-7920-4566-92c1-8166343cda98" />

# La technique

On a commencé à utiliser `dayHeaderFormat` avec le nouveau planning, et on a pas fait attention que ça override toutes les vues, même la vue mensuelle.

J'introduis donc ici une méthode `dayHeaderContent` qui customise uniquement les vues si on est en mode beta (nouveau planning) et dans un format adapté.