### PR TITLE
Inciter à utiliser ProConnect pour la création de compte agent

### DIFF
--- a/app/controllers/admin/territories/invitations_devise_controller.rb
+++ b/app/controllers/admin/territories/invitations_devise_controller.rb
@@ -1,6 +1,6 @@
 class Admin::Territories::InvitationsDeviseController < Devise::InvitationsController
   # Ce controller est uniquement utilisé pour permettre aux agents d'accepter les invitations
-  layout "application"
+  layout "application_agent_config"
 
   # Bloque l'accès aux méthodes du controller parent pour éviter de permettre d'envoyer des invitations n'importe comment
   before_action :block_controller_action, except: %i[edit update] # rubocop:disable Rails/LexicallyScopedActionFilter

--- a/app/javascript/stylesheets/structure/_authentication.scss
+++ b/app/javascript/stylesheets/structure/_authentication.scss
@@ -57,3 +57,7 @@
   margin-top: 8px;
   font-size: 13px;
 }
+
+.legacy-signup-toggle:has([aria-expanded="true"]) {
+  display: none;
+}

--- a/app/views/admin/territories/invitations_devise/_password_signup_form.html.slim
+++ b/app/views/admin/territories/invitations_devise/_password_signup_form.html.slim
@@ -1,0 +1,11 @@
+p.fr-hint-text Tous les champs sont obligatoires.
+= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }, builder: Dsfr::FormBuilder, display_required_tags: false do |f|
+  = render "devise/shared/dsfr_error_messages", resource: resource
+  = f.hidden_field :invitation_token
+  .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
+    .fr-col-md-6= f.dsfr_text_field :first_name, required: true
+    .fr-col-md-6= f.dsfr_text_field :last_name, required: true
+  = render "common/form/new_password_input", f: , hint: "Choisissez votre mot de passe"
+
+  .fr-btns-group.fr-btns-group--inline.fr-btns-group--right
+    .fr-mt-2w= f.submit t("devise.invitations.edit.submit_button"), class: "fr-btn"

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -3,22 +3,24 @@
 .fr-container
   .fr-grid-row.fr-grid-row--center
     .fr-col-xs-12.fr-col-md-8.fr-py-5w
-      - if display_pro_connect_button?
-        h2 Se créer un compte avec ProConnect
-        .rdv-text-align-center
-          = render "common/proconnect_button_dsfr", login_hint: resource.email
+      = dsfr_tabs do |tabs|
+        - if display_pro_connect_button?
+        = tabs.with_tab title: "Continuer avec ProConnect", active: true do
+          .rdv-text-align-center
+            = render "common/proconnect_button_dsfr", login_hint: resource.email
+        = tabs.with_tab title: "Continuer avec un email", active: true do
+          - if display_pro_connect_button?
+            = dsfr_alert type: :info, title: "Préférez la connexion par ProConnect" do
+              |> Vous êtes sur le point de créer un compte avec une adresse email. Pour une expérience simplifiée et sécurisée, nous vous recommandons d'utiliser ProConnect.
+              | ProConnect vous permet de vous connecter rapidement sans avoir à gérer un mot de passe supplémentaire. De plus, vous pourrez utiliser une authentification forte à deux facteurs.
+          = form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }, builder: Dsfr::FormBuilder, display_required_tags: false do |f|
+            p.fr-hint-text Tous les champs sont obligatoires.
+            = render "devise/shared/dsfr_error_messages", resource: resource
+            = f.hidden_field :invitation_token
+            .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
+              .fr-col-md-6= f.dsfr_text_field :first_name, required: true
+              .fr-col-md-6= f.dsfr_text_field :last_name, required: true
+            = render "common/form/new_password_input", f: , hint: "Choisissez votre mot de passe"
 
-        p.fr-mt-3w.fr-hr-or = "ou"
-
-      h2 Se créer un compte avec un mot de passe
-      = form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }, builder: Dsfr::FormBuilder, display_required_tags: false do |f|
-        p.fr-hint-text Tous les champs sont obligatoires.
-        = render "devise/shared/dsfr_error_messages", resource: resource
-        = f.hidden_field :invitation_token
-        .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
-          .fr-col-md-6= f.dsfr_text_field :first_name, required: true
-          .fr-col-md-6= f.dsfr_text_field :last_name, required: true
-        = render "common/form/new_password_input", f: , hint: "Choisissez votre mot de passe"
-
-        .fr-btns-group.fr-btns-group--inline.fr-btns-group--right
-          .fr-mt-2w= f.submit t("devise.invitations.edit.submit_button"), class: "fr-btn"
+            .fr-btns-group.fr-btns-group--inline.fr-btns-group--right
+              .fr-mt-2w= f.submit t("devise.invitations.edit.submit_button"), class: "fr-btn"

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -6,7 +6,7 @@
   .fr-grid-row.fr-grid-row--center
     .fr-col-xs-12.fr-col-md-10.fr-py-5w
       - if display_pro_connect_button?
-        p.rdv-text-align-center Pour finaliser votre création de compte, connectez-vous avec ProConnect.
+        p.rdv-text-align-center Pour créer votre compte, connectez-vous avec ProConnect.
         .rdv-text-align-center
           = render "common/proconnect_button_dsfr", login_hint: resource.email
 
@@ -22,7 +22,7 @@
 
         .fr-collapse#legacy-signup-form
           .fr-mt-3w
-            p.rdv-text-align-center Pour finaliser votre création de compte à l'aide d'un mot de passe, veuillez remplir le formulaire ci-dessous.
+            p.rdv-text-align-center Vous pouvez créer un compte avec un mot de passe sans utiliser ProConnect.
             = dsfr_alert type: :info, title: "Préférez la connexion par ProConnect", html_attributes: { class: "fr-mb-4v" } do
               | Vous êtes sur le point de créer un compte avec une adresse email. Pour une expérience simplifiée et sécurisée, nous vous recommandons d'utiliser ProConnect.
               br
@@ -30,5 +30,5 @@
             = render "password_signup_form"
 
       - else
-        p.rdv-text-align-center Pour finaliser votre création de compte, veuillez remplir le formulaire ci-dessous.
+        p.rdv-text-align-center Pour finaliser votre création de compte, nous avons besoins de quelques informations complémentaires.
         = render "password_signup_form"

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -5,6 +5,11 @@
 .fr-container
   .fr-grid-row.fr-grid-row--center
     .fr-col-xs-12.fr-col-md-10.fr-py-5w
+      - if resource.invited_by.present? && resource.organisations.one?
+        p.rdv-text-align-center
+          => resource.invited_by.full_name
+          | vous invite à rejoindre l'organisation « #{resource.organisations.first.name} ».
+
       - if display_pro_connect_button?
         p.rdv-text-align-center Pour créer votre compte, connectez-vous avec ProConnect.
         .rdv-text-align-center

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -1,26 +1,34 @@
-- content_for :title, "Création de compte sur #{current_domain.name}"
+- content_for :title do
+  .fr-h1
+    | Création de compte sur #{current_domain.name}
 
 .fr-container
   .fr-grid-row.fr-grid-row--center
-    .fr-col-xs-12.fr-col-md-8.fr-py-5w
-      = dsfr_tabs do |tabs|
-        - if display_pro_connect_button?
-        = tabs.with_tab title: "Continuer avec ProConnect", active: true do
-          .rdv-text-align-center
-            = render "common/proconnect_button_dsfr", login_hint: resource.email
-        = tabs.with_tab title: "Continuer avec un email", active: true do
-          - if display_pro_connect_button?
-            = dsfr_alert type: :info, title: "Préférez la connexion par ProConnect" do
-              |> Vous êtes sur le point de créer un compte avec une adresse email. Pour une expérience simplifiée et sécurisée, nous vous recommandons d'utiliser ProConnect.
-              | ProConnect vous permet de vous connecter rapidement sans avoir à gérer un mot de passe supplémentaire. De plus, vous pourrez utiliser une authentification forte à deux facteurs.
-          = form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }, builder: Dsfr::FormBuilder, display_required_tags: false do |f|
-            p.fr-hint-text Tous les champs sont obligatoires.
-            = render "devise/shared/dsfr_error_messages", resource: resource
-            = f.hidden_field :invitation_token
-            .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
-              .fr-col-md-6= f.dsfr_text_field :first_name, required: true
-              .fr-col-md-6= f.dsfr_text_field :last_name, required: true
-            = render "common/form/new_password_input", f: , hint: "Choisissez votre mot de passe"
+    .fr-col-xs-12.fr-col-md-10.fr-py-5w
+      - if display_pro_connect_button?
+        p.rdv-text-align-center Pour finaliser votre création de compte, connectez-vous avec ProConnect.
+        .rdv-text-align-center
+          = render "common/proconnect_button_dsfr", login_hint: resource.email
 
-            .fr-btns-group.fr-btns-group--inline.fr-btns-group--right
-              .fr-mt-2w= f.submit t("devise.invitations.edit.submit_button"), class: "fr-btn"
+        .fr-hr-or ou
+
+        .legacy-signup-toggle
+
+          p.rdv-text-align-center.fr-mt-3v Vous ne parvenez pas à utiliser ProConnect ?
+
+          .fr-mt-3v.rdv-text-align-center
+            button.fr-btn.fr-btn--tertiary[type="button" aria-expanded="false" aria-controls="legacy-signup-form"]
+              | Créer un compte avec un mot de passe
+
+        .fr-collapse#legacy-signup-form
+          .fr-mt-3w
+            p.rdv-text-align-center Pour finaliser votre création de compte à l'aide d'un mot de passe, veuillez remplir le formulaire ci-dessous.
+            = dsfr_alert type: :info, title: "Préférez la connexion par ProConnect", html_attributes: { class: "fr-mb-4v" } do
+              | Vous êtes sur le point de créer un compte avec une adresse email. Pour une expérience simplifiée et sécurisée, nous vous recommandons d'utiliser ProConnect.
+              br
+              | ProConnect vous permet de vous connecter rapidement sans avoir à gérer un mot de passe supplémentaire. De plus, vous pourrez utiliser une authentification forte à deux facteurs.
+            = render "password_signup_form"
+
+      - else
+        p.rdv-text-align-center Pour finaliser votre création de compte, veuillez remplir le formulaire ci-dessous.
+        = render "password_signup_form"

--- a/app/views/common/_proconnect_button_dsfr.html.slim
+++ b/app/views/common/_proconnect_button_dsfr.html.slim
@@ -6,7 +6,7 @@ form.fr-connect-group[action="#{pro_connect_auth_path}" method="get"]
   input[type="hidden" value="#{user_type}" name="user_type"]
   button.fr-connect.fr-proconnect
     span.fr-connect__login
-      | S’identifier avec
+      |> S’identifier avec
     span.fr-connect__brand
       | ProConnect
   p

--- a/spec/features/agents/account/agent_can_accept_invit_spec.rb
+++ b/spec/features/agents/account/agent_can_accept_invit_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe "Agent can accept invitation" do
 
       expect(redirect_url_query_params["login_hint"]).to eq agent.email
     end
+
+    it "hides the password form behind a collapse and reveals it on click", js: true do
+      agent.deliver_invitation
+      visit accept_agent_invitation_path(invitation_token: agent.raw_invitation_token)
+
+      # Le formulaire de mot de passe est caché initialement
+      expect(page).to have_content "Vous ne parvenez pas à utiliser ProConnect ?"
+      expect(page).to have_no_field "Prénom"
+
+      # Au clic sur le bouton, le formulaire apparaît
+      click_button "Créer un compte avec un mot de passe"
+      expect(page).to have_field "Prénom"
+
+      # Le texte et bouton d'invitation au collapse disparaissent
+      expect(page).to have_no_content "Vous ne parvenez pas à utiliser ProConnect ?"
+    end
   end
 
   context "when password is secure" do

--- a/spec/features/agents/account/agent_can_accept_invit_spec.rb
+++ b/spec/features/agents/account/agent_can_accept_invit_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Agent can accept invitation" do
     it "sets the login_hint to make sure the agent uses ProConnect with the right email and avoids getting stuck" do
       agent.deliver_invitation
       visit accept_agent_invitation_path(invitation_token: agent.raw_invitation_token)
-      expect(page).to have_content "Continuer avec ProConnect"
+      expect(page).to have_content "connectez-vous avec ProConnect"
       find(".fr-connect__brand").click
       begin
         click_button("S’identifier avec ProConnect")

--- a/spec/features/agents/account/agent_can_accept_invit_spec.rb
+++ b/spec/features/agents/account/agent_can_accept_invit_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe "Agent can accept invitation" do
     it "sets the login_hint to make sure the agent uses ProConnect with the right email and avoids getting stuck" do
       agent.deliver_invitation
       visit accept_agent_invitation_path(invitation_token: agent.raw_invitation_token)
-      expect(page).to have_content "Se créer un compte avec ProConnect"
+      expect(page).to have_content "Continuer avec ProConnect"
       find(".fr-connect__brand").click
       begin
-        click_button("ProConnect")
+        click_button("S’identifier avec ProConnect")
       rescue ActionController::RoutingError
         # Capybara essaye de suivre une redirection vers "https://fca.integ01.dev-agentconnect.fr/api/v2/authorize
         # ce qui n'est pas possible dans l'env de test (il ignore le host et il cherche /api/v2/authorize dans nos routes).

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
       current_email.click_link("Accepter l'invitation")
 
       begin
-        click_on "S’identifier avecProConnect"
+        click_on "S’identifier avec ProConnect"
       rescue ActionController::RoutingError
         # Capybara essaye de suivre une redirection vers "https://fca.integ01.dev-agentconnect.fr/
         # ce qui n'est pas possible dans l'env de test (il ignore le host et il cherche /authorize dans nos routes).


### PR DESCRIPTION
# Contexte

Dans l’objectif de renforcer la sécurité des comptes agents, nous souhaitons inciter les agents à utiliser ProConnect pour s’authentifier. En regardant la page actuelle de création de compte agent, la création de compte par courriel/mot de passe prend beaucoup de place.

<img width="1219" height="977" alt="image" src="https://github.com/user-attachments/assets/d2d4fd2a-52d4-43c8-b6cc-c41402b8d6a6" />

# Solution

Je propose dans un premier temps, de « cacher » l’inscription par email/mot de passe dans un onglet et à ajouter un petit message incitatif.

<img width="1249" height="531" alt="image" src="https://github.com/user-attachments/assets/4ddebd6e-6b94-4fb2-b41e-1dbc731fd85c" />
<img width="1226" height="970" alt="image" src="https://github.com/user-attachments/assets/dfb39aef-8b5b-41ff-a6d4-22870bf49697" />

