### PR TITLE
correction en dev : les boutons de letter opener marchent après un live reload

### DIFF
--- a/config/initializers/letter_opener.rb
+++ b/config/initializers/letter_opener.rb
@@ -1,6 +1,8 @@
-Rails.application.config.after_initialize do
-  next if !Rails.env.development? || !defined?(LetterOpenerWeb)
+return unless Rails.env.development?
 
+# On utilise to_prepare (et non after_initialize) car ce hook est réexécuté après chaque rechargement de code en
+# développement, ce qui garantit que le monkey-patch reste appliqué même après modification de fichiers.
+Rails.application.config.to_prepare do
   LetterOpenerWeb::Letter.class_eval do
     alias_method :original_adjust_link_targets, :adjust_link_targets
     def adjust_link_targets(contents)


### PR DESCRIPTION
Il y avait un bug qui m’irritait depuis un moment : les boutons de letter opener en local n’étaient pas très fiables. Ils marchaient juste après le démarrage du serveur mais au bout d’un moment ne fonctionnait plus.

J’avais compris que le problème venait du JS qui n’était plus executé au bout d’un moment. Il y avait déjà un monkey patch que j’avais oublié pour permettre d’éxecuter le JS inline de letter opener malgré nos CSP

Le problème était que ce monkey patch ne survivait pas au live reload qui se produit à chaque sauvegarde de fichier.

disclaimer : je n’ai pas investigué ni corrigé ce problème ni même écrit les commentaires, j’ai demandé à Claude de le faire, il a trouvé super vite et ça m’a l’air parfait 😶 