### PR TITLE
Bugfix : le calendrier des plages crée un RDV au clic

### DIFF
--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -43,7 +43,7 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
         end_time: Tod::TimeOfDay.new(12),
         secondary_start_time: nil,
         secondary_end_time: nil,
-      }
+      }.merge(params.permit(:first_day, :start_time, :end_time, :motif_ids))
     end
     @plage_ouverture = PlageOuverture.new(
       organisation: current_organisation,

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -33,18 +33,24 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
   end
 
   def new
-    @plage_ouverture = PlageOuverture.new
     if params[:duplicate_plage_ouverture_id].present?
       original_po = PlageOuverture.find(params[:duplicate_plage_ouverture_id])
-      @plage_ouverture.assign_attributes(original_po.slice(:title, :lieu_id, :motif_ids, :first_day, :start_time, :end_time, :secondary_start_time, :secondary_end_time, :recurrence))
+      defaults = original_po.slice(:title, :lieu_id, :motif_ids, :first_day, :start_time, :end_time, :secondary_start_time, :secondary_end_time, :recurrence)
     else
-      @plage_ouverture.assign_attributes(params.permit(:first_day, :start_time, :end_time, :motif_ids))
-      @plage_ouverture.first_day ||= Time.zone.today
-      @plage_ouverture.start_time ||= Tod::TimeOfDay.new(9)
-      @plage_ouverture.end_time ||= Tod::TimeOfDay.new(12)
+      defaults = {
+        first_day: Time.zone.now,
+        start_time: Tod::TimeOfDay.new(9),
+        end_time: Tod::TimeOfDay.new(12),
+        secondary_start_time: nil,
+        secondary_end_time: nil,
+      }
     end
-    @plage_ouverture.organisation = current_organisation
-    @plage_ouverture.agent = @agent
+    @plage_ouverture = PlageOuverture.new(
+      organisation: current_organisation,
+      motif_ids: params[:motif_ids],
+      agent: @agent,
+      **defaults
+    )
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
   end
 

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -33,24 +33,18 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
   end
 
   def new
+    @plage_ouverture = PlageOuverture.new
     if params[:duplicate_plage_ouverture_id].present?
       original_po = PlageOuverture.find(params[:duplicate_plage_ouverture_id])
-      defaults = original_po.slice(:title, :lieu_id, :motif_ids, :first_day, :start_time, :end_time, :secondary_start_time, :secondary_end_time, :recurrence)
+      @plage_ouverture.assign_attributes(original_po.slice(:title, :lieu_id, :motif_ids, :first_day, :start_time, :end_time, :secondary_start_time, :secondary_end_time, :recurrence))
     else
-      defaults = {
-        first_day: Time.zone.now,
-        start_time: Tod::TimeOfDay.new(9),
-        end_time: Tod::TimeOfDay.new(12),
-        secondary_start_time: nil,
-        secondary_end_time: nil,
-      }
+      @plage_ouverture.assign_attributes(params.permit(:first_day, :start_time, :end_time, :motif_ids))
+      @plage_ouverture.first_day ||= Time.zone.today
+      @plage_ouverture.start_time ||= Tod::TimeOfDay.new(9)
+      @plage_ouverture.end_time ||= Tod::TimeOfDay.new(12)
     end
-    @plage_ouverture = PlageOuverture.new(
-      organisation: current_organisation,
-      motif_ids: params[:motif_ids],
-      agent: @agent,
-      **defaults
-    )
+    @plage_ouverture.organisation = current_organisation
+    @plage_ouverture.agent = @agent
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
   end
 

--- a/app/javascript/application_agent.js
+++ b/app/javascript/application_agent.js
@@ -31,6 +31,7 @@ import { PlanningAgentSelect } from './components/planning-agent-select'
 import { planningAgentsSelect } from './components/planning-agents-select'
 import { AgendaMonoAgent } from './components/calendar'
 import { AgendaMultiAgent} from './components/calendar/agenda-multi-agent'
+import { AgendaPlages} from './components/agenda_plages'
 import { ParticipationSelect } from './components/rdv-user-select'
 import { Tooltips } from './components/tooltips'
 import { PlageOuvertureLieuSelection, PlageOuvertureSecondaryTimes } from './components/plage_ouverture.js'
@@ -119,6 +120,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
   new AgendaMonoAgent()
   new AgendaMultiAgent()
+  new AgendaPlages()
 
   new ParticipationSelect()
 

--- a/app/javascript/application_agent.js
+++ b/app/javascript/application_agent.js
@@ -31,7 +31,7 @@ import { PlanningAgentSelect } from './components/planning-agent-select'
 import { planningAgentsSelect } from './components/planning-agents-select'
 import { AgendaMonoAgent } from './components/calendar'
 import { AgendaMultiAgent} from './components/calendar/agenda-multi-agent'
-import { AgendaPlages} from './components/agenda_plages'
+import { AgendaPlageOuverture} from './components/agenda_plage_ouverture'
 import { ParticipationSelect } from './components/rdv-user-select'
 import { Tooltips } from './components/tooltips'
 import { PlageOuvertureLieuSelection, PlageOuvertureSecondaryTimes } from './components/plage_ouverture.js'
@@ -120,7 +120,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
   new AgendaMonoAgent()
   new AgendaMultiAgent()
-  new AgendaPlages()
+  new AgendaPlageOuverture()
 
   new ParticipationSelect()
 

--- a/app/javascript/components/agenda_plage_ouverture.js
+++ b/app/javascript/components/agenda_plage_ouverture.js
@@ -7,7 +7,7 @@ import {
   hiddenDays,
 } from './calendar/utils'
 
-export class AgendaPlages {
+export class AgendaPlageOuverture {
   constructor() {
     this.calendarEl = document.getElementById('agenda_plages');
     if (!this.calendarEl) {

--- a/app/javascript/components/agenda_plage_ouverture.js
+++ b/app/javascript/components/agenda_plage_ouverture.js
@@ -9,7 +9,7 @@ import {
 
 export class AgendaPlageOuverture {
   constructor() {
-    this.calendarEl = document.getElementById('agenda_plages');
+    this.calendarEl = document.getElementById('agenda_plage_ouverture');
     if (!this.calendarEl) {
       return;
     }

--- a/app/javascript/components/agenda_plages.js
+++ b/app/javascript/components/agenda_plages.js
@@ -1,0 +1,43 @@
+import { Calendar } from '@fullcalendar/core';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import {
+  defaultFullCalendarConfig,
+  hiddenDays,
+} from './calendar/utils'
+
+export class AgendaPlages {
+  constructor() {
+    this.calendarEl = document.getElementById('agenda_plages');
+    if (!this.calendarEl) {
+      return;
+    }
+
+    this.data = this.calendarEl.dataset
+    this.fullCalendarInstance = this.initFullCalendar(this.calendarEl)
+    this.fullCalendarInstance.render();
+  }
+
+  initFullCalendar = () => {
+    const options = {
+      plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
+      eventSources: JSON.parse(this.data.eventSourcesJson),
+      hiddenDays: hiddenDays(this.data),
+      select: this.selectEvent,
+      initialView: "timeGridWeek",
+      headerToolbar: { left: "today,prev,next,title", center: "dayGridMonth,timeGridWeek", right: "" },
+    }
+    return new Calendar(this.calendarEl, { ...defaultFullCalendarConfig(), ...options });
+  }
+
+  selectEvent = (info) => {
+    const urlSearchParams = new URLSearchParams({
+      first_day: info.startStr.slice(0, 10),
+      start_time: info.startStr.slice(11, 16),
+      end_time: info.endStr.slice(11, 16),
+      agent_id: this.data.agentId,
+    });
+    window.location = `/admin/organisations/${this.data.organisationId}/planning/plage_ouvertures/new?${urlSearchParams.toString()}`;
+  }
+}

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -14,6 +14,7 @@ import {
   betaWeekTitleFormat,
   dayHeaderContent,
   betaPlanningEnabled,
+  hiddenDays,
 } from './calendar/utils'
 
 import Bowser from "bowser";
@@ -37,21 +38,13 @@ export class AgendaMonoAgent {
   }
 
   initFullCalendar = () => {
-    const hiddenDays = []
-    if (this.data.displaySaturdays !== "true") {
-      hiddenDays.push(6);
-    }
-    if (this.data.displaySundays !== "true") {
-      hiddenDays.push(0);
-    }
-
     const options = {
       plugins: [dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin],
       eventSources: JSON.parse(this.data.eventSourcesJson),
       eventSourceFailure: handleAjaxError,
       initialDate: this.getDefaultDate(),
       initialView: this.getDefaultView(),
-      hiddenDays: hiddenDays,
+      hiddenDays: hiddenDays(this.data),
       titleFormat: betaPlanningEnabled() ? betaWeekTitleFormat : null,
       dayHeaderContent: dayHeaderContent,
       select: this.selectEvent,

--- a/app/javascript/components/calendar/agenda-multi-agent.js
+++ b/app/javascript/components/calendar/agenda-multi-agent.js
@@ -8,7 +8,8 @@ import {
   setupRealtimeRefresh,
   handleAjaxError,
   dayHeaderContent,
-  betaWeekTitleFormat
+  betaWeekTitleFormat,
+  hiddenDays,
 } from "./utils";
 
 class AgendaMultiAgent {
@@ -29,13 +30,6 @@ class AgendaMultiAgent {
     }
   }
   initFullCalendar = () => {
-    const hiddenDays = []
-    if (this.data.displaySaturdays !== "true") {
-      hiddenDays.push(6);
-    }
-    if (this.data.displaySundays !== "true") {
-      hiddenDays.push(0);
-    }
     const options = {
       plugins: [resourceTimegridPlugin, interactionPlugin],
       schedulerLicenseKey: "GPL-My-Project-Is-Open-Source",
@@ -54,7 +48,7 @@ class AgendaMultiAgent {
       customButtons: this.customButtons(),
       datesAboveResources: this.data.groupByAgent !== "true",
       datesSet: this.datesSet,
-      hiddenDays: hiddenDays,
+      hiddenDays: hiddenDays(this.data),
       select: this.selectEvent,
       eventDidMount: eventRenderer(),
       views: this.views(),

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -51,6 +51,7 @@ const defaultFullCalendarConfig = () => ({
   },
   slotMinTime: '07:00:00',
   slotMaxTime: '20:00:00',
+  selectAllow: (selectInfo) => selectInfo.endStr.slice(0, 10) === selectInfo.startStr.slice(0, 10), // Une sélection ne peut psa s'étendre sur plusieurs jours
   eventClassNames: eventClassNames,
   eventMouseLeave: (info) => $(info.el).tooltip('hide'), // extra security
 

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -26,6 +26,17 @@ export const dayHeaderContent = ({ date, view }) => {
   // else : on retourne null et FullCalendar utilise le formateur par défaut
 };
 
+export const hiddenDays = ({ displaySaturdays, displaySundays }) => {
+  const hiddenDays = []
+  if (displaySaturdays !== "true") {
+    hiddenDays.push(6);
+  }
+  if (displaySundays !== "true") {
+    hiddenDays.push(0);
+  }
+  return hiddenDays;
+};
+
 const defaultFullCalendarConfig = () => ({
   locale: frLocale,
   allDaySlot: false,

--- a/app/views/admin/planning/plage_ouvertures/calendar.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/calendar.html.slim
@@ -12,7 +12,7 @@
     = link_to t("admin.planning.plage_ouvertures.index.list_view"), admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: @agent.id, search: params[:search], current_tab: params[:current_tab]), class: "fr-btn fr-btn--secondary fr-icon-list-unordered"
     = link_to t("admin.planning.plage_ouvertures.index.create_plage_ouverture"),  new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: @agent.id), class: "fr-btn fr-btn--secondary"
 
-#calendar [
+#agenda_plages [
   data-agent-id="#{@agent.id}"
   data-organisation-id="#{@current_organisation.id}"
   data-display-saturdays="#{current_agent.display_saturdays}"

--- a/app/views/admin/planning/plage_ouvertures/calendar.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/calendar.html.slim
@@ -12,7 +12,7 @@
     = link_to t("admin.planning.plage_ouvertures.index.list_view"), admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: @agent.id, search: params[:search], current_tab: params[:current_tab]), class: "fr-btn fr-btn--secondary fr-icon-list-unordered"
     = link_to t("admin.planning.plage_ouvertures.index.create_plage_ouverture"),  new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: @agent.id), class: "fr-btn fr-btn--secondary"
 
-#agenda_plages [
+#agenda_plage_ouverture [
   data-agent-id="#{@agent.id}"
   data-organisation-id="#{@current_organisation.id}"
   data-display-saturdays="#{current_agent.display_saturdays}"

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
     it_behaves_like "can crud own plage ouvertures"
 
     it "can access a calendar view in the index" do
-      expect(page).not_to have_css("#agenda_plages")
+      expect(page).not_to have_css("#agenda_plage_ouverture")
       click_link("Vue calendrier")
-      expect(page).to have_css("#agenda_plages")
+      expect(page).to have_css("#agenda_plage_ouverture")
     end
 
     context "when the motif doesn't require a lieu" do

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
     it_behaves_like "can crud own plage ouvertures"
 
     it "can access a calendar view in the index" do
-      expect(page).not_to have_css("#calendar")
+      expect(page).not_to have_css("#agenda_plages")
       click_link("Vue calendrier")
-      expect(page).to have_css("#calendar")
+      expect(page).to have_css("#agenda_plages")
     end
 
     context "when the motif doesn't require a lieu" do


### PR DESCRIPTION
review app : https://rdv-service-public-review-app-pr6007.osc-secnum-fr1.scalingo.io/

# Contexte

Depuis beaucoup trop longtemps, nous avons ce comportement sur la vue calendrier des plages d'ouverture : quand je clic pour sélectionner un interval dans le calendrier, on me redirige vers le wizard de **création de RDV**. :facepalm: 

# Solution

J'ai préféré créer un nouveau fichier pour définir une config FullCalendar spécifique. Puisque le calendrier de plages est actuellement peu utilisé, on peut partir d'une config FullCalendar assez légère. J'ai simplement extrait `hiddenDays` qui nous est utile dans 3 calendriers (mono agent, multi agent et plages d'ouverture).

Au passage, je n'ai conservé que les vues mois et semaine, et j'ai viré le bouton "Préférences d’affichage" qui ne déclenchait rien de toute façon.

## Captures d'écran

Avant | Après
:- | -:
<img width="1864" height="1313" alt="image" src="https://github.com/user-attachments/assets/8c7d3278-8c5f-4c0e-aec3-ab5a19cdc5e6" /> | <img width="1864" height="1313" alt="image" src="https://github.com/user-attachments/assets/f8790ef0-4527-44b3-b42e-a27aeffee324" />

