### PR TITLE
Bugfix : impossible de créer un RDV sur l'agenda mensuel

### DIFF
--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -26,6 +26,25 @@ export const dayHeaderContent = ({ date, view }) => {
   // else : on retourne null et FullCalendar utilise le formateur par défaut
 };
 
+// On empêche de sélectionner plusieurs jours car ce n'est pas actuellement
+// pertinent ni pour les RDV ni pour les plages d'ouverture.
+const canSelectOnlyOneDay = (selectInfo) => {
+
+  // vue mensuelle (dayGridMonth)
+  if (selectInfo.allDay) {
+    // Quand on clique sur un seul jour, FullCalendar nous fournit un interval d'exactement 24h.
+    return selectInfo.end - selectInfo.start === 24 * 60 * 60 * 1000;
+  }
+
+  // vue hebdo / quotidienne (timeGrid___)
+  else {
+    const startDate = selectInfo.startStr.slice(0, 10);
+    const endDate = selectInfo.endStr.slice(0, 10);
+    return startDate === endDate;
+  }
+
+};
+
 export const hiddenDays = ({ displaySaturdays, displaySundays }) => {
   const hiddenDays = []
   if (displaySaturdays !== "true") {
@@ -51,7 +70,7 @@ const defaultFullCalendarConfig = () => ({
   },
   slotMinTime: '07:00:00',
   slotMaxTime: '20:00:00',
-  selectAllow: (selectInfo) => selectInfo.allDay || selectInfo.endStr.slice(0, 10) === selectInfo.startStr.slice(0, 10), // Une sélection ne peut psa s'étendre sur plusieurs jours
+  selectAllow: canSelectOnlyOneDay,
   eventClassNames: eventClassNames,
   eventMouseLeave: (info) => $(info.el).tooltip('hide'), // extra security
 

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -51,7 +51,7 @@ const defaultFullCalendarConfig = () => ({
   },
   slotMinTime: '07:00:00',
   slotMaxTime: '20:00:00',
-  selectAllow: (selectInfo) => selectInfo.endStr.slice(0, 10) === selectInfo.startStr.slice(0, 10), // Une sélection ne peut psa s'étendre sur plusieurs jours
+  selectAllow: (selectInfo) => selectInfo.allDay || selectInfo.endStr.slice(0, 10) === selectInfo.startStr.slice(0, 10), // Une sélection ne peut psa s'étendre sur plusieurs jours
   eventClassNames: eventClassNames,
   eventMouseLeave: (info) => $(info.el).tooltip('hide'), // extra security
 

--- a/spec/features/agents/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/agent_has_a_calendar_spec.rb
@@ -180,4 +180,37 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       expect(page).to have_selector(".fc-event", text: "Mon indispo")
     end
   end
+
+  describe "création de RDV depuis l'agenda" do
+    let!(:organisation) { create(:organisation) }
+    let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+    before do
+      login_as(agent, scope: :agent)
+    end
+
+    it "fonctionne depuis la vue mensuelle", js: true do
+      visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+      click_button "Mois"
+      monday = Time.zone.now.beginning_of_week.to_date
+      find(%(.fc-daygrid-day[data-date="#{monday}"])).click
+      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(monday, format: '%d/%m/%Y')} à 00:00")
+    end
+
+    it "fonctionne depuis la vue semaine", js: true do
+      visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+      click_button "Semaine"
+      # Je ne sais pas comment faire cliquer la spec sur la colonne du lundi, elle clique au milieu de l'élément donc sur le mercredi.
+      wednesday = Time.zone.now.beginning_of_week.to_date + 2
+      find('.fc-timegrid-slot-lane[data-time="08:30:00"]').click
+      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(wednesday, format: '%d/%m/%Y')} à 08:30")
+    end
+
+    it "fonctionne depuis la vue jour", js: true do
+      visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+      click_button "Journée"
+      find('.fc-timegrid-slot-lane[data-time="08:30:00"]').click
+      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(Time.zone.today, format: '%d/%m/%Y')} à 08:30")
+    end
+  end
 end


### PR DESCRIPTION
3 agents nous ont remonté "ne plus pouvoir créer de RDV depuis ce matin". Nous avons fini par comprendre qu'iels utilisaient la vue mensuelle.

J'ai cassé cette feature dans #6007 ern ajoutant une contrainte `selectAllow` qui ne gérait pas les sélection faîtes depuis une vue `dayGrid`, comme la vue mensuelle. Dans ce type de vue, `selectInfo.allDay` est à `true` quand l'on clique sur une journée.

J'ai donc écrit une fonction qui gère aussi ce cas.

J'en a profité pour ajouter des specs qui vérifient qu'on peut accéder au wizard de création de RDV quand on clique sur l'agenda, en version mois, semaine et jour. :sparkles: 