### PR TITLE
Suppression de code déprécié de redirection pour Crisp

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -111,13 +111,6 @@ NOTION_DATABASE_ID=28e2b05c-ed41-8048-8f5e-d34c80129504 # Base de données utili
 # Zammad
 ZAMMAD_API_TOKEN="voir https://zammad10.ethibox.fr/#profile/token_access (clé rattachée à un compte individuel Agent Zammad)"
 
-# << REMOVE AFTER 01/01/2026
-# Crisp
-# Bien que nous n’utilisions plus Crisp pour les nouveaux tickets, nous avons encore quelques tickets ouverts
-# On laisse cette variable pour continuer de faire fonctionner la redirection quand les personnes cliquent sur « Répondre via le chat »
-CRISP_WEBSITE_ID="voir app.crisp.chat > Paramètres > Mise en place et intégration"
-# >> REMOVE AFTER 01/01/2026
-
 # Metabase, pour la carte géographique des lieux sur la page stats
 METABASE_API_KEY="voir dans Admin settings > Authentication depuis https://rdv-service-public-metabase.osc-secnum-fr1.scalingo.io/"
 

--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -6,19 +6,6 @@ class Agents::PagesController < AgentAuthController
   def home
     skip_authorization
 
-    # << REMOVE AFTER 01/01/2026
-    # Bien que nous n’utilisions plus Crisp pour les nouveaux tickets, nous avons encore quelques tickets ouverts
-    # On laisse cette redirection pour les personnes qui cliquent sur « Répondre via le chat »
-    #
-    # Crisp propose aux utilisateurs de répondre aux mails soit par réponse de mail soit par le chat
-    # Comme nous ne pouvons pas retirer la mention du chat et que nous ne souhaitons pas le proposer comme moyen de
-    # contact, nous redirigeons les utilisateurs vers le chat Crisp si ils cliquent sur le lien dans le footer du mail
-    if params[:crisp_sid]
-      redirect_to_crisp_chat(params[:crisp_sid])
-      return
-    end
-    # >> REMOVE AFTER 01/01/2026
-
     accessible_organisations = policy_scope(Organisation, policy_scope_class: Agent::OrganisationPolicy::Scope)
 
     if accessible_organisations.count == 1
@@ -38,10 +25,4 @@ class Agents::PagesController < AgentAuthController
   def pundit_user
     current_agent
   end
-
-  # << REMOVE AFTER 01/01/2026
-  def redirect_to_crisp_chat(crisp_sid)
-    redirect_to "https://go.crisp.chat/chat/embed/?website_id=#{ENV['CRISP_WEBSITE_ID']}&crisp_sid=#{crisp_sid}", allow_other_host: true
-  end
-  # >> REMOVE AFTER 01/01/2026
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,19 +15,6 @@ class SearchController < ApplicationController
       return
     end
 
-    # << REMOVE AFTER 01/01/2026
-    # Bien que nous n’utilisions plus Crisp pour les nouveaux tickets, nous avons encore quelques tickets ouverts
-    # On laisse cette redirection pour les personnes qui cliquent sur « Répondre via le chat »
-    #
-    # Crisp propose aux utilisateurs de répondre aux mails soit par réponse de mail soit par le chat
-    # Comme nous ne pouvons pas retirer la mention du chat et que nous ne souhaitons pas le proposer comme moyen de
-    # contact, nous redirigeons les utilisateurs vers le chat Crisp si ils cliquent sur le lien dans le footer du mail
-    if params[:crisp_sid]
-      redirect_to_crisp_chat(params[:crisp_sid])
-      return
-    end
-    # >> REMOVE AFTER 01/01/2026
-
     if current_domain == Domain::RDV_SERVICE_PUBLIC
       @site_vitrine_page = true
       render "dsfr/rdv_mairie/homepage"
@@ -152,10 +139,4 @@ class SearchController < ApplicationController
   def agent_search_params
     params.permit(AgentPrescriptionSearchContext::STRONG_PARAMS_LIST)
   end
-
-  # << REMOVE AFTER 01/01/2026
-  def redirect_to_crisp_chat(crisp_sid)
-    redirect_to "https://go.crisp.chat/chat/embed/?website_id=#{ENV['CRISP_WEBSITE_ID']}&crisp_sid=#{crisp_sid}", allow_other_host: true
-  end
-  # >> REMOVE AFTER 01/01/2026
 end

--- a/spec/controllers/agents/pages_controller_spec.rb
+++ b/spec/controllers/agents/pages_controller_spec.rb
@@ -36,14 +36,5 @@ RSpec.describe Agents::PagesController, type: :controller do
         expect(response).to redirect_to(admin_organisations_path)
       end
     end
-
-    context "quand un id de session Crisp est présent" do
-      stub_env_with(CRISP_WEBSITE_ID: "abcde")
-
-      it "l’utilisateur est redirigé vers le chat Crisp" do
-        get :home, params: { crisp_sid: "123456" }
-        expect(response).to redirect_to("https://go.crisp.chat/chat/embed/?website_id=abcde&crisp_sid=123456")
-      end
-    end
   end
 end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -53,15 +53,6 @@ RSpec.describe SearchController, type: :controller do
       get :home
       expect(response).to be_successful
     end
-
-    context "quand un id de session Crisp est présent" do
-      stub_env_with(CRISP_WEBSITE_ID: "abcde")
-
-      it "l’utilisateur est redirigé vers le chat Crisp" do
-        get :home, params: { crisp_sid: "123456" }
-        expect(response).to redirect_to("https://go.crisp.chat/chat/embed/?website_id=abcde&crisp_sid=123456")
-      end
-    end
   end
 
   describe "#search_rdv" do


### PR DESCRIPTION
dans  https://github.com/betagouv/rdv-service-public/pull/5603 , Antoine avait introduit du code et indiqué qu’on pourrait le supprimer passé une certaine date.

Cette date est passée donc je supprime :) merci ! 

Je pense qu’on peut unset `CRISP_WEBSITE_ID` sur nos envs locaux et prod suite à ce déploiement