### PR TITLE
dsfr-view-components 4.0 -> 4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,8 +211,8 @@ GEM
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
-    dsfr-view-components (4.0)
-      dsfr-assets (~> 1.13.2)
+    dsfr-view-components (4.1)
+      dsfr-assets (>= 1.13.2, < 1.15)
       html-attributes-utils (~> 1)
       view_component (~> 3)
     erb (5.1.3)
@@ -913,7 +913,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   dsfr-assets (1.13.2) sha256=3395e15fa783a894e927889600ee9a1bbf45f3f3960590d76c0b4d92504e1c76
   dsfr-form_builder (0.0.7) sha256=16165ee281de4645617fdb79c4fc03384f9125cbbdf6a149daa1ef2bb367ffde
-  dsfr-view-components (4.0) sha256=a1f237df3c9ec6bd79493f17656084c9e2ae5d0aea51d7467a931885f5fd67ab
+  dsfr-view-components (4.1) sha256=9633c1f289b622cea2dc8624c27a49d7e94d8e1420727e81afe484ba2d6db352
   erb (5.1.3) sha256=566e53057b6ba48699f824b578473b391fa8aef100aa14afad1c46725fae0e67
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.2.11) sha256=d26e868cc21db88280a9ec1a50aa3da5d267eb9b2037ba7b831d6c2731f5df64


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6017.osc-secnum-fr1.scalingo.io/)

# Contexte

Je suis en train de travailler sur le remplacement du package DSFR au profit de la Gem `dsfr-assets`.
Étant donné que l’objectif est de passer à la version 1.14 du DSFR, j’ai besoin de mettre à jour `dsfr-view-components` afin de nous donner accès à `dsfr-assets` 1.14.
Cela nous permettra également d’utiliser le composant Menu Latéral, fraîchement intégré dans `dsfr-view-components`


