### PR TITLE
correction clavier number à la saisie du login code

### DIFF
--- a/app/views/users/sessions_by_code/new.html.slim
+++ b/app/views/users/sessions_by_code/new.html.slim
@@ -24,7 +24,8 @@
         = form.hidden_field :email
         = form.dsfr_text_field :code,
           label: "Code à 6 chiffres",
-          type: "number",
+          type: "text",
+          inputmode: "numeric",
           maxlength: 6,
           required: true,
           autocomplete: "off"


### PR DESCRIPTION
dans #6003 j’ai remplacé `input type="text"` par `type="number"` pour la saisie du login code

Je n’avais pas pensé que ça casserait la règle CSS qui permet d’afficher ces champs avec une font monospace grande et espacée 

ça casse aussi le support de maxlength = 6 qui ne marche que sur type="text" 🤯 
enfin ça affichait peut-être parfois des petits boutons incrémenter décrementer sur la droite 🤦 

je rétablis type="text" et je découvre inputmode="numeric" ici https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode


vérifié en review app sur mon android FF 

<img width="1080" height="2340" alt="code" src="https://github.com/user-attachments/assets/5d73223b-46ff-4192-ac0f-04ed83805d81" />

(dsl pour le screencapception)