### PR TITLE
Bugfix : message d’erreur incorrect à l'invitation d'agent sans orga

### DIFF
--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -50,6 +50,14 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
   def create
     all_params = params.require(:admin_agent).permit(:email, service_ids: [], organisation_ids: [])
     new_agent = Agent.new(all_params)
+
+    if new_agent.organisations.none?
+      @agent = new_agent
+      skip_authorization
+      flash.now[:error] = "Veuillez sélectionner au moins une organisation pour continuer."
+      render :new and return
+    end
+
     authorize(new_agent, policy_class: ::Configuration::AgentPolicy)
 
     create_agent = AdminCreatesAgent.new(


### PR DESCRIPTION
Closes #6016

Thread Mattermost : https://mattermost.incubateur.net/betagouv/pl/6eetwo3e1jdbmfaiu5968cumxy

Je suis parti sur un fix très minimal pour corriger le bug au plus vite, même si le bug n'est pas très important.

La solution propre serait de :
- faire d'`AdminCreatesAgent` un vrai form object avec des validations, et de le tester unitairemen
- améliorer la policy pour qu'elle autorise la création d'un nouvel agent sans orga (ce n'est pas son rôle de vérifier qu'il a bien une orga, elle doit juste vérifier que si des orgas / espaces sont passés, ils doivent être accessibles à l'agent courant). J'ai l'impression qu'on est dans un cas où la limite entre la policy et le form object est parfois assez fine.

Bref, je n'ai pas la bande passante pour faire ça donc je fais à regret le choix de la dette technique.

Dîtes-moi ce que vous en pensez !