### PR TITLE
Ajouter au contexte Sentry le super admin connecté

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,7 @@ class ApplicationController < ActionController::Base
       id: current_person&.id,
       role: current_person&.class&.name || "Guest",
       email: current_person&.email,
+      current_super_admin: current_super_admin&.email,
     }.compact
   end
 

--- a/app/controllers/user_auth_controller.rb
+++ b/app/controllers/user_auth_controller.rb
@@ -10,11 +10,7 @@ class UserAuthController < ApplicationController
   private
 
   def user_for_paper_trail
-    if current_super_admin.present?
-      current_super_admin.name_for_paper_trail(impersonated: current_user)
-    else
-      current_user.name_for_paper_trail
-    end
+    current_user.name_for_paper_trail
   end
 
   def user_not_authorized(exception)

--- a/app/models/super_admin.rb
+++ b/app/models/super_admin.rb
@@ -22,4 +22,11 @@ class SuperAdmin < ApplicationRecord
 
     "[Admin] #{full_name} pour #{impersonated.full_name}"
   end
+
+  # This method is called when calling #current_super_admin on a controller action that is automatically generated
+  # by the devise_token_auth gem. It can happen since these actions inherits from ApplicationController (see PR #1933).
+  # We monkey-patch it for it not to raise.
+  def self.dta_find_by(_attrs = {})
+    nil
+  end
 end

--- a/app/views/super_admins/agents/show.html.slim
+++ b/app/views/super_admins/agents/show.html.slim
@@ -1,16 +1,18 @@
+- agent = page.resource
+
 - content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) }
 header.main-content__header role="banner"
   h1.main-content__page-title
     = content_for(:title)
   div
-    - if page.resource.invitation_accepted_at.nil? && page.resource.password.nil?
-      => link_to "Inviter", invite_super_admins_agent_path(page.resource), method: :post, class: "button", data: { disable_with: "Veuillez patienter…"} if accessible_action?(page.resource, :invite)
-    - if sign_in_as_allowed?
-      => link_to "Se logger en tant que", sign_in_as_super_admins_agent_path(page.resource), class: "button" if accessible_action?(page.resource, :sign_in_as)
-    => link_to("Modifier", [:edit, namespace, page.resource], class: "button") if accessible_action?(page.resource, :edit)
-    => link_to("Migrer", new_super_admins_agent_migration_path(agent_id: page.resource.id), class: "button")
-    - if page.resource.roles.none?
-      = link_to("Ouvrir un compte", new_super_admins_compte_path(agent_id: page.resource.id), class: "button")
+    - if agent.invitation_accepted_at.nil? && agent.password.nil?
+      => link_to "Inviter", invite_super_admins_agent_path(agent), method: :post, class: "button", data: { disable_with: "Veuillez patienter…"} if accessible_action?(agent, :invite)
+    - if sign_in_as_allowed? && !agent.is_an_intervenant?
+      => link_to "Se logger en tant que", sign_in_as_super_admins_agent_path(agent), class: "button" if accessible_action?(agent, :sign_in_as)
+    => link_to("Modifier", [:edit, namespace, agent], class: "button") if accessible_action?(agent, :edit)
+    => link_to("Migrer", new_super_admins_agent_migration_path(agent_id: agent.id), class: "button")
+    - if agent.roles.none?
+      = link_to("Ouvrir un compte", new_super_admins_compte_path(agent_id: agent.id), class: "button")
 
 section.main-content__body
   dl
@@ -18,7 +20,7 @@ section.main-content__body
       dt.attribute-label id="#{attribute.name}"
         = t( "helpers.label.#{resource_name}.#{attribute.name}", default: attribute.name.titleize)
       dd class=("attribute-data attribute-data--#{attribute.html_class}") = render_field attribute,page: page
-  = render partial: "super_admins/history", locals: {resource: page.resource}
+  = render partial: "super_admins/history", locals: {resource: agent}
 
   header.main-content__header style="width: 100%;"
     h2.main-content__page-title
@@ -32,13 +34,13 @@ section.main-content__body
           th Action
       tbody
         - Agent::AVAILABLE_FEATURES.each do |feature|
-          - if page.resource.feature_enabled?(feature)
+          - if agent.feature_enabled?(feature)
             tr
               td= feature
               td Activée
-              td= link_to "Désactiver", toggle_feature_super_admins_agent_path(agent_id: page.resource.id, feature: feature, set_to: "false"), method: :post, class: "button"
+              td= link_to "Désactiver", toggle_feature_super_admins_agent_path(agent_id: agent.id, feature: feature, set_to: "false"), method: :post, class: "button"
           - else
             tr
               td= feature
               td Désactivée
-              td= link_to "Activer", toggle_feature_super_admins_agent_path(agent_id: page.resource.id, feature: feature, set_to: "true"), method: :post, class: "button"
+              td= link_to "Activer", toggle_feature_super_admins_agent_path(agent_id: agent.id, feature: feature, set_to: "true"), method: :post, class: "button"

--- a/spec/features/super_admin/use_correct_history_version_spec.rb
+++ b/spec/features/super_admin/use_correct_history_version_spec.rb
@@ -19,15 +19,4 @@ RSpec.describe "Use correct history version when a super admin is logged in and 
     click_button("Historique des changements")
     expect(page).to have_content("[Admin] #{super_admin.full_name} pour #{agent.full_name}")
   end
-
-  it "for a user", js: true do
-    login_as(user, scope: :user)
-    visit root_path
-    click_link "Vos informations"
-    fill_in("Téléphone", with: "0612345678")
-    click_on("Enregistrer")
-    expect(page).to have_content("Vos informations ont été mises à jour")
-
-    expect(user.reload.versions.last.whodunnit).to eq "[Admin] #{super_admin.full_name} pour #{user.full_name}"
-  end
 end


### PR DESCRIPTION
Nous avons eu aujourd'hui des erreurs sur Sentry qui indiquaient qu'un agent était connecté mais que son e-mail était `nil`.

https://sentry.incubateur.net/organizations/betagouv/issues/238157

```
undefined method 'include?' for nil (NoMethodError)

    email.include?(".gouv.fr")
         ^^^^^^^^^
```

@victormours suppose que c'est probablement un super admin qui s'est connecté en tant qu'un intervenant. Et en effet, le nom de famille de l'agent concerné est `"Médiateur de la ville"`.

Pour confirmer cette hypothèse j'ajoute donc ici dans les meta-données Sentry l'adresse e-mail du super admin actuellement connecté.

Je ne corrige pas la cause du crash, j'attends de voir si il a de nouveau lieu pour confirmer que c'est bien le fait d'un super admin.

## Au passage

Je vire du code mort qui gérait le login as usager.