### PR TITLE
Correction de specs pour utiliser le organisations.public_link_id plutot que id

### DIFF
--- a/spec/features/autodoc/rendez_vous_prescripteur_externe_spec.rb
+++ b/spec/features/autodoc/rendez_vous_prescripteur_externe_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Prendre RDV pour un usager en tant que prescripteur externe", js
     doc.start_section("Côté agent prescripteur")
     doc.add_text("Contexte : Je suis un agent prescripteur qui ne dispose pas de compte sur RDV Service Public et je veux prendre un RDV pour un usager")
 
-    visit "http://www.rdv-service-public-test.localhost/org/#{organisation.id}/"
+    visit "http://www.rdv-service-public-test.localhost/org/#{organisation.public_link_id}/"
     doc.add_screenshot(page,
                        text: "Je choisis le motif de rendez-vous",
                        wait_for: "Formation emails")

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
 
     context "il n’y a pas de créneaux dispos" do
       it "incite à passer par le moteur de l’ANTS", js: true do
-        visit "http://www.rdv-service-public-test.localhost/org/#{organisation.id}"
+        visit "http://www.rdv-service-public-test.localhost/org/#{organisation.public_link_id}"
         click_on "Passeport"
         expect(page).to have_content("Nombre de pré-demandes ANTS")
         expect(find_field(find("label", text: /pré-demandes ANTS/)[:for])[:value]).to eq("1")
@@ -451,7 +451,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
     end
 
     it "permet de choisir le nombre de dossiers à déposer" do
-      visit "http://www.rdv-service-public-test.localhost/org/#{organisation.id}"
+      visit "http://www.rdv-service-public-test.localhost/org/#{organisation.public_link_id}"
       click_on "Passeport"
       expect(page).to have_content("Nombre de pré-demandes ANTS")
       fill_in(find("label", text: /pré-demandes ANTS/)[:for], with: "2", fill_options: { clear: :backspace }) # ici on fait sans JS en remplissant le champ directement
@@ -497,7 +497,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
 
     context "l’usager tente de passer un nombre invalide à l’étape de séléction du nombre de pré-demandes" do
       specify do
-        visit "http://www.rdv-service-public-test.localhost/org/#{organisation.id}"
+        visit "http://www.rdv-service-public-test.localhost/org/#{organisation.public_link_id}"
         click_on "Passeport"
         expect(page).to have_content("Nombre de pré-demandes ANTS")
         fill_in(find("label", text: /pré-demandes ANTS/)[:for], with: "notanumber", fill_options: { clear: :backspace }) # ici on fait sans JS en remplissant le champ directement

--- a/spec/features/users/online_booking/on_rdv_service_public_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_service_public_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "User can search rdv on rdv service public" do
   end
 
   it "allows booking a rdv" do
-    visit "http://www.rdv-service-public-test.localhost/org/#{organisation.id}"
+    visit "http://www.rdv-service-public-test.localhost/org/#{organisation.public_link_id}"
     click_on("Clarification du dossier")
     click_on(lieu.name) # choix du lieu
 


### PR DESCRIPTION
# Contexte

Des specs failent depuis ce matin.

C’est du à cette PR https://github.com/betagouv/rdv-service-public/pull/6012 où je rends les liens publics `host/org/#{orga.id}` inaccessibles, seuls restent accessibles `host/org/#{orga.public_link_id}`

# Solution

Je propose ici de remplacer les liens pour corriger.

Certains des tests qui failent ont pourtant un `before { travel_to(date) }`. Je pense qu’il n'a pas fonctionné correctement car les `let!(:organisation) { create(:orga) }` doivent s'éxecuter avant ce before. 
On se retrouve donc dans des situations un peu absurdes : now = 2022 mais orga.created_at = 2026 🤷 
On pourrait aussi corriger ça mais ça demanderait plus de boulot