### PR TITLE
Utiliser des jobs unitaires pour la synchronisation CRM

### DIFF
--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -20,44 +20,17 @@ class CronJob::SynchronizeCrm < CronJob
 
     client.database_query(database_id: NOTION_DATABASE_ID, filter:) do |page|
       page.results.each do |notion_page|
-        ids = organisations_ids(notion_page)
-        next if ids.blank?
-
-        territory = Organisation.find(ids.first).territory
-        last_rdv = Rdv.where(organisation: ids).order(created_at: :desc).first
-        properties = {
-          "NOMBRE DE RDV" => Rdv.where(organisation: ids).count,
-          "DATE CREATION DERNIER RDV" => last_rdv ? { start: last_rdv.created_at.strftime("%Y-%m-%d") } : nil,
-          "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
-          "NOMBRE AGENTS ACTIFS" => territory.organisations_agents.where("last_sign_in_at >= ?", 30.days.ago).count,
-        }
-        client.update_page(page_id: notion_page.id, properties:)
+        SynchronizeCrmPageJob.perform_later(
+          notion_page_id: notion_page.id,
+          account_url: notion_page.properties["COMPTE PROD"].url,
+          notion_page_url: notion_page.url,
+          notion_page_title: notion_page.properties["Project name"]["title"][0]["plain_text"]
+        )
       end
     end
   end
 
   private
-
-  # Prend une URL de compte au format '/organisations/1' ou '/territories/1' et retourne les IDs des organisations correspondantes
-  # On ne retourne les IDs que si les organisations existent dans la base de données
-  def organisations_ids(notion_page)
-    account_url = notion_page.properties["COMPTE PROD"].url
-    if account_url.match('territories/(\d+)')
-      territory_id = account_url.match('territories/(\d+)')[1]
-      territory = Territory.find_by(id: territory_id)
-      Organisation.where(territory: territory).pluck(:id)
-    elsif account_url.match('organisations/(\d+)')
-      Organisation.where(id: account_url.match('organisations/(\d+)')[1]).pluck(:id)
-    else
-      MattermostApiClient.send_message(
-        channel: "startup-rdv-alertes-crm",
-        text: "L’URL du compte PROD de la carte Notion [#{notion_page.properties['Project name']['title'][0]['plain_text']}](#{notion_page.url}), est incorrecte.",
-        username: "CRM",
-        icon_url: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Notion-logo.svg/100px-Notion-logo.svg.png"
-      )
-      []
-    end
-  end
 
   def instance_hostname
     ENV["HOST"]

--- a/app/jobs/synchronize_crm_page_job.rb
+++ b/app/jobs/synchronize_crm_page_job.rb
@@ -1,5 +1,5 @@
 class SynchronizeCrmPageJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_whenever
 
   def perform(notion_page_id:, account_url:, notion_page_url:, notion_page_title:)
     return unless ENV["NOTION_API_SECRET"]

--- a/app/jobs/synchronize_crm_page_job.rb
+++ b/app/jobs/synchronize_crm_page_job.rb
@@ -1,0 +1,44 @@
+class SynchronizeCrmPageJob < ApplicationJob
+  queue_as :default
+
+  def perform(notion_page_id:, account_url:, notion_page_url:, notion_page_title:)
+    return unless ENV["NOTION_API_SECRET"]
+
+    ids = organisations_ids(account_url, notion_page_url, notion_page_title)
+    return if ids.blank?
+
+    territory = Organisation.find(ids.first).territory
+    last_rdv = Rdv.where(organisation: ids).order(created_at: :desc).first
+    properties = {
+      "NOMBRE DE RDV" => Rdv.where(organisation: ids).count,
+      "DATE CREATION DERNIER RDV" => last_rdv ? { start: last_rdv.created_at.strftime("%Y-%m-%d") } : nil,
+      "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
+      "NOMBRE AGENTS ACTIFS" => territory.organisations_agents.where("last_sign_in_at >= ?", 30.days.ago).count,
+    }
+    client.update_page(page_id: notion_page_id, properties:)
+  end
+
+  private
+
+  def organisations_ids(account_url, notion_page_url, notion_page_title)
+    if account_url.match('territories/(\d+)')
+      territory_id = account_url.match('territories/(\d+)')[1]
+      territory = Territory.find_by(id: territory_id)
+      Organisation.where(territory: territory).pluck(:id)
+    elsif account_url.match('organisations/(\d+)')
+      Organisation.where(id: account_url.match('organisations/(\d+)')[1]).pluck(:id)
+    else
+      MattermostApiClient.send_message(
+        channel: "startup-rdv-alertes-crm",
+        text: "L'URL du compte PROD de la carte Notion [#{notion_page_title}](#{notion_page_url}), est incorrecte.",
+        username: "CRM",
+        icon_url: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Notion-logo.svg/100px-Notion-logo.svg.png"
+      )
+      []
+    end
+  end
+
+  def client
+    @client ||= Notion::Client.new(token: ENV["NOTION_API_SECRET"])
+  end
+end

--- a/spec/jobs/cron_job/synchronize_crm_spec.rb
+++ b/spec/jobs/cron_job/synchronize_crm_spec.rb
@@ -1,21 +1,23 @@
 RSpec.describe CronJob::SynchronizeCrm, type: :job do
   let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/territories/1" }
-  let(:notion_page) { Notion::Messages::Message.new(id: "page_id", properties: { "COMPTE PROD": { url: compte_prod_url } }) }
+  let(:notion_page) do
+    Notion::Messages::Message.new(
+      id: "page_id",
+      url: "https://notion.so/page",
+      properties: {
+        "COMPTE PROD": { url: compte_prod_url },
+        "Project name": { "title" => [{ "plain_text" => "Mon projet" }] },
+      }
+    )
+  end
   let(:notion_client) { instance_double(Notion::Client) }
-  let(:territory) { create(:territory) }
-  let(:organisation_a) { create(:organisation, territory: territory) }
-  let(:organisation_b) { create(:organisation, territory: territory) }
-  let(:organisation_c) { create(:organisation, territory: territory) }
-  let!(:rdv_a) { create(:rdv, organisation: organisation_a) }
-  let!(:rdv_b) { create(:rdv, organisation: organisation_b, created_at: Date.yesterday) }
 
   before do
     allow(Notion::Client).to receive(:new).and_return(notion_client)
     allow(notion_client).to receive(:database_query).and_yield(Notion::Messages::Message.new(results: [notion_page]))
-    allow(notion_client).to receive(:update_page)
   end
 
-  context "quand la clef NOTION_API_SECRET n’est pas définie" do
+  context "quand la clef NOTION_API_SECRET n'est pas définie" do
     before do
       ENV["NOTION_API_SECRET"] = nil
     end
@@ -32,68 +34,13 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
       ENV["NOTION_API_SECRET"] = "secret"
     end
 
-    context "quand la variable COMPTE PROD de la page Notion est un territory" do
-      let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/territories/#{territory.id}" }
-
-      it "le nombre de RDV et la date du dernier RDV sont mis à jour dans la page Notion avec la somme des RDV de l'espace" do
-        described_class.new.perform
-
-        expect(notion_client).to have_received(:update_page).with(
-          page_id: "page_id",
-          properties: {
-            "NOMBRE DE RDV" => 2,
-            "DATE CREATION DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") },
-            "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
-            "NOMBRE AGENTS ACTIFS" => 0,
-          }
-        )
-      end
-    end
-
-    context "quand la variable COMPTE PROD de la page Notion est une organisation" do
-      let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/organisations/#{organisation_a.id}" }
-
-      it "le nombre de RDV et la date du dernier RDV sont mis à jour dans la page Notion avec la somme des RDV de l’organisation" do
-        described_class.new.perform
-
-        expect(notion_client).to have_received(:update_page).with(
-          page_id: "page_id",
-          properties: {
-            "NOMBRE DE RDV" => 1,
-            "DATE CREATION DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") },
-            "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
-            "NOMBRE AGENTS ACTIFS" => 0,
-          }
-        )
-      end
-
-      context "quand l’organisation n’a pas encore de RDV" do
-        let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/organisations/#{organisation_c.id}" }
-
-        it "le nombre de RDV est mis à jour dans la page Notion avec 0 et la date du dernier RDV est nulle" do
-          described_class.new.perform
-
-          expect(notion_client).to have_received(:update_page).with(
-            page_id: "page_id",
-            properties: {
-              "NOMBRE DE RDV" => 0,
-              "DATE CREATION DERNIER RDV" => nil,
-              "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
-              "NOMBRE AGENTS ACTIFS" => 0,
-            }
-          )
-        end
-      end
-    end
-
-    context "quand la variable COMPTE PROD de la page Notion est une organisation inconnue" do
-      let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/organisations/26739" }
-
-      it "ne fait rien" do
-        described_class.new.perform
-
-        expect(notion_client).not_to have_received(:update_page)
-      end
+    it "enqueue un job SynchronizeCrmPageJob pour chaque page Notion" do
+      expect { described_class.new.perform }.to have_enqueued_job(SynchronizeCrmPageJob).with(
+        notion_page_id: "page_id",
+        account_url: compte_prod_url,
+        notion_page_url: "https://notion.so/page",
+        notion_page_title: "Mon projet"
+      )
     end
   end
 end

--- a/spec/jobs/synchronize_crm_page_job_spec.rb
+++ b/spec/jobs/synchronize_crm_page_job_spec.rb
@@ -1,0 +1,155 @@
+RSpec.describe SynchronizeCrmPageJob, type: :job do
+  let(:notion_client) { instance_double(Notion::Client) }
+
+  before do
+    allow(Notion::Client).to receive(:new).and_return(notion_client)
+    allow(notion_client).to receive(:update_page)
+  end
+
+  context "quand la clef NOTION_API_SECRET n'est pas définie" do
+    let(:territory) { create(:territory) }
+
+    before do
+      ENV["NOTION_API_SECRET"] = nil
+    end
+
+    it "ne fait rien" do
+      described_class.new.perform(
+        notion_page_id: "page_id",
+        account_url: "https://demo.rdv-solidarites.fr/territories/#{territory.id}",
+        notion_page_url: "https://notion.so/page",
+        notion_page_title: "Mon projet"
+      )
+
+      expect(notion_client).not_to have_received(:update_page)
+    end
+  end
+
+  context "quand la clef NOTION_API_SECRET est définie" do
+    before do
+      ENV["NOTION_API_SECRET"] = "secret"
+    end
+
+    context "quand la variable COMPTE PROD est un territory" do
+      let(:territory) { create(:territory) }
+      let(:organisation_a) { create(:organisation, territory: territory) }
+      let(:organisation_b) { create(:organisation, territory: territory) }
+      let!(:rdv_a) { create(:rdv, organisation: organisation_a) }
+      let!(:rdv_b) { create(:rdv, organisation: organisation_b, created_at: Date.yesterday) }
+
+      it "le nombre de RDV et la date du dernier RDV sont mis à jour dans la page Notion avec la somme des RDV de l'espace" do
+        described_class.new.perform(
+          notion_page_id: "page_id",
+          account_url: "https://demo.rdv-solidarites.fr/territories/#{territory.id}",
+          notion_page_url: "https://notion.so/page",
+          notion_page_title: "Mon projet"
+        )
+
+        expect(notion_client).to have_received(:update_page).with(
+          page_id: "page_id",
+          properties: {
+            "NOMBRE DE RDV" => 2,
+            "DATE CREATION DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") },
+            "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
+            "NOMBRE AGENTS ACTIFS" => 0,
+          }
+        )
+      end
+    end
+
+    context "quand la variable COMPTE PROD est une organisation" do
+      let(:territory) { create(:territory) }
+      let(:organisation) { create(:organisation, territory: territory) }
+      let!(:rdv) { create(:rdv, organisation: organisation) }
+
+      it "le nombre de RDV et la date du dernier RDV sont mis à jour dans la page Notion avec la somme des RDV de l'organisation" do
+        described_class.new.perform(
+          notion_page_id: "page_id",
+          account_url: "https://demo.rdv-solidarites.fr/organisations/#{organisation.id}",
+          notion_page_url: "https://notion.so/page",
+          notion_page_title: "Mon projet"
+        )
+
+        expect(notion_client).to have_received(:update_page).with(
+          page_id: "page_id",
+          properties: {
+            "NOMBRE DE RDV" => 1,
+            "DATE CREATION DERNIER RDV" => { start: rdv.created_at.strftime("%Y-%m-%d") },
+            "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
+            "NOMBRE AGENTS ACTIFS" => 0,
+          }
+        )
+      end
+    end
+
+    context "quand l'organisation n'a pas encore de RDV" do
+      let(:territory) { create(:territory) }
+      let(:organisation) { create(:organisation, territory: territory) }
+
+      it "le nombre de RDV est mis à jour dans la page Notion avec 0 et la date du dernier RDV est nulle" do
+        described_class.new.perform(
+          notion_page_id: "page_id",
+          account_url: "https://demo.rdv-solidarites.fr/organisations/#{organisation.id}",
+          notion_page_url: "https://notion.so/page",
+          notion_page_title: "Mon projet"
+        )
+
+        expect(notion_client).to have_received(:update_page).with(
+          page_id: "page_id",
+          properties: {
+            "NOMBRE DE RDV" => 0,
+            "DATE CREATION DERNIER RDV" => nil,
+            "DATE CREATION ESPACE" => { start: territory.created_at.strftime("%Y-%m-%d") },
+            "NOMBRE AGENTS ACTIFS" => 0,
+          }
+        )
+      end
+    end
+
+    context "quand la variable COMPTE PROD est une organisation inconnue" do
+      it "ne fait rien" do
+        described_class.new.perform(
+          notion_page_id: "page_id",
+          account_url: "https://demo.rdv-solidarites.fr/organisations/26739",
+          notion_page_url: "https://notion.so/page",
+          notion_page_title: "Mon projet"
+        )
+
+        expect(notion_client).not_to have_received(:update_page)
+      end
+    end
+
+    context "quand la variable COMPTE PROD est incorrecte" do
+      before do
+        allow(MattermostApiClient).to receive(:send_message)
+      end
+
+      it "envoie un message Mattermost" do
+        described_class.new.perform(
+          notion_page_id: "page_id",
+          account_url: "https://demo.rdv-solidarites.fr/invalid/path",
+          notion_page_url: "https://notion.so/page",
+          notion_page_title: "Mon projet"
+        )
+
+        expect(MattermostApiClient).to have_received(:send_message).with(
+          channel: "startup-rdv-alertes-crm",
+          text: "L'URL du compte PROD de la carte Notion [Mon projet](https://notion.so/page), est incorrecte.",
+          username: "CRM",
+          icon_url: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Notion-logo.svg/100px-Notion-logo.svg.png"
+        )
+      end
+
+      it "ne met pas à jour la page Notion" do
+        described_class.new.perform(
+          notion_page_id: "page_id",
+          account_url: "https://demo.rdv-solidarites.fr/invalid/path",
+          notion_page_url: "https://notion.so/page",
+          notion_page_title: "Mon projet"
+        )
+
+        expect(notion_client).not_to have_received(:update_page)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Contexte

Le job de synchro du CRM commence à prendre beaucoup de temps (environ 30 minutes les derniers jours).

# Solution

Je propose donc de traiter chaque « page » dans un job séparé.
Cela ne corrigera pas le temps d’exécution, mais permettra le retry unitaire en cas d’erreur et permettra d’éviter de bloquer un thread de worker pendant 30 minutes (voir + s'il y a un déploiement ou un échec du job durant son exécution).

À la suite de ça : 

- Regarder si on ne peut pas améliorer les requêtes en base pour diminuer un peu le temps
- Voir avec Léa si on ne peut pas mettre à jour moins souvent certaines pages (notamment celles qui sont au status STOP)

