### PR TITLE
Ajout de l’id du FI ProConnect pour les agents

### DIFF
--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -190,6 +190,7 @@ class ProConnectController < ApplicationController
       first_name: callback_client.user_first_name,
       last_name: callback_client.user_last_name,
       proconnect_siret: callback_client.user_siret,
+      pro_connect_idp_id: callback_client.user_idp_id,
       pro_connect_2fa_active: callback_client.went_through_2fa?,
       invitation_token: nil, # Pour désactiver les anciens liens d'invitation
       invitation_accepted_at: agent.invitation_accepted_at || Time.zone.now,

--- a/app/dashboards/agent_dashboard.rb
+++ b/app/dashboards/agent_dashboard.rb
@@ -22,6 +22,7 @@ class AgentDashboard < Administrate::BaseDashboard
     rdvs: Field::HasMany.with_options(sort_by: :starts_at, direction: :desc),
     invitation_sent_at: Field::DateTime,
     pro_connect_openid_sub: Field::String,
+    pro_connect_idp_id: Field::String,
     pro_connect_2fa_active: Field::Boolean,
     deleted_at: Field::DateTime,
     created_at: Field::DateTime,
@@ -54,6 +55,7 @@ class AgentDashboard < Administrate::BaseDashboard
     rdvs
     invitation_sent_at
     pro_connect_openid_sub
+    pro_connect_idp_id
     pro_connect_2fa_active
     created_at
     deleted_at

--- a/app/services/pro_connect_open_id_client/auth.rb
+++ b/app/services/pro_connect_open_id_client/auth.rb
@@ -1,7 +1,7 @@
 # voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique
 module ProConnectOpenIdClient
   class Auth
-    SCOPES = "openid email given_name usual_name siret".freeze
+    SCOPES = "openid email given_name usual_name siret idp_id".freeze
     ACR_FOR_2FA = %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa].freeze
 
     def initialize(client_id:, client_secret:, login_hint: nil, force_login: false)

--- a/app/services/pro_connect_open_id_client/callback.rb
+++ b/app/services/pro_connect_open_id_client/callback.rb
@@ -43,6 +43,10 @@ module ProConnectOpenIdClient
       @user_info["siret"]
     end
 
+    def user_idp_id
+      @user_info["idp_id"]
+    end
+
     def openid_sub
       @user_info["sub"]
     end

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -56,6 +56,7 @@ tables:
       - logement
       - ants_pre_demande_number
       - franceconnect_openid_sub
+      - pro_connect_idp_id
       - pro_connect_openid_sub
       - encrypted_password
       - confirmation_token

--- a/db/migrate/20260121064312_add_pro_connect_idp_id_to_agents.rb
+++ b/db/migrate/20260121064312_add_pro_connect_idp_id_to_agents.rb
@@ -1,0 +1,5 @@
+class AddProConnectIdpIdToAgents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :agents, :pro_connect_idp_id, :string
+  end
+end

--- a/db/migrate/20260121064312_add_pro_connect_idp_id_to_agents.rb
+++ b/db/migrate/20260121064312_add_pro_connect_idp_id_to_agents.rb
@@ -1,5 +1,5 @@
 class AddProConnectIdpIdToAgents < ActiveRecord::Migration[8.0]
   def change
-    add_column :agents, :pro_connect_idp_id, :string
+    add_column :agents, :pro_connect_idp_id, :string, comment: "Fournisseur d'identité ProConnect (identity provider)"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_08_161928) do
+ActiveRecord::Schema[8.0].define(version: 2026_01_21_064312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -155,6 +155,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_08_161928) do
     t.string "caldav_sync_token"
     t.boolean "pro_connect_2fa_active"
     t.boolean "group_by_agent", default: false, null: false
+    t.string "pro_connect_idp_id"
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -155,7 +155,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_21_064312) do
     t.string "caldav_sync_token"
     t.boolean "pro_connect_2fa_active"
     t.boolean "group_by_agent", default: false, null: false
-    t.string "pro_connect_idp_id"
+    t.string "pro_connect_idp_id", comment: "Fournisseur d'identité ProConnect (identity provider)"
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProConnectController do
         client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
         redirect_uri: "http://test.host/agent_connect/callback",
         response_type: "code",
-        scope: "openid email given_name usual_name siret",
+        scope: "openid email given_name usual_name siret idp_id",
         state: be_a(String),
         nonce: be_a(String),
         claims: {
@@ -42,7 +42,7 @@ RSpec.describe ProConnectController do
           client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
           redirect_uri: "http://test.host/agent_connect/callback",
           response_type: "code",
-          scope: "openid email given_name usual_name siret",
+          scope: "openid email given_name usual_name siret idp_id",
           state: be_a(String),
           nonce: be_a(String),
           claims: {
@@ -71,7 +71,7 @@ RSpec.describe ProConnectController do
         client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
         redirect_uri: "http://test.host/agent_connect/callback",
         response_type: "code",
-        scope: "openid email given_name usual_name siret",
+        scope: "openid email given_name usual_name siret idp_id",
         state: be_a(String),
         nonce: be_a(String),
         claims: {
@@ -104,6 +104,7 @@ RSpec.describe ProConnectController do
         "given_name" => "Francis Factice",
         "usual_name" => "Factice",
         "siret" => "13002526500013",
+        "idp_id" => "fia1",
         "aud" => "4ec41582-1d60-4f12-a63b-d8abaace16ba",
         "exp" => 1717595030, "iat" => 1717594970, "iss" => "https://fca.integ01.dev-agentconnect.fr/api/v2",
       }
@@ -126,6 +127,7 @@ RSpec.describe ProConnectController do
           email: user_info["email"],
           first_name: "Francis",
           last_name: "Factice",
+          pro_connect_idp_id: user_info["idp_id"],
           pro_connect_2fa_active: with_2fa,
         }
         expect(agent).to have_attributes(expected_attrs)
@@ -352,6 +354,7 @@ RSpec.describe ProConnectController do
           "given_name" => "Jean Michel Factice",
           "usual_name" => "Factice",
           "siret" => "11006801200050",
+          "idp_id" => "fia1",
           "aud" => "4ec41582-1d60-4f12-a63b-d8abaace16ba",
           "exp" => 1717595030, "iat" => 1717594970, "iss" => "https://fca.integ01.dev-agentconnect.fr/api/v2",
         }
@@ -377,6 +380,7 @@ RSpec.describe ProConnectController do
           "given_name" => "Jean Michel Factice",
           "usual_name" => "Factice",
           "siret" => "11006801200050",
+          "idp_id" => "fia1",
           "aud" => "4ec41582-1d60-4f12-a63b-d8abaace16ba",
           "exp" => 1717595030, "iat" => 1717594970, "iss" => "https://fca.integ01.dev-agentconnect.fr/api/v2",
         }


### PR DESCRIPTION
# Contexte

On a quelques incertitudes sur le bon déroulé de la double authentification forcée sur certains FI. Dans un premier temps, nous allons adopter la même stratégique que DN (ex : DS) en le faisant que pour les comptes sur le FI ProConnect Identité. 
Dans un second temps, je pense qu’avoir cette valeur en base va nous permettre de tester FI par FI la double authentification forcée, éventuellement en lien avec les agents.
De plus, on a des FI qui ont de la double authentification par défaut (via une authentification par carte agent). On aimerait savoir lesquels.

# Solution

Ajout de la colonne `pro_connect_idp_id` pour les agents.
