### PR TITLE
Déplacer les options de notifications des RDV collectifs

### DIFF
--- a/app/views/admin/participations/_notifications_lifecycle.html.slim
+++ b/app/views/admin/participations/_notifications_lifecycle.html.slim
@@ -1,6 +1,28 @@
+/# locals: (participation:, editable: nil)
+
+ruby:
+  editable = (
+    participation.rdv.collectif? &&
+    request.path == Rails.application.routes.url_helpers.admin_organisation_rdv_path(current_organisation, participation.rdv)
+  ) if editable.nil?
+
+
 - user_to_notify = participation.user.user_to_notify
 - any_notifs = (user_to_notify.notifiable_by_email? || user_to_notify.notifiable_by_sms?)
-- if any_notifs
+- if editable
+  = form_for participation, url: admin_organisation_rdv_participation_path(current_organisation, participation.rdv, participation), builder: Dsfr::FormBuilder, namespace: "participation_#{participation.id}" do |form|
+    fieldset.fr-fieldset
+      .fr-checkbox-group--sm.fr-fieldset__element--inline
+        = form.dsfr_check_box :send_lifecycle_notifications, disabled: !any_notifs, label: "Modifications"
+        - if current_organisation.rdv_insertion?
+          span.text-muted.font-14= participation.rdv.motif.human_attribute_value(:visibility_type, context: :hint_checkbox)
+      .fr-checkbox-group--sm.fr-fieldset__element--inline
+        = form.dsfr_check_box :send_reminder_notification, disabled: !any_notifs, label: "Rappel"
+        - if current_organisation.rdv_insertion? || true
+          span.text-muted.font-14= participation.rdv.motif.human_attribute_value(:visibility_type, context: :hint_checkbox)
+      .fr-fieldset__element--inline
+        = form.submit "Enregistrer", class: "fr-btn fr-btn--tertiary fr-btn--sm", disabled: !any_notifs
+- elsif any_notifs
   - if !participation.send_lifecycle_notifications && !participation.send_reminder_notification
     span.mr-1
       span= icon("fr-icon-error-fill", class: "fr-icon--sm fr-mr-1v fr-message--error")

--- a/app/views/admin/participations/_notifications_lifecycle.html.slim
+++ b/app/views/admin/participations/_notifications_lifecycle.html.slim
@@ -1,11 +1,12 @@
 /# locals: (participation:, editable: nil)
 
 ruby:
-  editable = (
-    participation.rdv.collectif? &&
-    request.path == Rails.application.routes.url_helpers.admin_organisation_rdv_path(current_organisation, participation.rdv)
-  ) if editable.nil?
-
+  if editable.nil?
+    editable = (
+      participation.rdv.collectif? &&
+      request.path == Rails.application.routes.url_helpers.admin_organisation_rdv_path(current_organisation, participation.rdv)
+    )
+  end
 
 - user_to_notify = participation.user.user_to_notify
 - any_notifs = (user_to_notify.notifiable_by_email? || user_to_notify.notifiable_by_sms?)

--- a/app/views/admin/rdvs/_users_table.html.slim
+++ b/app/views/admin/rdvs/_users_table.html.slim
@@ -8,7 +8,8 @@
         th style="max-width: 30%" Participant·e
         - if rdv.requires_ants_predemande_number?
           th =t("activerecord.attributes.user.ants_pre_demande_number")
-        th colspan="2" Notifications
+        th Préférences de communication de l’usager
+        th Notifications pour ce RDV
         - if rdv.collectif?
           th.text-right Participation
     tbody id="rdv-users-list"


### PR DESCRIPTION
> [!NOTE]
> Cette PR est un support de discussion, ça ne fonctionne pas pour l'instant

review app : https://rdv-service-public-review-app-pr6035.osc-secnum-fr1.scalingo.io/admin/organisations/4/rdvs/8 `martine@demo.rdv-solidarites.fr` `Rdvservicepublictest1!`

# Contexte

Actuellement, on peut retirer des participants d'un RDV collectif de deux manières : 
1. depuis le `admin/rdvs#show` grace au toggle de statut de participation
2. depuis le `admin/rdvs#edit` avec le bouton supprimer

captures d'écran
| 1 | 2 |
| - | - |
| <img width="994" height="557" alt="image" src="https://github.com/user-attachments/assets/f53288be-f667-4e07-87b1-0732c9188d57" /> | <img width="735" height="592" alt="image" src="https://github.com/user-attachments/assets/7315ee4e-ab83-4701-b3d8-06f7f0a2077c" /> |

Le chemin 2 pose problème : on n'indique pas à l'agent si l'usager (et l'agent si ce n'est pas le current_agent) sera notifié ou non.

Je pense aussi que les deux moyens de faire la même chose ici nuisent à l'UX du produit.

# Solution

J’ai envie de supprimer le bloc d’édition des usagers depuis le `#edit` pour tous les RDV collectifs.

On peut déjà ajouter un participant à un RDV collectif depuis un autre chemin `#show` > Ajouter un participant. On peut aussi supprimer un participant via le chemin 1. comme indiqué plus haut.

La seule chose qu'on ne peut faire que dans le `#edit` est la modification des préférences de notifications de rappel et modification pour ce RDV spécifique (à ne pas confondre avec les préférences de communication globales de l'usager 🤯).

Je propose donc de rappatrier ces checkbox dans le `#show` .

Je pense que plus tard on pourra aussi remettre en cause la pertinence d'avoir ces checkboxes par participation plutôt qu’à l’échelle du RDV entier. Ça pose pas mal de questions et demanderait des changements plus profonds que je n'ai pas envie d'attaquer dans cette PR

## Captures 

<img width="374" height="395" alt="image" src="https://github.com/user-attachments/assets/44142f4c-a3c8-416c-b155-268512e666f3" />

<img width="2374" height="801" alt="image" src="https://github.com/user-attachments/assets/2975cbd4-0dd8-45c6-84f5-045d84ffe257" />