### PR TITLE
Informer les agents ProConnecté de la désactivation de l’authentification par mot de passe

### DIFF
--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -1,6 +1,7 @@
 header.header.bg-white
   = render "layouts/rdv_solidarites_instance_name"
   = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
+  = render "layouts/pro_connect_migration_notice"
 
   nav.navbar.navbar-expand-lg.bg-transparent.navbar-dsfr[role="navigation" aria-label="navigation"]
     = link_to root_path, class: "header-brand ml-4" do

--- a/app/views/layouts/_pro_connect_migration_notice.html.slim
+++ b/app/views/layouts/_pro_connect_migration_notice.html.slim
@@ -1,0 +1,6 @@
+- if current_agent&.pro_connect_openid_sub.present? && session[:pro_connect_id_token].blank?
+  = dsfr_notice title: "Information",
+          description: "Vous vous êtes connecté avec votre mot de passe, mais votre compte est également lié à ProConnect. Pour des raisons de sécurité, la connexion par mot de passe sera désactivée pour les comptes liés à ProConnect à partir du 16 février 2026.",
+          type: "info",
+          link_label: "En savoir plus",
+          link_href: "https://aide.rdv-service-public.fr/toutes-les-notions/connexion-via-proconnect"


### PR DESCRIPTION
# Contexte

Afin de renforcer la sécurité du produit et de pouvoir forcer la double authentification pour certains agents, on souhaite désactiver la possibilité pour les agents ProConnecté de se connecter avec un mot de passe.

# Solution

Dans cette PR, je propose donc d’informer les agents de cette décision s'ils ont un compte RDV associé à ProConnect mais qu’ils se sont connecté avec leur mot de passe.
Le bandeau propose un lien vers un petit article sur notre site d’aide : https://aide.rdv-service-public.fr/toutes-les-notions/connexion-via-proconnect

La date du 16 février est tout à fait discutable tout comme le wording.

## Captures d'écran

<img width="1759" height="434" alt="image" src="https://github.com/user-attachments/assets/6436885c-893d-4ab0-bad8-7095b8724fab" />
