### PR TITLE
Correction de tests flaky à cause d’un format de date ou du jour

### DIFF
--- a/spec/features/agents/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/agent_has_a_calendar_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       click_button "Mois"
       monday = Time.zone.now.beginning_of_week.to_date
       find(%(.fc-daygrid-day[data-date="#{monday}"])).click
-      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(monday, format: '%d/%m/%Y')} à 00:00")
+      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(monday, format: '%-d/%m/%Y')} à 00:00")
     end
 
     it "fonctionne depuis la vue semaine", js: true do
@@ -203,7 +203,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       # Je ne sais pas comment faire cliquer la spec sur la colonne du lundi, elle clique au milieu de l'élément donc sur le mercredi.
       wednesday = Time.zone.now.beginning_of_week.to_date + 2
       find('.fc-timegrid-slot-lane[data-time="08:30:00"]').click
-      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(wednesday, format: '%d/%m/%Y')} à 08:30")
+      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(wednesday, format: '%-d/%m/%Y')} à 08:30")
     end
 
     it "fonctionne depuis la vue jour", js: true do
@@ -212,7 +212,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       click_button "Journée"
       find('.fc-timegrid-slot-lane[data-time="08:30:00"]').click
       monday_next_week = Time.zone.today.beginning_of_week + 1.week
-      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(monday_next_week, format: '%d/%m/%Y')} à 08:30")
+      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(monday_next_week, format: '%-d/%m/%Y')} à 08:30")
     end
   end
 end

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
   it "works (creates local ExternalCalendarEvent rows for each event)" do
+    travel_to Time.zone.parse("2026-01-14 10:00:00")
+
     agent = create(
       :agent,
       caldav_agenda_url: "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/Y2FsOi8vMC8xMzk2Ng",


### PR DESCRIPTION
# Contexte

Je constate ce matin qu'il y a deux tests flaky 
- Un à cause du format du jour de la date. Dans le code, le jour est écrit sur 1 chiffre, et dans les tests, il est écrit sur deux.
- Un à cause d’une cassette qui contient des données dans le passé : les événements de la cassette VCR sont datés du 2026-01-13. Le job filtre les événements passés (avant `(Time.now - 1.week).beginning_of_week`). Avec la date actuelle (2026-01-26), le cutoff était le 2026-01-19, donc les événements étaient filtrés. En fixant la date au 2026-01-14, les événements sont dans la plage valide.

# Solution

- Je change le format de date dans les tests.
- Je fais un `travel_to` pour avoir une date qui correspond aux données qui sont dans la cassette VCR
