### PR TITLE
Changement de la gestion des erreurs 422 dans le client utilisé pour la migration inter-instances

### DIFF
--- a/app/lib/rdv_service_public_api_client.rb
+++ b/app/lib/rdv_service_public_api_client.rb
@@ -11,15 +11,8 @@ class RdvServicePublicApiClient
     return response.body if response.success?
 
     if response.status == 422
-      external_id_errors = response.body.dig("errors", "external_id")
-      external_id_taken = external_id_errors&.find do |error_hash|
-        error_hash["error"] == "taken"
-      end
-
-      if external_id_taken # L'appel a échoué parce que la ressource a déjà été créée sur le serveur distant
-        # On ne considère pas que c'est une erreur, parce que ça nous permet de faire des créations idempotentes
-        return response.body
-      end
+      # En cas d'erreur métier, on laisse le code client décider quoi faire
+      return response.body
     end
 
     raise(RequestError, "échec de la requête sur #{path} (status #{response.status}). Voir les breadcrumbs Sentry pour plus d'infos")

--- a/app/lib/rdv_service_public_api_client.rb
+++ b/app/lib/rdv_service_public_api_client.rb
@@ -11,11 +11,18 @@ class RdvServicePublicApiClient
     return response.body if response.success?
 
     if response.status == 422
+
+      unless ressource_already_created_error_response?(response)
+        # S'il y a une erreur métier pour autre chose que pour une erreur de création idempotente,
+        # on veut qu'elle soit observable dans Sentry
+        Sentry.capture_message(error_message(path, response))
+      end
+
       # En cas d'erreur métier, on laisse le code client décider quoi faire
       return response.body
     end
 
-    raise(RequestError, "échec de la requête sur #{path} (status #{response.status}). Voir les breadcrumbs Sentry pour plus d'infos")
+    raise(RequestError, error_message(path, response))
   end
 
   def get(path, params = {})
@@ -23,6 +30,18 @@ class RdvServicePublicApiClient
   end
 
   private
+
+  def error_message(path, response)
+    "échec de la requête sur #{path} (status #{response.status}). Voir les breadcrumbs Sentry pour plus d'infos"
+  end
+
+  def ressource_already_created_error_response?(response)
+    external_id_errors = response.body.dig("errors", "external_id")
+
+    external_id_errors&.find do |error_hash|
+      error_hash["error"] == "taken"
+    end
+  end
 
   def connection
     url = ENV.fetch("RDV_SERVICE_PUBLIC_OAUTH_BASE_URL")

--- a/spec/lib/rdv_service_public_api_client_spec.rb
+++ b/spec/lib/rdv_service_public_api_client_spec.rb
@@ -1,7 +1,24 @@
 RSpec.describe RdvServicePublicApiClient do
   stub_env_with RDV_SERVICE_PUBLIC_OAUTH_BASE_URL: "http://rdv.localhost"
 
-  context "pour une requête qui échoue" do
+  context "pour une requête qui renvoie une erreur 500" do
+    before do
+      stub_request(:post, "http://rdv.localhost/api/v1/plage_ouvertures")
+        .to_return(
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+          body: { errors: ["Unexpected internal error"] }.to_json
+        )
+    end
+
+    it "lève une exception" do
+      expect do
+        described_class.new("123456").post("plage_ouvertures", { lieu_external_ids: "asdf" })
+      end.to raise_error(RdvServicePublicApiClient::RequestError)
+    end
+  end
+
+  context "pour une requête qui échoue avec un statut 404" do
     before do
       stub_request(:post, "http://rdv.localhost/api/v1/plage_ouvertures")
         .to_return(
@@ -23,7 +40,7 @@ RSpec.describe RdvServicePublicApiClient do
     end
   end
 
-  context "pour une requête qui échoue à cause d'une erreur métier" do
+  context "pour une requête qui échoue à cause d'une erreur métier avec un statut 422" do
     before do
       stub_request(:post, "http://rdv.localhost/api/v1/motifs")
         .to_return(
@@ -33,15 +50,12 @@ RSpec.describe RdvServicePublicApiClient do
         )
     end
 
-    it "ajoute la requête et la réponse HTTP en breadcrumb Sentry et lève une exception" do
-      expect do
-        described_class.new("123456").post("motifs", {}) # Les paramètres ne sont pas utilisés pas le stub, donc on ne les précise pas
-      end.to raise_error(RdvServicePublicApiClient::RequestError) do |e|
-        Sentry.capture_exception(e)
-        request_breadcrumb, response_breadcrumb = sentry_events.last.breadcrumbs.compact
-        expect(request_breadcrumb.data[:body]).to be_present
-        expect(response_breadcrumb.data[:body]).to be_present
-      end
+    it "ne lève pas d'exception, mais renvoie la réponse pour que laisser le code client traiter l'erreur métier" do
+      response = described_class.new("123456").post("motifs", {}) # Les paramètres ne sont pas utilisés pas le stub, donc on ne les précise pas
+      expect(response).to eq({
+                               "error_messages" => ['base Il existe déjà dans Mon Organisation un motif Sur place nommé "Suivi de dossier" ouvert à tous les agents'],
+                               "errors" => { "base" => [{ "error" => "duplicate_detected" }] },
+                             })
     end
   end
 
@@ -56,7 +70,10 @@ RSpec.describe RdvServicePublicApiClient do
     end
 
     it "n'échoue pas, parce qu'on veut permettre de faire plusieurs fois des copies de données inter-instances sans doublons et sans lever d'erreur" do
-      described_class.new("123456").post("motifs", {}) # Les paramètres ne sont pas utilisés pas le stub, donc on ne les précise pas
+      response = described_class.new("123456").post("motifs", {}) # Les paramètres ne sont pas utilisés pas le stub, donc on ne les précise pas
+      expect(response).to eq(
+        { "error_messages" => ["external_id est déjà utilisé"], "errors" => { "external_id" => [{ "error" => "taken", "value" => "123ABC" }] } }
+      )
     end
   end
 end

--- a/spec/lib/rdv_service_public_api_client_spec.rb
+++ b/spec/lib/rdv_service_public_api_client_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe RdvServicePublicApiClient do
         )
     end
 
-    it "ne lève pas d'exception, mais renvoie la réponse pour que laisser le code client traiter l'erreur métier" do
+    it "ne lève pas d'exception, mais renvoie la réponse pour que laisser le code client traiter l'erreur métier et notifie Sentry pour qu'on ai de la visilité" do
+      expect(Sentry).to receive(:capture_message)
+
       response = described_class.new("123456").post("motifs", {}) # Les paramètres ne sont pas utilisés pas le stub, donc on ne les précise pas
       expect(response).to eq({
                                "error_messages" => ['base Il existe déjà dans Mon Organisation un motif Sur place nommé "Suivi de dossier" ouvert à tous les agents'],
@@ -70,6 +72,7 @@ RSpec.describe RdvServicePublicApiClient do
     end
 
     it "n'échoue pas, parce qu'on veut permettre de faire plusieurs fois des copies de données inter-instances sans doublons et sans lever d'erreur" do
+      expect(Sentry).not_to receive(:capture_message)
       response = described_class.new("123456").post("motifs", {}) # Les paramètres ne sont pas utilisés pas le stub, donc on ne les précise pas
       expect(response).to eq(
         { "error_messages" => ["external_id est déjà utilisé"], "errors" => { "external_id" => [{ "error" => "taken", "value" => "123ABC" }] } }


### PR DESCRIPTION
# Contexte

Dans le cadre de la migration inter-instances, on a eu à nouveau des erreurs de l'api (voir https://sentry.incubateur.net/organizations/betagouv/issues/239475/?environment=production).
Cette fois, on avait le message d'erreur suivant : `{"error_messages":["L’agent francis.factice@exemple.fr fait déjà partie de votre organisation."]}`.

C'est donc un cas similaire à l'erreur qui est déjà ignorée dans le code du client quand on refait une création idempotente.

Cette erreur bloque la suite de la migration, alors que toutes les données sont bonnes, et on a donc des agents bloqués.

# Solution

Plutôt que de gérer une à une toutes les situations où des erreurs 422 nous disent que les données sont déjà là, on revient légèrement en arrière sur ce qui a été fait dans https://github.com/betagouv/rdv-service-public/pull/5976, et on ne lève pas d'erreur au niveau du client en cas de réponse 422 (le statut pour les erreurs "métier").

On préfère laisser au code qui appelle le client le soin de décider que faire en fonction de l'erreur.

Et dans le cadre de la migration, c'est assez safe je pense d'ignorer ces erreurs. Si quelque chose de vraiment grave se passe, on aura des 404 ou des 500 par la suite.
