### PR TITLE
Correctif pour la page de stats structure par structure

### DIFF
--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -136,7 +136,7 @@ class Territory < ApplicationRecord
     if name.present?
       [name, departement_number.presence].compact.join(" - ")
     else
-      organisations.first.name
+      organisations.first&.name || "Espace archivé"
     end
   end
 

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe Territory, type: :model do
       territory = build(:territory, departement_number: nil, name: "Seine Saint-Denis")
       expect(territory.name_in_stats).to eq("Seine Saint-Denis")
     end
+
+    it "returns a default value for a territory without any organisations" do
+      territory = build(:territory, departement_number: nil, name: nil)
+      territory.organisations.delete_all
+      expect(territory.name_in_stats).to eq("Espace archivé")
+    end
   end
 
   describe "#waiting_room_enabled?" do


### PR DESCRIPTION
Correctif pour https://sentry.incubateur.net/organizations/betagouv/issues/198187/?environment=production&project=74

On a un territoire qui a supprimé son unique orga, ce qui lève une erreur quand on essaye d'afficher la page de stats structure par structure.

Ça semble raisonnable de mettre une valeur par défaut dans ce cas.