### PR TITLE
Afficher les demandes d’ouverture de compte traitées par ordre decroissant

### DIFF
--- a/app/controllers/super_admins/territory_creation_requests_controller.rb
+++ b/app/controllers/super_admins/territory_creation_requests_controller.rb
@@ -1,7 +1,13 @@
 module SuperAdmins
   class TerritoryCreationRequestsController < SuperAdmins::ApplicationController
     def index
-      @territory_creation_requests = policy_scope(TerritoryCreationRequest.where(response: params[:response]), policy_scope_class: SuperAdmin::TerritoryCreationRequestPolicy::Scope)
+      # Demandes en attente : les plus anciennes en premier
+      # Demandes traitées : les plus récentes en premier
+      order_direction = params[:response].nil? ? :asc : :desc
+      @territory_creation_requests = policy_scope(
+        TerritoryCreationRequest.where(response: params[:response]).order(created_at: order_direction),
+        policy_scope_class: SuperAdmin::TerritoryCreationRequestPolicy::Scope
+      )
 
       # le module Administrate::Punditize oblige à faire un appel à #authorize même si on est sur l'index
       authorize(@territory_creation_requests, policy_class: SuperAdmin::TerritoryCreationRequestPolicy)


### PR DESCRIPTION
# Contexte

Dans la super admin, on commence à avoir beaucoup de demandes d’ouverture de compte traitées. Actuellement, on les affiche par ordre croissant, ce qui nous oblige à descendre de la page pour voir les dernières demandes traitées.

# Solution

Je propose donc (avec accord de Léa) de changer cet ordre.
