### PR TITLE
Ne pas afficher la notice ProConnect aux SuperAdmins

### DIFF
--- a/app/views/layouts/_pro_connect_migration_notice.html.slim
+++ b/app/views/layouts/_pro_connect_migration_notice.html.slim
@@ -1,6 +1,7 @@
-- if current_agent&.pro_connect_openid_sub.present? && session[:pro_connect_id_token].blank?
-  = dsfr_notice title: "Information",
-          description: "Vous vous êtes connecté avec votre mot de passe, mais votre compte est également lié à ProConnect. Pour des raisons de sécurité, la connexion par mot de passe sera désactivée pour les comptes liés à ProConnect à partir du 16 février 2026.",
-          type: "info",
-          link_label: "En savoir plus",
-          link_href: "https://aide.rdv-service-public.fr/toutes-les-notions/connexion-via-proconnect"
+- unless session[:super_admin_signed_in_as_agent]
+  - if current_agent&.pro_connect_openid_sub.present? && session[:pro_connect_id_token].blank?
+    = dsfr_notice title: "Information",
+            description: "Vous vous êtes connecté avec votre mot de passe, mais votre compte est également lié à ProConnect. Pour des raisons de sécurité, la connexion par mot de passe sera désactivée pour les comptes liés à ProConnect à partir du 16 février 2026.",
+            type: "info",
+            link_label: "En savoir plus",
+            link_href: "https://aide.rdv-service-public.fr/toutes-les-notions/connexion-via-proconnect"


### PR DESCRIPTION
# Contexte

Lorsque j’ai ajouté le bandeau d’informations sur l’arrêt de connexion par mot de passe pour les agents qui sont ProConnecté, je n’ai pas pensé que ça allait s’afficher systématiquement pour les super admins.

# Solution

Je retire donc ce bandeau pour les super admins.
