### PR TITLE
Utilisation même wording agent introuvable et mot de passe incorrect

### DIFF
--- a/app/controllers/agents/passwords_controller.rb
+++ b/app/controllers/agents/passwords_controller.rb
@@ -12,7 +12,7 @@ class Agents::PasswordsController < Devise::PasswordsController
       end
     end
 
-    flash[:notice] = I18n.t("devise.passwords.send_paranoid_instructions")
+    flash[:notice] = I18n.t("devise.passwords.send_paranoid_instructions", email: resource_params[:email])
     redirect_to root_path
   end
 end

--- a/app/controllers/agents/passwords_controller.rb
+++ b/app/controllers/agents/passwords_controller.rb
@@ -3,16 +3,16 @@ class Agents::PasswordsController < Devise::PasswordsController
 
   def create
     agent = Agent.find_by(email: resource_params[:email])
-    if agent && !agent.complete?
-      if agent.invitation_sent_at
+
+    if agent
+      if agent.complete?
+        agent.send_reset_password_instructions
+      elsif agent.invitation_sent_at
         agent.invite!(nil, validate: false)
-        flash[:notice] = "Vous n'avez pas activé votre compte, un email vous a été envoyé."
-      else
-        flash[:notice] = "Votre compte n'a pas encore été activé, un email vous sera envoyé lorsque cela sera le cas."
       end
-      redirect_to root_path
-    else
-      super
     end
+
+    flash[:notice] = I18n.t("devise.passwords.send_paranoid_instructions")
+    redirect_to root_path
   end
 end

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -14,7 +14,7 @@ fr:
       invalid: "Email ou mot de passe incorrect."
       last_attempt: "Vous avez droit à une tentative avant que votre compte ne soit verrouillé."
       locked: "Votre compte est verrouillé."
-      not_found_in_database: "Email ou mot de passe invalide."
+      not_found_in_database: "Email ou mot de passe incorrect."
       timeout: "Votre session est expirée. Veuillez vous reconnecter pour continuer."
       unauthenticated: "Vous devez vous connecter ou vous inscrire pour continuer."
       unconfirmed: "Vous devez valider votre compte pour continuer."

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -74,7 +74,7 @@ fr:
     passwords:
       no_token: "Vous ne pouvez accéder à cette page sans passer par un e-mail de réinitialisation de mot de passe. Si vous avez utilisé un e-mail de ce type, assurez-vous d'utiliser l'URL complète."
       send_instructions: "Vous allez recevoir les instructions de réinitialisation du mot de passe dans quelques instants"
-      send_paranoid_instructions: "Si votre e-mail existe dans notre base de données, vous allez recevoir un lien de réinitialisation par e-mail"
+      send_paranoid_instructions: "Si un compte agent existe pour %{email}, alors un email de réinitialisation va y être envoyé avec un lien de réinitialisation de mot de passe"
       updated: "Votre mot de passe a été édité avec succès, votre connexion est désormais active"
       updated_not_active: "Votre mot de passe a été changé avec succès."
     registrations:

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -19,7 +19,8 @@ fr:
       unauthenticated: "Vous devez vous connecter ou vous inscrire pour continuer."
       unconfirmed: "Vous devez valider votre compte pour continuer."
       agent:
-        invalid: "Email ou mot de passe incorrect. Vous pouvez <a href='/agents/password/new'>réinitialiser votre mot de passe ici</a>."
+        not_found_in_database: "Email ou mot de passe incorrect. Si vous avez oublié votre mot de passe, vous pouvez <a href='/agents/password/new'>réinitialiser votre mot de passe ici</a>."
+        invalid: "Email ou mot de passe incorrect. Si vous avez oublié votre mot de passe, vous pouvez <a href='/agents/password/new'>réinitialiser votre mot de passe ici</a>."
     invitations:
       send_instructions: "L'utilisateur %{email} a été invité"
       invitation_token_invalid: "Votre invitation n'est pas valide."

--- a/spec/features/agents/account/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/account/agent_can_reset_his_password_spec.rb
@@ -1,9 +1,9 @@
-RSpec.describe "Agent resets his password spec" do
+RSpec.describe "Un agent peut réinitialiser son mot de passe" do
   let!(:agent) { create(:agent) }
 
   around { |example| perform_enqueued_jobs { example.run } }
 
-  it "works by sending a reset email" do
+  it "envoie un email de réinitialisation" do
     visit new_agent_password_path
     expect(page).to have_content("Mot de passe oublié ?")
     expect(page).to have_link("Se connecter")
@@ -24,7 +24,7 @@ RSpec.describe "Agent resets his password spec" do
     expect(page).to have_content("Votre mot de passe a été édité avec succès")
   end
 
-  it "works when using the user's password reset form" do
+  it "fonctionne via le formulaire de réinitialisation utilisateur" do
     visit new_user_password_path
     expect(page).to have_content("Mot de passe oublié ou première connexion ?")
     expect(page).to have_link("Se connecter")
@@ -38,5 +38,27 @@ RSpec.describe "Agent resets his password spec" do
     fill_in "Mot de passe", with: "correct H0rse battery! staple"
     expect { click_on "Enregistrer" }.to change { agent.reload.encrypted_password }
     expect(page).to have_content("Votre mot de passe a été édité avec succès")
+  end
+
+  context "quand l'email n'existe pas" do
+    it "affiche un message générique sans révéler que le compte n'existe pas" do
+      visit new_agent_password_path
+      fill_in "agent_email", with: "unknown@example.com"
+
+      expect { click_on "Envoyer" }.not_to change { ActionMailer::Base.deliveries.size }
+      expect(page).to have_content("Si votre e-mail existe dans notre base de données")
+    end
+  end
+
+  context "quand l'agent n'a pas encore accepté son invitation" do
+    let!(:agent_not_accepted) { create(:agent, :invitation_not_accepted) }
+
+    it "affiche un message générique et renvoie l'invitation" do
+      visit new_agent_password_path
+      fill_in "agent_email", with: agent_not_accepted.email
+
+      expect { click_on "Envoyer" }.to change { emails_sent_to(agent_not_accepted.email).size }.by(1)
+      expect(page).to have_content("Si votre e-mail existe dans notre base de données")
+    end
   end
 end

--- a/spec/features/agents/account/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/account/agent_can_reset_his_password_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Un agent peut réinitialiser son mot de passe" do
       fill_in "agent_email", with: "unknown@example.com"
 
       expect { click_on "Envoyer" }.not_to change { ActionMailer::Base.deliveries.size }
-      expect(page).to have_content("Si votre e-mail existe dans notre base de données")
+      expect(page).to have_content("Si un compte agent existe pour unknown@example.com, alors un email de réinitialisation va y être envoyé avec un lien de réinitialisation de mot de passe")
     end
   end
 
@@ -58,7 +58,7 @@ RSpec.describe "Un agent peut réinitialiser son mot de passe" do
       fill_in "agent_email", with: agent_not_accepted.email
 
       expect { click_on "Envoyer" }.to change { emails_sent_to(agent_not_accepted.email).size }.by(1)
-      expect(page).to have_content("Si votre e-mail existe dans notre base de données")
+      expect(page).to have_content("Si un compte agent existe pour #{agent_not_accepted.email}, alors un email de réinitialisation va y être envoyé avec un lien de réinitialisation de mot de passe")
     end
   end
 end


### PR DESCRIPTION
# Contexte

Suite à [cette PR](https://github.com/betagouv/rdv-service-public/pull/5282), nous affichons 2 phrases différentes quand l’agent n’existe pas en base ou quand son mot de passe est incorrect.

Quand il n’existe pas en base : « Email ou mot de passe incorrect. »
Quand il existe, mais qu’il n’a pas utilisé le bon mot de passe : « Email ou mot de passe incorrect. Vous pouvez réinitialiser votre mot de passe ici. »

# Solution

Afin d’éviter de laisser deviner à un potentiel attaquant s'il y a ou non un compte derrière un email, je propose d’utiliser le même message dans les deux cas.
De plus je propose un petit changement dans la formulation.

