### PR TITLE
Page d'erreur 400

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,8 @@
 class ErrorsController < ApplicationController
+  def bad_request
+    render status: :bad_request, layout: rendered_layout
+  end
+
   def not_found
     render status: :not_found, layout: rendered_layout
   end

--- a/app/views/errors/bad_request.html.slim
+++ b/app/views/errors/bad_request.html.slim
@@ -1,0 +1,16 @@
+.fr-grid-row
+  .fr-col-12.fr-col-md-8
+    h1.fr-h1 Requête invalide
+
+    p Erreur 400
+
+    p La requête envoyée est invalide. Veuillez nous excuser pour la gêne occasionnée.
+
+    p Si le problème persiste, n'hésitez pas à nous contacter.
+
+    .fr-btns-group.fr-btns-group--inline
+      = link_to "Contactez-nous", new_aide_demande_support_path(sujet: "Erreur 400", message: "\n\n--- votre message au-dessus ---\n\nErreur rencontrée sur la page : #{request.original_url}"), class: "fr-btn"
+      = link_to("Retour à l'accueil", root_path, class: "fr-btn fr-btn--secondary")
+
+  .fr-col-0.fr-col-md-4
+    = image_tag "static_pages/not_found_illustration.svg", class: "img-fluid fr-p-3w", alt: ""

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -465,6 +465,7 @@ Rails.application.routes.draw do
 
   draw :operators
 
+  match "/400", to: "errors#bad_request", via: :all
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all
 


### PR DESCRIPTION
  # Contexte

La méthode [params.expect](https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect) est la nouvelle manière recommandée de définir des attentes sur les params dans les controlleurs rails plutot que require et permit

On a commencé à l'utiliser récemment dans le `Users::SessionsByCodeController#create` : `params.[..].expect(:email, :code)`. 

Cette méthode lève une `ActionController::ParameterMissing` et Rails renvoie une réponse HTTP 400.

L'application utilise `config.exceptions_app = routes` pour afficher des pages d'erreur personnalisées. Des routes existent pour `/404` et `/500`, mais pas pour `/400`. En production, l'utilisateur voit donc une page blanche avec un statut 400 sans aucun contenu dans le body, c'est la page d'erreur native du navigateur.

## Reproduction

Pour reproduire le bug : 

- tentez de vous connecter avec une adresse email usager existante : https://demo.rdv-solidarites.fr/users/sign_in
- renseignez un mauvais code
- re-renseignez un mauvais code
- →  L’email n'est pas bien repassé en param => expect échoue => 400 

# Solution

  On ajoute une page d'erreur 400 suivant le même pattern que les pages 404 et 500 existantes :
  - Une route `/400` vers `ErrorsController#bad_request`
  - Une action `bad_request` dans `ErrorsController`
  - Un template `errors/bad_request.html.slim` avec le même style que la page 404 (titre, code erreur, message explicatif, boutons de contact et de retour à l'accueil)

  ## Captures d'écran

| avant | après|
| - | - | 
<img width="1154" height="755" alt="400" src="https://github.com/user-attachments/assets/82682d1c-9212-415c-b419-223475cf6a9a" /> | <img width="1198" height="725" alt="400-fixed" src="https://github.com/user-attachments/assets/20f12c49-3e4e-4167-b64f-0de3fa869183" />

> [!NOTE]
> Je me demande si on devrait prévenir via Sentry pour ces erreurs 🤔 et je vais corriger le bug de la connexion dans une PR à part de celle-ci