### PR TITLE
Commencer à déprécier la synchronisation Webcal

### DIFF
--- a/app/views/agents/calendar_sync/show.html.slim
+++ b/app/views/agents/calendar_sync/show.html.slim
@@ -21,12 +21,14 @@ div.d-flex.justify-content-center.align-items-center.flex-wrap
       div.rdv-text-align-center
         = link_to "Connecter mon compte Outlook (Microsoft 365)", agents_calendar_sync_outlook_sync_path, class: "fr-btn"
 
-  div.card.w-100
-    div.card-body
-      h5.card-title Lien Webcal
-      p Vous pouvez synchroniser votre agenda externe grâce à un lien Webcal. Vos rendez-vous seront visibles sur votre agenda externe, mais parfois avec quelques heures de retard.
-      div.rdv-text-align-center
-        = link_to "Synchronisation par lien Webcal", agents_calendar_sync_webcal_sync_path, class: "fr-btn"
+  - if current_agent.calendar_uid.present?
+    div.card.w-100
+      div.card-body
+        h5.card-title Lien Webcal
+        p Vous pouvez synchroniser votre agenda externe grâce à un lien Webcal. Vos rendez-vous seront visibles sur votre agenda externe, mais parfois avec quelques heures de retard.
+        p Nous recommandons d'utiliser la synchronisation CalDAV à la place.
+        div.rdv-text-align-center
+          = link_to "Synchronisation par lien Webcal", agents_calendar_sync_webcal_sync_path, class: "fr-btn fr-btn--secondary"
 
   h2.fr-h6 Notifications par email
   p.fr-col-12 Vous pouvez aussi recevoir un email avec une invitation ics pour chaque rendez-vous, absence et plage d'ouverture.


### PR DESCRIPTION
# Contexte

Suite à la sortie de la synchronisation bidirectionnelle avec Caldav, la synchronisation avec Webcal n'est plus utile du tout : elle est souvent lente (ce qui ne la rend pas fiable, ce qui est presque pire que de ne pas avoir de synchro du tout), difficile à utiliser et ne fonctionne que dans un sens.

Par ailleurs, le mode d'authentification à webcal est inexistant (c'est juste des liens cachés), donc on ne peut pas mettre de données personnelles dans cette synchro, et même sans données personnelles c'est pas génial en terme de sécurité.

# Solution

On déprécie Webcal pour encourager caldav à la place. Pour le moment on se contente de ne plus proposer cette option aux agents qui ne l'ont jamais utilisée, pour éviter qu'on ai de nouveaux agents qui l'utilisent.

# Prochaines étapes

- Continuer d'améliorer la synchro caldav et de la rendre plus pratique à configurer
- Tracker les appels à l'endpoint webcal pour les différents agents pour savoir quels liens webcal sont inutilisés (et les supprimer)
- Fermer définitivement cette synchro.

## Captures d'écran

### Pour un agent qui n'a jamais utilisé Webcal
Avant | Après
:- | -:
<img width="1309" height="962" alt="Screenshot 2026-01-29 at 12 43 35" src="https://github.com/user-attachments/assets/7c87f164-cab9-4eac-a291-e750bcbc1ce1" />|<img width="1337" height="928" alt="Screenshot 2026-01-29 at 12 42 55" src="https://github.com/user-attachments/assets/32a98a4e-aca7-44b6-8dd9-eb9d957d4f7d" />



### Pour un agent qui a déjà utilisé Webcal
Avant | Après
:- | -:
<img width="1309" height="962" alt="Screenshot 2026-01-29 at 12 43 35" src="https://github.com/user-attachments/assets/7c87f164-cab9-4eac-a291-e750bcbc1ce1" />|<img width="1340" height="954" alt="Screenshot 2026-01-29 at 12 41 12" src="https://github.com/user-attachments/assets/a7b9f797-0992-4376-acb3-8ca2f7d635c5" />


