### PR TITLE
Correction d'une 400 lors de la saisie d'un code de login erroné

### DIFF
--- a/app/controllers/users/sessions_by_code_controller.rb
+++ b/app/controllers/users/sessions_by_code_controller.rb
@@ -24,7 +24,8 @@ class Users::SessionsByCodeController < ApplicationController
     elsif login_service.should_redirect_to_code_request?
       redirect_to new_users_sessions_by_code_path(email:), flash: { error: login_service.error }
     else
-      @existing_login_code = LoginCode.most_recent_usable_for(email: login_service.email)
+      @email = login_service.email
+      @existing_login_code = LoginCode.most_recent_usable_for(email:)
       @existing_login_code.errors.add(:base, login_service.error)
       render :new
     end

--- a/spec/features/users/account/user_can_login_using_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_code_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
     end
   end
 
+  context "l’usager entre un mauvais code puis le bon" do
+    before { create(:login_code, email: "marco@lolmail.fr", code: "123456", created_at: 1.minute.ago) }
+
+    specify do
+      visit new_users_sessions_by_code_path(email: "marco@lolmail.fr")
+      fill_in("Code à 6 chiffres", with: "999999")
+      click_on "Valider"
+      expect(page).not_to have_content("Connexion réussie")
+      expect(page).to have_content("Veuillez renseigner le dernier code qui vous a été envoyé par email")
+      fill_in("Code à 6 chiffres", with: "123456")
+      click_on "Valider"
+      expect(page).to have_content("Connexion réussie")
+    end
+  end
+
   context "l’usager attend trop longtemps, le code est expiré" do
     before { create(:login_code, email: "marco@lolmail.fr", code: "123456", created_at: 1.hour.ago) }
 


### PR DESCRIPTION
# Contexte

Dans #6059 on a amélioré l'affichage de l'erreur 400 qui se produit. Ça sera utile à l'avenir si ce problème se reproduit. 

Il faut maintenant corriger le bug et ne plus faire de 400 ! 

## Reproduction

Pour reproduire le bug : 

- tentez de vous connecter avec une adresse email usager existante : https://demo.rdv-solidarites.fr/users/sign_in
- renseignez un mauvais code
- re-renseignez un mauvais code
- →  L’email n'est pas bien repassé en param => expect échoue => 400 

Merci @Teodora-Stanki de l'avoir repéré et signalé ! 

# Solution

Le correctif est simple : il faut définir `@email` avant de faire `render :new` depuis le `#create`

Review app : https://rdv-service-public-review-app-pr6061.osc-secnum-fr1.scalingo.io/users/sign_in avec `patricia_duroy@demo.rdv-solidarites.fr`