### PR TITLE
Correction de la fermeture d'orga quand on est l'ultime admin de territoire

### DIFF
--- a/app/services/agent_removal.rb
+++ b/app/services/agent_removal.rb
@@ -25,7 +25,7 @@ class AgentRemoval
   end
 
   def should_soft_delete?
-    (@agent.organisations - [@organisation]).empty?
+    (@agent.organisations - [@organisation]).empty? && @agent.territorial_roles.empty?
   end
 
   def confirmation_message

--- a/spec/services/agent_removal_spec.rb
+++ b/spec/services/agent_removal_spec.rb
@@ -93,8 +93,9 @@ RSpec.describe AgentRemoval, type: :service do
     let!(:organisation) { create(:organisation) }
     let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
 
-    it "soft-delete l'agent" do
+    it "fonctionne et soft-delete l'agent" do
       described_class.new(agent, organisation).remove!
+      expect(organisation.agents).not_to include(agent)
       expect(agent.reload.deleted_at).not_to be_nil
     end
   end
@@ -105,10 +106,13 @@ RSpec.describe AgentRemoval, type: :service do
     let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
     let!(:territorial_role) { create(:agent_territorial_role, agent:, territory:) }
 
-    it "ne raise pas d'erreur" do
+    it "retire l'agent de l'orga mais ne soft-delete pas l'agent, iel conserve son rôle territorial" do
       service = described_class.new(agent, organisation)
       expect(service).to be_valid
-      expect { service.remove! }.not_to raise_error
+      service.remove!
+      expect(agent.organisations).not_to include(organisation)
+      expect(agent.reload.deleted_at).to be_nil
+      expect(agent.territories).to include(territory)
     end
   end
 
@@ -120,10 +124,13 @@ RSpec.describe AgentRemoval, type: :service do
     let!(:territorial_role) { create(:agent_territorial_role, agent: agent, territory:) }
     let!(:territorial_role1) { create(:agent_territorial_role, agent: agent1, territory:) }
 
-    it "ne raise pas d'erreur" do
+    it "retire l'agent de l'orga mais ne soft-delete pas l'agent, iel conserve son rôle territorial" do
       service = described_class.new(agent, organisation)
       expect(service).to be_valid
-      expect { service.remove! }.not_to raise_error
+      service.remove!
+      expect(agent.organisations).not_to include(organisation)
+      expect(agent.reload.deleted_at).to be_nil
+      expect(agent.territories).to include(territory)
     end
   end
 
@@ -149,6 +156,17 @@ RSpec.describe AgentRemoval, type: :service do
       let(:agent) { build(:agent, organisations: [organisation1, organisation2]) }
 
       it { is_expected.to be false }
+    end
+
+    context "dernière orga de l'agent mais iel a un rôle territorial" do
+      let!(:territory) { create(:territory) }
+      let!(:organisation) { create(:organisation, territory:) }
+      let!(:agent) { create(:agent, organisations: [organisation]) }
+      let!(:territorial_role) { create(:agent_territorial_role, agent: agent, territory:) }
+
+      it "retourne false" do
+        expect(described_class.new(agent, organisation).should_soft_delete?).to be false
+      end
     end
   end
 end

--- a/spec/services/agent_removal_spec.rb
+++ b/spec/services/agent_removal_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe AgentRemoval, type: :service do
     end
   end
 
-  context "when the agent is the only admin of the org" do
+  context "l'agent est le seul admin de l'organisation mais il y a d'autres agents basiques" do
     let!(:organisation) { create(:organisation) }
     let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
     let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
@@ -86,6 +86,44 @@ RSpec.describe AgentRemoval, type: :service do
       expect do
         described_class.new(agent, organisation).remove!
       end.to raise_error(ActiveRecord::RecordNotDestroyed)
+    end
+  end
+
+  context "l'agent est le seul admin de l'organisation et il n'y a aucun agent basique" do
+    let!(:organisation) { create(:organisation) }
+    let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+    it "soft-delete l'agent" do
+      described_class.new(agent, organisation).remove!
+      expect(agent.reload.deleted_at).not_to be_nil
+    end
+  end
+
+  context "l'agent est admin de l'orga et le seul admin de l'espace" do
+    let!(:territory) { create(:territory) }
+    let!(:organisation) { create(:organisation, territory:) }
+    let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+    let!(:territorial_role) { create(:agent_territorial_role, agent:, territory:) }
+
+    it "ne raise pas d'erreur" do
+      service = described_class.new(agent, organisation)
+      expect(service).to be_valid
+      expect { service.remove! }.not_to raise_error
+    end
+  end
+
+  context "l'agent est admin de l'orga et aussi admin de l'espace (mais pas le seul)" do
+    let!(:territory) { create(:territory) }
+    let!(:organisation) { create(:organisation, territory:) }
+    let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+    let!(:agent1) { create(:agent) }
+    let!(:territorial_role) { create(:agent_territorial_role, agent: agent, territory:) }
+    let!(:territorial_role1) { create(:agent_territorial_role, agent: agent1, territory:) }
+
+    it "ne raise pas d'erreur" do
+      service = described_class.new(agent, organisation)
+      expect(service).to be_valid
+      expect { service.remove! }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
# Contexte

[Ticket Zammad](https://zammad10.ethibox.fr/#ticket/zoom/33507) - [erreur sentry](https://sentry.incubateur.net/organizations/betagouv/issues/207156/events/recommended/?environment=production&project=74&query=user.id%3A%2210648%22&referrer=issue-stream)

Lorsqu'un agent est seul admin de l'espace dans lequel il tente de fermer sa dernière orga ça échoue car la suppression de son rôle territorial échoue.

Le chemin c'est : 
- on retire les autres agents de l'orga via AgentRemoval
- on retire l'agent courant de l'orga via AgentRemoval
- cette méthode teste « est-ce que c'est la derniere orga de l'agent ? »
- oui => elle essaie de soft delete l'agent

# Solution

Je propose ici de ne pas soft-delete l'agent s'iel est admin d'espace.

En effet, un agent qui est admin d'espace mais n'a plus aucun rôle dans des orgas peut quand même utiliser la plateforme, notamment pour ré-ouvrir des orgas fermées 🤯 

Je me demande si ça a du sens pour un agent qui n'est pas admin d'espace de soft-delete son compte lorsqu'il clique sur « fermer une orga ». Peut-être qu'il faudrait arrêter ce comportement entièrement, peu importe qu'iel soit admin d'espace ou non. 