### PR TITLE
Source gems from https://beta.gem.coop/cooldown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source "https://beta.gem.coop/cooldown"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.4.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ PATH
       omniauth-oauth2 (~> 1.8)
 
 GEM
-  remote: https://rubygems.org/
+  remote: https://beta.gem.coop/cooldown/
   specs:
     actioncable (8.0.4)
       actionpack (= 8.0.4)


### PR DESCRIPTION
`gem.coop` commence à proposer un système de cooldown, ils l'annoncé ici : https://gem.coop/updates/4/

Je propose de le tester, je crois que le risque est faible, au pire si on a des soucis on repasse chez les gros vilains de `rubygems.org`. :shrug: 
