### PR TITLE
Correctif connexion usager déjà FranceConnecté via login code

### DIFF
--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -66,7 +66,8 @@ class Users::LoginService
   end
 
   def update_user(user)
-    if user.first_name != first_name || user.last_name != last_name
+    if (user.first_name != first_name || user.last_name != last_name) &&
+       !user.logged_once_with_franceconnect? # les users FranceConnectés ne peuvent pas modifier leur identité
       user.update!(first_name: first_name, last_name: last_name)
     end
   end

--- a/spec/services/users/login_service_spec.rb
+++ b/spec/services/users/login_service_spec.rb
@@ -71,4 +71,30 @@ RSpec.describe Users::LoginService, type: :service do
       expect(service.error).to eq "Code invalide"
     end
   end
+
+  context "login code avec nom prénom différents pour un usager existant" do
+    let!(:user) { create(:user, email: "test@example.com", first_name: "Martyna", last_name: "Gorski") }
+    let!(:login_code) { create(:login_code, email: "test@example.com", code: "123456", created_at: 2.minutes.ago, first_name: "Joana", last_name: "Duri") }
+    let(:service) { described_class.new(email: "test@example.com", code: "123456", sign_in_user_lambda:) }
+
+    it "connecte l'usagere et modifie son nom prénom" do
+      expect(sign_in_user_lambda).to receive(:call).with(user)
+      expect(service.perform).to be true
+      expect(user.reload.first_name).to eq("Joana")
+      expect(user.reload.last_name).to eq("Duri")
+    end
+  end
+
+  context "login code avec nom prénom différents pour un usager existant déjà FranceConnecté" do
+    let!(:user) { create(:user, :using_france_connect, email: "test@example.com", first_name: "Martyna", last_name: "Gorski") }
+    let!(:login_code) { create(:login_code, email: "test@example.com", code: "123456", created_at: 2.minutes.ago, first_name: "Joana", last_name: "Duri") }
+    let(:service) { described_class.new(email: "test@example.com", code: "123456", sign_in_user_lambda:) }
+
+    it "connecte l'usagere mais ne modifie pas son nom prénom" do
+      expect(sign_in_user_lambda).to receive(:call).with(user)
+      expect(service.perform).to be true
+      expect(user.reload.first_name).to eq("Martyna")
+      expect(user.reload.last_name).to eq("Gorski")
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

Corrige https://sentry.incubateur.net/organizations/betagouv/issues/242852/?project=74&referrer=webhooks_plugin

Depuis ce matin et #6014 on demande le nom prénom à l'usager en même temps que son email. Lorsqu'iel renseigne correctement le code envoyé par mail, on upsert le user trouvé sur base de l'email.

Pour les usagers FranceConnectés ça ne marche pas : on ne peut pas modifier leurs noms prénoms. 

# Solution

Ne pas essayer de mettre à jour les noms prénoms des users FranceConnectés

Ça va faire une interface bizarre car l'usager va avoir renseigné son nom prénom puis on va lui afficher un nom prénom différents qui viennent de FC 🤷 Ça sera corrigé lorsqu'on aura tué l'unicité des comptes usagers par email je pense.