### PR TITLE
Corrige crash en cas d'erreur dans le before callback Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -45,7 +45,7 @@ Sentry.init do |config|
 
     event
   rescue StandardError
-    event.set_tags(error_in_before_send_callback: true)
+    event.tags[:error_in_before_send_callback] = true
     event
   end
 


### PR DESCRIPTION
J'ai lancé le serveur en local sans connexion internet et j'ai eu : 

> exception happened in background worker: undefined method 'set_tags' for an instance of Sentry::ErrorEvent

Et en effet, en regardant le code de la classe `Sentry::ErrorEvent`, on voit que le setter est `tags=` et on voit dans l'initializer que c'est un hash (`@tags = {}`).