### PR TITLE
Fix LAPINS-620 (clé étrangère de InstanceExport à GoodJob::Batch)

### DIFF
--- a/db/migrate/20260202144719_remove_foreign_key_between_instance_exports_and_good_job_batches.rb
+++ b/db/migrate/20260202144719_remove_foreign_key_between_instance_exports_and_good_job_batches.rb
@@ -1,0 +1,5 @@
+class RemoveForeignKeyBetweenInstanceExportsAndGoodJobBatches < ActiveRecord::Migration[8.0]
+  def change
+    remove_foreign_key :instance_exports, :good_job_batches
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_28_172200) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_02_144719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -938,7 +938,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_28_172200) do
   add_foreign_key "file_attentes", "rdvs"
   add_foreign_key "file_attentes", "users"
   add_foreign_key "instance_exports", "agents"
-  add_foreign_key "instance_exports", "good_job_batches"
   add_foreign_key "lieux", "organisations"
   add_foreign_key "motif_categories_territories", "motif_categories"
   add_foreign_key "motif_categories_territories", "territories"


### PR DESCRIPTION
Régulièrement GoodJob tente de nettoyer les jobs terminées (voir la valeur de `cleanup_preserved_jobs_before_seconds_ago`).

Or, lors de la mise en place des exports d'instance, on a introduit une clé étrangère entre les `InstanceExport` et la table `GoodJob::Batch`. Cela a pour conséquence de faire crasher le cleanup régulier des jobs.

Cela a géré plusieurs milliers d'erreur, et donc une charge pour le Sentry de l'incubateur et du bruit pour la vigie.

# Solution

Je vois deux solutions possibles : 
1. retirer la clé étrangère et assumer d'avoir dans `instance_exports.good_job_batch_id` des valeurs qui ne pointent plus vers rien
2. faire en sorte de cleanup nos exports d'instance, en vidant leur colonne `good_job_batch_id` une fois que tout s'est bien passé

Mon cœur balance entre les deux, la première est plus simple, la seconde est plus propre mais risque de nous remonter encore des erreurs de foreign key si des exports plantent pandant plusieurs jours.

J'ai choisi la première.