### PR TITLE
Ajout du champ sensitive account à l’anonymizer

### DIFF
--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -105,6 +105,7 @@ tables:
       - remember_created_at
       - pro_connect_openid_sub
       - pro_connect_2fa_active
+      - sensitive_account
     non_anonymized_column_names:
       - reset_password_sent_at
       - last_sign_in_at


### PR DESCRIPTION
# Contexte

On s’était dit avec @francois-ferrandis que cela serait bien d’anonymizer cette colonne, mais j’ai oublié de le faire.
Ce n’est pas du tout critique, car cette donnée n’est pas exposée, mais on n'en a pas non plus besoin dans Metabase donc on préfère le retirer.