### PR TITLE
Correction de la synchronisation Caldav en cas de changement de la transparence

### DIFF
--- a/app/jobs/caldav/import_absences_from_caldav_job.rb
+++ b/app/jobs/caldav/import_absences_from_caldav_job.rb
@@ -42,9 +42,14 @@ module Caldav
       collection = agent.caldav_client.calendars.sync(agent.caldav_agenda_url, agent.caldav_sync_token)
       new_sync_token = collection.sync_token
 
+      # On met à jour les événements modifiés qui sont « OPAQUE » (considérés comme occupés)
+      updated_events = collection.changes.select(&:calendar_data).select { |event| consider_busy?(event) }
+
+      # On supprime les événements modifiés qui sont « TRANSPARENT » (considérés comme libres)
+      deleted_events = collection.changes.select(&:calendar_data).reject { |event| consider_busy?(event) }.map(&:url)
+
       # Le serveur Caldav de la Suite Numérique signale une suppression à travers un calendar_data vide.
-      updated_events = collection.changes.select(&:calendar_data)
-      deleted_events = collection.changes.reject(&:calendar_data).map(&:url)
+      deleted_events += collection.changes.reject(&:calendar_data).map(&:url)
 
       # D'autres serveurs Caldav peuvent utiliser le tableau `deletions` pour signaler une suppression
       deleted_events += collection.deletions

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -68,7 +68,32 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
     end
   end
 
-  it "logs the response to Sentry if token fetch returns an unexpected body" do
+  context "quand l’agent a un token et des événements en BDD" do
+    around do |example|
+      # TODO: on utilise pour le moment la cassette de création mais il faudrait faire une cassette dédiée
+      VCR.use_cassette("caldav/token_via_propfind", allow_playback_repeats: true) do
+        example.run
+      end
+    end
+
+    let(:agent) { create(:agent, :with_caldav_config, caldav_sync_token: "rsuneaitren") }
+
+    it "supprime un événement s’il est déjà enregistré localement mais qu'il devient TRANSP:TRANSPARENT" do
+      ExternalCalendarEvent.create(
+        agent:,
+        url: "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/c766aa62-c76e-48eb-a6a1-c5a496ec740b.ics",
+        starts_at: Time.zone.tomorrow.change(hour: 9, min: 0),
+        ends_at: Time.zone.tomorrow.change(hour: 10, min: 0)
+      )
+
+      VCR.use_cassette("caldav/transparent_event") do
+        expect { described_class.new.perform(agent.id) }.to change(ExternalCalendarEvent, :count).by(-1)
+        expect(ExternalCalendarEvent.where(url: "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/c766aa62-c76e-48eb-a6a1-c5a496ec740b.ics")).to be_empty
+      end
+    end
+  end
+
+  it "enregistre la réponse dans Sentry si la récupération du token retourne un body inattendu" do
     cal_url = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id"
     stub_request(:propfind, cal_url)
       .and_return({ status: 500, body: "ceci est mon corps", headers: { "Set-Cookie" => "secret" } })

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
   let(:agent) { create(:agent, :with_caldav_config) }
 
-  context "when agent does not have a token and DB is empty" do
+  context "quand l'agent n'a pas de token et que la BDD est vide" do
     around do |example|
       VCR.use_cassette("caldav/token_via_propfind", allow_playback_repeats: true) do
         example.run
       end
     end
 
-    it "works creates local ExternalCalendarEvent row for each event and saves token" do
+    it "crée une ligne ExternalCalendarEvent locale pour chaque événement et enregistre le token" do
       VCR.use_cassette("caldav/event_list_weekly_and_daily") do
         expect { described_class.new.perform(agent.id) }.to(
           change(ExternalCalendarEvent, :count).by(2).and(
@@ -34,28 +34,28 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
       expect(daily_event.raw_ical).not_to include("SUMMARY:Weekly") # scrubbed with Ical::Scrubber
     end
 
-    describe "handling TRANSP" do
-      it "ignores an event if it is non-recurring and marked as TRANSP:TRANSPARENT" do
+    describe "gestion de TRANSP" do
+      it "ignore un événement s'il est non récurrent et marqué TRANSP:TRANSPARENT" do
         VCR.use_cassette("caldav/transparent_event") do
           expect { described_class.new.perform(agent.id) }.not_to change(ExternalCalendarEvent, :count)
         end
       end
 
-      it "ignores an event if it is recurring and marked as TRANSP:TRANSPARENT" do
+      it "ignore un événement s'il est récurrent et marqué TRANSP:TRANSPARENT" do
         VCR.use_cassette("caldav/transparent_recur_event") do
           expect { described_class.new.perform(agent.id) }.not_to change(ExternalCalendarEvent, :count)
         end
       end
 
       # Un événement récurrent
-      it "stores an event if it is recurring and marked as TRANSP:TRANSPARENT but has at least one opaque exception" do
+      it "enregistre un événement s'il est récurrent et marqué TRANSP:TRANSPARENT mais a au moins une exception opaque" do
         VCR.use_cassette("caldav/transparent_recur_event_with_one_opaque_exception") do
           expect { described_class.new.perform(agent.id) }.to change(ExternalCalendarEvent, :count).by(1)
         end
       end
     end
 
-    it "does not create events if the external URL corresponds to a local Rdv" do
+    it "ne crée pas d'événements si l'URL externe correspond à un Rdv local" do
       url_of_local_event = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/fa75d9fe-2063-465e-a323-dd8ae7589746.ics"
       url_of_legit_event = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/6a54e0b7-93cf-43e4-a854-afd8e3d3f2c4.ics"
       create(:agents_rdv, agent:, caldav_url: url_of_local_event)
@@ -114,7 +114,7 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
     expect(response_breadcrumb.data[:headers]["Set-Cookie"]).to eq("[FILTERED]")
   end
 
-  describe "job debounce" do
+  describe "debounce du job" do
     around do |example|
       VCR.use_cassette("caldav/token_via_propfind", allow_playback_repeats: true) do
         VCR.use_cassette("caldav/no_event", allow_playback_repeats: true) do
@@ -123,14 +123,14 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
       end
     end
 
-    it "prevents from enqueuing the same job if it ran less than a minute ago" do
+    it "empêche d'enqueuer le même job s'il a été exécuté il y a moins d'une minute" do
       described_class.new.perform(agent.id)
       travel_to(10.seconds.from_now) { expect { described_class.perform_later(agent.id) }.not_to have_enqueued_job }
       travel_to(50.seconds.from_now) { expect { described_class.perform_later(agent.id) }.not_to have_enqueued_job }
       travel_to(70.seconds.from_now) { expect { described_class.perform_later(agent.id) }.to have_enqueued_job(described_class).with(agent.id) }
     end
 
-    it "prevents from performing the same job if it ran less than a minute ago" do
+    it "empêche d'exécuter le même job s'il a été exécuté il y a moins d'une minute" do
       agent_a = create(:agent, :with_caldav_config)
       agent_b = create(:agent, :with_caldav_config)
 


### PR DESCRIPTION
# Contexte

Lors de la synchronisation CalDAV, quand un événement déjà importé localement devient `TRANSP:TRANSPARENT` (c'est-à-dire considéré comme « libre » par l'utilisateur), il n'était pas supprimé de la base de données. Seuls les événements sans `calendar_data` (supprimés côté serveur) étaient traités comme des suppressions.

Cela signifiait qu'un agent pouvait marquer un événement comme « disponible » dans son calendrier externe, mais l'absence restait visible dans RDV Service Public.

# Solution

Dans `ImportAbsencesFromCaldavJob`, on sépare désormais les événements modifiés qui ont un `calendar_data` en deux catégories :
- **OPAQUE** (occupé) → mis à jour normalement
- **TRANSPARENT** (libre) → ajoutés à la liste des suppressions

Les tests ont aussi été traduits en français et un nouveau cas de test couvre le scénario où un événement existant devient TRANSPARENT lors d'un sync.

