### PR TITLE
Ajoute `absences.caldav_url` aux colonnes ignorées

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -1,4 +1,6 @@
 class Absence < ApplicationRecord
+  self.ignored_columns += %w[caldav_url]
+
   # Mixins
   has_paper_trail
   include WebhookDeliverable


### PR DESCRIPTION
Dans #6031 on a déplacé le stockage des événements caldav dans `ExternalCalendarEvent`, et donc `absences.caldav_url` n'est plus du tout utilisé.

Dans la prochaine PR je pourrai virer tous les `ignored_columns` qui trainent. :broom: 