### PR TITLE
Bugfix: indispos Caldav non affichées sur l'agenda multi-agents

### DIFF
--- a/app/controllers/admin/api/agenda/external_calendar_events_controller.rb
+++ b/app/controllers/admin/api/agenda/external_calendar_events_controller.rb
@@ -23,7 +23,7 @@ class Admin::Api::Agenda::ExternalCalendarEventsController < Admin::Api::BaseCon
   private
 
   def agents
-    if params[:agent_id].to_i == current_agent.id
+    if Array(params[:agent_id]).compact_blank.map(&:to_i) == [current_agent.id]
       [current_agent]
     else
       # La scope de policy pour ExternalCalendarEvent délèguent à Agent::AgentPolicy::Scope.

--- a/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
+++ b/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
@@ -6,7 +6,7 @@ ruby:
   event_sources = [
     admin_api_agenda_rdvs_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, format: :json),
     admin_api_agenda_absences_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, format: :json),
-    admin_api_agenda_external_calendar_events_path(agent_id: @agent, format: :json),
+    admin_api_agenda_external_calendar_events_path(agent_id: @agents.map(&:id), format: :json),
     admin_api_agenda_plage_ouvertures_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, mixed_with_rdvs: true, format: :json),
   ]
   event_sources.push(OffDays.to_full_calendar_array) unless current_territory.work_on_sunday?


### PR DESCRIPTION
Mauvais copié-collé de ma part quand j'ai ajouté les `admin_api_agenda_external_calendar_events_path` dans les vues. Pour la multi agents il fallait utiliser `agent_id: @agents.map(&:id)`.