### PR TITLE
Passage de fullcalendar v5 à la v6

### DIFF
--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -30,6 +30,10 @@ export class AgendaMonoAgent {
     this.data = this.calendarEl.dataset
     this.fullCalendarInstance = this.initFullCalendar(this.calendarEl)
     this.fullCalendarInstance.render();
+    // Les icônes prev/next ont role="img" sans aria-label, ce qui pose un problème d'accessibilité.
+    // Ces icônes sont purement décoratives, on peut donc retirer le rôle d'image pour qu'elles soient ignorées par les lecteurs d'écran.
+    // On a placé des titles sur les boutons pour aider les personnes utilisant des lecteurs d’écrans. (voir buttonHints)
+    this.calendarEl.querySelectorAll('.fc-icon[role="img"]').forEach(el => el.removeAttribute('role'));
     setupRealtimeRefresh(this.fullCalendarInstance, [this.data.agentId]);
   }
 
@@ -46,6 +50,24 @@ export class AgendaMonoAgent {
       select: this.selectEvent,
       headerToolbar: betaPlanningEnabled() ? betaHeaderToolbarLayout : classicHeaderToolbarLayout,
       customButtons: { preferencesModalToggle },
+      buttonHints: {
+        prev: (navUnit) => {
+          const labels = {
+            Jour: "Jour précédent",
+            Semaine: "Semaine précédente",
+            Mois: "Mois précédent",
+          };
+          return labels[navUnit] || "Précédent";
+        },
+        next: (navUnit) => {
+          const labels = {
+            Jour: "Jour suivant",
+            Semaine: "Semaine suivante",
+            Mois: "Mois suivant",
+          };
+          return labels[navUnit] || "Suivant";
+        },
+      },
       views: {
         timeGridOneDay: {
           type: 'timeGrid',

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -50,24 +50,6 @@ export class AgendaMonoAgent {
       select: this.selectEvent,
       headerToolbar: betaPlanningEnabled() ? betaHeaderToolbarLayout : classicHeaderToolbarLayout,
       customButtons: { preferencesModalToggle },
-      buttonHints: {
-        prev: (navUnit) => {
-          const labels = {
-            Jour: "Jour précédent",
-            Semaine: "Semaine précédente",
-            Mois: "Mois précédent",
-          };
-          return labels[navUnit] || "Précédent";
-        },
-        next: (navUnit) => {
-          const labels = {
-            Jour: "Jour suivant",
-            Semaine: "Semaine suivante",
-            Mois: "Mois suivant",
-          };
-          return labels[navUnit] || "Suivant";
-        },
-      },
       views: {
         timeGridOneDay: {
           type: 'timeGrid',

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -27,7 +27,7 @@ export const dayHeaderContent = ({ date, view }) => {
       return new Intl.DateTimeFormat('fr-FR', CUSTOM_HEADER_FORMATS[view.type]).format(date);
     }
   }
-  // else : on retourne null et FullCalendar utilise le formateur par défaut
+  return true; // v6 : retourner true pour afficher le contenu par défaut
 };
 
 // On empêche de sélectionner plusieurs jours car ce n'est pas actuellement
@@ -240,25 +240,26 @@ const setupRealtimeRefresh = (fullCalendarInstance, agentIds) => {
   setInterval(refreshDisconnectedWarning, 500);
 };
 
-const handleAjaxError = (response) => {
+const handleAjaxError = (error) => {
   if (window.ajaxErrorHandledAt) {
     const secondsSinceLast = (Date.now() - window.ajaxErrorHandledAt) / 1000;
     if (secondsSinceLast < 60) return
   }
   window.ajaxErrorHandledAt = Date.now()
 
-  switch (response.xhr.status) {
+  const status = error.response ? error.response.status : 0;
+  switch (status) {
     case 401:
       window.location = this.calendarEl.attributes["data-sign-in-path"].value;
       break;
     case 500:
-      alert(`Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
+      alert(`Le chargement du calendrier a échoué; un rapport d'erreur a été transmis à l'équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
       break;
     case 0:
       alert(`Le chargement du calendrier a échoué, probablement car votre connexion internet a été coupée.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
       break;
     default:
-      alert(`Le chargement du calendrier a échoué avec une erreur ${response.xhr.status}\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`)
+      alert(`Le chargement du calendrier a échoué avec une erreur ${status}\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`)
   }
 };
 

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -253,7 +253,7 @@ const handleAjaxError = (error) => {
       window.location = this.calendarEl.attributes["data-sign-in-path"].value;
       break;
     case 500:
-      alert(`Le chargement du calendrier a échoué; un rapport d'erreur a été transmis à l'équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
+      alert(`Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
       break;
     case 0:
       alert(`Le chargement du calendrier a échoué, probablement car votre connexion internet a été coupée.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -60,8 +60,28 @@ export const hiddenDays = ({ displaySaturdays, displaySundays }) => {
   return hiddenDays;
 };
 
+const buttonHints = {
+  prev: (navUnit) => {
+    const labels = {
+      Jour: "Jour précédent",
+      Semaine: "Semaine précédente",
+      Mois: "Mois précédent",
+    };
+    return labels[navUnit] || "Précédent";
+  },
+  next: (navUnit) => {
+    const labels = {
+      Jour: "Jour suivant",
+      Semaine: "Semaine suivante",
+      Mois: "Mois suivant",
+    };
+    return labels[navUnit] || "Suivant";
+  },
+};
+
 const defaultFullCalendarConfig = () => ({
   locale: frLocale,
+  buttonHints,
   allDaySlot: false,
   height: "auto",
   selectable: true,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,5 @@
   },
   "browserslist": [
     "cover 98.0% in FR and not dead"
-  ],
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
     "build": "webpack --config webpack.config.js"
   },
   "dependencies": {
-    "@fullcalendar/core": "^5.11.5",
-    "@fullcalendar/daygrid": "^5.11.5",
-    "@fullcalendar/interaction": "^5.11.5",
-    "@fullcalendar/list": "^5.11.5",
-    "@fullcalendar/resource-timegrid": "^5.11.5",
-    "@fullcalendar/timegrid": "^5.11.5",
+    "@fullcalendar/core": "^6.1.15",
+    "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/interaction": "^6.1.15",
+    "@fullcalendar/list": "^6.1.15",
+    "@fullcalendar/resource": "^6.1.15",
+    "@fullcalendar/resource-timegrid": "^6.1.15",
+    "@fullcalendar/timegrid": "^6.1.15",
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.21",
     "@rails/actioncable": ">=7.0",
@@ -46,5 +47,6 @@
   },
   "browserslist": [
     "cover 98.0% in FR and not dead"
-  ]
+  ],
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,94 +7,63 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
   integrity sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==
 
-"@fullcalendar/common@~5.11.5":
-  version "5.11.5"
-  resolved "https://registry.yarnpkg.com/@fullcalendar/common/-/common-5.11.5.tgz#1a30a852b33ab5c1b04f4ee558941bed3c72d07f"
-  integrity sha512-3iAYiUbHXhjSVXnYWz27Od2cslztUPsOwiwKlfGvQxBixv2Kl6a8IPwaijKFYJHXdwYmfPoEgK7rvqAGVoIYwA==
+"@fullcalendar/core@^6.1.15":
+  version "6.1.20"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/core/-/core-6.1.20.tgz#e4cfa767a9b8b7dad015b33fcb8acb0fac986a85"
+  integrity sha512-1cukXLlePFiJ8YKXn/4tMKsy0etxYLCkXk8nUCFi11nRONF2Ba2CD5b21/ovtOO2tL6afTJfwmc1ed3HG7eB1g==
   dependencies:
-    tslib "^2.1.0"
-
-"@fullcalendar/core@^5.11.5":
-  version "5.11.5"
-  resolved "https://registry.yarnpkg.com/@fullcalendar/core/-/core-5.11.5.tgz#0a5265a84f7c35969df64baf6417fa85a31cae7c"
-  integrity sha512-M/WQuq1+uUHxFDEIu2ib/aaPZ70VsRk2ITECo/WCLSLTVWcHPXwEg83reyP3G8JrMM4gRL4vScEHhX0U5aoNSw==
-  dependencies:
-    "@fullcalendar/common" "~5.11.5"
     preact "~10.12.1"
-    tslib "^2.1.0"
 
-"@fullcalendar/daygrid@^5.11.5", "@fullcalendar/daygrid@~5.11.5":
-  version "5.11.5"
-  resolved "https://registry.yarnpkg.com/@fullcalendar/daygrid/-/daygrid-5.11.5.tgz#2825ed691eadf72c6a2979bcde871de74681fc7a"
-  integrity sha512-hMpq0U3Nucys2jDD+crbkJCr+tVt3fDw04OE3fbpisuzqtrHxIzRmnUOdbWUjJQyToAAkt7UVUQ9E7hYdmvyGA==
-  dependencies:
-    "@fullcalendar/common" "~5.11.5"
-    tslib "^2.1.0"
+"@fullcalendar/daygrid@^6.1.15", "@fullcalendar/daygrid@~6.1.20":
+  version "6.1.20"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/daygrid/-/daygrid-6.1.20.tgz#fcf33af4ea908b46fd755414278341811e01bdf8"
+  integrity sha512-AO9vqhkLP77EesmJzuU+IGXgxNulsA8mgQHynclJ8U70vSwAVnbcLG9qftiTAFSlZjiY/NvhE7sflve6cJelyQ==
 
-"@fullcalendar/interaction@^5.11.5":
-  version "5.11.5"
-  resolved "https://registry.yarnpkg.com/@fullcalendar/interaction/-/interaction-5.11.5.tgz#035f9650edd0ee795e4c81505ae38aaf3a344bf1"
-  integrity sha512-Vg9uw8zKXZc2RP7it88U8R/kxJIQsK4pyv+s+RhlvT5NBZ9KLOh5y2xGCS4A4hyY7qLrzugxnKYlu6NwNqJ/RQ==
-  dependencies:
-    "@fullcalendar/common" "~5.11.5"
-    tslib "^2.1.0"
+"@fullcalendar/interaction@^6.1.15":
+  version "6.1.20"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/interaction/-/interaction-6.1.20.tgz#a73a53af5f93ac261f864b025ae80201609f1cd7"
+  integrity sha512-p6txmc5txL0bMiPaJxe2ip6o0T384TyoD2KGdsU6UjZ5yoBlaY+dg7kxfnYKpYMzEJLG58n+URrHr2PgNL2fyA==
 
-"@fullcalendar/list@^5.11.5":
-  version "5.11.5"
-  resolved "https://registry.yarnpkg.com/@fullcalendar/list/-/list-5.11.5.tgz#0440383f795a6a754f0b62d089ed3ffdf5603845"
-  integrity sha512-ZYMPT4CVt9tIYkVVNx7CKkB2xc+n9L56+vgXkurptgYgPsacXYkcpF/1Hy/B5LKlg0ROEF9Qfftjow8xjANqaA==
-  dependencies:
-    "@fullcalendar/common" "~5.11.5"
-    tslib "^2.1.0"
+"@fullcalendar/list@^6.1.15":
+  version "6.1.20"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/list/-/list-6.1.20.tgz#d218906f0c50e1a7232a176df2426269f8601319"
+  integrity sha512-7Hzkbb7uuSqrXwTyD0Ld/7SwWNxPD6SlU548vtkIpH55rZ4qquwtwYdMPgorHos5OynHA4OUrZNcH51CjrCf2g==
 
-"@fullcalendar/premium-common@~5.11.5":
-  version "5.11.5"
-  resolved "https://registry.yarnpkg.com/@fullcalendar/premium-common/-/premium-common-5.11.5.tgz#06ee413355c7ea4b8047ab6339bd2adf13d2972e"
-  integrity sha512-QMLOm+MKxvsbji4wt7YGqB73IqwHD+y2JD1DZ3t0LCq2Ul6QtQjNxRP7/7DklXPI8atXoJRRXzwqRq+8O9FFHw==
-  dependencies:
-    "@fullcalendar/common" "~5.11.5"
-    tslib "^2.1.0"
+"@fullcalendar/premium-common@~6.1.20":
+  version "6.1.20"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/premium-common/-/premium-common-6.1.20.tgz#92007ce764a9abdade65b9e997a5a5cf9be70342"
+  integrity sha512-rT+AitNnRyZuFEtYvsB1OJ2g1Bq2jmTR6qdn/dEU6LwkIj/4L499goLtMOena/JyJ31VBztdHrccX//36QrY3w==
 
-"@fullcalendar/resource-common@~5.11.5":
-  version "5.11.5"
-  resolved "https://registry.yarnpkg.com/@fullcalendar/resource-common/-/resource-common-5.11.5.tgz#83d568b4a5a405f84058c435fd6f548b4f464771"
-  integrity sha512-r7Jsd9ge65m9AShyWAOUUdRulyOKI3p0a7lOcilQ1KXDy0d1O2KpPa27sqRzpofLoDoSrteVP7dirU8Lg20sTA==
+"@fullcalendar/resource-daygrid@~6.1.20":
+  version "6.1.20"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/resource-daygrid/-/resource-daygrid-6.1.20.tgz#b0189a1b3f4707d19fd386c2258b2bb1590f17bd"
+  integrity sha512-g1rhNsTiGyx6U/01MCjRjQfpmkHpJABoTLS9TR2jcMa7X0SJd2xNd88phoMhIkYdfp+cZ29VOjhwN+3Xg6aohg==
   dependencies:
-    "@fullcalendar/common" "~5.11.5"
-    "@fullcalendar/premium-common" "~5.11.5"
-    tslib "^2.1.0"
+    "@fullcalendar/daygrid" "~6.1.20"
+    "@fullcalendar/premium-common" "~6.1.20"
 
-"@fullcalendar/resource-daygrid@~5.11.5":
-  version "5.11.5"
-  resolved "https://registry.yarnpkg.com/@fullcalendar/resource-daygrid/-/resource-daygrid-5.11.5.tgz#21ac6721abf08a91e55f0c06432d368dc247c1c1"
-  integrity sha512-/QCdpZ1Soy8xfT6W3/JDi4l9ZIsPe92monvH2o7zJ6NcVd5vVQY0AwGYdQNWyNd5WJy5jVC9/pX1lhE0ARup9A==
+"@fullcalendar/resource-timegrid@^6.1.15":
+  version "6.1.20"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/resource-timegrid/-/resource-timegrid-6.1.20.tgz#00cf040e71a0b24e324164482c48e20c1f83fbe9"
+  integrity sha512-uMf9ERh1c/WeYHg5CPNGxYorkamDzfwUh2o9XS+9fR+KypIIovH1ArflOZF42XFsdrvQx61vDF0alt6/cOqT8Q==
   dependencies:
-    "@fullcalendar/common" "~5.11.5"
-    "@fullcalendar/daygrid" "~5.11.5"
-    "@fullcalendar/premium-common" "~5.11.5"
-    "@fullcalendar/resource-common" "~5.11.5"
-    tslib "^2.1.0"
+    "@fullcalendar/premium-common" "~6.1.20"
+    "@fullcalendar/resource-daygrid" "~6.1.20"
+    "@fullcalendar/timegrid" "~6.1.20"
 
-"@fullcalendar/resource-timegrid@^5.11.5":
-  version "5.11.5"
-  resolved "https://registry.yarnpkg.com/@fullcalendar/resource-timegrid/-/resource-timegrid-5.11.5.tgz#c9333874f6537e16ebf9c104eb7fbf112226c270"
-  integrity sha512-pq1tGd5U7oEK5makuEec8zWVTIOCTvHI/xW92fOZoI5JhSq4qAR5xl3SdYCrDheHhtztkQyEmP3bfQnC4dnQSw==
+"@fullcalendar/resource@^6.1.15":
+  version "6.1.20"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/resource/-/resource-6.1.20.tgz#5cc60c3e28956c6ed8e62fc01482d2265d23ab70"
+  integrity sha512-vpQs1eYJbc1zGOzF3obVVr+XsHTMTG7STKVQBEGy3AeFgfosRkUz+3DUawmy98vSjJUYOAQHO+pWW0ek0n5g0w==
   dependencies:
-    "@fullcalendar/common" "~5.11.5"
-    "@fullcalendar/premium-common" "~5.11.5"
-    "@fullcalendar/resource-common" "~5.11.5"
-    "@fullcalendar/resource-daygrid" "~5.11.5"
-    "@fullcalendar/timegrid" "~5.11.5"
-    tslib "^2.1.0"
+    "@fullcalendar/premium-common" "~6.1.20"
 
-"@fullcalendar/timegrid@^5.11.5", "@fullcalendar/timegrid@~5.11.5":
-  version "5.11.5"
-  resolved "https://registry.yarnpkg.com/@fullcalendar/timegrid/-/timegrid-5.11.5.tgz#b2a823c6102acaa58f1958fb1a67a5a1951bc076"
-  integrity sha512-OEH5mrTclwxgUbb51N6qr7ifzNkR74ygUEFpiMLyyUjkp7a76N6BsAP5mBQnTOpTTUZBu9tAOmfcnvi7skUayQ==
+"@fullcalendar/timegrid@^6.1.15", "@fullcalendar/timegrid@~6.1.20":
+  version "6.1.20"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/timegrid/-/timegrid-6.1.20.tgz#929813235375c2fa3b387691ef5b1dcbb7b86dde"
+  integrity sha512-4H+/MWbz3ntA50lrPif+7TsvMeX3R1GSYjiLULz0+zEJ7/Yfd9pupZmAwUs/PBpA6aAcFmeRr0laWfcz1a9V1A==
   dependencies:
-    "@fullcalendar/common" "~5.11.5"
-    "@fullcalendar/daygrid" "~5.11.5"
-    tslib "^2.1.0"
+    "@fullcalendar/daygrid" "~6.1.20"
 
 "@hotwired/stimulus@^3.2.2":
   version "3.2.2"
@@ -1371,11 +1340,6 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
-
-tslib@^2.1.0:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 update-browserslist-db@^1.2.0:
   version "1.2.3"


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6080.osc-secnum-fr1.scalingo.io/)

## Contexte

FullCalendar était en v5.11.5, une version qui n'est plus maintenue. La v6 apporte notamment le passage de XHR à la Fetch API pour les event sources, et un changement de comportement des content injection functions (retourner `undefined` affiche désormais un conteneur vide au lieu du contenu par défaut).

Ce passage a FullCalendar 6 nous permet de préparer de la v7 qui devrait être meilleur en terme d’accessibilité.

## Changements

- Mise à jour des 6 packages `@fullcalendar/*` de la v5.11.5 vers la v6.1.x
- Ajout du package `@fullcalendar/resource` (nouvelle peer dependency de `@fullcalendar/resource-timegrid` en v6)
- Adaptation de `handleAjaxError` : `response.xhr.status` → `error.response.status` (Fetch API)
- Adaptation de `dayHeaderContent` : ajout d'un `return true` pour conserver l'affichage par défaut des en-têtes

## Test plan

- [x] Naviguer sur l'agenda mono-agent → le calendrier s'affiche, les en-têtes de colonnes sont corrects
- [x] Naviguer sur l'agenda multi-agents → le calendrier resource s'affiche avec les colonnes par agent
- [x] Naviguer sur les plages d'ouverture → le calendrier s'affiche
- [x] Tester le rdv_plan → le calendrier s'affiche, la sélection de créneau fonctionne
- [x] Vérifier les tooltips au survol des événements
- [x] Vérifier l'absence de warning de licence dans la console


