### PR TITLE
Changement du wording du lien SMS

### DIFF
--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -77,7 +77,7 @@ class Users::RdvSms < Users::BaseSms
     details += "\n\n"
 
     url = rdv_short_from_token_url(token, host: domain_host).sub(%r{https?://}, "")
-    links = "Infos/annulation: #{url}"
+    links = "Gérer mon RDV: #{url}"
 
     links += "\n#{rdv.phone_number}" if rdv.phone_number.present?
 

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Users::RdvSms, type: :service do
       it do
         expect(subject).to include("RDV PMI vendredi 10/12 13h10")
         expect(subject).to include("10 rue d'ici, Paris, 75016")
-        expect(subject).to include("Infos/annulation")
+        expect(subject).to include("Gérer mon RDV")
         expect(subject).to include("www.rdv-solidarites-test.localhost/r/12345")
         expect(subject).not_to include("Ne Doit pas s'afficher")
       end
@@ -107,7 +107,7 @@ RSpec.describe Users::RdvSms, type: :service do
     it do
       expect(subject).to include("RDV modifié: PMI vendredi 10/12 13h10")
       expect(subject).to include("10 rue d'ici, Paris, 75016")
-      expect(subject).to include("Infos/annulation")
+      expect(subject).to include("Gérer mon RDV")
       expect(subject).to include("www.rdv-solidarites-test.localhost/r/2345")
     end
 
@@ -200,7 +200,7 @@ RSpec.describe Users::RdvSms, type: :service do
       expect(subject).to include("RDV PMI vendredi 10/12 13h10")
       expect(subject).to include("MDS Centre")
       expect(subject).to include("10 rue d'ici, Paris, 75016")
-      expect(subject).to include("Infos/annulation")
+      expect(subject).to include("Gérer mon RDV")
       expect(subject).to include("www.rdv-solidarites-test.localhost/r/7777")
     end
   end


### PR DESCRIPTION
# Contexte

La mention de l’annulation dans le texte du lien porte à confusion chez certains usagers qui ont l’impression que leur RDV a été annulé.

# Solution

On propose donc un nouveau wording qui nous permet à la fois d’indiquer qu’il y a possibilité d’en savoir + et de faire des actions.

Vu que c’est Nesserine qui a modifié le fichier, voici officiellement son premier commit 🎉 