### PR TITLE
Fix : agent déjà défini au début du create session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sentry_user
-    current_person = current_agent || current_user || current_prescripteur
+    current_person = warden.user(:agent) || warden.user(:user) || warden.user(:prescripteur)
     {
       id: current_person&.id,
       role: current_person&.class&.name || "Guest",
@@ -58,9 +58,10 @@ class ApplicationController < ActionController::Base
   end
 
   def storable_location?
+    return false if devise_controller?
     return false if current_agent || current_user
 
-    request.get? && is_navigational_format? && !devise_controller? && !request.xhr? && request.fullpath != root_path
+    request.get? && is_navigational_format? && !request.xhr? && request.fullpath != root_path
   end
 
   def store_user_location!


### PR DESCRIPTION
# Contexte

Sur le `Agents::SessionsController`, Devise déclare un `prepend_before_action :allow_params_authentication!` qui autorise Warden à authentifier via les paramètres du formulaire (email + mot de passe).

Problème : deux méthodes dans `ApplicationController` appelaient `current_agent` dans des `before_action` qui s'exécutent **après** `allow_params_authentication!` mais **avant** l'action `create` du controller de sessions. L'appel à `current_agent` déclenche `warden.authenticate(scope: :agent)`, ce qui fait que Warden utilise les paramètres du formulaire pour authentifier l'agent avant même que l'action `create` ne s'exécute.

Cela rend impossible toute logique de blocage de l'authentification par mot de passe dans la méthode `create` (par exemple pour les comptes liés à ProConnect), puisque l'agent est déjà authentifié quand l'action commence.

Cette PR est donc préalable à ma prochaine PR sur l’interdiction de la connexion par email + mot de passe pour les agents qui sont ProConnectés.

# Solution

- **`storable_location?`** : réordonner les conditions pour vérifier `devise_controller?` en premier. Le sessions controller est un Devise controller, donc on court-circuite immédiatement sans jamais appeler `current_agent`. Le comportement pour les autres controllers reste inchangé puisque `!devise_controller?` était déjà vérifié dans la condition.

- **`sentry_user`** : remplacer `current_agent || current_user || current_prescripteur` par `warden.user(:agent) || warden.user(:user) || warden.user(:prescripteur)`. Contrairement à `current_agent`, `warden.user` consulte uniquement les utilisateurs déjà authentifiés sans déclencher de nouvelles stratégies d'authentification.