### PR TITLE
Suppression de la connexion par mot de passe pour les agents ProConnectés

### DIFF
--- a/app/controllers/agents/passwords_controller.rb
+++ b/app/controllers/agents/passwords_controller.rb
@@ -5,7 +5,7 @@ class Agents::PasswordsController < Devise::PasswordsController
     agent = Agent.find_by(email: resource_params[:email])
 
     if agent
-      if agent.complete?
+      if agent.complete? && agent.pro_connect_openid_sub.blank? # Les agents qui sont ProConnectés ne peuvent plus se connecter par mot de passe
         agent.send_reset_password_instructions
       elsif agent.invitation_sent_at
         agent.invite!(nil, validate: false)

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -28,6 +28,12 @@ class Agents::SessionsController < Devise::SessionsController
     # this is the first line of Devise::SessionsController#create
     self.resource = warden.authenticate!(auth_options)
 
+    if resource.pro_connect_openid_sub.present?
+      sign_out(resource)
+      redirect_to new_agent_session_path(pro_connect_required: resource.email)
+      return
+    end
+
     return if reset_current_agent_password_if_weak!(params[:agent][:password])
 
     super

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -24,6 +24,13 @@ class Users::PasswordsController < Devise::PasswordsController
   # This code is extracted from Devise::PasswordsController#create
   # with references to resource_class and resource_name hardcoded to Agent and :agent.
   def create_for_agent
+    agent = Agent.find_by(email: resource_params[:email])
+    if agent&.pro_connect_openid_sub.present?
+      flash[:notice] = I18n.t("devise.passwords.send_instructions")
+      respond_with({}, location: after_sending_reset_password_instructions_path_for(:agent))
+      return
+    end
+
     self.resource = Agent.send_reset_password_instructions(resource_params)
     yield resource if block_given?
 

--- a/app/views/agents/sessions/new.html.slim
+++ b/app/views/agents/sessions/new.html.slim
@@ -1,18 +1,24 @@
 - content_for :title do
   .fr-h1 Connexion agent à #{current_domain.name}
 
-- if display_pro_connect_button?
+- if params[:pro_connect_required].present?
+  = dsfr_alert(title: "Connexion par mot de passe désactivée sur votre compte", type: :info, html_attributes: { class: "fr-mb-6v" }) do
+    p Votre compte #{current_domain.name} étant lié à un compte ProConnect, depuis le 16 février 2026, la connexion par mot de passe n'est plus disponible. Veuillez utiliser le bouton ProConnect ci-dessous.
   div.text-center
-    = render "common/proconnect_button_dsfr"
+    = render "common/proconnect_button_dsfr", login_hint: params[:pro_connect_required]
+- else
+  - if display_pro_connect_button?
+    div.text-center
+      = render "common/proconnect_button_dsfr"
 
-  p.fr-hr-or ou
+    p.fr-hr-or ou
 
-p.text-muted.mb-2 Entrez votre email et votre mot de passe.
-= form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .form-group
-    = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr", autocomplete: "email"
-    = render "common/form/current_password_input", f:, forgotten_password_link: true
+  p.text-muted.mb-2 Entrez votre email et votre mot de passe.
+  = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
+    = render "devise/shared/error_messages", resource: resource
+    .form-group
+      = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr", autocomplete: "email"
+      = render "common/form/current_password_input", f:, forgotten_password_link: true
 
-  .form-group.mb-0.rdv-text-align-center
-    = f.submit "Se connecter", class: "fr-btn"
+    .form-group.mb-0.rdv-text-align-center
+      = f.submit "Se connecter", class: "fr-btn"

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -1,8 +1,6 @@
 header.header.bg-white
   = render "layouts/rdv_solidarites_instance_name"
   = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
-  = render "layouts/pro_connect_migration_notice"
-
   nav.navbar.navbar-expand-lg.bg-transparent.navbar-dsfr[role="navigation" aria-label="navigation"]
     = link_to root_path, class: "header-brand ml-4" do
       = image_tag current_domain.dark_logo_path, alt: current_domain.name, class: "logo-dsfr logo-dsfr--compactable"

--- a/app/views/layouts/_pro_connect_migration_notice.html.slim
+++ b/app/views/layouts/_pro_connect_migration_notice.html.slim
@@ -1,7 +1,0 @@
-- unless session[:super_admin_signed_in_as_agent]
-  - if current_agent&.pro_connect_openid_sub.present? && session[:pro_connect_id_token].blank?
-    = dsfr_notice title: "Information",
-            description: "Vous vous êtes connecté avec votre mot de passe, mais votre compte est également lié à ProConnect. Pour des raisons de sécurité, la connexion par mot de passe sera désactivée pour les comptes liés à ProConnect à partir du 16 février 2026.",
-            type: "info",
-            link_label: "En savoir plus",
-            link_href: "https://aide.rdv-service-public.fr/toutes-les-notions/connexion-via-proconnect"

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -74,7 +74,7 @@ fr:
     passwords:
       no_token: "Vous ne pouvez accéder à cette page sans passer par un e-mail de réinitialisation de mot de passe. Si vous avez utilisé un e-mail de ce type, assurez-vous d'utiliser l'URL complète."
       send_instructions: "Vous allez recevoir les instructions de réinitialisation du mot de passe dans quelques instants"
-      send_paranoid_instructions: "Si un compte agent existe pour %{email}, alors un email de réinitialisation va y être envoyé avec un lien de réinitialisation de mot de passe"
+      send_paranoid_instructions: "Si un compte agent existe pour %{email} et que ce compte n’est pas associé à un compte ProConnect, alors un email de réinitialisation va y être envoyé avec un lien de réinitialisation de mot de passe"
       updated: "Votre mot de passe a été édité avec succès, votre connexion est désormais active"
       updated_not_active: "Votre mot de passe a été changé avec succès."
     registrations:

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -3,10 +3,34 @@ RSpec.describe Agents::SessionsController do
 
   before do
     request.env["devise.mapping"] = Devise.mappings[:agent] # d'après la doc de Devise
-    sign_in agent
+  end
+
+  describe "#create" do
+    context "when the agent has a pro_connect_openid_sub" do
+      let(:agent) { create(:agent, password: "c0rrecThorse!", pro_connect_openid_sub: "some-sub") }
+
+      it "signs out the agent and redirects to the login page with pro_connect_required param" do
+        post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
+
+        expect(response).to redirect_to(new_agent_session_path(pro_connect_required: agent.email))
+        expect(session["warden.agent.key"]).to be_nil
+      end
+    end
+
+    context "when the agent does not have a pro_connect_openid_sub" do
+      let(:agent) { create(:agent, password: "c0rrecThorse!") }
+
+      it "signs in the agent normally" do
+        post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
+
+        expect(controller.current_agent).to eq(agent)
+      end
+    end
   end
 
   describe "#destroy" do
+    before { sign_in agent }
+
     context "when the agent was logged in with ProConnect" do
       stub_env_with(PRO_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2")
 

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Agents::SessionsController do
     context "when the agent has a pro_connect_openid_sub" do
       let(:agent) { create(:agent, password: "c0rrecThorse!", pro_connect_openid_sub: "some-sub") }
 
-      it "signs out the agent and redirects to the login page with pro_connect_required param" do
+      it "fails authentication and redirects to the login page with pro_connect_required param" do
         post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
 
         expect(response).to redirect_to(new_agent_session_path(pro_connect_required: agent.email))

--- a/spec/features/agents/account/agent_can_login_spec.rb
+++ b/spec/features/agents/account/agent_can_login_spec.rb
@@ -11,6 +11,21 @@ RSpec.describe "Agent can login" do
       .to(be_within(10.seconds).of(Time.zone.now))
   end
 
+  context "when the agent has a pro_connect_openid_sub" do
+    it "redirects to the login page with a ProConnect message when password is correct" do
+      agent = create(:agent, password: "c0rrecThorse!", pro_connect_openid_sub: "some-sub")
+      visit new_agent_session_path
+      fill_in "Adresse email", with: agent.email
+      fill_in "Mot de passe", with: "c0rrecThorse!"
+      click_on "Se connecter"
+
+      expect(page).to have_content("Connexion par mot de passe désactivée sur votre compte")
+      expect(page).to have_content("ProConnect")
+      expect(page).not_to have_content("Adresse email")
+      expect(page).not_to have_content("Mot de passe")
+    end
+  end
+
   context "when the agent's password is too weak" do
     let(:agent) do
       build(:agent, password: "tropfaible").tap do |a|

--- a/spec/features/agents/account/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/account/agent_can_reset_his_password_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe "Un agent peut réinitialiser son mot de passe" do
       visit new_agent_password_path
       fill_in "agent_email", with: pro_connect_agent.email
       expect { click_on "Envoyer" }.not_to change { emails_sent_to(pro_connect_agent.email).size }
-      expect(page).to have_content(I18n.t("devise.passwords.send_instructions"))
+      expected_message = "Si un compte agent existe pour #{pro_connect_agent.email} et que ce compte n’est pas associé à " \
+                         "un compte ProConnect, alors un email de réinitialisation va y être envoyé avec un lien de réinitialisation de mot de passe"
+      expect(page).to have_content(expected_message)
     end
 
     it "n’envoie pas le mail de réinitialisation depuis le formulaire usager" do
@@ -64,7 +66,9 @@ RSpec.describe "Un agent peut réinitialiser son mot de passe" do
       fill_in "agent_email", with: "unknown@example.com"
 
       expect { click_on "Envoyer" }.not_to change { ActionMailer::Base.deliveries.size }
-      expect(page).to have_content("Si un compte agent existe pour unknown@example.com, alors un email de réinitialisation va y être envoyé avec un lien de réinitialisation de mot de passe")
+      expected_message = "Si un compte agent existe pour unknown@example.com et que ce compte n’est pas associé à " \
+                         "un compte ProConnect, alors un email de réinitialisation va y être envoyé avec un lien de réinitialisation de mot de passe"
+      expect(page).to have_content(expected_message)
     end
   end
 
@@ -76,7 +80,9 @@ RSpec.describe "Un agent peut réinitialiser son mot de passe" do
       fill_in "agent_email", with: agent_not_accepted.email
 
       expect { click_on "Envoyer" }.to change { emails_sent_to(agent_not_accepted.email).size }.by(1)
-      expect(page).to have_content("Si un compte agent existe pour #{agent_not_accepted.email}, alors un email de réinitialisation va y être envoyé avec un lien de réinitialisation de mot de passe")
+      expected_message = "Si un compte agent existe pour #{agent_not_accepted.email} et que ce compte n’est pas associé à " \
+                         "un compte ProConnect, alors un email de réinitialisation va y être envoyé avec un lien de réinitialisation de mot de passe"
+      expect(page).to have_content(expected_message)
     end
   end
 end

--- a/spec/features/agents/account/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/account/agent_can_reset_his_password_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe "Un agent peut réinitialiser son mot de passe" do
     expect(page).to have_content("Votre mot de passe a été édité avec succès")
   end
 
+  context "quand l’agent à un sub ProConnect" do
+    let!(:pro_connect_agent) { create(:agent, pro_connect_openid_sub: "some-sub") }
+
+    it "n’envoie pas le mail de réinitialisation depuis le formulaire agent" do
+      visit new_agent_password_path
+      fill_in "agent_email", with: pro_connect_agent.email
+      expect { click_on "Envoyer" }.not_to change { emails_sent_to(pro_connect_agent.email).size }
+      expect(page).to have_content(I18n.t("devise.passwords.send_instructions"))
+    end
+
+    it "n’envoie pas le mail de réinitialisation depuis le formulaire usager" do
+      visit new_user_password_path
+      fill_in "user_email", with: pro_connect_agent.email
+      expect { click_on "Envoyer" }.not_to change { emails_sent_to(pro_connect_agent.email).size }
+      expect(page).to have_content(I18n.t("devise.passwords.send_instructions"))
+    end
+  end
+
   it "fonctionne via le formulaire de réinitialisation utilisateur" do
     visit new_user_password_path
     expect(page).to have_content("Mot de passe oublié ou première connexion ?")


### PR DESCRIPTION
# Contexte

Afin de s’ouvrir la porte à de nouvelles fonctionnalités, notamment : 
- la double authentification forte
- l’ouverture de salles sur Visio
- d’autres interopérabilités

On souhaite que nos agents qui ont un compte ProConnect associé à leur compte RDV ne puisse plus se connecter par mot de passe.

# Solution

- Lorsque l’agent saisi un email et un mot de passe valide, on lui affiche une alerte pour lui indiquer qu’il ne peut plus se connecter par mot de passe et on lui affiche le bouton ProConnect (qui va le rediriger avec son mail pré-rempli)
- Quand le mot de passe est invalide, on fait comme d’habitude 
- Lors d’une demande de réinitialisation de mot de passe, on n’envoie pas le mail si l’agent est connecté par ProConnect

## Captures d'écran

<img width="3018" height="1528" alt="image" src="https://github.com/user-attachments/assets/fd50330c-b197-4000-8128-4be0e66ce6dd" />

