### PR TITLE
Correction de la migration inter-instance pour les rendez-vous dont l'agent a été supprimé

### DIFF
--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -43,67 +43,8 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
   end
 
   # Cet endpoint est utilisé seulement pour la copie des données d'une instance à l'autre, il n'est donc pas documenté.
-  def create # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-    # On crée le rendez-vous via ActiveRecord sans lancer les Notifiers, ce qui évite de déclencher des callbacks de notifications pour les agents et les usager
-    rdv = Rdv.new(
-      params.permit(%w[starts_at status cancelled_at context ends_at name max_participants_count])
-    )
-
-    if rdv.starts_at > Time.zone.now
-      raise "Cet endpoint ne doit pas être utilisé pour créer des rendez-vous à venir"
-    end
-
-    Rdv.transaction do
-      oauth_application = doorkeeper_token&.application
-
-      rdv.lieu_id = ExternalReference.find_by(item_type: "Lieu", external_id: params[:lieu_external_id], oauth_application:)&.item_id
-      rdv.motif_id = ExternalReference.find_by(item_type: "Motif", external_id: params[:motif_external_id], oauth_application:)&.item_id
-      rdv.organisation_id = rdv.motif.organisation_id
-
-      rdv.agents = Agent.where(email: params[:agent_emails])
-
-      rdv.created_by = if params[:created_by_type] == "User"
-                         # On peut uniquement utiliser cette logique pour les users parce qu'on n'a pas d'external_ids sur les agents ou les prescripteurs
-                         ExternalReference.find_by(item_type: params[:created_by_type], external_id: params[:created_by_external_id], oauth_application:)&.item
-                       else
-                         # Il faut un created_by sur le rendez-vous pour initialiser les created_by des participations
-                         # Mais le champs n'est pas utilisé à part pour envoyer des notifications (ce qu'on ne fait pas ici)
-                         # ou identifier un prescripteur, ce qui n'est pas très utile pour les rendez-vous passés.
-                         # On peut donc se permettre de faire l'approximation que c'est l'agent du rendez-vous qui l'a créé.
-                         #
-                         #
-                         # Ça permet d'éviter d'avoir à copier les informations des prescripteurs (pour le moment).
-                         rdv.agents.first
-                       end
-
-      authorize(rdv, :update?, policy_class: Agent::RdvPolicy)
-
-      if rdv.collectif?
-        rdv.save!
-
-        params[:participations].each do |participation_params|
-          Participation.create(
-            rdv: rdv,
-            user_id: ExternalReference.find_by(item_type: "User", external_id: participation_params[:user_external_id], oauth_application:)&.item_id,
-            status: participation_params[:status],
-            created_by: rdv.created_by
-          )
-        end
-      else
-        user_external_ids = params[:participations].map { |p| p[:user_external_id] }
-        rdv.user_ids = ExternalReference.where(item_type: "User", external_id: user_external_ids, oauth_application:).map(&:item_id)
-        rdv.save!
-      end
-
-      if params[:external_reference].present?
-        ExternalReference.create!(
-          params.require(:external_reference).permit(:external_id, :external_url).merge(
-            item: rdv,
-            oauth_application:
-          )
-        )
-      end
-    end
+  def create
+    rdv = CreateRdvInNewInstance.new(params:, controller: self, oauth_application: doorkeeper_token&.application).create!
 
     render json: RdvBlueprint.render(rdv)
   end

--- a/app/jobs/instance_exports/copy_planning_job.rb
+++ b/app/jobs/instance_exports/copy_planning_job.rb
@@ -103,7 +103,9 @@ class InstanceExports::CopyPlanningJob < ApplicationJob
       instance_export.api_client.post(
         "rdvs",
         {
-          agent_emails: rdv.agents.pluck(:email),
+          agents: rdv.agents.map do |agent|
+            agent.attributes.symbolize_keys.slice(:email, :first_name, :last_name, :deleted_at)
+          end,
           lieu_external_id: rdv.lieu_id,
           motif_external_id: rdv.motif_id,
 

--- a/app/services/create_rdv_in_new_instance.rb
+++ b/app/services/create_rdv_in_new_instance.rb
@@ -5,7 +5,22 @@ class CreateRdvInNewInstance
     @oauth_application = oauth_application
   end
 
-  def create! # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def create!
+    rdv = build_rdv
+
+    controller.send(:authorize, rdv, :update?, policy_class: Agent::RdvPolicy)
+
+    Rdv.transaction do
+      save_rdv_and_participations!(rdv)
+      create_external_reference!(rdv)
+    end
+
+    rdv
+  end
+
+  private
+
+  def build_rdv
     # On crée le rendez-vous via ActiveRecord sans lancer les Notifiers, ce qui évite de déclencher des callbacks de notifications pour les agents et les usager
     rdv = Rdv.new(
       params.permit(%w[starts_at status cancelled_at context ends_at name max_participants_count])
@@ -35,40 +50,38 @@ class CreateRdvInNewInstance
                        rdv.agents.first
                      end
 
-    controller.send(:authorize, rdv, :update?, policy_class: Agent::RdvPolicy)
-
-    Rdv.transaction do
-      if rdv.collectif?
-        rdv.save!
-
-        params[:participations].each do |participation_params|
-          Participation.create(
-            rdv: rdv,
-            user_id: ExternalReference.find_by(item_type: "User", external_id: participation_params[:user_external_id], oauth_application:)&.item_id,
-            status: participation_params[:status],
-            created_by: rdv.created_by
-          )
-        end
-      else
-        user_external_ids = params[:participations].map { |p| p[:user_external_id] }
-        rdv.user_ids = ExternalReference.where(item_type: "User", external_id: user_external_ids, oauth_application:).map(&:item_id)
-        rdv.save!
-      end
-
-      if params[:external_reference].present?
-        ExternalReference.create!(
-          params.require(:external_reference).permit(:external_id, :external_url).merge(
-            item: rdv,
-            oauth_application:
-          )
-        )
-      end
-    end
-
     rdv
   end
 
-  private
+  def save_rdv_and_participations!(rdv)
+    if rdv.collectif?
+      rdv.save!
+
+      params[:participations].each do |participation_params|
+        Participation.create(
+          rdv: rdv,
+          user_id: ExternalReference.find_by(item_type: "User", external_id: participation_params[:user_external_id], oauth_application:)&.item_id,
+          status: participation_params[:status],
+          created_by: rdv.created_by
+        )
+      end
+    else
+      user_external_ids = params[:participations].pluck(:user_external_id)
+      rdv.user_ids = ExternalReference.where(item_type: "User", external_id: user_external_ids, oauth_application:).map(&:item_id)
+      rdv.save!
+    end
+  end
+
+  def create_external_reference!(rdv)
+    if params[:external_reference].present?
+      ExternalReference.create!(
+        params.require(:external_reference).permit(:external_id, :external_url).merge(
+          item: rdv,
+          oauth_application:
+        )
+      )
+    end
+  end
 
   attr_reader :params, :controller, :oauth_application
 end

--- a/app/services/create_rdv_in_new_instance.rb
+++ b/app/services/create_rdv_in_new_instance.rb
@@ -20,7 +20,7 @@ class CreateRdvInNewInstance
 
   private
 
-  def build_rdv
+  def build_rdv # rubocop:disable Metrics/PerceivedComplexity
     # On crée le rendez-vous via ActiveRecord sans lancer les Notifiers, ce qui évite de déclencher des callbacks de notifications pour les agents et les usager
     rdv = Rdv.new(
       params.permit(%w[starts_at status cancelled_at context ends_at name max_participants_count])
@@ -34,7 +34,13 @@ class CreateRdvInNewInstance
     rdv.motif_id = ExternalReference.find_by(item_type: "Motif", external_id: params[:motif_external_id], oauth_application:)&.item_id
     rdv.organisation_id = rdv.motif.organisation_id
 
-    rdv.agents = Agent.where(email: params[:agent_emails])
+    params[:agents].each do |agent_attributes|
+      rdv.agents << if agent_attributes[:deleted_at]
+                      find_or_build_deleted_agent(agent_attributes)
+                    else
+                      rdv.organisation.agents.find_by(email: agent_attributes[:email])
+                    end
+    end
 
     rdv.created_by = if params[:created_by_type] == "User"
                        # On peut uniquement utiliser cette logique pour les users parce qu'on n'a pas d'external_ids sur les agents ou les prescripteurs
@@ -81,6 +87,15 @@ class CreateRdvInNewInstance
         )
       )
     end
+  end
+
+  def find_or_build_deleted_agent(agent_attributes)
+    Agent.where.not(deleted_at: nil).find_by(email: agent_attributes[:email]) || build_deleted_agent(agent_attributes)
+  end
+
+  def build_deleted_agent(agent_attributes)
+    # On doit créer un faux mot de passe pour éviter une erreur de validation
+    Agent.new(agent_attributes.permit(%w[email first_name last_name deleted_at]).merge(password: SecureRandom.base64(32)))
   end
 
   attr_reader :params, :controller, :oauth_application

--- a/app/services/create_rdv_in_new_instance.rb
+++ b/app/services/create_rdv_in_new_instance.rb
@@ -1,0 +1,74 @@
+class CreateRdvInNewInstance
+  def initialize(params:, controller:, oauth_application:)
+    @params = params
+    @controller = controller
+    @oauth_application = oauth_application
+  end
+
+  def create! # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # On crée le rendez-vous via ActiveRecord sans lancer les Notifiers, ce qui évite de déclencher des callbacks de notifications pour les agents et les usager
+    rdv = Rdv.new(
+      params.permit(%w[starts_at status cancelled_at context ends_at name max_participants_count])
+    )
+
+    if rdv.starts_at > Time.zone.now
+      raise "Cet endpoint ne doit pas être utilisé pour créer des rendez-vous à venir"
+    end
+
+    rdv.lieu_id = ExternalReference.find_by(item_type: "Lieu", external_id: params[:lieu_external_id], oauth_application:)&.item_id
+    rdv.motif_id = ExternalReference.find_by(item_type: "Motif", external_id: params[:motif_external_id], oauth_application:)&.item_id
+    rdv.organisation_id = rdv.motif.organisation_id
+
+    rdv.agents = Agent.where(email: params[:agent_emails])
+
+    rdv.created_by = if params[:created_by_type] == "User"
+                       # On peut uniquement utiliser cette logique pour les users parce qu'on n'a pas d'external_ids sur les agents ou les prescripteurs
+                       ExternalReference.find_by(item_type: params[:created_by_type], external_id: params[:created_by_external_id], oauth_application:)&.item
+                     else
+                       # Il faut un created_by sur le rendez-vous pour initialiser les created_by des participations
+                       # Mais le champs n'est pas utilisé à part pour envoyer des notifications (ce qu'on ne fait pas ici)
+                       # ou identifier un prescripteur, ce qui n'est pas très utile pour les rendez-vous passés.
+                       # On peut donc se permettre de faire l'approximation que c'est l'agent du rendez-vous qui l'a créé.
+                       #
+                       #
+                       # Ça permet d'éviter d'avoir à copier les informations des prescripteurs (pour le moment).
+                       rdv.agents.first
+                     end
+
+    controller.send(:authorize, rdv, :update?, policy_class: Agent::RdvPolicy)
+
+    Rdv.transaction do
+      if rdv.collectif?
+        rdv.save!
+
+        params[:participations].each do |participation_params|
+          Participation.create(
+            rdv: rdv,
+            user_id: ExternalReference.find_by(item_type: "User", external_id: participation_params[:user_external_id], oauth_application:)&.item_id,
+            status: participation_params[:status],
+            created_by: rdv.created_by
+          )
+        end
+      else
+        user_external_ids = params[:participations].map { |p| p[:user_external_id] }
+        rdv.user_ids = ExternalReference.where(item_type: "User", external_id: user_external_ids, oauth_application:).map(&:item_id)
+        rdv.save!
+      end
+
+      if params[:external_reference].present?
+        ExternalReference.create!(
+          params.require(:external_reference).permit(:external_id, :external_url).merge(
+            item: rdv,
+            oauth_application:
+          )
+        )
+      end
+    end
+
+    rdv
+  end
+
+  private
+
+  attr_reader :params, :controller, :oauth_application
+end

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "RDV API" do
   describe "#create" do
     context "pour une migration inter-instance d'un rendez-vous pris par un usager" do
       let(:user_on_old_instance) { create(:user, organisations: [organisation_on_old_instance]) }
-      let(:rdv_on_old_instance) do
+      let!(:rdv_on_old_instance) do
         create(:rdv, agents: [agent_on_old_instance], motif: motif_on_old_instance,
                      users: [user_on_old_instance], starts_at: 2.weeks.ago, created_by: user_on_old_instance,
                      lieu: lieu_on_old_instance, organisation: instance_export.source_organisation)
@@ -134,7 +134,7 @@ RSpec.describe "RDV API" do
       let(:user_on_new_instance) { create(:user, organisations: [organisation]) }
       let!(:user_external_reference) { create(:external_reference, item: user_on_new_instance, external_id: user_on_old_instance.id, oauth_application: application) }
 
-      it "sends all the information to the new instance" do
+      let(:request_params) do
         request_params = nil
         allow_any_instance_of(RdvServicePublicApiClient).to receive(:post) do |_object, _path, params| # rubocop:disable RSpec/AnyInstance
           request_params = params
@@ -143,12 +143,41 @@ RSpec.describe "RDV API" do
         # On démarre le test depuis le job qui fait la synchronisation pour vérifier que la sérialisation marche bien avec le controller
         # On exécute le job afin que sa requête API soit enregistrée dans request_params par le block ci-dessus.
         InstanceExports::CopyPlanningJob::CopyRdvJob.new.perform(instance_export.id, rdv_on_old_instance.id, Domain::RDV_AIDE_NUMERIQUE.id)
+        request_params
+      end
 
+      it "sends all the information to the new instance" do
         expect do
           post "/api/v1/rdvs", headers:, params: request_params, as: :json
         end.to change(Rdv, :count).by(1)
 
         expect(Rdv.last.created_by).to eq user_on_new_instance
+      end
+
+      context "quand l'agent du rendez-vous a été supprimé" do
+        let(:other_agent_on_old_instance) { create(:agent, basic_role_in_organisations: [instance_export.source_organisation]) }
+
+        let!(:rdv_on_old_instance) do
+          create(:rdv, agents: [other_agent_on_old_instance], motif: motif_on_old_instance,
+                       users: [user_on_old_instance], starts_at: 2.weeks.ago, created_by: user_on_old_instance,
+                       lieu: lieu_on_old_instance, organisation: instance_export.source_organisation)
+        end
+
+        before do
+          AgentRemoval.new(other_agent_on_old_instance, instance_export.source_organisation).remove!
+        end
+
+        it "essaye de créer le rendez-vous" do
+          # On génère la requête, puis on supprime les données pour simuler le fait d'être sur une autre instance
+          params = request_params
+
+          rdv_on_old_instance.destroy
+          other_agent_on_old_instance.delete
+
+          expect { post("/api/v1/rdvs", headers:, params:, as: :json) }.to change(Rdv, :count).by(1)
+
+          expect(Rdv.last.created_by).to eq user_on_new_instance
+        end
       end
     end
 

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -163,9 +163,7 @@ RSpec.describe "RDV API" do
                        lieu: lieu_on_old_instance, organisation: instance_export.source_organisation)
         end
 
-        before do
-          AgentRemoval.new(other_agent_on_old_instance, instance_export.source_organisation).remove!
-        end
+        before { AgentRemoval.new(other_agent_on_old_instance, instance_export.source_organisation).remove! }
 
         it "essaye de créer le rendez-vous" do
           # On génère la requête, puis on supprime les données pour simuler le fait d'être sur une autre instance
@@ -176,7 +174,9 @@ RSpec.describe "RDV API" do
 
           expect { post("/api/v1/rdvs", headers:, params:, as: :json) }.to change(Rdv, :count).by(1)
 
-          expect(Rdv.last.created_by).to eq user_on_new_instance
+          created_rdv = Rdv.last
+          expect(created_rdv.agents.first.deleted_at).to be_present
+          expect(created_rdv.created_by).to eq user_on_new_instance
         end
       end
     end

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -165,8 +165,8 @@ RSpec.describe "RDV API" do
 
         before { AgentRemoval.new(other_agent_on_old_instance, instance_export.source_organisation).remove! }
 
-        it "essaye de créer le rendez-vous" do
-          # On génère la requête, puis on supprime les données pour simuler le fait d'être sur une autre instance
+        it "crée le rendez-vous avec un agent supprimé" do
+          # On génère les params, puis on supprime les données pour simuler le fait d'être sur une autre instance
           params = request_params
 
           rdv_on_old_instance.destroy


### PR DESCRIPTION
Correctif pour certaines occurrences de https://sentry.incubateur.net/organizations/betagouv/issues/244997

# Contexte

La copie de certain rendez-vous depuis l'ancienne instance vers la nouvelle échoue parce que l'agent qui a fait le rendez-vous a été supprimé.

Pour rappel, quand un agent est supprimé et qu'il n'est plus dans aucune organisation, son adresse email est anonymisée (avec un format du style `agent_1234@deleted.rdv-solidarites.fr`), mais on garde son nom et prénom. Cela permet de garder un historique des rendez-vous fait par les usagers qui étaient accompagnés par cet agent.

Le problème est que puisque l'agent n'est pas copié lors de la première étape de la migration, le rendez-vous est invalide et n'est pas créé du tout.

# Solution

On envoie plus d'informations sur chaque agent qui a fait le rendez-vous pour permettre de créer des agents supprimés à la volée quand c'est nécessaire.

Pour une fois, une relecture commit par commit permet de distinguer les refactoring préliminaire du vrai fix.

