### PR TITLE
définir un ReplyTo: user.email pour les mails transferrés aux agents

### DIFF
--- a/app/mailers/agents/reply_transfer_mailer.rb
+++ b/app/mailers/agents/reply_transfer_mailer.rb
@@ -13,8 +13,10 @@ class Agents::ReplyTransferMailer < ApplicationMailer
     @reply_body = reply_body
     @attachment_names = source_mail.attachments.map(&:filename).join(", ")
     @date = relative_date(@rdv.starts_at)
+    opts = {}
+    opts[:reply_to] = rfc5322_name_and_email(@author.full_name, @author.email) if @author.email.present?
 
-    mail(to: agents.map(&:email), subject: t(".title", date: @date))
+    mail(to: agents.map(&:email), subject: t(".title", date: @date), **opts)
   end
 
   # @param [Rdv] rdv

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe TransferEmailReplyJob do
         transferred_email = ActionMailer::Base.deliveries.last
         expect(transferred_email.to).to eq(["je_suis_un_agent@departement.fr"])
         expect(transferred_email[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+        expect(transferred_email[:reply_to].to_s).to eq(%("Bénédicte FICIAIRE" <bene_ficiaire@lapin.fr>))
         expect(transferred_email.html_part.body.to_s).to include("Dans le cadre du RDV du 20 mai, l'usager⋅e Bénédicte FICIAIRE a envoyé")
         expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
         expect(transferred_email.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost/admin/organisations/#{rdv.organisation_id}/rdvs/#{rdv.id}))


### PR DESCRIPTION
# TODO

- [ ] vérifier dans les git blame pourquoi on ne l'avait pas fait avant
- [ ] modifier la phrase du bas « ne pas répondre à cet email »
- [ ] rajouter des specs
- [ ] améliorer les previews

# Contexte

Lorsqu'un usager répond à un mail de notification qu'on lui a envoyé, le mail est reçu par les serveurs de Brevo qui nous le transfèrent via un webhook. Lorsque nous trouvons un email agent ou orga à qui le transférons, nous le faisons. Ça nous évite de faire le support à la place des agents.

Certains agents / orgas mettent en place des réponses auto à tous les emails. Par exemple  maisondessolidarites18@paris.fr demande systématiquement un numéro de dossier ou d'usager présent par email : https://zammad10.ethibox.fr/#ticket/zoom/33744

Aujourd'hui ces emails auto de contre-réponse des agents nous arrivent car nous envoyons les emails aux agents depuis notre adresse `From: support@rdv-solidartes.fr` par ex

# Solution

Je propose ici de rajouter un `ReplyTo: user.email` dans l'email envoyé aux agents quand c'est possible. 

## captures

Avant|Après
|-|-|
<img width="947" height="929" alt="image" src="https://github.com/user-attachments/assets/238f550c-755e-4cb7-af33-655c833cbaed" />|