### PR TITLE
Add visio_url to Rdv blueprint

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -2,7 +2,8 @@ class RdvBlueprint < Blueprinter::Base
   identifier :id
 
   fields :uuid, :status, :starts_at, :ends_at, :duration_in_min, :address, :context, :cancelled_at,
-         :max_participants_count, :users_count, :name, :collectif, :created_by_type, :created_by_id, :created_at
+         :max_participants_count, :users_count, :name, :collectif, :created_by_type, :created_by_id, :created_at,
+         :visio_url
 
   # Retrocompatibilité avec l'ancien format de l'API pour created_by
   field :created_by do |rdv, _options|


### PR DESCRIPTION
# Contexte

Il y a des organisations de l'insertion qui commencent à utiliser les rdvs par visioconférence pour les bénéficiaires du RSA. Jusqu'à présent côté rdv-insertion nous ne prenions pas en compte les motifs via visio conférence (et les rdvs associés), mais nous devons maintenant le faire pour pouvoir envoyer des notifications spécifiques à rdv-insertion pour ce type de rdv.

# Solution

Pour cela, nous avons besoin d'avoir l'url de la visio. J'expose donc ce que retourne `rdv#visio_url` dans les webhooks de rdv. Ainsi nous récupérons l'url de visio custom si elle a été précisée et l'url de visio par défaut si elle ne l'a pas été.