### PR TITLE
Correction du lien et de l'affichage de la bannière pour les rendez-vous d'accompagnement

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -1,12 +1,6 @@
 module AgentsHelper
   def may_need_onboarding_help?
-    return false if current_agent.territory_creation_request.blank?
-
-    if defined?(current_organisation)
-      # Pour éviter d'avoir des problèmes de perfs en faisant un COUNT(*) sur tous les rdvs de l'organisation,
-      # on limite à 5 puisque c'est le nombre qu'on considère comme un bon indicateur que l'organisation a réussi à configurer son compte
-      current_organisation.rdvs.limit(5).count < 5
-    elsif defined?(current_territory)
+    if defined?(current_territory)
       Rdv.joins(:organisation).where(organisation: { territory_id: current_territory.id }).limit(5).count < 5
     end
   end

--- a/app/views/admin/onboarding/_banner.html.slim
+++ b/app/views/admin/onboarding/_banner.html.slim
@@ -5,23 +5,23 @@
 
   - if needs_motif && current_organisation.lieux.enabled.none?
     - content_for :onboarding_banner do
-      .fr-callout.fr-pb-2w
+      .fr-callout.fr-pb-2w.fr-mt-2w
         h2.fr-h6 🌱 Bienvenue sur votre espace #{current_domain.name} !
         p Pour commencer, vous pouvez créer votre premier motif de rendez-vous.
         = link_to("Créer un motif", new_admin_organisation_motif_path(current_organisation), class: "fr-btn")
   - elsif needs_lieu(current_organisation)
     - content_for :onboarding_banner do
-      .fr-callout.fr-pb-2w
+      .fr-callout.fr-pb-2w.fr-mt-2w
         p.fr-mr-2w 🌿 Vous pouvez maintenant ajouter le lieu où vous allez faire vos rendez-vous.
         = link_to("Ajouter un lieu", new_admin_organisation_lieu_path(current_organisation), class: "fr-btn")
   - elsif needs_motif
     - content_for :onboarding_banner do
-      .fr-callout.fr-pb-2w
+      .fr-callout.fr-pb-2w.fr-mt-2w
         p.fr-mr-2w 🌿 Vous pouvez maintenant créer un motif de rendez-vous.
         = link_to("Créer un motif", new_admin_organisation_motif_path(current_organisation), class: "fr-btn")
   - elsif current_organisation.rdvs.none? && current_organisation.motifs.bookable_by_everyone.none?
     - content_for :onboarding_banner do
-      .fr-callout.fr-pb-2w
+      .fr-callout.fr-pb-2w.fr-mt-2w
         - if in_agenda
           p 🪴 Vous pouvez prendre votre premier rendez-vous en cliquant sur l'horaire de votre choix dans l'agenda
         - else

--- a/app/views/layouts/_meet_the_team_banner.html.slim
+++ b/app/views/layouts/_meet_the_team_banner.html.slim
@@ -5,4 +5,4 @@
         span.fr-notice__desc
           | Besoin d'aide pour bien démarrer ? Nous pouvons vous aider
           = " "
-          = external_link_to("Rencontrer l'équipe", "https://cal.com/team/rdv-service-public/accompagnement", class: "fr-btn fr-btn--tertiary fr-ml-1w")
+          = external_link_to("Rencontrer l'équipe", "https://rdv.anct.gouv.fr/motif/dou6Am4v/rendez-vous-d-accompagnement", class: "fr-btn fr-btn--tertiary fr-ml-1w")


### PR DESCRIPTION
# Contexte

En cherchant à voir quel lien on propose pour les rendez-vous d'accompagnement, on s'est rendu compte qu'on avait oublié d'afficher la bannière qui propose ces rdvs aux agents qui s'ouvrent un compte en complète autonomie.

# Solution

Vu avec Mehdi : on propose des rendez-vous d'accompagnement à tous les agents qui sont dans un espace qui a fait moins de 5 rdvs.

Et on peut donc passer à un lien RDV SP plutôt que cal.com (enfin !), et corriger une marge au passage (ma passion du moment)
