### PR TITLE
Fixup #6104

### DIFF
--- a/app/jobs/webhook_build_and_send_job.rb
+++ b/app/jobs/webhook_build_and_send_job.rb
@@ -1,5 +1,5 @@
 class WebhookBuildAndSendJob < ApplicationJob
-  def perform(payload, webhook_endpoint_id)
-    WebhookJob.perform_now(payload, webhook_endpoint_id)
+  def perform(record:, action:, webhook_endpoint_id:)
+    WebhookJob.perform_now(record:, action:, webhook_endpoint_id:)
   end
 end


### PR DESCRIPTION
Dans #6104 j'ai fait une erreur de copier coller et j'ai pas mis la bonne signature pour `WebhookBuildAndSendJob` :grimacing: 

Je viens de cancel la CI de mise en prod de #6104, comme ça on met en prod direct avec le fixup.