### PR TITLE
Corrige un crash lors du test de sectorisation

### DIFF
--- a/app/views/admin/territories/sectorisation_tests/_attribution.html.slim
+++ b/app/views/admin/territories/sectorisation_tests/_attribution.html.slim
@@ -1,7 +1,7 @@
 - if attribution.level_agent?
   div
     / cette vérification évite d’afficher les noms d’agents que l’agent courant n’a pas le droit de voir
-    - if Configuration::AgentPolicy.new(AgentContext.new(current_agent), attribution.agent).show?
+    - if Agent::AgentPolicy::Scope.new(current_agent, Agent.all).resolve.include?(attribution.agent)
       | L’agent #{attribution.agent.full_name_and_service}
     - else
       | Un agent (#{attribution.agent.services_short_names})


### PR DESCRIPTION
Issue Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/246322

Ce matin un agent a voulu tester sa secto (sur la nouvelle instance !) mais le code de test de secto est cassé depuis août 2024 (#4529).

Je fais donc un fix rapide où j'utilise une policy existante. J'ai testé en local mais je n'ai pas écrit de test vu la fréquence d'usage (exceptionnellement basse !) de cette feature. 

# Avant

<img width="2156" height="1225" alt="image" src="https://github.com/user-attachments/assets/4aa616e4-6b70-45ee-a7e0-ac90a8d440ce" />

# Après

<img width="1681" height="1229" alt="image" src="https://github.com/user-attachments/assets/f14005f2-ed07-44ee-932c-22243367a42b" />
