### PR TITLE
[CI] Utiliser Redis comme service plutôt que zhulik/redis-action@1.1.0 (obsolète)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,14 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports: ["5432:5432"]
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports: ["6379:6379"]
     steps:
       - uses: actions/checkout@v4
       - uses: WitherZuo/set-timezone@v1.0.0
@@ -146,8 +154,6 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-      - name: Set up Redis
-        uses: zhulik/redis-action@1.1.0
       - name: Cache js dependencies
         uses: actions/cache@v4
         with:
@@ -208,6 +214,14 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports: ["5432:5432"]
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports: ["6379:6379"]
     steps:
       - uses: actions/checkout@v4
       - uses: WitherZuo/set-timezone@v1.0.0
@@ -222,8 +236,6 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-      - name: Set up Redis
-        uses: zhulik/redis-action@1.1.0
       - name: Cache js dependencies
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
L'action GitHub ` zhulik/redis-action@1.1.0` a commencé à planter aujourd'hui avec cette erreur :

> docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.

Claude me dit que la façon moderne de setup Redis est de passer par un service conainerisé, comme on le fait déjà pour Postgres. Visiblement ça règle le problème et ça nous débarrasse d'une GitHub action créée par un illustre inconnu.