### PR TITLE
Éviter les requêtes inutiles sur chaque page (step 1: `current_agent.roles`)

### DIFF
--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -20,6 +20,12 @@ class AgentAuthController < ApplicationController
     @organisation = current_organisation
   end
 
+  def current_agent
+    super.tap do |agent|
+      agent.roles.load
+    end
+  end
+
   def current_organisation
     @current_organisation ||= Organisation.find(params[:organisation_id])
   end

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -21,7 +21,7 @@ class AgentAuthController < ApplicationController
   end
 
   def current_agent
-    super.tap(&:preload_roles)
+    super.tap { _1&.preload_roles }
   end
 
   def current_organisation

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -21,9 +21,9 @@ class AgentAuthController < ApplicationController
   end
 
   def current_agent
-    super.tap do |agent|
-      agent.roles.load
-    end
+    # Précharger les `roles` à chaque requête permet d'utiliser des helpers
+    # conçus pour manipuler des agents avec des roles préchargés.
+    super.tap { |agent| agent&.roles&.load }
   end
 
   def current_organisation

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -21,9 +21,7 @@ class AgentAuthController < ApplicationController
   end
 
   def current_agent
-    # Précharger les `roles` à chaque requête permet d'utiliser des helpers
-    # conçus pour manipuler des agents avec des roles préchargés.
-    super.tap { |agent| agent&.roles&.load }
+    super.tap(&:preload_roles)
   end
 
   def current_organisation

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -9,12 +9,6 @@ module AdminHelper
     tag.span(value.presence || "N/A", class: value.blank? ? "text-muted" : "")
   end
 
-  def current_agent_role
-    return nil if current_agent.nil? || current_organisation.nil?
-
-    @current_agent_role ||= current_agent.roles.find_by(organisation: current_organisation)
-  end
-
   # Build a dummy model linked the organisation to fetch its policy.
   # eg. current_agent_can_create_agent_in?(current_organisation)
   def current_agent_can_create_agent_in?(organisation)

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -89,11 +89,11 @@ module AgentsHelper
   def navigation_scoped_by_agent_services?(current_agent, current_organisation)
     return false if current_agent.secretaire?
 
-    !current_agent.roles.access_level_admin.exists?(organisation_id: current_organisation.id)
+    !current_agent.admin_in_organisation?(current_organisation)
   end
 
   def current_organisation_in_left_menu(&block)
-    if current_agent.organisations.count > 1
+    if current_agent.organisations_count > 1
       link_to(".left-submenu-account", "data-toggle" => :collapse, "aria-expanded" => "false", class: "side-menu__item", &block)
     else
       tag.div(class: "pt-2 pr-2 pb-2 pl-3", &block)

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -4,6 +4,7 @@ class Agent < ApplicationRecord
   self.ignored_columns += %w[connected_with_agent_connect]
   include Agent::CaldavConfiguration
   include Agent::FeatureFlags
+  include Agent::PreloadRoles
 
   encrypts :caldav_password, deterministic: true
 
@@ -238,19 +239,6 @@ class Agent < ApplicationRecord
       roles.find { _1.organisation_id == organisation_id }&.access_level
     else
       roles.where(organisation_id:).pick(:access_level)
-    end
-  end
-
-  def organisations_count
-    # Si `roles` est chargé, `size` va compter les objets, sinon elle va envoyer un COUNT en base
-    roles.size
-  end
-
-  def organisation_ids
-    if roles.loaded?
-      roles.map(&:organisation_id)
-    else
-      super
     end
   end
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -232,19 +232,17 @@ class Agent < ApplicationRecord
   end
 
   def access_level_in(organisation)
+    organisation_id = organisation.respond_to?(:id) ? organisation.id : organisation
+
     if roles.loaded?
-      roles.find { _1.organisation_id == organisation.id }&.access_level
+      roles.find { _1.organisation_id == organisation_id }&.access_level
     else
-      roles.where(organisation_id: organisation.id).pick(:access_level)
+      roles.where(organisation_id:).pick(:access_level)
     end
   end
 
-  def admin_roles
-    roles.to_a.select { _1.access_level == AgentRole::ACCESS_LEVEL_ADMIN }
-  end
-
   def organisations_count
-    # roles est préchargé
+    # Si `roles` est chargé, `size` va compter les objets, sinon elle va envoyer un COUNT en base
     roles.size
   end
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -233,9 +233,26 @@ class Agent < ApplicationRecord
 
   def access_level_in(organisation)
     if roles.loaded?
-      roles.find { _1.organisation == organisation }&.access_level
+      roles.find { _1.organisation_id == organisation.id }&.access_level
     else
-      roles.where(organisation: organisation).pick(:access_level)
+      roles.where(organisation_id: organisation.id).pick(:access_level)
+    end
+  end
+
+  def admin_roles
+    roles.to_a.select { _1.access_level == AgentRole::ACCESS_LEVEL_ADMIN }
+  end
+
+  def organisations_count
+    # roles est préchargé
+    roles.size
+  end
+
+  def organisation_ids
+    if roles.loaded?
+      roles.map(&:organisation_id)
+    else
+      super
     end
   end
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -232,8 +232,8 @@ class Agent < ApplicationRecord
     access_level_in(organisation) == AgentRole::ACCESS_LEVEL_ADMIN
   end
 
-  def access_level_in(organisation)
-    organisation_id = organisation.respond_to?(:id) ? organisation.id : organisation
+  def access_level_in(organisation_or_id)
+    organisation_id = organisation_or_id.respond_to?(:id) ? organisation_or_id.id : organisation_or_id
 
     if roles.loaded?
       roles.find { _1.organisation_id == organisation_id }&.access_level

--- a/app/models/concerns/agent/preload_roles.rb
+++ b/app/models/concerns/agent/preload_roles.rb
@@ -1,0 +1,27 @@
+# Ce concern regroupe les méthodes utilisées pour éviter de faire plusieurs
+# requêtes à Postgres à chaque chargement de page pour récupérer :
+# - les droits de l'agent courant sur l'organisation courante
+# - le nombre d'organisations de l'agent courant
+
+module Agent::PreloadRoles
+  extend ActiveSupport::Concern
+
+  # Précharger les `roles` à chaque requête permet d'utiliser des helpers
+  # conçus pour manipuler des agents avec des `roles` préchargés.
+  def preload_roles
+    roles.load
+  end
+
+  def organisations_count
+    # Si `roles` est chargé, `size` va compter les objets, sinon elle va envoyer un COUNT en base
+    roles.size
+  end
+
+  def organisation_ids
+    if roles.loaded?
+      roles.map(&:organisation_id)
+    else
+      super
+    end
+  end
+end

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -9,15 +9,9 @@ class Agent::AgentPolicy < ApplicationPolicy
     record == current_agent
   end
 
-  # rubocop:disable Style/ArrayIntersect
   def admin_in_record_organisation?
-    (
-      record.roles.map(&:organisation_id) &
-        current_agent.admin_roles.map(&:organisation_id)
-    ).any?
+    record.organisation_ids.any? { current_agent.admin_in_organisation?(_1) }
   end
-
-  # rubocop:enable Style/ArrayIntersect
 
   alias show? current_agent_or_admin_in_record_organisation?
   alias new? current_agent_or_admin_in_record_organisation?

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -13,7 +13,7 @@ class Agent::AgentPolicy < ApplicationPolicy
   def admin_in_record_organisation?
     (
       record.roles.map(&:organisation_id) &
-        current_agent.roles.access_level_admin.pluck(:organisation_id)
+        current_agent.admin_roles.map(&:organisation_id)
     ).any?
   end
 

--- a/app/policies/agent/organisation_policy.rb
+++ b/app/policies/agent/organisation_policy.rb
@@ -1,6 +1,6 @@
 class Agent::OrganisationPolicy < ApplicationPolicy
   def in_organisation?
-    current_agent.admin_in_organisation?(record)
+    current_agent.organisation_ids.include?(@record.id)
   end
 
   def admin_in_organisation?

--- a/app/policies/agent/organisation_policy.rb
+++ b/app/policies/agent/organisation_policy.rb
@@ -1,6 +1,6 @@
 class Agent::OrganisationPolicy < ApplicationPolicy
   def in_organisation?
-    current_agent.organisation_ids.include?(@record.id)
+    current_agent.admin_in_organisation?(record)
   end
 
   def admin_in_organisation?

--- a/app/policies/agent/organisation_policy.rb
+++ b/app/policies/agent/organisation_policy.rb
@@ -4,7 +4,7 @@ class Agent::OrganisationPolicy < ApplicationPolicy
   end
 
   def admin_in_organisation?
-    current_agent.roles.access_level_admin.pluck(:organisation_id).include?(record.id)
+    current_agent.admin_in_organisation?(record)
   end
 
   def territorial_admin?

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -23,7 +23,7 @@ class Agent::RdvPolicy < ApplicationPolicy
   alias versions? show?
 
   def destroy?
-    current_agent.access_level_in(@record.organisation) == AgentRole::ACCESS_LEVEL_ADMIN
+    current_agent.admin_in_organisation?(@record.organisation)
   end
 
   def self.explain(organisation, agent)

--- a/app/views/admin/agents/_fil_ariane.html.slim
+++ b/app/views/admin/agents/_fil_ariane.html.slim
@@ -2,7 +2,7 @@
 
 ruby:
   titles_and_paths = [
-    (["Configuration", admin_organisation_configuration_path(current_organisation)] if current_agent_role.admin?),
+    (["Configuration", admin_organisation_configuration_path(current_organisation)] if current_agent.admin_in_organisation?(current_organisation)),
     (["Agents", admin_organisation_agents_path(current_organisation)] if current_page_title),
   ].compact
 

--- a/app/views/admin/agents/edit.html.slim
+++ b/app/views/admin/agents/edit.html.slim
@@ -39,7 +39,7 @@
             = ff.input :access_level,
               collection: @roles,
               label_method: -> { render("admin/agents/role_labels/#{_1}", { services: @agent.services }) },
-              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations.count > 1),
+              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations_count > 1),
               as: :radio_buttons
 
           / allow turning an intervenant into an agent with an account

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -18,7 +18,7 @@
             = ff.input :access_level,
               collection: @roles,
               label_method: -> { render("admin/agents/role_labels/#{_1}", { services: @services }) },
-              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations.count > 1),
+              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations_count > 1),
               as: :radio_buttons,
               label: "",
               html: { class: "mt-4" }

--- a/app/views/admin/lieux/_fil_ariane.html.slim
+++ b/app/views/admin/lieux/_fil_ariane.html.slim
@@ -2,7 +2,7 @@
 
 ruby:
   titles_and_paths = [
-    (["Configuration", admin_organisation_configuration_path(current_organisation)] if current_agent_role.admin?),
+    (["Configuration", admin_organisation_configuration_path(current_organisation)] if current_agent.admin_in_organisation?(current_organisation)),
     (["Lieux", admin_organisation_lieux_path(current_organisation)] if current_page_title),
   ].compact
 

--- a/app/views/admin/motifs/_fil_ariane.html.slim
+++ b/app/views/admin/motifs/_fil_ariane.html.slim
@@ -2,7 +2,7 @@
 
 ruby:
   titles_and_paths = [
-    (["Configuration", admin_organisation_configuration_path(current_organisation)] if current_agent_role.admin?),
+    (["Configuration", admin_organisation_configuration_path(current_organisation)] if current_agent.admin_in_organisation?(current_organisation)),
     (["Motifs de rendez-vous", admin_organisation_motifs_path(current_organisation)] if current_page_title),
   ].compact
 

--- a/app/views/admin/rdvs/a_renseigner.html.slim
+++ b/app/views/admin/rdvs/a_renseigner.html.slim
@@ -5,7 +5,7 @@
 
 p Merci d'indiquer si ces rendez-vous se sont bien passés comme prévu.
 
-- if current_agent.organisations.count > 1
+- if current_agent.organisations_count > 1
   p Cette page liste les rendez-vous à renseigner de toutes vos organisations.
 
 - if @rdvs.total_count > 0

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -17,7 +17,7 @@ header.header.bg-white
               | Nouveautés
               - if BlogPost.new_content_for_agent?(current_agent)
                 .ml-1.fr-badge.fr-badge--new.fr-badge--sm.fr-pl-3v
-          - elsif defined?(current_organisation) && current_organisation && current_agent.organisations.count <= 1 && current_agent.admin_in_organisation?(current_organisation)
+          - elsif defined?(current_organisation) && current_organisation && current_agent.organisations_count <= 1 && current_agent.admin_in_organisation?(current_organisation)
             = link_to "Passer à RDV Service Public", admin_organisation_instance_exports_path(current_organisation), class: "btn text-primary-blue link-dsfr"
 
         li#rdv-account-dropdown.list-inline-item.dropdown.mr-2

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -22,7 +22,7 @@ nav.left-side-menu-wrapper
                   = current_organisation.name
                   - if navigation_scoped_by_agent_services?(current_agent, current_organisation)
                     span= current_agent.services_short_names
-              - if current_agent.organisations.count > 1
+              - if current_agent.organisations_count > 1
                 div.d-flex.align-items-center
                   = icon("fr-icon-arrow-down-s-line", class: "menu-arrow")
           = render "layouts/left_menu/organisation_switcher"

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -84,7 +84,7 @@ nav.left-side-menu-wrapper
             span.fr-icon-bar-chart-box-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
             | Statistiques
 
-        - unless current_agent_role.admin?
+        - unless current_agent.admin_in_organisation?(current_organisation)
           li.fr-pb-0
             = active_link_to admin_organisation_lieux_path(current_organisation), class: "side-menu__item"
               = lieu_icon(class: "fr-icon--sm fr-mr-1w")
@@ -94,7 +94,7 @@ nav.left-side-menu-wrapper
               = motif_icon(class: "fr-icon--sm fr-mr-1w")
               | Motifs
 
-        - if current_agent_role.admin?
+        - if current_agent.admin_in_organisation?(current_organisation)
           li.fr-pb-0
             = link_to admin_organisation_configuration_path(current_organisation), class: "side-menu__item #{'active' if menu_top_level_item == 'settings'}"
               span.fr-icon-settings-5-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]

--- a/app/views/layouts/left_menu/_organisation_switcher.html.slim
+++ b/app/views/layouts/left_menu/_organisation_switcher.html.slim
@@ -1,5 +1,5 @@
 ul.list-unstyled.left-submenu-account.collapse
-  - if current_agent.organisations.count > 10
+  - if current_agent.organisations_count > 10
     li
       = link_to "Changer d'organisation", admin_organisations_path, class: "side-menu__item side-menu__item--small pl-4"
   - else

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
     shared_examples "existing agent is added to organization" do
       it "adds agent to organisation and redirects to the agents list and does not create a new agent" do
         expect { subject }.not_to change(Agent, :count)
-        expect(existing_agent.organisation_ids).to include(organisation.id)
+        expect(existing_agent.reload.organisation_ids).to include(organisation.id)
         expect(response).to redirect_to(admin_organisation_agents_path(organisation.id))
       end
     end

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
       .where(external_references: { external_id: "absence:#{absence_du_collegue.id}" })
     expect(copied_absence).to be_present
 
-    login_as(agent_rdv_sp, scope: :agent)
+    login_as(agent_rdv_sp.reload, scope: :agent)
     visit "http://www.rdv-service-public-test.localhost/admin/organisations/#{created_organisation.id}/agents"
 
     doc.add_screenshot(page,


### PR DESCRIPTION
# Contexte

Dans un contexte où l'on veut scaler, il semble pertinent de suivre des bonnes pratiques de performances. Le nombre de requête en base pour une page donnée est souvent un bon indicateur.

Actuellement, pour afficher la page "Support", dont le contenu ne demande aucun chargement en base, donc c'est -à-dire pour charger **le menu de gauche et la barre d'en haut**, nous envoyons **17 requêtes à Postgres**.

# Solution

Dans cette première étape je me charge d'éliminer des appels différents que l'on fait à la base pour déterminer quelles sont les orgas de l'agent courant, et si il est admin de l'orga courant.

Pour ce faire : 
- charger `current_agent.roles` quand on définit `current_agent`
- introduire des méthodes de helper sur `Agent` qui prennent avantage du fait que `#roles` soit chargé

**On passe de 17 à 12 requêtes pour chaque page chargée. :zap:** 

## Considérations de sécurité

Je me suis demandé si ce n'était pas dangereux d'utiliser les `roles` chargés en mémoire. En effet, dans un cas où l'on changerait les `roles` d'un agent, puis on appellerait une policy pour vérifier ses droits, il est possible que les `roles` soient alors périmés, et que l'on autorise mal.

Ceci étant dit, puisque cette PR fait uniquement en sorte de précharger les `roles` pour le `current_agent`, il faudrait qu'il s'agisse d'une requête durant laquelle on modifie les rôles de l'agent courant **puis** qu'on examine ces `roles` pour déterminer une autorisations. J'ai donc l'impression que c'est quelque-chose qu'on ne fait jamais.

Je veux bien votre avis sur le niveau de risque. :pray: 

## Captures d'écran

Avant | Après
:- | -:
<img width="1253" height="542" alt="image" src="https://github.com/user-attachments/assets/c0ea9aff-2aaf-482d-97de-aa5dab88739d" /> | <img width="1253" height="542" alt="image" src="https://github.com/user-attachments/assets/d0841079-ff80-4f72-a867-05dbf1aef966" />

