### PR TITLE
WIP - Investigations timeouts Redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://beta.gem.coop/cooldown"
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.4.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ PATH
       omniauth-oauth2 (~> 1.8)
 
 GEM
-  remote: https://beta.gem.coop/cooldown/
+  remote: https://rubygems.org/
   specs:
     actioncable (8.0.4)
       actionpack (= 8.0.4)

--- a/scripts/stress_redis.rb
+++ b/scripts/stress_redis.rb
@@ -11,14 +11,14 @@
 require "benchmark"
 
 LARGE_VALUE_SIZE = 100 * 1024 * 1024 # 100 MB
-REDIS_KEY_BIG = "test:big_file"
-REDIS_KEY_SMALL = "test:ping"
+REDIS_KEY_BIG = "test:big_file".freeze
+REDIS_KEY_SMALL = "test:ping".freeze
 NUM_READERS = 5
 READ_INTERVAL = 0.1 # seconds between read attempts
 
 REDIS_URL = Rails.configuration.x.redis_url
-READER_TIMEOUT = 0.1   # short timeout to detect blocking
-WRITER_TIMEOUT = 30     # long timeout for large operations
+READER_TIMEOUT = 0.1 # short timeout to detect blocking
+WRITER_TIMEOUT = 30 # long timeout for large operations
 
 def new_redis(timeout:)
   Redis.new(url: REDIS_URL, timeout: timeout, ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })
@@ -39,13 +39,13 @@ stop_readers = Concurrent::AtomicBoolean.new(false)
 reader_futures = NUM_READERS.times.map do |i|
   Concurrent::Future.execute do
     reader = new_redis(timeout: READER_TIMEOUT)
-    while !stop_readers.true?
+    until stop_readers.true?
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       begin
         reader.get(REDIS_KEY_SMALL)
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
         reader_results << { reader: i, elapsed: elapsed.round(4), error: nil }
-      rescue => e
+      rescue StandardError => e
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
         reader_results << { reader: i, elapsed: elapsed.round(4), error: "#{e.class}: #{e.message}" }
       end
@@ -96,13 +96,13 @@ stop_readers = Concurrent::AtomicBoolean.new(false)
 reader_futures = NUM_READERS.times.map do |i|
   Concurrent::Future.execute do
     reader = new_redis(timeout: READER_TIMEOUT)
-    while !stop_readers.true?
+    until stop_readers.true?
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       begin
         reader.get(REDIS_KEY_SMALL)
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
         read_reader_results << { reader: i, elapsed: elapsed.round(4), error: nil }
-      rescue => e
+      rescue StandardError => e
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
         read_reader_results << { reader: i, elapsed: elapsed.round(4), error: "#{e.class}: #{e.message}" }
       end

--- a/scripts/stress_redis.rb
+++ b/scripts/stress_redis.rb
@@ -1,38 +1,48 @@
-# Test: Does a large Redis SET block other clients enough to cause timeouts?
+# Test: Does a large Redis SET/GET block other clients enough to cause timeouts?
 #
-# Hypothesis: Redis is single-threaded, so writing a ~100MB value blocks all
-# other commands until the write is fully received and processed.
-# If the write takes longer than REDIS_TIMEOUT (5s), concurrent readers will
-# get Redis::CannotConnectError / timeout errors.
+# Hypothesis: Redis is single-threaded, so writing/reading a ~100MB value blocks all
+# other commands until the operation is fully processed.
 #
-# Run this in a Rails console connected to production Redis (or a similar setup).
+# We use a short timeout (0.1s) for readers to detect even brief blocking,
+# and a long timeout (5s) for the large operations themselves.
+#
+# Run this with: rails runner scripts/stress_redis.rb
 
 require "benchmark"
 
-LARGE_VALUE_SIZE = 1000 * 1024 * 1024 # 100 MB
+LARGE_VALUE_SIZE = 100 * 1024 * 1024 # 100 MB
 REDIS_KEY_BIG = "test:big_file"
 REDIS_KEY_SMALL = "test:ping"
 NUM_READERS = 5
 READ_INTERVAL = 0.1 # seconds between read attempts
+
+REDIS_URL = Rails.configuration.x.redis_url
+READER_TIMEOUT = 0.1   # short timeout to detect blocking
+WRITER_TIMEOUT = 30     # long timeout for large operations
+
+def new_redis(timeout:)
+  Redis.new(url: REDIS_URL, timeout: timeout, ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })
+end
 
 # Prepare the large value in memory first (so we only measure Redis time)
 large_value = "x" * LARGE_VALUE_SIZE
 puts "Prepared #{LARGE_VALUE_SIZE / 1024 / 1024} MB value in memory"
 
 # Pre-set a small key so readers have something to GET
-Redis.with_connection { |r| r.set(REDIS_KEY_SMALL, "pong") }
+new_redis(timeout: WRITER_TIMEOUT).set(REDIS_KEY_SMALL, "pong")
 
 # Track reader results
 reader_results = Concurrent::Array.new
 stop_readers = Concurrent::AtomicBoolean.new(false)
 
-# Launch reader threads that continuously try to read from Redis
+# Launch reader threads that continuously try to read from Redis with a short timeout
 reader_futures = NUM_READERS.times.map do |i|
   Concurrent::Future.execute do
+    reader = new_redis(timeout: READER_TIMEOUT)
     while !stop_readers.true?
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       begin
-        Redis.with_connection { |r| r.get(REDIS_KEY_SMALL) }
+        reader.get(REDIS_KEY_SMALL)
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
         reader_results << { reader: i, elapsed: elapsed.round(4), error: nil }
       rescue => e
@@ -41,6 +51,7 @@ reader_futures = NUM_READERS.times.map do |i|
       end
       sleep READ_INTERVAL
     end
+    reader.close
   end
 end
 
@@ -49,8 +60,9 @@ sleep 0.5
 
 # Now write the large value and measure how long it takes
 puts "Writing #{LARGE_VALUE_SIZE / 1024 / 1024} MB to Redis..."
+writer = new_redis(timeout: WRITER_TIMEOUT)
 write_time = Benchmark.realtime do
-  Redis.with_connection { |r| r.set(REDIS_KEY_BIG, large_value) }
+  writer.set(REDIS_KEY_BIG, large_value)
 end
 puts "Write completed in #{write_time.round(3)}s"
 
@@ -59,23 +71,66 @@ sleep 1
 stop_readers.make_true
 reader_futures.each(&:value)
 
-# Cleanup
-Redis.with_connection do |r|
-  r.del(REDIS_KEY_BIG)
-  r.del(REDIS_KEY_SMALL)
+def report(label, results, duration)
+  errors = results.select { _1[:error] }
+  slow_reads = results.select { _1[:elapsed] > READER_TIMEOUT }
+  max_read = results.max_by { _1[:elapsed] }
+
+  puts "\n--- #{label} ---"
+  puts "Duration: #{duration.round(3)}s"
+  puts "Total read attempts: #{results.size}"
+  puts "Errors: #{errors.size}"
+  errors.each { puts "  #{_1}" }
+  puts "Reads > #{READER_TIMEOUT}s: #{slow_reads.size}"
+  slow_reads.each { puts "  reader=#{_1[:reader]} elapsed=#{_1[:elapsed]}s" }
+  puts "Slowest read: reader=#{max_read[:reader]} elapsed=#{max_read[:elapsed]}s #{max_read[:error]}" if max_read
 end
 
-# Report
-puts "\n--- Results ---"
-puts "Write time: #{write_time.round(3)}s"
+write_reader_results = reader_results
+report("Phase 1: SET #{LARGE_VALUE_SIZE / 1024 / 1024} MB", write_reader_results, write_time)
 
-errors = reader_results.select { _1[:error] }
-slow_reads = reader_results.select { _1[:elapsed] > 1.0 }
-max_read = reader_results.max_by { _1[:elapsed] }
+# --- Phase 2: GET the large value while readers are active ---
+read_reader_results = Concurrent::Array.new
+stop_readers = Concurrent::AtomicBoolean.new(false)
 
-puts "Total read attempts: #{reader_results.size}"
-puts "Errors: #{errors.size}"
-errors.each { puts "  #{_1}" }
-puts "Reads > 1s: #{slow_reads.size}"
-slow_reads.each { puts "  reader=#{_1[:reader]} elapsed=#{_1[:elapsed]}s" }
-puts "Slowest read: reader=#{max_read[:reader]} elapsed=#{max_read[:elapsed]}s #{max_read[:error]}" if max_read
+reader_futures = NUM_READERS.times.map do |i|
+  Concurrent::Future.execute do
+    reader = new_redis(timeout: READER_TIMEOUT)
+    while !stop_readers.true?
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      begin
+        reader.get(REDIS_KEY_SMALL)
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+        read_reader_results << { reader: i, elapsed: elapsed.round(4), error: nil }
+      rescue => e
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+        read_reader_results << { reader: i, elapsed: elapsed.round(4), error: "#{e.class}: #{e.message}" }
+      end
+      sleep READ_INTERVAL
+    end
+    reader.close
+  end
+end
+
+sleep 0.5
+
+puts "\nReading #{LARGE_VALUE_SIZE / 1024 / 1024} MB from Redis..."
+reader_big = new_redis(timeout: WRITER_TIMEOUT)
+read_time = Benchmark.realtime do
+  reader_big.get(REDIS_KEY_BIG)
+end
+puts "Read completed in #{read_time.round(3)}s"
+
+sleep 1
+stop_readers.make_true
+reader_futures.each(&:value)
+
+report("Phase 2: GET #{LARGE_VALUE_SIZE / 1024 / 1024} MB", read_reader_results, read_time)
+
+# Cleanup
+cleanup = new_redis(timeout: WRITER_TIMEOUT)
+cleanup.del(REDIS_KEY_BIG)
+cleanup.del(REDIS_KEY_SMALL)
+cleanup.close
+writer.close
+reader_big.close

--- a/scripts/stress_redis.rb
+++ b/scripts/stress_redis.rb
@@ -1,0 +1,81 @@
+# Test: Does a large Redis SET block other clients enough to cause timeouts?
+#
+# Hypothesis: Redis is single-threaded, so writing a ~100MB value blocks all
+# other commands until the write is fully received and processed.
+# If the write takes longer than REDIS_TIMEOUT (5s), concurrent readers will
+# get Redis::CannotConnectError / timeout errors.
+#
+# Run this in a Rails console connected to production Redis (or a similar setup).
+
+require "benchmark"
+
+LARGE_VALUE_SIZE = 1000 * 1024 * 1024 # 100 MB
+REDIS_KEY_BIG = "test:big_file"
+REDIS_KEY_SMALL = "test:ping"
+NUM_READERS = 5
+READ_INTERVAL = 0.1 # seconds between read attempts
+
+# Prepare the large value in memory first (so we only measure Redis time)
+large_value = "x" * LARGE_VALUE_SIZE
+puts "Prepared #{LARGE_VALUE_SIZE / 1024 / 1024} MB value in memory"
+
+# Pre-set a small key so readers have something to GET
+Redis.with_connection { |r| r.set(REDIS_KEY_SMALL, "pong") }
+
+# Track reader results
+reader_results = Concurrent::Array.new
+stop_readers = Concurrent::AtomicBoolean.new(false)
+
+# Launch reader threads that continuously try to read from Redis
+reader_futures = NUM_READERS.times.map do |i|
+  Concurrent::Future.execute do
+    while !stop_readers.true?
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      begin
+        Redis.with_connection { |r| r.get(REDIS_KEY_SMALL) }
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+        reader_results << { reader: i, elapsed: elapsed.round(4), error: nil }
+      rescue => e
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+        reader_results << { reader: i, elapsed: elapsed.round(4), error: "#{e.class}: #{e.message}" }
+      end
+      sleep READ_INTERVAL
+    end
+  end
+end
+
+# Give readers a moment to start
+sleep 0.5
+
+# Now write the large value and measure how long it takes
+puts "Writing #{LARGE_VALUE_SIZE / 1024 / 1024} MB to Redis..."
+write_time = Benchmark.realtime do
+  Redis.with_connection { |r| r.set(REDIS_KEY_BIG, large_value) }
+end
+puts "Write completed in #{write_time.round(3)}s"
+
+# Let readers run a bit more after the write
+sleep 1
+stop_readers.make_true
+reader_futures.each(&:value)
+
+# Cleanup
+Redis.with_connection do |r|
+  r.del(REDIS_KEY_BIG)
+  r.del(REDIS_KEY_SMALL)
+end
+
+# Report
+puts "\n--- Results ---"
+puts "Write time: #{write_time.round(3)}s"
+
+errors = reader_results.select { _1[:error] }
+slow_reads = reader_results.select { _1[:elapsed] > 1.0 }
+max_read = reader_results.max_by { _1[:elapsed] }
+
+puts "Total read attempts: #{reader_results.size}"
+puts "Errors: #{errors.size}"
+errors.each { puts "  #{_1}" }
+puts "Reads > 1s: #{slow_reads.size}"
+slow_reads.each { puts "  reader=#{_1[:reader]} elapsed=#{_1[:elapsed]}s" }
+puts "Slowest read: reader=#{max_read[:reader]} elapsed=#{max_read[:elapsed]}s #{max_read[:error]}" if max_read


### PR DESCRIPTION
Note : le code de cette PR ainsi que sa description on été rédigés par Claude puis édité par moi-même.

## Contexte

Depuis le 28 janvier à 20h10, nous observons cette erreur en production :

> Connection timed out - user specified timeout (rediss://production-rdv-mairie-3091.redis.a.osc-secnum-fr1.scalingo-dbs.com:30200) (Redis::CannotConnectError)

https://sentry.incubateur.net/organizations/betagouv/issues/241531

Nous avons eu 127 occurrences en 2 semaines.

<img width="2056" height="505" alt="image" src="https://github.com/user-attachments/assets/14c8643b-912e-4939-bcd1-20acb8f4b0b2" />


Les timeouts sont actuellement configurés à 5 secondes, ce qui semble assez généreux.

```ruby
  REDIS_TIMEOUT = 5 # timeout for each individual connection, see https://github.com/redis/redis-rb?tab=readme-ov-file#timeouts
```

https://github.com/redis/redis-rb?tab=readme-ov-file#timeouts

Les deux instances de l'application (avec des serveurs Redis séparés) sont touchées. L'instance historique a actuellement une RAM Redis élevée, la nouvelle non.

## Investigation

### Analyse du code déployé autour du 28 janvier

Aucun commit déployé ce jour-là ne touche à Redis, sa configuration, ou ses gems :
- `e45f0825` — Suppression du feature flag Caldav (impact négligeable, peu d'utilisateurs)
- `53bdd2e0` — Tri des demandes d'ouverture de compte (changement UI uniquement)

### Hypothèse 1 : Épuisement du pool de connexions Redis

Testée en saturant le pool (4 connexions occupées pendant 6s avec un timeout de 5s).
Résultat : l'erreur obtenue est `ConnectionPool::TimeoutError`, **pas** `Redis::CannotConnectError`. Ce n'est donc pas la cause.

### Hypothèse 2 : Le rollout Caldav surcharge Redis

Le feature flag Caldav a été retiré le 28 janvier, mais seulement quelques agents utilisent cette fonctionnalité. Impact négligeable sur la charge Redis.

### Hypothèse 3 : Redis bloqué par une opération volumineuse (nature single-threaded)

Redis est single-threaded : 

> Redis executes commands on a single main thread, but uses threads for networking, disk persistence, and memory cleanup.

Une opération volumineuse (SET ou GET d'une grosse valeur) bloque toutes les autres commandes le temps de son exécution.

Le script `scripts/stress_redis.rb` teste cette hypothèse en lançant des lecteurs concurrents (timeout 0.1s) pendant qu'une opération volumineuse est en cours (SET puis GET de 100 MB).

**Résultats sur un Redis distant (review app Scalingo avec un Redis exceptionnellement ouvert sur Internet) :**

- **Phase 1 (SET 100 MB)** : écriture en ~16s, aucun impact sur les lecteurs (le temps est dominé par le transfert réseau, Redis reste réactif pendant la réception des données)
- **Phase 2 (GET 100 MB)** : nous avons pu reproduire l'erreur de production `Connection timed out - user specified timeout (Redis::CannotConnectError)` sur les lecteurs concurrents

### Conclusion

L'erreur de production peut être reproduite lorsqu'un GET d'une valeur volumineuse est en cours. Nous avons dû pour ça réduire le timeout des lectures de 5 à 0.1 secondes, ce qui est assez extrême.

Le suspect principal est `RedisFileStorable#load_file`, utilisé par les exports (`RdvsExportSendEmailJob` / `ParticipationsExportSendEmailJob`), qui stocke et relit des fichiers XLS compressés dans Redis.

## Script de stress test

Le script `scripts/stress_redis.rb` peut être exécuté via `rails runner` sur la review app Scalingo pour reproduire le problème.