### PR TITLE
Stocker les exports dans Postgres plutôt que Redis

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -161,6 +161,12 @@ class CronJob < ApplicationJob
     end
   end
 
+  class DestroyExpiredExportFileBlobs < CronJob
+    def perform
+      ExportFileBlob.joins(:export).where(exports: { expires_at: ..Time.zone.now }).delete_all
+    end
+  end
+
   class DestroyRedisWaitingRoomKeys < CronJob
     def perform
       Rdv.reset_user_in_waiting_room!

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -4,10 +4,4 @@ class ExportJob < ApplicationJob
   # Les exports ne sont pas urgents, et ils sont longs à exécuter,
   # donc il est raisonnable qu'ils laissent la priorité aux autres jobs.
   queue_with_priority 10
-
-  private
-
-  def redis_key(export_id)
-    "ExportJob-#{export_id}"
-  end
 end

--- a/app/jobs/participations_export_page_job.rb
+++ b/app/jobs/participations_export_page_job.rb
@@ -1,12 +1,7 @@
 class ParticipationsExportPageJob < ExportJob
   def perform(participations_ids, page_index, export_id)
-    redis_key = redis_key(export_id)
-
     rows = ParticipationExporter.rows_from_participations(Participation.where(id: participations_ids).order(id: :desc))
 
-    Redis.with_connection do |redis|
-      redis.hset(redis_key, page_index, rows.to_json)
-      redis.expire(redis_key, 1.week)
-    end
+    ExportFileBlob.create!(export_id: export_id, page_index: page_index, data: rows.to_json)
   end
 end

--- a/app/jobs/participations_export_send_email_job.rb
+++ b/app/jobs/participations_export_send_email_job.rb
@@ -8,15 +8,11 @@ class ParticipationsExportSendEmailJob < ExportJob
 
   def perform(batch, _params)
     export = Export.find(batch.properties[:export_id])
-    redis_key = redis_key(export.id)
-
-    page_numbers = Redis.with_connection { _1.hkeys(redis_key) }.map(&:to_i).sort
+    page_blobs = export.export_file_blobs.pages.order(:page_index)
 
     rows_enum = Enumerator.new do |yielder|
-      page_numbers.each do |page_number|
-        json = Redis.with_connection { _1.hget(redis_key, page_number) }
-
-        JSON.parse(json).each do |row|
+      page_blobs.each do |blob|
+        JSON.parse(blob.data).each do |row|
           yielder << row
         end
       end
@@ -27,6 +23,8 @@ class ParticipationsExportSendEmailJob < ExportJob
       file.rewind
       export.store_file(file.read)
     end
+
+    page_blobs.delete_all
 
     Agents::ExportMailer.participations_export(export.id).deliver_later
   end

--- a/app/jobs/rdvs_export_page_job.rb
+++ b/app/jobs/rdvs_export_page_job.rb
@@ -1,12 +1,7 @@
 class RdvsExportPageJob < ExportJob
   def perform(rdv_ids, page_index, export_id)
-    redis_key = redis_key(export_id)
-
     rows = RdvExporter.rows_from_rdvs(Rdv.where(id: rdv_ids).order(starts_at: :desc))
 
-    Redis.with_connection do |redis|
-      redis.hset(redis_key, page_index, rows.to_json)
-      redis.expire(redis_key, 1.week)
-    end
+    ExportFileBlob.create!(export_id: export_id, page_index: page_index, data: rows.to_json)
   end
 end

--- a/app/jobs/rdvs_export_send_email_job.rb
+++ b/app/jobs/rdvs_export_send_email_job.rb
@@ -8,15 +8,11 @@ class RdvsExportSendEmailJob < ExportJob
 
   def perform(batch, _params)
     export = Export.find(batch.properties[:export_id])
-    redis_key = redis_key(export.id)
-
-    page_numbers = Redis.with_connection { _1.hkeys(redis_key) }.map(&:to_i).sort
+    page_blobs = export.export_file_blobs.pages.order(:page_index)
 
     rows_enum = Enumerator.new do |yielder|
-      page_numbers.each do |page_number|
-        json = Redis.with_connection { _1.hget(redis_key, page_number) }
-
-        JSON.parse(json).each do |row|
+      page_blobs.each do |blob|
+        JSON.parse(blob.data).each do |row|
           yielder << row
         end
       end
@@ -27,6 +23,8 @@ class RdvsExportSendEmailJob < ExportJob
       file.rewind
       export.store_file(file.read)
     end
+
+    page_blobs.delete_all
 
     Agents::ExportMailer.rdv_export(export.id).deliver_later
   end

--- a/app/models/concerns/redis_file_storable.rb
+++ b/app/models/concerns/redis_file_storable.rb
@@ -4,26 +4,16 @@ module RedisFileStorable
   class FileNotFoundError < StandardError; end
 
   def load_file
-    compressed_file = Redis.with_connection { _1.get(redis_file_key) }
-    raise FileNotFoundError, "Can't find file at key #{redis_file_key.inspect}" unless compressed_file
+    blob = export_file_blobs.find_by(page_index: nil)
+    raise FileNotFoundError, "Can't find file blob for Export##{id}" unless blob
 
-    Zlib.inflate(compressed_file)
+    Zlib.inflate(blob.data)
   end
 
   def store_file(content)
     transaction do
       update!(computed_at: Time.zone.now)
-      compressed_file = Zlib.deflate(content)
-      Redis.with_connection do |redis|
-        redis.set(redis_file_key, compressed_file)
-        redis.expire(redis_file_key, (expires_at - Time.zone.now).seconds.to_i)
-      end
+      export_file_blobs.create!(page_index: nil, data: Zlib.deflate(content))
     end
-  end
-
-  private
-
-  def redis_file_key
-    "Export#redis_file_key-#{id}"
   end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -15,6 +15,7 @@ class Export < ApplicationRecord
 
   # Relations
   belongs_to :agent
+  has_many :export_file_blobs, dependent: :destroy
 
   # Validations
   validates :expires_at, :file_name, presence: true

--- a/app/models/export_file_blob.rb
+++ b/app/models/export_file_blob.rb
@@ -1,0 +1,5 @@
+class ExportFileBlob < ApplicationRecord
+  belongs_to :export
+
+  scope :pages, -> { where.not(page_index: nil) }
+end

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -473,6 +473,9 @@ tables:
       - created_at
       - updated_at
 
+  - table_name: export_file_blobs
+    truncated: true
+
   - table_name: oauth_applications
     anonymized_column_names:
       - secret

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -49,6 +49,11 @@ Rails.application.configure do
       class: "CronJob::DestroyRedisWaitingRoomKeys",
     },
 
+    destroy_expired_export_file_blobs: {
+      cron: "every day at 00:15 Europe/Paris",
+      class: "CronJob::DestroyExpiredExportFileBlobs",
+    },
+
     destroy_old_rdvs_and_inactive_users_job: {
       cron: "every day at 22:00 Europe/Paris",
       class: "CronJob::DestroyOldRdvsAndInactiveAccountsJob",

--- a/db/migrate/20260213081619_create_export_file_blobs.rb
+++ b/db/migrate/20260213081619_create_export_file_blobs.rb
@@ -1,0 +1,12 @@
+class CreateExportFileBlobs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :export_file_blobs do |t|
+      t.uuid :export_id, null: false
+      t.integer :page_index
+      t.binary :data, null: false
+      t.datetime :created_at, null: false
+      t.index %i[export_id page_index]
+      t.foreign_key :exports
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_09_094348) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_13_081619) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -209,6 +209,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_09_094348) do
     t.string "categories", default: [], array: true
     t.string "external_url", null: false
     t.datetime "published_at", null: false
+  end
+
+  create_table "export_file_blobs", force: :cascade do |t|
+    t.uuid "export_id", null: false
+    t.integer "page_index"
+    t.binary "data", null: false
+    t.datetime "created_at", null: false
+    t.index ["export_id", "page_index"], name: "index_export_file_blobs_on_export_id_and_page_index"
   end
 
   create_table "exports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -864,7 +872,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_09_094348) do
     t.index ["birth_date"], name: "index_users_on_birth_date"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_through"], name: "index_users_on_created_through"
-    t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
+    t.index ["email"], name: "index_users_on_email", where: "(email IS NOT NULL)"
     t.index ["first_name"], name: "index_users_on_first_name"
     t.index ["franceconnect_openid_sub"], name: "index_users_on_franceconnect_openid_sub", where: "(franceconnect_openid_sub IS NOT NULL)"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
@@ -930,6 +938,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_09_094348) do
   add_foreign_key "annotations", "territories"
   add_foreign_key "annotations", "users"
   add_foreign_key "api_calls", "agents"
+  add_foreign_key "export_file_blobs", "exports"
   add_foreign_key "exports", "agents"
   add_foreign_key "external_calendar_events", "agents"
   add_foreign_key "external_references", "oauth_applications"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -872,7 +872,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_13_081619) do
     t.index ["birth_date"], name: "index_users_on_birth_date"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_through"], name: "index_users_on_created_through"
-    t.index ["email"], name: "index_users_on_email", where: "(email IS NOT NULL)"
+    t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
     t.index ["first_name"], name: "index_users_on_first_name"
     t.index ["franceconnect_openid_sub"], name: "index_users_on_franceconnect_openid_sub", where: "(franceconnect_openid_sub IS NOT NULL)"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true


### PR DESCRIPTION
Note : le code de cette PR ainsi que sa description on été rédigés par Claude puis corrigés par moi-même (et c'était agréable).

## Contexte

Nous avons depuis le 28 janvier des timeouts Redis (127 occurrences en 2 semaines). Nous faisons la supposition que ces timeouts pourraient être causés par le stockage des exports.

Contexte détaillé ici : #6116

## Résumé

Les fichiers d'export (pages intermédiaires et fichier final) étaient stockés dans Redis. Ce changement les déplace vers Postgres dans une nouvelle table dédiée `export_file_blobs`, ce qui évite de surcharger Redis avec des données volumineuses (à garder en RAM) et des appels longs, suspectés de causer des timeouts.

### Détail des changements

- **Nouvelle table `export_file_blobs`** : stocke les données avec `export_id`, `page_index` (pages intermédiaires) ou `page_index NULL` (fichier final assemblé), et `data` (binaire)
- **`RedisFileStorable`** : réécrit pour lire/écrire dans `export_file_blobs` au lieu de Redis
- **Jobs de pages** (`RdvsExportPageJob`, `ParticipationsExportPageJob`) : `INSERT` Postgres au lieu de `HSET` Redis
- **Jobs d'envoi d'email** (`RdvsExportSendEmailJob`, `ParticipationsExportSendEmailJob`) : lecture depuis Postgres, puis nettoyage des pages intermédiaires après assemblage du fichier final
- **`ExportJob`** : suppression du helper `redis_key` devenu inutile
- **Cron `DestroyExpiredExportFileBlobs`** : nettoyage quotidien à 00h15 des blobs associés aux exports expirés à minuit

### Performance

Testé en local avec un export de 8 000 RDV : chaque écriture de page prend ~2ms, et l'écriture finale du fichier assemblé prend aussi ~2ms.