### PR TITLE
Refacto UserRdvWizard

### DIFF
--- a/app/controllers/concerns/can_have_rdv_wizard_context.rb
+++ b/app/controllers/concerns/can_have_rdv_wizard_context.rb
@@ -13,7 +13,7 @@ module CanHaveRdvWizardContext
 
     parsed_params = Rack::Utils.parse_nested_query(parsed_uri.query).to_h.symbolize_keys
     Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: "parsed_params", data: { parsed_params:, ip: request.remote_ip }))
-    rdv_wizard = UserRdvWizard::Step1.new(nil, parsed_params)
+    rdv_wizard = UserRdvWizard.new(nil, parsed_params)
     # L'usager doit être connecté afin de voir les créneaux pour un motif de Follow Up
     return if rdv_wizard.motif&.follow_up?
 

--- a/app/controllers/concerns/can_have_rdv_wizard_context.rb
+++ b/app/controllers/concerns/can_have_rdv_wizard_context.rb
@@ -13,7 +13,7 @@ module CanHaveRdvWizardContext
 
     parsed_params = Rack::Utils.parse_nested_query(parsed_uri.query).to_h.symbolize_keys
     Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: "parsed_params", data: { parsed_params:, ip: request.remote_ip }))
-    rdv_wizard = UserRdvWizard.new(nil, parsed_params)
+    rdv_wizard = Users::RdvBuilder.new(nil, parsed_params)
     # L'usager doit être connecté afin de voir les créneaux pour un motif de Follow Up
     return if rdv_wizard.motif&.follow_up?
 

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -27,12 +27,12 @@ class Users::RdvWizardStepsController < UserAuthController
   end
 
   def create
-    @rdv_wizard = UserRdvWizard.new(current_user, rdv_params.merge(user_params))
+    @rdv_wizard = UserRdvWizard.new(current_user, rdv_params)
     @rdv = @rdv_wizard.rdv
-    @rdv_booking_form = Users::RdvBookingForm.new(user: current_user, rdv_wizard: @rdv_wizard, domain: current_domain)
+    @rdv_booking_form = Users::RdvBookingForm.new(user: current_user, rdv_wizard: @rdv_wizard, domain: current_domain, user_attributes: user_params[:user].to_h.symbolize_keys)
     skip_authorization
-    success = @rdv_wizard.valid? && @rdv_wizard.user.benign_errors.blank?
-    success &&= @rdv_wizard.save if current_step[:name] == "step1"
+    success = @rdv_booking_form.valid? && @rdv_booking_form.user.benign_errors.blank?
+    success &&= @rdv_booking_form.save if current_step[:name] == "step1"
     if success
       redirect_to new_users_rdv_wizard_step_path(@rdv_wizard.to_query.merge(step: next_step[:number]))
     else

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -31,7 +31,9 @@ class Users::RdvWizardStepsController < UserAuthController
     @rdv = @rdv_wizard.rdv
     @rdv_booking_form = Users::RdvBookingForm.new(user: current_user, rdv_wizard: @rdv_wizard, domain: current_domain)
     skip_authorization
-    if @rdv_wizard.valid? && @rdv_wizard.user.benign_errors.blank? && @rdv_wizard.save
+    success = @rdv_wizard.valid? && @rdv_wizard.user.benign_errors.blank?
+    success &&= @rdv_wizard.save if current_step[:name] == "step1"
+    if success
       redirect_to new_users_rdv_wizard_step_path(@rdv_wizard.to_query.merge(step: next_step[:number]))
     else
       render current_step[:name], locals: { current_step:, max_step: steps.size, next_step: }

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -14,7 +14,7 @@ class Users::RdvWizardStepsController < UserAuthController
   include TokenInvitable
 
   def new
-    @rdv_wizard = UserRdvWizard.new(current_user, query_params)
+    @rdv_wizard = Users::RdvBuilder.new(current_user, query_params)
     @rdv = @rdv_wizard.rdv
     @rdv_booking_form = Users::RdvBookingForm.new(user: current_user, rdv_wizard: @rdv_wizard, domain: current_domain)
     authorize(@rdv, policy_class: User::RdvPolicy)
@@ -27,7 +27,7 @@ class Users::RdvWizardStepsController < UserAuthController
   end
 
   def create
-    @rdv_wizard = UserRdvWizard.new(current_user, rdv_params)
+    @rdv_wizard = Users::RdvBuilder.new(current_user, rdv_params)
     @rdv = @rdv_wizard.rdv
     @rdv_booking_form = Users::RdvBookingForm.new(user: current_user, rdv_wizard: @rdv_wizard, domain: current_domain, user_attributes: user_params[:user].to_h.symbolize_keys)
     skip_authorization

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -9,6 +9,8 @@ class Users::RdvWizardStepsController < UserAuthController
     { organisation_ids: [], referent_ids: [], external_organisation_ids: [] },
   ].freeze
 
+  before_action :set_skip_proches_step
+
   include TokenInvitable
 
   def new
@@ -38,13 +40,20 @@ class Users::RdvWizardStepsController < UserAuthController
 
   protected
 
+  # L'étape 2 propose de prendre rendez-vous pour un proche
+  # Dans le cas d'une invitation, c'est l'usager qui est invité, donc on saute cette étape
+  # Si l'usager est un professionnel connecté via ProConnect, on ne lui propose pas non plus de prendre rendez-vous pour un proche
+  def set_skip_proches_step
+    @skip_proches_step = current_user.signed_in_with_invitation_token? || current_user.pro_connect_openid_sub
+  end
+
   def steps
     steps = {
       step1: {
         name: "step1",
         number: 1,
         title: "Vos informations",
-        next_step: UserRdvWizard::Base.skip_proches_step?(current_user) ? :step3 : :step2,
+        next_step: @skip_proches_step ? :step3 : :step2,
         stepper_index: 1,
       },
       step2: {
@@ -58,11 +67,11 @@ class Users::RdvWizardStepsController < UserAuthController
         name: "step3",
         number: 3,
         title: "Confirmation",
-        stepper_index: UserRdvWizard::Base.skip_proches_step?(current_user) ? 2 : 3,
+        stepper_index: @skip_proches_step ? 2 : 3,
       },
     }
 
-    steps.delete(:step2) if UserRdvWizard::Base.skip_proches_step?(current_user)
+    steps.delete(:step2) if @skip_proches_step
 
     steps
   end

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -99,7 +99,9 @@ class Users::RdvWizardStepsController < UserAuthController
   end
 
   def query_params
-    params.permit(*RDV_PERMITTED_PARAMS, *EXTRA_PERMITTED_PARAMS)
+    result = params.permit(*RDV_PERMITTED_PARAMS, *EXTRA_PERMITTED_PARAMS)
+    result[:user_ids] = [result[:created_user_id]] if result[:created_user_id].present?
+    result
   end
 
   def user_params

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -14,7 +14,7 @@ class Users::RdvWizardStepsController < UserAuthController
   include TokenInvitable
 
   def new
-    @rdv_wizard = rdv_wizard_for(current_user, query_params)
+    @rdv_wizard = UserRdvWizard.new(current_user, query_params)
     @rdv = @rdv_wizard.rdv
     @rdv_booking_form = Users::RdvBookingForm.new(user: current_user, rdv_wizard: @rdv_wizard, domain: current_domain)
     authorize(@rdv, policy_class: User::RdvPolicy)
@@ -27,7 +27,7 @@ class Users::RdvWizardStepsController < UserAuthController
   end
 
   def create
-    @rdv_wizard = rdv_wizard_for(current_user, rdv_params.merge(user_params))
+    @rdv_wizard = UserRdvWizard.new(current_user, rdv_params.merge(user_params))
     @rdv = @rdv_wizard.rdv
     @rdv_booking_form = Users::RdvBookingForm.new(user: current_user, rdv_wizard: @rdv_wizard, domain: current_domain)
     skip_authorization
@@ -89,11 +89,6 @@ class Users::RdvWizardStepsController < UserAuthController
 
   def next_step
     steps[current_step[:next_step]]
-  end
-
-  def rdv_wizard_for(current_user, request_params)
-    klass = "UserRdvWizard::#{current_step[:name].camelize}".constantize
-    klass.new(current_user, request_params)
   end
 
   def rdv_params

--- a/app/form_models/concerns/rdv_builder_concern.rb
+++ b/app/form_models/concerns/rdv_builder_concern.rb
@@ -1,0 +1,92 @@
+# Utilisé par UserRdvWizard et PrescripteurRdvWizard
+module RdvBuilderConcern
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :rdv
+
+    delegate :motif, :starts_at, :service, to: :rdv
+  end
+
+  def build_rdv_from_attributes(attributes)
+    @attributes = attributes.to_h.symbolize_keys
+
+    if @attributes[:rdv_collectif_id].present?
+      @rdv = Rdv.collectif.bookable_by_everyone_or_agents_and_prescripteurs_or_invited_users.find(@attributes[:rdv_collectif_id])
+    else
+      @rdv = Rdv.new({
+        user_ids: [@user&.id],
+      }.merge(@attributes.slice(:starts_at, :user_ids, :motif_id)))
+      @rdv.duration_in_min = duration_in_min
+      @rdv.organisation_id = @rdv.motif.organisation_id
+    end
+  end
+
+  def creneau
+    # La validation de ce paramètre ANTS est faite ici pour simplifier la gestion des cas problématiques
+    # qui peuvent se produire aux étapes de prise de RDV pré sign-in et post-sign-in. Les autres params
+    # sont très peu validés. Le cas d’erreur principal qui peut se produire est qu’aucun créneau ne soit
+    # trouvé pour les params passés. On s’appuie donc sur ce cas pour gérer l’erreur de validation ANTS
+    return nil if ants_pre_demandes_count.present? && !AntsPreDemandesCountValidator.count_valid?(ants_pre_demandes_count)
+
+    @creneau ||= CreneauxSearch::ForUser.creneau_for(
+      user: @user,
+      motif: motif,
+      lieu: lieu,
+      starts_at: @rdv.starts_at,
+      geo_search: geo_search,
+      duration_in_min:
+    )
+  end
+
+  def geo_search
+    @geo_search ||= Users::GeoSearch.new(**@attributes.slice(:departement, :city_code, :street_ban_id))
+  end
+
+  def to_query
+    {
+      motif_id: rdv.motif.id, starts_at: rdv.starts_at.to_s, user_ids: users&.map(&:id), rdv_collectif_id: rdv.id,
+    }.merge(
+      @attributes.slice(
+        *WebSearchContext::ADDRESS_SELECTION_PARAMS,
+        :where, :lieu_id, :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id,
+        :referent_ids, :external_organisation_ids, :duration, :ants_pre_demandes_count
+      )
+    )
+  end
+
+  def params_to_selections
+    if @rdv.present?
+      return @attributes.merge(service: @rdv.motif.service_id, motif_name_with_location_type: @rdv.motif.name_with_location_type)
+    end
+
+    @attributes
+  end
+
+  def lieu_id = @attributes[:lieu_id]
+  def ants_pre_demandes_count = @attributes[:ants_pre_demandes_count].presence&.to_i
+
+  def duration_in_min
+    if @attributes[:duration]
+      @attributes[:duration].to_i
+    elsif @attributes[:ants_pre_demandes_count].present?
+      motif.default_duration_in_min * @attributes[:ants_pre_demandes_count].to_i
+    else
+      motif.default_duration_in_min
+    end
+  end
+
+  def users
+    if @rdv.collectif?
+      return [] unless @user
+
+      @user.available_users_for_rdv.where(id: @attributes[:user_ids]).presence || [@user]
+    else
+      @rdv.users.presence || [@user].compact
+    end
+  end
+
+  def lieu
+    @lieu ||= lieu_id.present? ? Lieu.find(lieu_id) : nil
+  end
+end

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -1,12 +1,14 @@
 class PrescripteurRdvWizard
   include ActiveModel::Model
-  include RdvBuilderConcern
 
+  attr_reader :rdv_builder
   attr_accessor :prescripteur
+
+  delegate :motif, :starts_at, :service, :rdv, :creneau, :to_query, :lieu_id, :ants_pre_demandes_count, to: :rdv_builder
 
   def initialize(attributes, domain)
     attributes = attributes.deep_symbolize_keys
-    build_rdv_from_attributes(attributes)
+    @rdv_builder = Users::RdvBuilder.new(nil, attributes)
     @prescripteur = Prescripteur.new(attributes[:prescripteur]) if attributes[:prescripteur].present?
     @user_attributes = attributes[:user]
     @domain = domain
@@ -17,7 +19,7 @@ class PrescripteurRdvWizard
     ActiveRecord::Base.transaction do
       find_or_create_user
 
-      if @rdv.collectif?
+      if rdv.collectif?
         create_participation!
       else
         create_rdv!
@@ -28,7 +30,7 @@ class PrescripteurRdvWizard
   end
 
   def params_to_selections
-    super.merge(prescripteur: 1)
+    rdv_builder.params_to_selections.merge(prescripteur: 1)
   end
 
   private
@@ -36,7 +38,7 @@ class PrescripteurRdvWizard
   def create_rdv!
     rdv.assign_attributes(
       created_by: @prescripteur,
-      lieu: lieu,
+      lieu: rdv_builder.lieu,
       organisation: motif.organisation,
       agents: [creneau.agent],
       participations: [participation]
@@ -51,7 +53,7 @@ class PrescripteurRdvWizard
   end
 
   def participation
-    @participation ||= Participation.new(rdv: @rdv, user: @user, created_by: @prescripteur)
+    @participation ||= Participation.new(rdv: rdv, user: @user, created_by: @prescripteur)
   end
 
   def find_or_create_user

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -1,4 +1,4 @@
-class PrescripteurRdvWizard < UserRdvWizard::Base
+class PrescripteurRdvWizard < UserRdvWizard
   attr_accessor :prescripteur
 
   def initialize(attributes, domain)

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -1,16 +1,19 @@
-class PrescripteurRdvWizard < UserRdvWizard
+class PrescripteurRdvWizard
+  include ActiveModel::Model
+  include RdvBuilderConcern
+
   attr_accessor :prescripteur
 
   def initialize(attributes, domain)
     attributes = attributes.deep_symbolize_keys
-    super(nil, attributes)
+    build_rdv_from_attributes(attributes)
     @prescripteur = Prescripteur.new(attributes[:prescripteur]) if attributes[:prescripteur].present?
     @user_attributes = attributes[:user]
     @domain = domain
   end
 
   def create!
-    creneau # On précharge le créneau en dehors de la transaction pour éviter les erreurs  ActiveRecord::AsynchronousQueryInsideTransactionError lors des requêtes asynchrones
+    creneau # On précharge le créneau en dehors de la transaction pour éviter les erreurs ActiveRecord::AsynchronousQueryInsideTransactionError lors des requêtes asynchrones
     ActiveRecord::Base.transaction do
       find_or_create_user
 

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -1,8 +1,0 @@
-class UserRdvWizard
-  include RdvBuilderConcern
-
-  def initialize(user, attributes)
-    @user = user
-    build_rdv_from_attributes(attributes)
-  end
-end

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -1,140 +1,123 @@
-module UserRdvWizard
-  # cf https://medium.com/@nicolasblanco/developing-a-wizard-or-multi-steps-forms-in-rails-d2f3b7c692ce
+class UserRdvWizard
+  include ActiveModel::Model
 
-  class Base
-    include ActiveModel::Model
+  attr_accessor :rdv, :user
 
-    attr_accessor :rdv, :user
+  delegate :motif, :starts_at, :service, to: :rdv
+  delegate :errors, to: :user
 
-    delegate :motif, :starts_at, :service, to: :rdv
+  validate :phone_number_present_for_motif_by_phone
 
-    def initialize(user, attributes)
-      @user = user
-      @attributes = attributes.to_h.symbolize_keys
-      if attributes[:rdv_collectif_id].present?
-        @rdv = Rdv.collectif.bookable_by_everyone_or_agents_and_prescripteurs_or_invited_users.find(attributes[:rdv_collectif_id])
-      else
-        @rdv = Rdv.new({
-          user_ids: [user&.id],
-        }.merge(@attributes.slice(:starts_at, :user_ids, :motif_id)))
-        @rdv.duration_in_min = duration_in_min
-        @rdv.organisation_id = @rdv.motif.organisation_id
-      end
+  def initialize(user, attributes)
+    @user = user
+    @attributes = attributes.to_h.symbolize_keys
+
+    if attributes[:rdv_collectif_id].present?
+      @rdv = Rdv.collectif.bookable_by_everyone_or_agents_and_prescripteurs_or_invited_users.find(attributes[:rdv_collectif_id])
+    else
+      @rdv = Rdv.new({
+        user_ids: [user&.id],
+      }.merge(@attributes.slice(:starts_at, :user_ids, :motif_id)))
+      @rdv.duration_in_min = duration_in_min
+      @rdv.organisation_id = @rdv.motif.organisation_id
     end
 
-    def params_to_selections
-      if @rdv.present?
-        return @attributes.merge(service: @rdv.motif.service_id, motif_name_with_location_type: @rdv.motif.name_with_location_type)
-      end
+    @user&.assign_attributes(@attributes.fetch(:user, {}))
+  end
 
-      @attributes
+  def params_to_selections
+    if @rdv.present?
+      return @attributes.merge(service: @rdv.motif.service_id, motif_name_with_location_type: @rdv.motif.name_with_location_type)
     end
 
-    def creneau
-      # La validation de ce paramètre ANTS est faite ici pour simplifier la gestion des cas problématiques
-      # qui peuvent se produire aux étapes de prise de RDV pré sign-in et post-sign-in. Les autres params
-      # sont très peu validés. Le cas d’erreur principal qui peut se produire est qu’aucun créneau ne soit
-      # trouvé pour les params passés. On s’appuie donc sur ce cas pour gérer l’erreur de validation ANTS
-      return nil if ants_pre_demandes_count.present? && !AntsPreDemandesCountValidator.count_valid?(ants_pre_demandes_count)
+    @attributes
+  end
 
-      @creneau ||= CreneauxSearch::ForUser.creneau_for(
-        user: @user,
-        motif: motif,
-        lieu: lieu,
-        starts_at: @rdv.starts_at,
-        geo_search: geo_search,
-        duration_in_min:
+  def creneau
+    # La validation de ce paramètre ANTS est faite ici pour simplifier la gestion des cas problématiques
+    # qui peuvent se produire aux étapes de prise de RDV pré sign-in et post-sign-in. Les autres params
+    # sont très peu validés. Le cas d’erreur principal qui peut se produire est qu’aucun créneau ne soit
+    # trouvé pour les params passés. On s’appuie donc sur ce cas pour gérer l’erreur de validation ANTS
+    return nil if ants_pre_demandes_count.present? && !AntsPreDemandesCountValidator.count_valid?(ants_pre_demandes_count)
+
+    @creneau ||= CreneauxSearch::ForUser.creneau_for(
+      user: @user,
+      motif: motif,
+      lieu: lieu,
+      starts_at: @rdv.starts_at,
+      geo_search: geo_search,
+      duration_in_min:
+    )
+  end
+
+  def geo_search
+    @geo_search ||= Users::GeoSearch.new(**@attributes.slice(:departement, :city_code, :street_ban_id))
+  end
+
+  def to_query
+    {
+      motif_id: rdv.motif.id, starts_at: rdv.starts_at.to_s, user_ids: users&.map(&:id), rdv_collectif_id: rdv.id,
+    }.merge(
+      @attributes.slice(
+        *WebSearchContext::ADDRESS_SELECTION_PARAMS,
+        :where, :lieu_id, :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id,
+        :referent_ids, :external_organisation_ids, :duration, :ants_pre_demandes_count
       )
+    )
+  end
+
+  def save
+    # we make sure the email can be updated only if it is blank
+    @user.skip_reconfirmation! if @user.email_was.blank?
+
+    # dans la vue on appelle form_for(user) plutôt que form_for(user_rdv_wizard),
+    # il faut donc ajouter des validations (et des erreurs) sur l'objet user
+    if rdv.requires_ants_predemande_number?
+      @user.singleton_class.include(User::AntsPreDemandeNumberStatusValidationConcern)
+      @user.ants_meeting_point_id = lieu_id # used in AntsPreDemandeNumberStatusValidation
     end
 
-    def geo_search
-      @geo_search ||= Users::GeoSearch.new(**@attributes.slice(:departement, :city_code, :street_ban_id))
-    end
+    valid? && @user.save
+  end
 
-    def to_query
-      {
-        motif_id: rdv.motif.id, starts_at: rdv.starts_at.to_s, user_ids: users&.map(&:id), rdv_collectif_id: rdv.id,
-      }.merge(
-        @attributes.slice(
-          *WebSearchContext::ADDRESS_SELECTION_PARAMS,
-          :where, :lieu_id, :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id,
-          :referent_ids, :external_organisation_ids, :duration, :ants_pre_demandes_count
-        )
-      )
-    end
+  def lieu_id = @attributes[:lieu_id]
+  def ants_pre_demandes_count = @attributes[:ants_pre_demandes_count].presence&.to_i
 
-    def save
-      true
-    end
-
-    def lieu_id = @attributes[:lieu_id]
-    def ants_pre_demandes_count = @attributes[:ants_pre_demandes_count].presence&.to_i
-
-    def duration_in_min
-      if @attributes[:duration]
-        @attributes[:duration].to_i
-      elsif @attributes[:ants_pre_demandes_count].present?
-        motif.default_duration_in_min * @attributes[:ants_pre_demandes_count].to_i
-      else
-        motif.default_duration_in_min
-      end
-    end
-
-    def users
-      if @rdv.collectif?
-        return [] unless @user
-
-        @user.available_users_for_rdv.where(id: @attributes[:user_ids]).presence || [@user]
-      else
-        @rdv.users.presence || [@user].compact
-      end
-    end
-
-    def display_france_connect?
-      motif.organisation.online_booking_for_particuliers
-    end
-
-    def display_pro_connect?
-      motif.organisation.online_booking_for_professionnels
-    end
-
-    private
-
-    def lieu
-      @lieu ||= lieu_id.present? ? Lieu.find(lieu_id) : nil
+  def duration_in_min
+    if @attributes[:duration]
+      @attributes[:duration].to_i
+    elsif @attributes[:ants_pre_demandes_count].present?
+      motif.default_duration_in_min * @attributes[:ants_pre_demandes_count].to_i
+    else
+      motif.default_duration_in_min
     end
   end
 
-  class Step1 < Base
-    delegate :errors, to: :user
+  def users
+    if @rdv.collectif?
+      return [] unless @user
 
-    validate :phone_number_present_for_motif_by_phone
-
-    def phone_number_present_for_motif_by_phone
-      errors.add(:phone_number, :missing_for_phone_motif) if rdv.motif.phone? && user.phone_number.blank?
-    end
-
-    def initialize(user, attributes)
-      super
-      @user&.assign_attributes(@attributes.fetch(:user, {}))
-    end
-
-    def save
-      # we make sure the email can be updated only if it is blank
-      @user.skip_reconfirmation! if @user.email_was.blank?
-
-      # dans la vue on appelle form_for(user) plutôt que form_for(user_rdv_wizard),
-      # il faut donc ajouter des validations (et des erreurs) sur l'objet user
-      if rdv.requires_ants_predemande_number?
-        @user.singleton_class.include(User::AntsPreDemandeNumberStatusValidationConcern)
-        @user.ants_meeting_point_id = lieu_id # used in AntsPreDemandeNumberStatusValidation
-      end
-
-      valid? && @user.save
+      @user.available_users_for_rdv.where(id: @attributes[:user_ids]).presence || [@user]
+    else
+      @rdv.users.presence || [@user].compact
     end
   end
 
-  class Step2 < Base; end
+  def display_france_connect?
+    motif.organisation.online_booking_for_particuliers
+  end
 
-  class Step3 < Base; end
+  def display_pro_connect?
+    motif.organisation.online_booking_for_professionnels
+  end
+
+  private
+
+  def lieu
+    @lieu ||= lieu_id.present? ? Lieu.find(lieu_id) : nil
+  end
+
+  def phone_number_present_for_motif_by_phone
+    errors.add(:phone_number, :missing_for_phone_motif) if rdv.motif.phone? && user.phone_number.blank?
+  end
 end

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -134,15 +134,7 @@ module UserRdvWizard
     end
   end
 
-  class Step2 < Base
-    def initialize(user, attributes)
-      if attributes[:created_user_id].present?
-        attributes[:user_ids] = [attributes[:created_user_id]]
-      end
-
-      super
-    end
-  end
+  class Step2 < Base; end
 
   class Step3 < Base; end
 end

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -1,32 +1,9 @@
 class UserRdvWizard
-  include ActiveModel::Model
   include RdvBuilderConcern
-
-  attr_accessor :user
-
-  delegate :errors, to: :user
-
-  validate :phone_number_present_for_motif_by_phone
 
   def initialize(user, attributes)
     @user = user
     build_rdv_from_attributes(attributes)
-
-    @user&.assign_attributes(@attributes.fetch(:user, {}))
-  end
-
-  def save
-    # we make sure the email can be updated only if it is blank
-    @user.skip_reconfirmation! if @user.email_was.blank?
-
-    # dans la vue on appelle form_for(user) plutôt que form_for(user_rdv_wizard),
-    # il faut donc ajouter des validations (et des erreurs) sur l'objet user
-    if rdv.requires_ants_predemande_number?
-      @user.singleton_class.include(User::AntsPreDemandeNumberStatusValidationConcern)
-      @user.ants_meeting_point_id = lieu_id # used in AntsPreDemandeNumberStatusValidation
-    end
-
-    valid? && @user.save
   end
 
   def display_france_connect?
@@ -35,11 +12,5 @@ class UserRdvWizard
 
   def display_pro_connect?
     motif.organisation.online_booking_for_professionnels
-  end
-
-  private
-
-  def phone_number_present_for_motif_by_phone
-    errors.add(:phone_number, :missing_for_phone_motif) if rdv.motif.phone? && user.phone_number.blank?
   end
 end

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -98,19 +98,6 @@ module UserRdvWizard
       motif.organisation.online_booking_for_professionnels
     end
 
-    # On a parfois besoin de cette méthode avant d'avoir une instance de RdvWizard, donc on factorise l'implémentation
-    # avec cette méthode de classe
-    def self.skip_proches_step?(user)
-      # L'étape 2 propose de prendre rendez-vous pour un proche
-      # Dans le cas d'une invitation, c'est l'usager qui est invité, donc on saute cette étape
-      # Si l'usager est un professionnel connecté via ProConnect, on ne lui propose pas non plus de prendre rendez-vous pour un proche
-      user.signed_in_with_invitation_token? || user.pro_connect_openid_sub
-    end
-
-    def skip_proches_step?
-      self.class.skip_proches_step?(user)
-    end
-
     private
 
     def lieu

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -5,12 +5,4 @@ class UserRdvWizard
     @user = user
     build_rdv_from_attributes(attributes)
   end
-
-  def display_france_connect?
-    motif.organisation.online_booking_for_particuliers
-  end
-
-  def display_pro_connect?
-    motif.organisation.online_booking_for_professionnels
-  end
 end

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -1,69 +1,18 @@
 class UserRdvWizard
   include ActiveModel::Model
+  include RdvBuilderConcern
 
-  attr_accessor :rdv, :user
+  attr_accessor :user
 
-  delegate :motif, :starts_at, :service, to: :rdv
   delegate :errors, to: :user
 
   validate :phone_number_present_for_motif_by_phone
 
   def initialize(user, attributes)
     @user = user
-    @attributes = attributes.to_h.symbolize_keys
-
-    if attributes[:rdv_collectif_id].present?
-      @rdv = Rdv.collectif.bookable_by_everyone_or_agents_and_prescripteurs_or_invited_users.find(attributes[:rdv_collectif_id])
-    else
-      @rdv = Rdv.new({
-        user_ids: [user&.id],
-      }.merge(@attributes.slice(:starts_at, :user_ids, :motif_id)))
-      @rdv.duration_in_min = duration_in_min
-      @rdv.organisation_id = @rdv.motif.organisation_id
-    end
+    build_rdv_from_attributes(attributes)
 
     @user&.assign_attributes(@attributes.fetch(:user, {}))
-  end
-
-  def params_to_selections
-    if @rdv.present?
-      return @attributes.merge(service: @rdv.motif.service_id, motif_name_with_location_type: @rdv.motif.name_with_location_type)
-    end
-
-    @attributes
-  end
-
-  def creneau
-    # La validation de ce paramètre ANTS est faite ici pour simplifier la gestion des cas problématiques
-    # qui peuvent se produire aux étapes de prise de RDV pré sign-in et post-sign-in. Les autres params
-    # sont très peu validés. Le cas d’erreur principal qui peut se produire est qu’aucun créneau ne soit
-    # trouvé pour les params passés. On s’appuie donc sur ce cas pour gérer l’erreur de validation ANTS
-    return nil if ants_pre_demandes_count.present? && !AntsPreDemandesCountValidator.count_valid?(ants_pre_demandes_count)
-
-    @creneau ||= CreneauxSearch::ForUser.creneau_for(
-      user: @user,
-      motif: motif,
-      lieu: lieu,
-      starts_at: @rdv.starts_at,
-      geo_search: geo_search,
-      duration_in_min:
-    )
-  end
-
-  def geo_search
-    @geo_search ||= Users::GeoSearch.new(**@attributes.slice(:departement, :city_code, :street_ban_id))
-  end
-
-  def to_query
-    {
-      motif_id: rdv.motif.id, starts_at: rdv.starts_at.to_s, user_ids: users&.map(&:id), rdv_collectif_id: rdv.id,
-    }.merge(
-      @attributes.slice(
-        *WebSearchContext::ADDRESS_SELECTION_PARAMS,
-        :where, :lieu_id, :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id,
-        :referent_ids, :external_organisation_ids, :duration, :ants_pre_demandes_count
-      )
-    )
   end
 
   def save
@@ -80,29 +29,6 @@ class UserRdvWizard
     valid? && @user.save
   end
 
-  def lieu_id = @attributes[:lieu_id]
-  def ants_pre_demandes_count = @attributes[:ants_pre_demandes_count].presence&.to_i
-
-  def duration_in_min
-    if @attributes[:duration]
-      @attributes[:duration].to_i
-    elsif @attributes[:ants_pre_demandes_count].present?
-      motif.default_duration_in_min * @attributes[:ants_pre_demandes_count].to_i
-    else
-      motif.default_duration_in_min
-    end
-  end
-
-  def users
-    if @rdv.collectif?
-      return [] unless @user
-
-      @user.available_users_for_rdv.where(id: @attributes[:user_ids]).presence || [@user]
-    else
-      @rdv.users.presence || [@user].compact
-    end
-  end
-
   def display_france_connect?
     motif.organisation.online_booking_for_particuliers
   end
@@ -112,10 +38,6 @@ class UserRdvWizard
   end
 
   private
-
-  def lieu
-    @lieu ||= lieu_id.present? ? Lieu.find(lieu_id) : nil
-  end
 
   def phone_number_present_for_motif_by_phone
     errors.add(:phone_number, :missing_for_phone_motif) if rdv.motif.phone? && user.phone_number.blank?

--- a/app/form_models/users/rdv_booking_form.rb
+++ b/app/form_models/users/rdv_booking_form.rb
@@ -5,10 +5,27 @@ class Users::RdvBookingForm
 
   delegate :to_query, :motif, :service, :rdv, to: :rdv_wizard
 
-  def initialize(user:, rdv_wizard:, domain:)
+  validate :validate_phone_number_present_for_motif_by_phone
+
+  def initialize(user:, rdv_wizard:, domain:, user_attributes: {})
     @user = user
     @rdv_wizard = rdv_wizard
     @domain = domain
+    @user.assign_attributes(user_attributes)
+  end
+
+  def save
+    # we make sure the email can be updated only if it is blank
+    @user.skip_reconfirmation! if @user.email_was.blank?
+
+    # dans la vue on appelle form_for(user) plutôt que form_for(user_rdv_wizard),
+    # il faut donc ajouter des validations (et des erreurs) sur l'objet user
+    if rdv.requires_ants_predemande_number?
+      @user.singleton_class.include(User::AntsPreDemandeNumberStatusValidationConcern)
+      @user.ants_meeting_point_id = rdv_wizard.lieu_id # used in AntsPreDemandeNumberStatusValidation
+    end
+
+    valid? && @user.save
   end
 
   def show_birth_date_field? = !signed_in_with_invitation_token? && rdv.territory&.enable_birth_date_field?
@@ -26,4 +43,10 @@ class Users::RdvBookingForm
   def address_value = user.address.nil? ? to_query[:where] : user.address
 
   def show_social_fields? = service.nil? || service.user_field_groups.include?(:social)
+
+  private
+
+  def validate_phone_number_present_for_motif_by_phone
+    errors.add(:phone_number, :missing_for_phone_motif) if rdv.motif.phone? && user.phone_number.blank?
+  end
 end

--- a/app/services/users/rdv_builder.rb
+++ b/app/services/users/rdv_builder.rb
@@ -1,16 +1,15 @@
-# Utilisé par UserRdvWizard et PrescripteurRdvWizard
-module RdvBuilderConcern
-  extend ActiveSupport::Concern
+class Users::RdvBuilder
+  attr_reader :rdv
 
-  included do
-    attr_accessor :rdv
+  delegate :motif, :starts_at, :service, to: :rdv
 
-    delegate :motif, :starts_at, :service, to: :rdv
+  def initialize(user, attributes)
+    @user = user
+    @attributes = attributes.to_h.symbolize_keys
+    build_rdv # on instancie le RDV dès l'initialize pour préserver le comportement actuel
   end
 
-  def build_rdv_from_attributes(attributes)
-    @attributes = attributes.to_h.symbolize_keys
-
+  def build_rdv
     if @attributes[:rdv_collectif_id].present?
       @rdv = Rdv.collectif.bookable_by_everyone_or_agents_and_prescripteurs_or_invited_users.find(@attributes[:rdv_collectif_id])
     else

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -57,7 +57,7 @@ ul.list-group.list-group-flush.fr-mt-0
           | Usager :&nbsp;
           = users_to_sentence(rdv_wizard.users)
         .col-auto
-          - step = @rdv_wizard.skip_proches_step? ? 1 : 2
+          - step = @skip_proches_step ? 1 : 2
           = dsfr_link_to "Modifier", new_users_rdv_wizard_step_path(step: , **@rdv_wizard.to_query), title: "Modifier les usagers"
     li.list-group-item
       .row

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -49,7 +49,7 @@ ul.list-group.list-group-flush.fr-mt-0
         = rdv_starts_at_and_duration(rdv_wizard.rdv, :human)
       .col-auto
         = dsfr_link_to "Modifier", path_to_creneau_selection(rdv_wizard.params_to_selections), title: "Modifier la date du rendez-vous"
-  - if rdv_wizard.is_a?(UserRdvWizard::Step3)
+  - if local_assigns[:show_user_info]
     li.list-group-item
       .row
         .col

--- a/app/views/users/rdv_wizard_steps/step1.html.slim
+++ b/app/views/users/rdv_wizard_steps/step1.html.slim
@@ -8,7 +8,7 @@
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body
-        = form_for @rdv_booking_form, as: :user, url: users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query.except(:rdv)), method: "post", builder: Dsfr::FormBuilder do |f|
+        = form_for @rdv_booking_form, as: :user, url: users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), method: "post", builder: Dsfr::FormBuilder do |f|
           = render "users/users/form_fields", f: f
           - @rdv_wizard.to_query.each do |wizard_key, wizard_value|
             = hidden_field_tag "rdv[#{wizard_key}]", wizard_value

--- a/app/views/users/rdv_wizard_steps/step3.html.slim
+++ b/app/views/users/rdv_wizard_steps/step3.html.slim
@@ -6,7 +6,7 @@
   .fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
     = dsfr_stepper(title: current_step[:title], value: current_step[:stepper_index], max: max_step)
     .card
-      = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
+      = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard, show_user_info: true
       .card-body.rdv-text-align-right
         - if @rdv_wizard.rdv.collectif?
           = link_to "Confirmer ma participation", users_rdv_participations_path(@rdv_wizard.rdv, user_id: @rdv_wizard.users.first.id), method: :post, class: "fr-btn", data: { disable_with: "Veuillez patienter…"}

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -3,11 +3,11 @@
   = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard if @rdv_wizard.present?
 
   .card-body
-    - if @rdv_wizard.nil? || @rdv_wizard.display_france_connect?
+    - if @rdv_wizard.nil? || @rdv_wizard.rdv.motif.organisation.online_booking_for_particuliers
       = render "common/franceconnect_button", display_title: false
 
     / Contrairement à FranceConnect, on n'affiche pas le bouton ProConnect en dehors de la prise de rendez-vous
-    - if display_pro_connect_button? && @rdv_wizard&.display_pro_connect?
+    - if display_pro_connect_button? && @rdv_wizard&.rdv&.motif&.organisation&.online_booking_for_professionnels
       p.fr-hr-or ou
       .rdv-text-align-center
         = render "common/proconnect_button_dsfr", user_type: "user"

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Users::RdvWizardStepsController, type: :controller do
     let(:starts_at) { Time.zone.parse("2020-03-03 10h00") }
     let!(:mock_creneau) { instance_double(Creneau) }
     let!(:mock_rdv) { build(:rdv, starts_at: starts_at, users: [user], created_by: user) } # cannot use instance_double because it breaks pundit inference
-    let(:mock_user_rdv_wizard) { instance_double(UserRdvWizard::Step2, creneau: mock_creneau, rdv: mock_rdv) }
+    let(:mock_user_rdv_wizard) { instance_double(UserRdvWizard, creneau: mock_creneau, rdv: mock_rdv) }
 
     before { travel_to Date.parse("2020-03-01").in_time_zone + 8.hours }
 
     context "logged in user" do
       before do
-        allow(UserRdvWizard::Step2).to \
+        allow(UserRdvWizard).to \
           receive(:new).with(
             user,
             hash_including(
@@ -44,13 +44,11 @@ RSpec.describe Users::RdvWizardStepsController, type: :controller do
     end
 
     context "usager connecté via une invitation" do
-      let(:mock_step1_wizard) { instance_double(UserRdvWizard::Step1, creneau: mock_creneau, rdv: mock_rdv) }
-
       before do
         sign_in user
         user.signed_in_with_invitation_token!
         allow(controller).to receive(:current_user).and_return(user)
-        allow(UserRdvWizard::Step1).to receive(:new).and_return(mock_step1_wizard)
+        allow(UserRdvWizard).to receive(:new).and_return(mock_user_rdv_wizard)
         allow(Users::RdvBookingForm).to receive(:new).and_return(instance_double(Users::RdvBookingForm))
       end
 
@@ -62,11 +60,10 @@ RSpec.describe Users::RdvWizardStepsController, type: :controller do
 
     context "usager connecté via ProConnect" do
       let!(:user) { create(:user, pro_connect_openid_sub: "some-openid-sub") }
-      let(:mock_step1_wizard) { instance_double(UserRdvWizard::Step1, creneau: mock_creneau, rdv: mock_rdv) }
 
       before do
         sign_in user
-        allow(UserRdvWizard::Step1).to receive(:new).and_return(mock_step1_wizard)
+        allow(UserRdvWizard).to receive(:new).and_return(mock_user_rdv_wizard)
         allow(Users::RdvBookingForm).to receive(:new).and_return(instance_double(Users::RdvBookingForm))
       end
 

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Users::RdvWizardStepsController, type: :controller do
     let(:starts_at) { Time.zone.parse("2020-03-03 10h00") }
     let!(:mock_creneau) { instance_double(Creneau) }
     let!(:mock_rdv) { build(:rdv, starts_at: starts_at, users: [user], created_by: user) } # cannot use instance_double because it breaks pundit inference
-    let(:mock_user_rdv_wizard) { instance_double(UserRdvWizard, creneau: mock_creneau, rdv: mock_rdv) }
+    let(:mock_user_rdv_wizard) { instance_double(Users::RdvBuilder, creneau: mock_creneau, rdv: mock_rdv) }
 
     before { travel_to Date.parse("2020-03-01").in_time_zone + 8.hours }
 
     context "logged in user" do
       before do
-        allow(UserRdvWizard).to \
+        allow(Users::RdvBuilder).to \
           receive(:new).with(
             user,
             hash_including(
@@ -48,7 +48,7 @@ RSpec.describe Users::RdvWizardStepsController, type: :controller do
         sign_in user
         user.signed_in_with_invitation_token!
         allow(controller).to receive(:current_user).and_return(user)
-        allow(UserRdvWizard).to receive(:new).and_return(mock_user_rdv_wizard)
+        allow(Users::RdvBuilder).to receive(:new).and_return(mock_user_rdv_wizard)
         allow(Users::RdvBookingForm).to receive(:new).and_return(instance_double(Users::RdvBookingForm))
       end
 
@@ -63,7 +63,7 @@ RSpec.describe Users::RdvWizardStepsController, type: :controller do
 
       before do
         sign_in user
-        allow(UserRdvWizard).to receive(:new).and_return(mock_user_rdv_wizard)
+        allow(Users::RdvBuilder).to receive(:new).and_return(mock_user_rdv_wizard)
         allow(Users::RdvBookingForm).to receive(:new).and_return(instance_double(Users::RdvBookingForm))
       end
 

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -42,5 +42,38 @@ RSpec.describe Users::RdvWizardStepsController, type: :controller do
         expect(response).to redirect_to(new_user_session_path)
       end
     end
+
+    context "usager connecté via une invitation" do
+      let(:mock_step1_wizard) { instance_double(UserRdvWizard::Step1, creneau: mock_creneau, rdv: mock_rdv) }
+
+      before do
+        sign_in user
+        user.signed_in_with_invitation_token!
+        allow(controller).to receive(:current_user).and_return(user)
+        allow(UserRdvWizard::Step1).to receive(:new).and_return(mock_step1_wizard)
+        allow(Users::RdvBookingForm).to receive(:new).and_return(instance_double(Users::RdvBookingForm))
+      end
+
+      it "le step 1 pointe vers le step 3 comme prochaine étape" do
+        get :new, params: { step: 1, motif_id: motif.id, lieu_id: lieu.id, starts_at: starts_at }
+        expect(controller.send(:next_step)[:number]).to eq(3)
+      end
+    end
+
+    context "usager connecté via ProConnect" do
+      let!(:user) { create(:user, pro_connect_openid_sub: "some-openid-sub") }
+      let(:mock_step1_wizard) { instance_double(UserRdvWizard::Step1, creneau: mock_creneau, rdv: mock_rdv) }
+
+      before do
+        sign_in user
+        allow(UserRdvWizard::Step1).to receive(:new).and_return(mock_step1_wizard)
+        allow(Users::RdvBookingForm).to receive(:new).and_return(instance_double(Users::RdvBookingForm))
+      end
+
+      it "le step 1 pointe vers le step 3 comme prochaine étape" do
+        get :new, params: { step: 1, motif_id: motif.id, lieu_id: lieu.id, starts_at: starts_at }
+        expect(controller.send(:next_step)[:number]).to eq(3)
+      end
+    end
   end
 end

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -7,336 +7,62 @@ RSpec.describe UserRdvWizard do
   let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif, starts_at: Time.zone.parse("2020-10-20 09h30")) }
   let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
 
-  describe "#new" do
-    let(:mock_geo_search) { instance_double(Users::GeoSearch) }
-    let(:attributes) do
-      {
-        starts_at: creneau.starts_at,
-        motif_id: motif.id,
-        lieu_id: lieu.id,
-        user_ids: [user_for_rdv.id],
-        departement: "62",
-        city_code: "62100",
-      }
-    end
-
-    it "works" do
-      returned_creneau = Creneau.new
-
-      allow(Users::GeoSearch).to receive(:new)
-        .with(departement: "62", city_code: "62100")
-        .and_return(mock_geo_search)
-      allow(CreneauxSearch::ForUser).to receive(:creneau_for).with(
-        user: user,
-        motif: motif,
-        lieu: lieu,
-        starts_at: Time.zone.parse("2020-10-20 09h30"),
-        geo_search: mock_geo_search,
-        duration_in_min: 30
-      ).and_return(returned_creneau)
-      rdv_wizard = described_class.new(user, attributes)
-      expect(rdv_wizard.rdv.user_ids).to eq [user_for_rdv.id]
-      expect(rdv_wizard.creneau).to eq returned_creneau
-    end
-
-    it "avec un duration_in_min différent de celui du motif" do
-      returned_creneau = Creneau.new
-      allow(Users::GeoSearch).to receive(:new)
-        .with(departement: "62", city_code: "62100")
-        .and_return(mock_geo_search)
-      allow(CreneauxSearch::ForUser).to receive(:creneau_for).with(
-        user: user,
-        motif: motif,
-        lieu: lieu,
-        starts_at: Time.zone.parse("2020-10-20 09h30"),
-        geo_search: mock_geo_search,
-        duration_in_min: 60
-      ).and_return(returned_creneau)
-      rdv_wizard = described_class.new(user, attributes.merge(duration: 60))
-      expect(rdv_wizard.rdv.user_ids).to eq [user_for_rdv.id]
-      expect(rdv_wizard.creneau).to eq returned_creneau
-    end
+  let(:mock_geo_search) { instance_double(Users::GeoSearch) }
+  let(:attributes) do
+    {
+      starts_at: creneau.starts_at,
+      motif_id: motif.id,
+      lieu_id: lieu.id,
+      user_ids: [user_for_rdv.id],
+      departement: "62",
+      city_code: "62100",
+    }
   end
 
-  describe "#save" do
-    context "when everything is ok" do
-      let(:motif) { create(:motif, :at_public_office, organisation: organisation) }
-      let(:attributes) do
-        {
-          starts_at: creneau.starts_at,
-          motif_id: motif.id,
-          lieu_id: lieu.id,
-          user_ids: [user_for_rdv.id],
-          user: {
-            first_name: "Léa",
-            last_name: "Boubakar",
-            phone_number: nil,
-          },
-          departement: "62",
-          city_code: "62100",
-        }
-      end
+  it "construit un RDV et un créneau" do
+    returned_creneau = Creneau.new
 
-      it { expect(described_class.new(user, attributes).save).to be true }
-    end
+    allow(Users::GeoSearch).to receive(:new)
+      .with(departement: "62", city_code: "62100")
+      .and_return(mock_geo_search)
+    allow(CreneauxSearch::ForUser).to receive(:creneau_for).with(
+      user: user,
+      motif: motif,
+      lieu: lieu,
+      starts_at: Time.zone.parse("2020-10-20 09h30"),
+      geo_search: mock_geo_search,
+      duration_in_min: 30
+    ).and_return(returned_creneau)
+    rdv_wizard = described_class.new(user, attributes)
+    expect(rdv_wizard.rdv.user_ids).to eq [user_for_rdv.id]
+    expect(rdv_wizard.creneau).to eq returned_creneau
+  end
 
-    context "pour un RDV de passeport ANTS Mairie" do
-      include_context "rdv_mairie_api_authentication"
-      let!(:territory) { create(:territory, :mairies) }
-      let!(:organisation) { create(:organisation, territory:, name: "Mairie de Wavignies") }
-      let!(:motif_category) { create(:motif_category, :passeport) }
-      let!(:motif) { create(:motif, organisation:, motif_category:) }
+  it "avec un duration_in_min différent de celui du motif" do
+    returned_creneau = Creneau.new
+    allow(Users::GeoSearch).to receive(:new)
+      .with(departement: "62", city_code: "62100")
+      .and_return(mock_geo_search)
+    allow(CreneauxSearch::ForUser).to receive(:creneau_for).with(
+      user: user,
+      motif: motif,
+      lieu: lieu,
+      starts_at: Time.zone.parse("2020-10-20 09h30"),
+      geo_search: mock_geo_search,
+      duration_in_min: 60
+    ).and_return(returned_creneau)
+    rdv_wizard = described_class.new(user, attributes.merge(duration: 60))
+    expect(rdv_wizard.rdv.user_ids).to eq [user_for_rdv.id]
+    expect(rdv_wizard.creneau).to eq returned_creneau
+  end
 
-      context "l’usager fournit un numéro de pré-demande valide" do
-        before { stub_ants_status_ok("VALID12345", status: "validated", meeting_point_id: lieu.id, appointments: []) }
+  context "Rdv collectif - bookable by agents and prescripteurs" do
+    let(:motif) { create(:motif, :at_public_office, organisation: organisation, bookable_by: :agents_and_prescripteurs, collectif: true) }
+    let!(:rdv) { create(:rdv, motif: motif, organisation: organisation) }
+    let(:attributes) { { rdv_collectif_id: rdv.id } }
 
-        let(:attributes) do
-          {
-            starts_at: creneau.starts_at,
-            motif_id: motif.id,
-            lieu_id: lieu.id,
-            user_ids: [user_for_rdv.id],
-            user: {
-              first_name: "Léa",
-              last_name: "Boubakar",
-              phone_number: "0612345678",
-              ants_pre_demande_number: "VALID12345",
-            },
-            departement: "62",
-            city_code: "62100",
-          }
-        end
-
-        it { expect(described_class.new(user, attributes).save).to be true }
-      end
-
-      context "l’usager fournit un numéro de pré-demande vide" do
-        let(:attributes) do
-          {
-            starts_at: creneau.starts_at,
-            motif_id: motif.id,
-            lieu_id: nil,
-            user_ids: [user_for_rdv.id],
-            user: {
-              first_name: "Léa",
-              last_name: "Boubakar",
-              phone_number: "0612345678",
-              ants_pre_demande_number: "",
-            },
-            departement: "62",
-            city_code: "62100",
-          }
-        end
-
-        it "empêche la création" do
-          form = described_class.new(user, attributes)
-          res = form.save
-          expect(res).to be false
-          expect(form.errors.count).to eq(1)
-          expect(form.errors.first.attribute).to eq(:ants_pre_demande_number)
-          # le message affiché est en fait celui sur le user
-          expect(form.errors.first.full_message).to eq("Numéro de pré-demande ANTS doit être renseigné")
-        end
-      end
-
-      context "l’usager fournit un numéro de pré-demande ANTS non reconnu" do
-        before { stub_ants_status_ok("VALID12345", status: "unknown", meeting_point_id: lieu.id, appointments: []) }
-
-        let(:attributes) do
-          {
-            starts_at: creneau.starts_at,
-            motif_id: motif.id,
-            lieu_id: lieu.id,
-            user_ids: [user_for_rdv.id],
-            user: {
-              first_name: "Léa",
-              last_name: "Boubakar",
-              phone_number: "0612345678",
-              ants_pre_demande_number: "VALID12345",
-            },
-            departement: "62",
-            city_code: "62100",
-          }
-        end
-
-        it "empêche la création" do
-          form = described_class.new(user, attributes)
-          res = form.save
-          expect(res).to be false
-          expect(form.errors.count).to eq(1)
-          expect(form.errors.first.attribute).to eq(:ants_pre_demande_number)
-          expect(form.errors.first.full_message).to eq("Numéro de pré-demande ANTS n'est pas reconnu par l'ANTS")
-        end
-      end
-
-      context "l’usager fournit un numéro de pré-demande ANTS qui a déjà un appointment" do
-        before do
-          stub_ants_status_ok(
-            "VALID12345",
-            status: "validated",
-            meeting_point_id: lieu.id,
-            appointments: [{ "meeting_point" => "Mairie de Montrouge", "management_url" => "http://rdvsympa.fr/123" }]
-          )
-        end
-
-        let(:attributes) do
-          {
-            starts_at: creneau.starts_at,
-            motif_id: motif.id,
-            lieu_id: lieu.id,
-            user_ids: [user_for_rdv.id],
-            user: {
-              first_name: "Léa",
-              last_name: "Boubakar",
-              phone_number: "0612345678",
-              ants_pre_demande_number: "VALID12345",
-            },
-            departement: "62",
-            city_code: "62100",
-          }
-        end
-
-        it "empêche la création" do
-          form = described_class.new(user, attributes)
-          res = form.save
-          expect(res).to be false
-          expect(form.errors.count).to eq(1)
-          expect(form.errors.first.attribute).to eq(:_benign)
-          expect(form.errors.first.message).to eq(
-            <<-TXT.squish
-              Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Montrouge.
-              Veuillez <a href="http://rdvsympa.fr/123" target="_blank">annuler ce RDV</a> avant d'en prendre un nouveau.
-          TXT
-          )
-        end
-      end
-
-      context "l’usager fournit un numéro de pré-demande ANTS qui a déjà un appointment mais ignore les avertissements" do
-        before do
-          stub_ants_status_ok(
-            "VALID12345",
-            status: "validated",
-            meeting_point_id: lieu.id,
-            appointments: [{ "meeting_point" => "Mairie de Montrouge", "management_url" => "http://rdvsympa.fr/123" }]
-          )
-        end
-
-        let(:attributes) do
-          {
-            starts_at: creneau.starts_at,
-            motif_id: motif.id,
-            lieu_id: lieu.id,
-            user_ids: [user_for_rdv.id],
-            user: {
-              first_name: "Léa",
-              last_name: "Boubakar",
-              phone_number: "0612345678",
-              ants_pre_demande_number: "VALID12345",
-              ignore_benign_errors: "true",
-            },
-            departement: "62",
-            city_code: "62100",
-          }
-        end
-
-        it "n’empêche pas la création" do
-          form = described_class.new(user, attributes)
-          res = form.save
-          expect(res).to be true
-        end
-      end
-
-      context "l’usager fournit un numéro de pré-demande ANTS valide mais l’API ANTS timeout" do
-        before { allow(AntsApi).to receive(:status).and_raise(Typhoeus::Errors::TimeoutError) }
-
-        let(:attributes) do
-          {
-            starts_at: creneau.starts_at,
-            motif_id: motif.id,
-            lieu_id: nil,
-            user_ids: [user_for_rdv.id],
-            user: {
-              first_name: "Léa",
-              last_name: "Boubakar",
-              phone_number: "0612345678",
-              ants_pre_demande_number: "VALID12345",
-            },
-            departement: "62",
-            city_code: "62100",
-          }
-        end
-
-        it "empêche la création" do
-          form = described_class.new(user, attributes)
-          res = form.save
-          expect(res).to be false
-          expect(form.errors.count).to eq(1)
-          expect(form.errors.first.attribute).to eq(:ants_pre_demande_number)
-          expect(form.errors.first.full_message).to eq("Numéro de pré-demande ANTS n'a pas pu être validé à cause d'une erreur inattendue. Merci de réessayer dans 30 secondes.")
-        end
-      end
-    end
-
-    context "when the motif is by phone" do
-      let(:motif) { create(:motif, :by_phone, organisation: organisation) }
-
-      context "when the lieu is nil" do
-        let(:attributes) do
-          {
-            starts_at: creneau.starts_at,
-            motif_id: motif.id,
-            lieu_id: nil,
-            user_ids: [user_for_rdv.id],
-            user: {
-              first_name: "Léa",
-              last_name: "Boubakar",
-              phone_number: "0612345678",
-            },
-            departement: "62",
-            city_code: "62100",
-          }
-        end
-
-        it { expect(described_class.new(user, attributes).save).to be true }
-      end
-
-      context "when the phone number is blank" do
-        let(:attributes) do
-          {
-            starts_at: creneau.starts_at,
-            motif_id: motif.id,
-            lieu_id: lieu.id,
-            user_ids: [user_for_rdv.id],
-            user: {
-              first_name: "Léa",
-              last_name: "Boubakar",
-              phone_number: nil,
-            },
-            departement: "62",
-            city_code: "62100",
-          }
-        end
-
-        it { expect(described_class.new(user, attributes).save).to be false }
-
-        it "return false with a rdv by_phone and user without phone" do
-          rdv_wizard = described_class.new(user, attributes)
-          rdv_wizard.valid?
-          expect(rdv_wizard.errors.full_messages.join(", ")).to eq("Le numéro de téléphone est obligatoire car le RDV aura lieu par téléphone")
-        end
-      end
-    end
-
-    context "Rdv collectif" do
-      context "bookable by agents and prescripteurs" do
-        let(:motif) { create(:motif, :at_public_office, organisation: organisation, bookable_by: :agents_and_prescripteurs, collectif: true) }
-        let!(:rdv) { create(:rdv, motif: motif, organisation: organisation) }
-        let(:attributes) { { rdv_collectif_id: rdv.id } }
-
-        it "finds the Rdv" do
-          expect(described_class.new(user_for_rdv, attributes).rdv).to eq(rdv)
-        end
-      end
+    it "trouve le RDV existant" do
+      expect(described_class.new(user_for_rdv, attributes).rdv).to eq(rdv)
     end
   end
 end

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe UserRdvWizard do
+RSpec.describe UserRdvWizard::Step1 do # rubocop:disable RSpec/SpecFilePathFormat
   let!(:organisation) { create(:organisation) }
   let!(:user) { create(:user) }
   let!(:user_for_rdv) { create(:user) }
@@ -34,7 +34,7 @@ RSpec.describe UserRdvWizard do
         geo_search: mock_geo_search,
         duration_in_min: 30
       ).and_return(returned_creneau)
-      rdv_wizard = UserRdvWizard::Step1.new(user, attributes)
+      rdv_wizard = described_class.new(user, attributes)
       expect(rdv_wizard.rdv.user_ids).to eq [user_for_rdv.id]
       expect(rdv_wizard.creneau).to eq returned_creneau
     end
@@ -52,13 +52,13 @@ RSpec.describe UserRdvWizard do
         geo_search: mock_geo_search,
         duration_in_min: 60
       ).and_return(returned_creneau)
-      rdv_wizard = UserRdvWizard::Step1.new(user, attributes.merge(duration: 60))
+      rdv_wizard = described_class.new(user, attributes.merge(duration: 60))
       expect(rdv_wizard.rdv.user_ids).to eq [user_for_rdv.id]
       expect(rdv_wizard.creneau).to eq returned_creneau
     end
   end
 
-  describe "Step1#save" do
+  describe "#save" do
     context "when everything is ok" do
       let(:motif) { create(:motif, :at_public_office, organisation: organisation) }
       let(:attributes) do
@@ -77,7 +77,7 @@ RSpec.describe UserRdvWizard do
         }
       end
 
-      it { expect(UserRdvWizard::Step1.new(user, attributes).save).to be true }
+      it { expect(described_class.new(user, attributes).save).to be true }
     end
 
     context "pour un RDV de passeport ANTS Mairie" do
@@ -107,7 +107,7 @@ RSpec.describe UserRdvWizard do
           }
         end
 
-        it { expect(UserRdvWizard::Step1.new(user, attributes).save).to be true }
+        it { expect(described_class.new(user, attributes).save).to be true }
       end
 
       context "l’usager fournit un numéro de pré-demande vide" do
@@ -129,7 +129,7 @@ RSpec.describe UserRdvWizard do
         end
 
         it "empêche la création" do
-          form = UserRdvWizard::Step1.new(user, attributes)
+          form = described_class.new(user, attributes)
           res = form.save
           expect(res).to be false
           expect(form.errors.count).to eq(1)
@@ -160,7 +160,7 @@ RSpec.describe UserRdvWizard do
         end
 
         it "empêche la création" do
-          form = UserRdvWizard::Step1.new(user, attributes)
+          form = described_class.new(user, attributes)
           res = form.save
           expect(res).to be false
           expect(form.errors.count).to eq(1)
@@ -197,7 +197,7 @@ RSpec.describe UserRdvWizard do
         end
 
         it "empêche la création" do
-          form = UserRdvWizard::Step1.new(user, attributes)
+          form = described_class.new(user, attributes)
           res = form.save
           expect(res).to be false
           expect(form.errors.count).to eq(1)
@@ -240,7 +240,7 @@ RSpec.describe UserRdvWizard do
         end
 
         it "n’empêche pas la création" do
-          form = UserRdvWizard::Step1.new(user, attributes)
+          form = described_class.new(user, attributes)
           res = form.save
           expect(res).to be true
         end
@@ -267,7 +267,7 @@ RSpec.describe UserRdvWizard do
         end
 
         it "empêche la création" do
-          form = UserRdvWizard::Step1.new(user, attributes)
+          form = described_class.new(user, attributes)
           res = form.save
           expect(res).to be false
           expect(form.errors.count).to eq(1)
@@ -297,7 +297,7 @@ RSpec.describe UserRdvWizard do
           }
         end
 
-        it { expect(UserRdvWizard::Step1.new(user, attributes).save).to be true }
+        it { expect(described_class.new(user, attributes).save).to be true }
       end
 
       context "when the phone number is blank" do
@@ -317,10 +317,10 @@ RSpec.describe UserRdvWizard do
           }
         end
 
-        it { expect(UserRdvWizard::Step1.new(user, attributes).save).to be false }
+        it { expect(described_class.new(user, attributes).save).to be false }
 
         it "return false with a rdv by_phone and user without phone" do
-          rdv_wizard = UserRdvWizard::Step1.new(user, attributes)
+          rdv_wizard = described_class.new(user, attributes)
           rdv_wizard.valid?
           expect(rdv_wizard.errors.full_messages.join(", ")).to eq("Le numéro de téléphone est obligatoire car le RDV aura lieu par téléphone")
         end
@@ -334,7 +334,7 @@ RSpec.describe UserRdvWizard do
         let(:attributes) { { rdv_collectif_id: rdv.id } }
 
         it "finds the Rdv" do
-          expect(UserRdvWizard::Step1.new(user_for_rdv, attributes).rdv).to eq(rdv)
+          expect(described_class.new(user_for_rdv, attributes).rdv).to eq(rdv)
         end
       end
     end

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe UserRdvWizard::Step1 do # rubocop:disable RSpec/SpecFilePathFormat
+RSpec.describe UserRdvWizard do
   let!(:organisation) { create(:organisation) }
   let!(:user) { create(:user) }
   let!(:user_for_rdv) { create(:user) }

--- a/spec/form_models/users/rdv_booking_form_spec.rb
+++ b/spec/form_models/users/rdv_booking_form_spec.rb
@@ -1,0 +1,316 @@
+RSpec.describe Users::RdvBookingForm do
+  let!(:organisation) { create(:organisation) }
+  let!(:user) { create(:user) }
+  let!(:user_for_rdv) { create(:user) }
+  let!(:motif) { create(:motif, organisation: organisation, default_duration_in_min: 30) }
+  let!(:lieu) { create(:lieu, organisation: organisation) }
+  let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif, starts_at: Time.zone.parse("2020-10-20 09h30")) }
+  let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
+  let(:domain) { Domain::RDV_SERVICE_PUBLIC }
+
+  describe "#save" do
+    context "when everything is ok" do
+      let(:motif) { create(:motif, :at_public_office, organisation: organisation) }
+      let(:rdv_wizard) do
+        UserRdvWizard.new(
+          user, {
+            starts_at: creneau.starts_at,
+            motif_id: motif.id,
+            lieu_id: lieu.id,
+            user_ids: [user_for_rdv.id],
+            departement: "62",
+            city_code: "62100",
+          }
+        )
+      end
+      let(:user_attributes) do
+        {
+          first_name: "Léa",
+          last_name: "Boubakar",
+          phone_number: nil,
+        }
+      end
+
+      it { expect(described_class.new(user:, rdv_wizard:, user_attributes:, domain:).save).to be true }
+    end
+
+    context "pour un RDV de passeport ANTS Mairie" do
+      include_context "rdv_mairie_api_authentication"
+      let!(:territory) { create(:territory, :mairies) }
+      let!(:organisation) { create(:organisation, territory:, name: "Mairie de Wavignies") }
+      let!(:motif_category) { create(:motif_category, :passeport) }
+      let!(:motif) { create(:motif, organisation:, motif_category:) }
+
+      context "l'usager fournit un numéro de pré-demande valide" do
+        before { stub_ants_status_ok("VALID12345", status: "validated", meeting_point_id: lieu.id, appointments: []) }
+
+        let(:rdv_wizard) do
+          UserRdvWizard.new(
+            user, {
+              starts_at: creneau.starts_at,
+              motif_id: motif.id,
+              lieu_id: lieu.id,
+              user_ids: [user_for_rdv.id],
+              departement: "62",
+              city_code: "62100",
+            }
+          )
+        end
+        let(:user_attributes) do
+          {
+            first_name: "Léa",
+            last_name: "Boubakar",
+            phone_number: "0612345678",
+            ants_pre_demande_number: "VALID12345",
+          }
+        end
+
+        it { expect(described_class.new(user:, rdv_wizard:, user_attributes:, domain:).save).to be true }
+      end
+
+      context "l'usager fournit un numéro de pré-demande vide" do
+        let(:rdv_wizard) do
+          UserRdvWizard.new(
+            user, {
+              starts_at: creneau.starts_at,
+              motif_id: motif.id,
+              lieu_id: nil,
+              user_ids: [user_for_rdv.id],
+              departement: "62",
+              city_code: "62100",
+            }
+          )
+        end
+        let(:user_attributes) do
+          {
+            first_name: "Léa",
+            last_name: "Boubakar",
+            phone_number: "0612345678",
+            ants_pre_demande_number: "",
+          }
+        end
+
+        it "empêche la création" do
+          form = described_class.new(user:, rdv_wizard:, user_attributes:, domain:)
+          res = form.save
+          expect(res).to be false
+          expect(form.errors.count).to eq(1)
+          expect(form.errors.first.attribute).to eq(:ants_pre_demande_number)
+          # le message affiché est en fait celui sur le user
+          expect(form.errors.first.full_message).to eq("Numéro de pré-demande ANTS doit être renseigné")
+        end
+      end
+
+      context "l'usager fournit un numéro de pré-demande ANTS non reconnu" do
+        before { stub_ants_status_ok("VALID12345", status: "unknown", meeting_point_id: lieu.id, appointments: []) }
+
+        let(:rdv_wizard) do
+          UserRdvWizard.new(
+            user, {
+              starts_at: creneau.starts_at,
+              motif_id: motif.id,
+              lieu_id: lieu.id,
+              user_ids: [user_for_rdv.id],
+              departement: "62",
+              city_code: "62100",
+            }
+          )
+        end
+        let(:user_attributes) do
+          {
+            first_name: "Léa",
+            last_name: "Boubakar",
+            phone_number: "0612345678",
+            ants_pre_demande_number: "VALID12345",
+          }
+        end
+
+        it "empêche la création" do
+          form = described_class.new(user:, rdv_wizard:, user_attributes:, domain:)
+          res = form.save
+          expect(res).to be false
+          expect(form.errors.count).to eq(1)
+          expect(form.errors.first.attribute).to eq(:ants_pre_demande_number)
+          expect(form.errors.first.full_message).to eq("Numéro de pré-demande ANTS n'est pas reconnu par l'ANTS")
+        end
+      end
+
+      context "l'usager fournit un numéro de pré-demande ANTS qui a déjà un appointment" do
+        before do
+          stub_ants_status_ok(
+            "VALID12345",
+            status: "validated",
+            meeting_point_id: lieu.id,
+            appointments: [{ "meeting_point" => "Mairie de Montrouge", "management_url" => "http://rdvsympa.fr/123" }]
+          )
+        end
+
+        let(:rdv_wizard) do
+          UserRdvWizard.new(
+            user, {
+              starts_at: creneau.starts_at,
+              motif_id: motif.id,
+              lieu_id: lieu.id,
+              user_ids: [user_for_rdv.id],
+              departement: "62",
+              city_code: "62100",
+            }
+          )
+        end
+        let(:user_attributes) do
+          {
+            first_name: "Léa",
+            last_name: "Boubakar",
+            phone_number: "0612345678",
+            ants_pre_demande_number: "VALID12345",
+          }
+        end
+
+        it "empêche la création" do
+          form = described_class.new(user:, rdv_wizard:, user_attributes:, domain:)
+          res = form.save
+          expect(res).to be false
+          expect(form.errors.count).to eq(1)
+          expect(form.errors.first.attribute).to eq(:_benign)
+          expect(form.errors.first.message).to eq(
+            <<-TXT.squish
+              Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Montrouge.
+              Veuillez <a href="http://rdvsympa.fr/123" target="_blank">annuler ce RDV</a> avant d'en prendre un nouveau.
+          TXT
+          )
+        end
+      end
+
+      context "l'usager fournit un numéro de pré-demande ANTS qui a déjà un appointment mais ignore les avertissements" do
+        before do
+          stub_ants_status_ok(
+            "VALID12345",
+            status: "validated",
+            meeting_point_id: lieu.id,
+            appointments: [{ "meeting_point" => "Mairie de Montrouge", "management_url" => "http://rdvsympa.fr/123" }]
+          )
+        end
+
+        let(:rdv_wizard) do
+          UserRdvWizard.new(
+            user, {
+              starts_at: creneau.starts_at,
+              motif_id: motif.id,
+              lieu_id: lieu.id,
+              user_ids: [user_for_rdv.id],
+              departement: "62",
+              city_code: "62100",
+            }
+          )
+        end
+        let(:user_attributes) do
+          {
+            first_name: "Léa",
+            last_name: "Boubakar",
+            phone_number: "0612345678",
+            ants_pre_demande_number: "VALID12345",
+            ignore_benign_errors: "true",
+          }
+        end
+
+        it "n'empêche pas la création" do
+          form = described_class.new(user:, rdv_wizard:, user_attributes:, domain:)
+          res = form.save
+          expect(res).to be true
+        end
+      end
+
+      context "l'usager fournit un numéro de pré-demande ANTS valide mais l'API ANTS timeout" do
+        before { allow(AntsApi).to receive(:status).and_raise(Typhoeus::Errors::TimeoutError) }
+
+        let(:rdv_wizard) do
+          UserRdvWizard.new(
+            user, {
+              starts_at: creneau.starts_at,
+              motif_id: motif.id,
+              lieu_id: nil,
+              user_ids: [user_for_rdv.id],
+              departement: "62",
+              city_code: "62100",
+            }
+          )
+        end
+        let(:user_attributes) do
+          {
+            first_name: "Léa",
+            last_name: "Boubakar",
+            phone_number: "0612345678",
+            ants_pre_demande_number: "VALID12345",
+          }
+        end
+
+        it "empêche la création" do
+          form = described_class.new(user:, rdv_wizard:, user_attributes:, domain:)
+          res = form.save
+          expect(res).to be false
+          expect(form.errors.count).to eq(1)
+          expect(form.errors.first.attribute).to eq(:ants_pre_demande_number)
+          expect(form.errors.first.full_message).to eq("Numéro de pré-demande ANTS n'a pas pu être validé à cause d'une erreur inattendue. Merci de réessayer dans 30 secondes.")
+        end
+      end
+    end
+
+    context "when the motif is by phone" do
+      let(:motif) { create(:motif, :by_phone, organisation: organisation) }
+
+      context "when the lieu is nil" do
+        let(:rdv_wizard) do
+          UserRdvWizard.new(
+            user, {
+              starts_at: creneau.starts_at,
+              motif_id: motif.id,
+              lieu_id: nil,
+              user_ids: [user_for_rdv.id],
+              departement: "62",
+              city_code: "62100",
+            }
+          )
+        end
+        let(:user_attributes) do
+          {
+            first_name: "Léa",
+            last_name: "Boubakar",
+            phone_number: "0612345678",
+          }
+        end
+
+        it { expect(described_class.new(user:, rdv_wizard:, user_attributes:, domain:).save).to be true }
+      end
+
+      context "when the phone number is blank" do
+        let(:rdv_wizard) do
+          UserRdvWizard.new(
+            user, {
+              starts_at: creneau.starts_at,
+              motif_id: motif.id,
+              lieu_id: lieu.id,
+              user_ids: [user_for_rdv.id],
+              departement: "62",
+              city_code: "62100",
+            }
+          )
+        end
+        let(:user_attributes) do
+          {
+            first_name: "Léa",
+            last_name: "Boubakar",
+            phone_number: nil,
+          }
+        end
+
+        it { expect(described_class.new(user:, rdv_wizard:, user_attributes:, domain:).save).to be false }
+
+        it "return false with a rdv by_phone and user without phone" do
+          form = described_class.new(user:, rdv_wizard:, user_attributes:, domain:)
+          form.valid?
+          expect(form.errors.full_messages.join(", ")).to eq("Le numéro de téléphone est obligatoire car le RDV aura lieu par téléphone")
+        end
+      end
+    end
+  end
+end

--- a/spec/form_models/users/rdv_booking_form_spec.rb
+++ b/spec/form_models/users/rdv_booking_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Users::RdvBookingForm do
     context "when everything is ok" do
       let(:motif) { create(:motif, :at_public_office, organisation: organisation) }
       let(:rdv_wizard) do
-        UserRdvWizard.new(
+        Users::RdvBuilder.new(
           user, {
             starts_at: creneau.starts_at,
             motif_id: motif.id,
@@ -45,7 +45,7 @@ RSpec.describe Users::RdvBookingForm do
         before { stub_ants_status_ok("VALID12345", status: "validated", meeting_point_id: lieu.id, appointments: []) }
 
         let(:rdv_wizard) do
-          UserRdvWizard.new(
+          Users::RdvBuilder.new(
             user, {
               starts_at: creneau.starts_at,
               motif_id: motif.id,
@@ -70,7 +70,7 @@ RSpec.describe Users::RdvBookingForm do
 
       context "l'usager fournit un numéro de pré-demande vide" do
         let(:rdv_wizard) do
-          UserRdvWizard.new(
+          Users::RdvBuilder.new(
             user, {
               starts_at: creneau.starts_at,
               motif_id: motif.id,
@@ -105,7 +105,7 @@ RSpec.describe Users::RdvBookingForm do
         before { stub_ants_status_ok("VALID12345", status: "unknown", meeting_point_id: lieu.id, appointments: []) }
 
         let(:rdv_wizard) do
-          UserRdvWizard.new(
+          Users::RdvBuilder.new(
             user, {
               starts_at: creneau.starts_at,
               motif_id: motif.id,
@@ -146,7 +146,7 @@ RSpec.describe Users::RdvBookingForm do
         end
 
         let(:rdv_wizard) do
-          UserRdvWizard.new(
+          Users::RdvBuilder.new(
             user, {
               starts_at: creneau.starts_at,
               motif_id: motif.id,
@@ -192,7 +192,7 @@ RSpec.describe Users::RdvBookingForm do
         end
 
         let(:rdv_wizard) do
-          UserRdvWizard.new(
+          Users::RdvBuilder.new(
             user, {
               starts_at: creneau.starts_at,
               motif_id: motif.id,
@@ -224,7 +224,7 @@ RSpec.describe Users::RdvBookingForm do
         before { allow(AntsApi).to receive(:status).and_raise(Typhoeus::Errors::TimeoutError) }
 
         let(:rdv_wizard) do
-          UserRdvWizard.new(
+          Users::RdvBuilder.new(
             user, {
               starts_at: creneau.starts_at,
               motif_id: motif.id,
@@ -260,7 +260,7 @@ RSpec.describe Users::RdvBookingForm do
 
       context "when the lieu is nil" do
         let(:rdv_wizard) do
-          UserRdvWizard.new(
+          Users::RdvBuilder.new(
             user, {
               starts_at: creneau.starts_at,
               motif_id: motif.id,
@@ -284,7 +284,7 @@ RSpec.describe Users::RdvBookingForm do
 
       context "when the phone number is blank" do
         let(:rdv_wizard) do
-          UserRdvWizard.new(
+          Users::RdvBuilder.new(
             user, {
               starts_at: creneau.starts_at,
               motif_id: motif.id,

--- a/spec/form_models/users/rdv_builder_spec.rb
+++ b/spec/form_models/users/rdv_builder_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe UserRdvWizard do
+RSpec.describe Users::RdvBuilder do
   let!(:organisation) { create(:organisation) }
   let!(:user) { create(:user) }
   let!(:user_for_rdv) { create(:user) }


### PR DESCRIPTION
> [!NOTE]
> Grosse PR de refacto découpée en commits digestes, à lire avec les espaces ignorés

fait suite à #6091 · remplace #6089, #6102, #6103 😅 

Dans cette variante je préserve le `UserRdvWizard` mais je fais en sorte que le `RdvBookingForm` soit le vrai et unique Form object : c'est lui qui a le `#save` et les validations. 