### PR TITLE
Script pour les comptes agents compromis

### DIFF
--- a/scripts/invalidate_agent_accounts.rb
+++ b/scripts/invalidate_agent_accounts.rb
@@ -1,0 +1,14 @@
+# Usage: bundle exec rails runner scripts/invalidate_agent_accounts.rb agent1@domain.fr agent2@domain.fr ...
+# invalide le mot de passe des agents et déconnecte les sessions existantes
+
+emails = ARGV.map(&:downcase).uniq
+emails.each do |email|
+  puts "Invalidating account for #{email}..."
+  agent = Agent.find_by(email:)
+  PaperTrail.request.whodunnit = "invalidate_agent_accounts_script"
+  agent.encrypted_password = ""
+  agent.paper_trail.save_with_version
+  raise unless agent.reload.encrypted_password == "" # il n'y a pas de save_with_version!
+
+  puts "Invalidated account for #{email}."
+end


### PR DESCRIPTION
# Description

Ce script permet : 
- de supprimer le mot de passe , les agents devront demander un lien de réinitialisation puis en redéfinir un
- de déconnecter les éventuelles sessions existantes
- de stocker une version papertrail pour garder l'info

## Pourquoi est-ce que ça déconnecte la session malgré le cookie store ? 

Le token de session stocké dans les cookies inclut un `authenticatable_salt` du Agent.

L'implémentation par défaut dans Devise est :

```rb
  def authenticatable_salt
    encrypted_password[0, 29] if encrypted_password.present?
  end
```

cf https://github.com/heartcombo/devise/blob/main/lib/devise/models/database_authenticatable.rb#L158-L160

À chaque requête, Warden appelle `serialize_from_session`, qui récupère l'agent en base et compare le `salt` stocké dans le cookie avec le `authenticatable_salt` actuel. cf https://github.com/heartcombo/devise/blob/main/lib/devise/models/authenticatable.rb#L231

Quand le `salt` ne correspond plus, la session est considérée comme invalide et l'utilisateur est déconnecté.