### PR TITLE
Amélioration affichage prescripteurs sur rdvs#show pour les RDV collectifs

### DIFF
--- a/app/views/admin/participations/_user_row.html.slim
+++ b/app/views/admin/participations/_user_row.html.slim
@@ -7,6 +7,16 @@ tr
         .participation_birthdate.small
           = icon("fr-icon-calendar-line", class: "fr-icon--sm fr-mr-1v")
           = "Né·e le #{I18n.l(participation.user.birth_date)}"
+    - if participation.prescription?
+      - author = participation.created_by
+      .d-flex.card-text.mt-1
+        = icon("fr-icon-user-add-fill", class: "text-primary-blue fr-mr-1w")
+        div
+          | Prescripteur·ice : #{author.full_name} (#{mail_to(author.email)}
+          - if author.is_a?(Prescripteur) && author.phone_number.present?
+            |< – #{phone_to(author.phone_number)}
+          |> )
+
   - if participation.rdv.requires_ants_predemande_number?
     td
       = participation.user.ants_pre_demande_number

--- a/app/views/admin/participations/_user_row.html.slim
+++ b/app/views/admin/participations/_user_row.html.slim
@@ -9,13 +9,11 @@ tr
           = "Né·e le #{I18n.l(participation.user.birth_date)}"
     - if participation.prescription?
       - author = participation.created_by
-      .d-flex.card-text.mt-1
-        = icon("fr-icon-user-add-fill", class: "text-primary-blue fr-mr-1w")
-        div
-          | Prescripteur·ice : #{author.full_name} (#{mail_to(author.email)}
-          - if author.is_a?(Prescripteur) && author.phone_number.present?
-            |< – #{phone_to(author.phone_number)}
-          |> )
+      .fr-mt-1w
+        | Prescrit par #{author.full_name} (#{mail_to(author.email)}
+        - if author.is_a?(Prescripteur) && author.phone_number.present?
+          |< – #{phone_to(author.phone_number)}
+        |> )
 
   - if participation.rdv.requires_ants_predemande_number?
     td

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -41,30 +41,6 @@
       => "Agent".pluralize(rdv.agents.size)
     = agents_to_sentence(rdv.agents)
 
-- rdv.participations.select(&:prescription?).each do |participation|
-  - author = participation.created_by
-  .d-flex.card-text.mt-1
-    = icon("fr-icon-user-add-fill", class: "text-primary-blue fr-mr-1w")
-    div
-      |> Rendez-vous pris par
-      a href="#prescripteur-explanation#{participation.id}" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="collapseExample"
-        = author.full_name
-  .collapse.alert-info.p-2.m-2 id="prescripteur-explanation#{participation.id}"
-    p
-      |> La réservation a été faite par un prescripteur qui ne participera pas au rendez-vous (agent d'accueil, conseiller).
-    p
-      |> Ce rendez-vous a été pris sur un créneau ouvert au public.
-    p.mb-0
-      |> Si vous pensez qu'il y a eu une erreur lors de la prise de rendez-vous, vous pouvez contacter
-      strong => author.full_name
-      - if author.is_a?(Prescripteur) && author.phone_number.present?
-        |> au
-        strong => phone_to(author.phone_number)
-        |> ou
-      |> à l'adresse
-      strong = mail_to(author.email)
-      | .
-
 - if rdv.public_office? && rdv.overlapping_plages_ouvertures?
   div.my-3
     .alert.alert-warning.mt-1.mb-0

--- a/app/views/admin/rdvs/_users_table.html.slim
+++ b/app/views/admin/rdvs/_users_table.html.slim
@@ -16,5 +16,6 @@
         = render "admin/participations/user_row", participation:, contextual_agents:
 
 - if rdv.participations.any?(&:prescription?)
-  .fr-mb-2w.fr-text--sm
-    | ℹ️ Les prescripteur·ices (agent d'accueil, conseiller·e) ne participent pas aux RDV.
+  .fr-mb-2w.fr-text--sm.text-muted
+    = icon "fr-icon-info-line", class: "fr-icon--sm fr-mr-1w"
+    | Les prescripteur·ices (agent d'accueil, conseiller·e) ne participent pas aux RDV.

--- a/app/views/admin/rdvs/_users_table.html.slim
+++ b/app/views/admin/rdvs/_users_table.html.slim
@@ -14,3 +14,7 @@
     tbody id="rdv-users-list"
       - rdv.participations.sort_by { _1.user.last_name.downcase }.each do |participation|
         = render "admin/participations/user_row", participation:, contextual_agents:
+
+- if rdv.participations.any?(&:prescription?)
+  .fr-mb-2w.fr-text--sm
+    | ℹ️ Les prescripteur·ices (agent d'accueil, conseiller·e) ne participent pas aux RDV.

--- a/spec/features/agents/rdv_details_spec.rb
+++ b/spec/features/agents/rdv_details_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe "Agent can see RDV details correctly" do
     it "displays the prescripteur when present" do
       rdv.participations.last.update!(created_by: prescripteur)
       visit admin_organisation_rdvs_path(organisation)
-      expect(page).to have_content("Prescripteur·ice : Jean VALJEAN")
+      expect(page).to have_content("Prescrit par Jean VALJEAN")
     end
 
     it "displays the agent prescripteur when present" do
       rdv.participations.last.update!(created_by: agent, created_by_agent_prescripteur: true)
       visit admin_organisation_rdvs_path(organisation)
-      expect(page).to have_content("Prescripteur·ice : Bruce WAYNE")
+      expect(page).to have_content("Prescrit par Bruce WAYNE")
     end
 
     it "Allows showing RDVs data and correctly displays user notifications and notif info" do

--- a/spec/features/agents/rdv_details_spec.rb
+++ b/spec/features/agents/rdv_details_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe "Agent can see RDV details correctly" do
     it "displays the prescripteur when present" do
       rdv.participations.last.update!(created_by: prescripteur)
       visit admin_organisation_rdvs_path(organisation)
-      expect(page).to have_content("Rendez-vous pris par Jean VALJEAN")
+      expect(page).to have_content("Prescripteur·ice : Jean VALJEAN")
     end
 
     it "displays the agent prescripteur when present" do
       rdv.participations.last.update!(created_by: agent, created_by_agent_prescripteur: true)
       visit admin_organisation_rdvs_path(organisation)
-      expect(page).to have_content("Rendez-vous pris par Bruce WAYNE")
+      expect(page).to have_content("Prescripteur·ice : Bruce WAYNE")
     end
 
     it "Allows showing RDVs data and correctly displays user notifications and notif info" do


### PR DESCRIPTION
# Contexte

L'affichage des prescripteurs sur la vue RDV collectif est peu pratique : 
- l'agent ne peut pas savoir quel agent a pris RDV pour quel usager
- les coordonnées des prescripteurs sont cachées derrière un clic
- la liste s'allonge vite en cas de nombreux prescripteur·ices

# Solution

On propose de rappatrier l'info du prescripteur·ice vers la ligne de participation dans le tableau, en dessous du nom de l'usager

Je propose aussi de mettre un petit texte explicatif commun en bas du tableau . Je ne dis pas dans quels cas contacter car ça ne parait pas super clair aujourd'hui.

## Captures d'écran

Avant | Après
:- | -:
<img width="1011" height="629" alt="image" src="https://github.com/user-attachments/assets/292eb9eb-7661-4112-95d5-14989a62b3a3" /> | <img width="1011" height="709" alt="image" src="https://github.com/user-attachments/assets/e57442ec-45ba-4a18-845b-6ca08fd37a04" />


## review app

https://rdv-service-public-review-app-pr6124.osc-secnum-fr1.scalingo.io/admin/organisations/4/rdvs/6

`martine@demo.rdv-solidarites.fr`
`Rdvservicepublictest1!`

