### PR TITLE
Ajout d’une erreur lorsqu’on essaye de créer une review app sans être connecté

### DIFF
--- a/scripts/create_review_app.rb
+++ b/scripts/create_review_app.rb
@@ -1,6 +1,11 @@
 require "English"
 require "shellwords"
 
+unless system("scalingo whoami", out: IO::NULL, err: IO::NULL)
+  puts "Erreur : vous n'êtes pas connecté à la CLI Scalingo. Lancez 'scalingo login' d'abord."
+  exit(1)
+end
+
 pr_number = `gh pr view --json number --jq '.number'`.strip
 exit(1) if $CHILD_STATUS.exitstatus != 0 # On quitte si aucune PR n'est liée à la branche courante
 


### PR DESCRIPTION
# Contexte

J’ai essayé de lancer une review app alors que je n’étais pas connecté à la CLI Scalingo. Le script était bloqué sans explication.

# Solution

Je propose donc de rajouter un test et un message d’erreur si nous ne sommes pas connectés à la CLI Scalingo.
