### PR TITLE
Instances multiples en local

### DIFF
--- a/.env.rdv_solidarites.sample
+++ b/.env.rdv_solidarites.sample
@@ -1,7 +1,5 @@
 # Rails configuration
 HOST=http://localhost:3001
-# overmind passes its default port (5000) if unspecified
-PORT=3001
 
 # This is used to provide redirections to rdv-insertion.fr website and to handle webhook endpoints in the seeds
 # It is needed as an env variable because seeds can be used on staging envs
@@ -13,7 +11,9 @@ RDV_INSERTION_SECRET=rdv-solidarites
 
 RDV_SOLIDARITES_INSTANCE_NAME="RDV_SOLIDARITES_DEV"
 
-# Shared Secrets for external services
+DEFAULT_DOMAIN_IS_RDV_SOLIDARITES=true
+
+# Shared Secrets used for RDV Insertion
 SHARED_SECRET_FOR_AGENTS_AUTH=123456
 
 # On a des identifiants ProConnect différents pour nos trois marques en production, mais en local c'est la même valeur pour les trois

--- a/.env.rdv_solidarites.sample
+++ b/.env.rdv_solidarites.sample
@@ -1,3 +1,6 @@
+# Ce fichier contient les variable d'env spécifiques à l'instance historique RDV Solidarités.
+RDV_SOLIDARITES_INSTANCE_NAME="RDV_SOLIDARITES_DEV"
+
 # Rails configuration
 HOST=http://localhost:3001
 
@@ -9,7 +12,6 @@ RDV_INSERTION_HOST=http://localhost:8000
 # It is needed as an env variable because seeds can be used on staging envs
 RDV_INSERTION_SECRET=rdv-solidarites
 
-RDV_SOLIDARITES_INSTANCE_NAME="RDV_SOLIDARITES_DEV"
 
 DEFAULT_DOMAIN_IS_RDV_SOLIDARITES=true
 
@@ -19,7 +21,7 @@ SHARED_SECRET_FOR_AGENTS_AUTH=123456
 # On a des identifiants ProConnect différents pour nos trois marques en production, mais en local c'est la même valeur pour les trois
 PRO_CONNECT_RDVS_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
 PRO_CONNECT_RDVAN_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
-# pour récupérer les trois clés suivantes en local https://vaultwarden.incubateur.net/#/vault?organizationId=2662d2f2-17f4-49c2-907c-0e7049c28cb7&collectionId=e5e23afd-18f2-4da1-af4a-77d97bbb2684&itemId=2d8626d9-62cc-4b03-a62f-11a07eb67c46
+# pour récupérer les clés suivantes en local https://vaultwarden.incubateur.net/#/vault?organizationId=2662d2f2-17f4-49c2-907c-0e7049c28cb7&collectionId=e5e23afd-18f2-4da1-af4a-77d97bbb2684&itemId=2d8626d9-62cc-4b03-a62f-11a07eb67c46
 # cf docs/interconnexions/proconnect.md
 PRO_CONNECT_RDVS_CLIENT_SECRET=""
 PRO_CONNECT_RDVAN_CLIENT_SECRET=""

--- a/.env.rdv_solidarites.sample
+++ b/.env.rdv_solidarites.sample
@@ -1,0 +1,25 @@
+# Rails configuration
+HOST=http://localhost:3001
+# overmind passes its default port (5000) if unspecified
+PORT=3001
+
+# This is used to provide redirections to rdv-insertion.fr website and to handle webhook endpoints in the seeds
+# It is needed as an env variable because seeds can be used on staging envs
+RDV_INSERTION_HOST=http://localhost:8000
+
+# This is the secret used for the rdv-insertion webhook endpoints in the seeds
+# It is needed as an env variable because seeds can be used on staging envs
+RDV_INSERTION_SECRET=rdv-solidarites
+
+RDV_SOLIDARITES_INSTANCE_NAME="RDV_SOLIDARITES_DEV"
+
+# Shared Secrets for external services
+SHARED_SECRET_FOR_AGENTS_AUTH=123456
+
+# On a des identifiants ProConnect différents pour nos trois marques en production, mais en local c'est la même valeur pour les trois
+PRO_CONNECT_RDVS_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
+PRO_CONNECT_RDVAN_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
+# pour récupérer les trois clés suivantes en local https://vaultwarden.incubateur.net/#/vault?organizationId=2662d2f2-17f4-49c2-907c-0e7049c28cb7&collectionId=e5e23afd-18f2-4da1-af4a-77d97bbb2684&itemId=2d8626d9-62cc-4b03-a62f-11a07eb67c46
+# cf docs/interconnexions/proconnect.md
+PRO_CONNECT_RDVS_CLIENT_SECRET=""
+PRO_CONNECT_RDVAN_CLIENT_SECRET=""

--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,5 @@
 # Rails configuration
 HOST=http://localhost:3000
-# overmind passes its default port (5000) if unspecified
-PORT=3000
 SECRET_KEY_BASE=rdv-sp-key-rd123
 
 # Feature flags and App configuration

--- a/.env.sample
+++ b/.env.sample
@@ -10,14 +10,6 @@ DEGRADED_SERVICE_MESSAGE_AGENTS=
 
 SIGN_IN_AS_ALLOWED=true
 
-# This is used to provide redirections to rdv-insertion.fr website and to handle webhook endpoints in the seeds
-# It is needed as an env variable because seeds can be used on staging envs
-RDV_INSERTION_HOST=http://localhost:8000
-
-# This is the secret used for the rdv-insertion webhook endpoints in the seeds
-# It is needed as an env variable because seeds can be used on staging envs
-RDV_INSERTION_SECRET=rdv-solidarites
-
 # SuperAdmin
 ## HTTP Basic authentication in local
 ADMIN_BASIC_AUTH_PASSWORD=change_me
@@ -55,7 +47,7 @@ DEVELOPMENT_SMTP_HOST=smtp.mailtrap.io
 DEVELOPMENT_SMTP_DOMAIN=smtp.mailtrap.io
 DEVELOPMENT_SMTP_PORT=2525
 
-RDV_SOLIDARITES_INSTANCE_NAME=
+RDV_SOLIDARITES_INSTANCE_NAME="RDV_SERVICE_PUBLIC_DEV"
 
 # Forcer l'affichage du favicon de production en dev ou review app
 # FORCE_PRODUCTION_FAVICON=true
@@ -66,7 +58,6 @@ POSTGRES_USER=
 POSTGRES_PASSWORD=
 
 # Shared Secrets for external services
-SHARED_SECRET_FOR_AGENTS_AUTH=123456
 ANTS_API_AUTH_TOKEN=fake_ants_api_auth_token
 ANTS_RDV_OPT_AUTH_TOKEN="voir https://vaultwarden.incubateur.net/#/vault?itemId=f5a2605f-f706-4560-a70d-8c4cdc4fe1fe"
 ANTS_RDV_API_URL="https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api"
@@ -75,13 +66,9 @@ PRO_CONNECT_BASE_URL="https://fca.integ01.dev-agentconnect.fr/api/v2"
 
 # On a des identifiants ProConnect différents pour nos trois marques en production, mais en local c'est la même valeur pour les trois
 PRO_CONNECT_RDVSP_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
-PRO_CONNECT_RDVS_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
-PRO_CONNECT_RDVAN_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
 # pour récupérer les trois clés suivantes en local https://vaultwarden.incubateur.net/#/vault?organizationId=2662d2f2-17f4-49c2-907c-0e7049c28cb7&collectionId=e5e23afd-18f2-4da1-af4a-77d97bbb2684&itemId=2d8626d9-62cc-4b03-a62f-11a07eb67c46
 # cf docs/interconnexions/proconnect.md
-PRO_CONNECT_RDVS_CLIENT_SECRET=""
 PRO_CONNECT_RDVSP_CLIENT_SECRET=""
-PRO_CONNECT_RDVAN_CLIENT_SECRET=""
 
 # Décommenter s'il y a besoin de désactiver le bouton ProConnect
 # PRO_CONNECT_DISABLED=true

--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,9 @@
+# Cette variable permet de distinguer sur quelle instance on est en local.
+# Par défaut on est sur une imitation de l'instance de production RDV Service Public
+# Il est aussi possible d'utiliser une imitation de l'instance historique RDV Solidarités
+# (voir .env.rdv_solidarites.sample)
+RDV_SOLIDARITES_INSTANCE_NAME="RDV_SERVICE_PUBLIC_DEV"
+
 # Rails configuration
 HOST=http://localhost:3000
 SECRET_KEY_BASE=rdv-sp-key-rd123
@@ -45,8 +51,6 @@ DEVELOPMENT_SMTP_HOST=smtp.mailtrap.io
 DEVELOPMENT_SMTP_DOMAIN=smtp.mailtrap.io
 DEVELOPMENT_SMTP_PORT=2525
 
-RDV_SOLIDARITES_INSTANCE_NAME="RDV_SERVICE_PUBLIC_DEV"
-
 # Forcer l'affichage du favicon de production en dev ou review app
 # FORCE_PRODUCTION_FAVICON=true
 
@@ -64,7 +68,7 @@ PRO_CONNECT_BASE_URL="https://fca.integ01.dev-agentconnect.fr/api/v2"
 
 # On a des identifiants ProConnect différents pour nos trois marques en production, mais en local c'est la même valeur pour les trois
 PRO_CONNECT_RDVSP_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
-# pour récupérer les trois clés suivantes en local https://vaultwarden.incubateur.net/#/vault?organizationId=2662d2f2-17f4-49c2-907c-0e7049c28cb7&collectionId=e5e23afd-18f2-4da1-af4a-77d97bbb2684&itemId=2d8626d9-62cc-4b03-a62f-11a07eb67c46
+# pour récupérer la clé suivante en local https://vaultwarden.incubateur.net/#/vault?organizationId=2662d2f2-17f4-49c2-907c-0e7049c28cb7&collectionId=e5e23afd-18f2-4da1-af4a-77d97bbb2684&itemId=2d8626d9-62cc-4b03-a62f-11a07eb67c46
 # cf docs/interconnexions/proconnect.md
 PRO_CONNECT_RDVSP_CLIENT_SECRET=""
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-debug.log*
 .DS_Store
 .env
 .env.development
+.env.rdv_solidarites
 .ruby-gemset
 lapins.kdbx
 .vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install: ## Setup development environment
 	bin/setup
 
 run: ## Start the application (web, jobs et webpack)
-	overmind start -f Procfile.dev
+	OVERMIND_SKIP_ENV=true overmind start -f Procfile.dev
 
 lint: lint_rubocop lint_slim lint_brakeman ## Run all linters
 

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: ./bin/start_web_server
+web: bundle exec puma
 jobs: bundle exec good_job start
 postdeploy: bundle exec rake db:migrate

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,5 +1,7 @@
-web: ./bin/start_web_server
+web: PORT=3000 ./bin/start_web_server
 jobs: bundle exec good_job start
+web_rdv_solidarites: PORT=3001 bundle exec dotenv --overwrite -f ".env,.env.rdv_solidarites" puma
+jobs_rdv_solidarites: bundle exec dotenv -f ".env,.env.rdv_solidarites" good_job start
 js: yarn build --mode=development --watch --progress
 mss_web: PORT=3010 bundle exec ruby scripts/mon_suivi_social_local.rb
 ants_web: PORT=3020 bundle exec ruby scripts/ants_app.rb

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,6 +1,6 @@
 web: PORT=3000 ./bin/start_web_server
 jobs: bundle exec good_job start
-web_rdv_solidarites: PORT=3001 bundle exec dotenv --overwrite -f ".env,.env.rdv_solidarites" puma
+web_rdv_solidarites: PORT=3001 bundle exec dotenv -f ".env.rdv_solidarites,.env" puma
 jobs_rdv_solidarites: bundle exec dotenv -f ".env,.env.rdv_solidarites" good_job start
 js: yarn build --mode=development --watch --progress
 mss_web: PORT=3010 bundle exec ruby scripts/mon_suivi_social_local.rb

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: PORT=3000 ./bin/start_web_server
+web: PORT=3000 bundle exec puma
 jobs: bundle exec good_job start
 web_rdv_solidarites: PORT=3001 bundle exec dotenv -f ".env.rdv_solidarites,.env" puma
 jobs_rdv_solidarites: bundle exec dotenv -f ".env,.env.rdv_solidarites" good_job start

--- a/bin/setup
+++ b/bin/setup
@@ -17,6 +17,9 @@ FileUtils.chdir APP_ROOT do
   unless File.exist?(".env")
     FileUtils.cp ".env.sample", ".env"
   end
+  unless File.exist?(".env.rdv_solidarites")
+    FileUtils.cp ".env.rdv_solidarites.sample", ".env.rdv_solidarites"
+  end
 
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
@@ -24,8 +27,10 @@ FileUtils.chdir APP_ROOT do
   system! "yarn install --frozen-lockfile"
   system! "yarn run playwright install chromium --with-deps"
 
-  puts "\n== Preparing database =="
+  puts "\n== Preparing database for both local instances =="
   system! "bin/rails db:prepare"
+  system! "bundle exec dotenv -f '.env.rdv_solidarites,.env' bin/rails db:prepare"
+
 
   puts "\n== Preparing parallel test databases =="
   system! "RAILS_ENV=test rake parallel:create"

--- a/bin/start_web_server
+++ b/bin/start_web_server
@@ -1,1 +1,0 @@
-bundle exec puma

--- a/config/database.yml
+++ b/config/database.yml
@@ -49,7 +49,7 @@ development:
   collation: en_US.UTF-8 # pour être raccord avec la config sur Scalingo
   ctype: en_US.UTF-8
   template: template0 # cette base est immutable sur Postgresql v16+
-  database: lapin_development
+  database: <%= (ENV["RDV_SOLIDARITES_INSTANCE_NAME"] || "lapin_development").downcase %>
 
 test:
   <<: *default

--- a/docs/1-installation.md
+++ b/docs/1-installation.md
@@ -21,10 +21,7 @@ make install  ## appelle bin/setup
 
 Pour certaines fonctionnalités comme ProConnect ou des appels à des API distantes, vous aurez besoin de récupérer des variables d'env depuis Vaulwarden. Le fichier .env contient des instructions pour chaque variable.
 
-Vous pouvez ensuite lancer le serveur avec :
-```bash
-make run      ## appelle overmind start -f Procfile.dev
-```
+Vous pouvez ensuite lancer le serveur avec `make run`
 
 ## Commandes
 


### PR DESCRIPTION
# Contexte

Pour débugger certains cas de la migration inter-instances, j'aurais besoin de pouvoir lancer les deux instances en local, avec leur workers et deux bases de données différentes.

Cette PR apporte l'outillage pour rendre ça possible sans setup supplémentaire.

# Solution

Le coeur de la solution est d'avoir un fichier `database.yml` qui utilise une variable d'env pour permettre pointer vers deux DB différentes en local, un fichier .env qui fait le setup de RDV Service Public, et un fichier `.env.rdv_solidarites` facultatif qui permet de lancer des commandes pour la deuxième instance.

Plus de détails :
- En lançant `make run`, on lance les serveurs webs et les workers pour les deux instances.
- Les commandes rails classique `bundle exec rails c`, `bundle exec rails db:migrate` fonctionnent pour une seule instance (celle qui tourne sur le port 300 avec le make run).
- Pour lancer des commandes spécifiques à l'instance rdv solidarités, il faut suivre l'exemple du `Procfile.dev`, et utiliser le préfixe `bundle exec dotenv -f ".env,.env.rdv_solidarites"`. Par exemple `bundle exec dotenv -f ".env,.env.rdv_solidarites" rails db:migrate`
- Tout cela est basé sur les valeurs des fichiers `.env` et `.env.rdv_solidarites`. Si vous voulez changer ce comportement pour que RDV Solidarités soit l'instance principale qui tourne sur le port 3000 (par exemple pour bosser sur RDV Insertion 😉 ), vous pouvez mettre `RDV_SOLIDARITES_INSTANCE_NAME="RDV_SOLIDARITES_DEV"` dans votre `.env`). Ça veut aussi dire que si vous ne touchez pas à vos fichier d'env, tout continue à fonctionner comme avant.