### PR TITLE
On repasse sur Rubygems temporairement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://beta.gem.coop/cooldown"
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.4.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ PATH
       omniauth-oauth2 (~> 1.8)
 
 GEM
-  remote: https://beta.gem.coop/cooldown/
+  remote: https://rubygems.org/
   specs:
     actioncable (8.0.4)
       actionpack (= 8.0.4)


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6130.osc-secnum-fr1.scalingo.io/)

# Contexte

On a rencontré une erreur un peu étrange aujourd’hui avec cette nouvelle source, de type : 

```
--- ERROR REPORT TEMPLATE -------------------------------------------------------

NoMethodError: undefined method '+' for nil
  /Users/antoinegirard/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/compact_index_client/parser.rb:74:in 'Bundler::CompactIndexClient::Parser#parse_version_checksum'

[…]

--- TEMPLATE END ----------------------------------------------------------------

Unfortunately, an unexpected error occurred, and Bundler cannot continue.
```

# Solution

On a regardé un peu avec François et nous n’avons pas trop compris d’où ça venait. 
Vu qu’on a pas mal d’occupations en ce moment (et qu’on a déjà eu des petits bugs la semaine passée avec gem.coop), on propose de repasser temporairement sur rubygems.org en attendant que ça se stabilise.

