### PR TITLE
Corrige la flaky spec find(".xdsoft_time", text: "14:15")

### DIFF
--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -82,10 +82,8 @@ RSpec.describe "Agent can create a Rdv with wizard" do
     end
 
     fill_in "Durée en minutes", with: "35"
-    # cannot use fill_in here because the datepicker does not autoclose as expected
-    find(:label, "Commence à").click
-    find(".xdsoft_calendar .xdsoft_date", text: "11").click
-    find(".xdsoft_time", text: "14:15").click
+    # Le datepicker JS est capricieux et cause des flaky specs donc on modifie la valeur du champ directement.
+    page.execute_script("document.getElementById('rdv_starts_at').value = '11/10/2019 14:15'")
     select("DIALO Alain", from: "rdv_agent_ids")
     select("MARTIN Robert", from: "rdv_agent_ids")
     click_button("Continuer")


### PR DESCRIPTION
Depuis quelques mois nous rencontrons une flaky spec, dont voici une occurrence : 

https://github.com/betagouv/rdv-service-public/actions/runs/22069170325/job/63768891257?pr=6080

> Failure/Error: find(".xdsoft_time", text: "14:15").click
>  -> Unable to find visible css ".xdsoft_time" with text "14:15"

# Solution

Il s'agit probablement d'un race condition causée par le comportement du datepicker, qui soit :

- se referme parfois après avoir cliqué sur la date, et donc on ne peut pas cliquer sur l'heure
- n'affiche pas `14:15` de façon visible sur la page, et donc il faudrait scroller pour cliquer dessus (peut-être)

Afin de ne pas perdre trop de temps je préfère aller au plus simple et modifier la valeur du champ directement pour ne plus avoir à manipuler le datepicker.

Note : j'ajoute ce problème à la liste des raisons pour lesquelles on devrait passer aux datepickers natifs. :rage1: 

## Possibilités d'autres solutions


<details>

<summary>Afficher les réflexions de Claude sur les causes et solutions possibles</summary>

## Flaky spec analysis: `Agent can create a Rdv with wizard > create a RDV with a single_use lieu > works`

### Failure

```
Failure/Error: find(".xdsoft_time", text: "14:15").click

Capybara::ElementNotFound:
  Unable to find visible css ".xdsoft_time" with text "14:15"
# ./spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb:88:in 'step3'
```

This happens right after clicking a date in the calendar at line 87:

```ruby
find(".xdsoft_calendar .xdsoft_date", text: "11").click
```

### Root causes

There are two likely causes, both related to the xdsoft datetimepicker behavior:

#### 1. The picker closes after date selection (most likely)

The comment on line 85 already hints at instability: *"cannot use fill_in here because the datepicker does not autoclose as expected"*. The xdsoft datetimepicker can be unpredictable about when it opens/closes. When clicking the date "11" in the calendar, the picker **sometimes closes the entire popup** before the test gets to select the time. This is a race condition — depending on rendering speed and event propagation, the picker may or may not stay open after a date click.

When it closes, all `.xdsoft_time` elements become invisible, and Capybara fails with `Unable to find visible css ".xdsoft_time"`.

#### 2. The time "14:15" is not in the visible scroll area

The datetimepicker is configured with `step: 5` (`app/javascript/components/datetimepicker.js:25`), producing ~288 time slots from 00:00 to 23:55. The time list is a scrollable container. "14:15" is roughly in the middle of the list. After clicking a date, the scroll position of the time list is non-deterministic — it may reset to midnight or jump to the "current" time. With a JS driver, Capybara checks browser-level visibility, and elements clipped by an `overflow: auto/hidden` container can be considered not visible.

### Possible fixes

- **Add a wait/assertion between date and time clicks** to ensure the picker (and time panel) is still visible before searching for the time:
  ```ruby
  find(".xdsoft_calendar .xdsoft_date", text: "11").click
  expect(page).to have_css(".xdsoft_timepicker", visible: true) # wait for time panel
  find(".xdsoft_time", text: "14:15").click
  ```

- **Scroll the time into view** before clicking:
  ```ruby
  time_element = find(".xdsoft_time", text: "14:15", visible: :all)
  page.execute_script("arguments[0].scrollIntoView(true)", time_element)
  time_element.click
  ```

- **Bypass the picker entirely** with `execute_script` to set the value directly, similar to what's done for latitude/longitude on lines 80-81:
  ```ruby
  page.execute_script("document.querySelector('[data-behaviour=datetimepicker]').value = '11/10/2019 14:15'")
  ```
  This is the most robust approach since it removes the UI flakiness entirely, though it does reduce the integration coverage of the datepicker widget.

</details>