### PR TITLE
Correction gestion des attributs cassés dans Users::RdvBuilder

### DIFF
--- a/app/services/users/rdv_builder.rb
+++ b/app/services/users/rdv_builder.rb
@@ -16,7 +16,7 @@ class Users::RdvBuilder
       @rdv = Rdv.new(user_ids: [@user&.id])
       @rdv.assign_attributes(@attributes.slice(:starts_at, :user_ids, :motif_id))
       @rdv.duration_in_min = duration_in_min
-      @rdv.organisation_id = @rdv.motif.organisation_id
+      @rdv.organisation_id = @rdv.motif&.organisation_id
     end
   end
 
@@ -34,6 +34,8 @@ class Users::RdvBuilder
     # sont très peu validés. Le cas d’erreur principal qui peut se produire est qu’aucun créneau ne soit
     # trouvé pour les params passés. On s’appuie donc sur ce cas pour gérer l’erreur de validation ANTS
     return nil if ants_pre_demandes_count.present? && !AntsPreDemandesCountValidator.count_valid?(ants_pre_demandes_count)
+
+    return nil if starts_at.nil? || motif.nil?
 
     @creneau ||= CreneauxSearch::ForUser.creneau_for(
       user: @user,
@@ -67,10 +69,10 @@ class Users::RdvBuilder
   def duration_in_min
     if @attributes[:duration]
       @attributes[:duration].to_i
-    elsif @attributes[:ants_pre_demandes_count].present?
+    elsif @attributes[:ants_pre_demandes_count].present? && motif.present?
       motif.default_duration_in_min * @attributes[:ants_pre_demandes_count].to_i
     else
-      motif.default_duration_in_min
+      motif&.default_duration_in_min
     end
   end
 
@@ -85,6 +87,6 @@ class Users::RdvBuilder
   end
 
   def lieu
-    @lieu ||= lieu_id.present? ? Lieu.find(lieu_id) : nil
+    @lieu ||= lieu_id.present? ? Lieu.find_by(id: lieu_id) : nil
   end
 end

--- a/spec/form_models/users/rdv_builder_spec.rb
+++ b/spec/form_models/users/rdv_builder_spec.rb
@@ -56,6 +56,83 @@ RSpec.describe Users::RdvBuilder do
     expect(rdv_wizard.creneau).to eq returned_creneau
   end
 
+  context "le motif_id ne correspond à aucun motif existant" do
+    let(:attributes) do
+      {
+        starts_at: Time.zone.parse("2020-10-20 09h30"),
+        motif_id: 0,
+        lieu_id: lieu.id,
+        user_ids: [user_for_rdv.id],
+        departement: "62",
+        city_code: "62100",
+      }
+    end
+
+    it "ne lève pas d'erreurs" do
+      rdv_builder = described_class.new(user, attributes)
+      expect(rdv_builder.rdv.motif).to be_nil
+      expect(rdv_builder.rdv.organisation_id).to be_nil
+      expect(rdv_builder.rdv.duration_in_min).to be_nil
+      expect(rdv_builder.creneau).to be_nil
+    end
+  end
+
+  context "le lieu_id ne correspond à aucun lieu existant" do
+    let(:attributes) do
+      {
+        starts_at: creneau.starts_at,
+        motif_id: motif.id,
+        lieu_id: 0,
+        user_ids: [user_for_rdv.id],
+        departement: "62",
+        city_code: "62100",
+      }
+    end
+
+    it "ne lève pas d'erreurs" do
+      rdv_builder = described_class.new(user, attributes)
+      expect(rdv_builder.lieu).to be_nil
+      expect(rdv_builder.creneau).to be_nil
+    end
+  end
+
+  context "starts_at est nil" do
+    let(:attributes) do
+      {
+        starts_at: nil,
+        motif_id: motif.id,
+        lieu_id: lieu.id,
+        user_ids: [user_for_rdv.id],
+        departement: "62",
+        city_code: "62100",
+      }
+    end
+
+    it "ne lève pas d'erreurs" do
+      rdv_builder = described_class.new(user, attributes)
+      expect(rdv_builder.creneau).to be_nil
+    end
+  end
+
+  context "ants_pre_demandes_count présent mais motif inexistant" do
+    let(:attributes) do
+      {
+        starts_at: Time.zone.parse("2020-10-20 09h30"),
+        motif_id: 0,
+        lieu_id: lieu.id,
+        user_ids: [user_for_rdv.id],
+        departement: "62",
+        city_code: "62100",
+        ants_pre_demandes_count: "2",
+      }
+    end
+
+    it "ne lève pas d'erreurs" do
+      rdv_builder = described_class.new(user, attributes)
+      expect(rdv_builder.duration_in_min).to be_nil
+    end
+  end
+
   context "Rdv collectif - bookable by agents and prescripteurs" do
     let(:motif) { create(:motif, :at_public_office, organisation: organisation, bookable_by: :agents_and_prescripteurs, collectif: true) }
     let!(:rdv) { create(:rdv, motif: motif, organisation: organisation) }


### PR DESCRIPTION
# Contexte

Il y a plusieurs erreurs qui se produisent dans le `Users::RdvBuilder` (anciennement `UserRdvWizard`) pour cause d'ID dépréciés de lieu, de motif ou de param `starts_at` manquant :

https://sentry.incubateur.net/organizations/betagouv/issues/247530
https://sentry.incubateur.net/organizations/betagouv/issues/247531
https://sentry.incubateur.net/organizations/betagouv/issues/247535

Ce n'est pas la PR de refacto #6119 qui a introduit ça, les problèmes prééxistaient mais avec des stacktrace différentes.

Je pense que ces situations sont attendues au moins pour une partie : un motif ou un lieu peut être supprimé et le user a gardé en session ou est en train de naviguer dessus.

## Solution

J'améliore le support de ces cas dans le `Users::RdvBuilder` lui même pour ne pas lever d'erreur mais simplement renvoyer des réponses vides.

J'ai un petit doute car ça risque de cacher des cas problématiques au milieu des cas attendus 🤷 Je pense qu'on a pas mal de tests sur le parcours en général néanmoins pour être relativement confiant et je ne vois pas trop comment faire autrement.