### PR TITLE
Handle visio motifs on rdv-i creneaux api

### DIFF
--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -19,13 +19,13 @@ class Api::Rdvinsertion::InvitationsController < Api::Rdvinsertion::AgentAuthBas
     @creneau_availability_count ||= begin
       counter = 0
       invitation_search_context.matching_motifs.each do |motif|
-        if motif.phone?
-          counter += creneaux_available_for_motif(motif).all_creneaux.size
-        else
+        if motif.public_office?
           motif.lieux.each do |lieu|
             counter += creneaux_available_for_motif(motif, lieu).all_creneaux.size
             break if relevant_limit_reached?(counter)
           end
+        else
+          counter += creneaux_available_for_motif(motif).all_creneaux.size
         end
         break if relevant_limit_reached?(counter)
       end
@@ -35,10 +35,10 @@ class Api::Rdvinsertion::InvitationsController < Api::Rdvinsertion::AgentAuthBas
 
   def creneau_available?
     invitation_search_context.matching_motifs.any? do |motif|
-      if motif.phone?
-        creneaux_available_for_motif(motif).creneaux.any?
-      else
+      if motif.public_office?
         motif.lieux.any? { |lieu| creneaux_available_for_motif(motif, lieu).creneaux.any? }
+      else
+        creneaux_available_for_motif(motif).creneaux.any?
       end
     end
   end

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -125,6 +125,18 @@ RSpec.describe "Available Creneaux Count for Invitation" do
       let!(:plage_ouverture_with_secto) { create(:plage_ouverture, motifs: [motif_with_secto], lieu: lieu, organisation: org_with_secto, first_day: now + 4.days) }
       let!(:plage_ouverture_with_secto_expired) { create(:plage_ouverture, motifs: [motif_with_secto], lieu: lieu, organisation: org_with_secto, first_day: now - 10.days) }
 
+      let!(:org_visio) { create(:organisation, territory: territory33) }
+      let!(:motif_visio) do
+        create(
+          :motif,
+          location_type: :visio, min_public_booking_delay: 3.days, max_public_booking_delay: 1.month,
+          bookable_by: "agents_and_prescripteurs_and_invited_users", organisation: org_visio, default_duration_in_min: 45
+        )
+      end
+      let!(:plage_ouverture_visio) do
+        create(:plage_ouverture, motifs: [motif_visio], lieu: nil, organisation: org_visio, first_day: now + 4.days)
+      end
+
       let!(:lieu) { create(:lieu, name: "Bordeaux Centre", address: "Place de la bourse, Bordeaux, 33000", organisation: organisation1) }
       let!(:lieu2) { create(:lieu, name: "Bruges", address: "3 Rue Gabriel Fauré, Bruges, 33520", organisation: organisation1) }
       let!(:lieu3) { create(:lieu, name: "Loin de Bordeaux", address: "7 Av. du Commandant l'Herminier, Arès, 33740", organisation: other_org_without_po) }
@@ -289,6 +301,19 @@ RSpec.describe "Available Creneaux Count for Invitation" do
             let!(:street_ban_id) { "33063_1155" }
 
             it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+          end
+        end
+
+        context "Avec un motif visio" do
+          let!(:"organisation_ids[]") { [org_visio.id] }
+
+          it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+
+          context "Avec le paramètre total_count" do
+            let!(:total_count) { "true" }
+
+            # 5 créneaux disponibles sur la plage d'ouverture visio (4h, motif de 45min)
+            it { expect(parsed_response_body["creneau_availability_count"]).to eq(5) }
           end
         end
       end


### PR DESCRIPTION
# Contexte

Depuis #6101 on gère les rdvs par visioconférence pour les orgas sur rdv-i. Seulement l'endpoint `/api/rdvinsertion/invitations/creneau_availability` qui permet de voir s'il y a des créneaux de rdv avant d'envoyer une invitation ne prenait pas  en compte les créneaux sur des motifs par visio. 

# Solution

Je fais en sorte de toujours compter les créneaux sur l'endpoint `/api/rdvinsertion/invitations/creneau_availability`, quelque soit le type de rdv.