### PR TITLE
Ne plus afficher les agents opérant les RDV collectifs côté usagers

### DIFF
--- a/app/views/search/_rdv_collectif.html.slim
+++ b/app/views/search/_rdv_collectif.html.slim
@@ -16,10 +16,6 @@ li.card
         |> Durée :
         strong = "#{rdv.duration_in_min} minutes"
       li.card-text.fr-mb-1w
-        span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
-        |> Animé par
-        strong = agents_to_sentence(rdv.agents)
-      li.card-text.fr-mb-1w
         span.fr-icon-team-fill.fr-mr-1w[aria-hidden="true"]
         = I18n.t("rdvs.participants", count: rdv.users_count)
 


### PR DESCRIPTION
# Contexte

Aujourd'hui on affiche dans le parcours usagers les noms prénoms et services des agents de RDV collectifs.

Il semble que ça n'est pas été une décision très réfléchie mais plutôt un effet de bord. En se posant la question aujourd'hui de garder ou non cette info côté usager, il y a des pour et des contre : 
- pour : info pertinente dans certains / de nombreux cas, par ex je propose des RDV avec moi à mes collègues
- pour : réassurance des usagers, sérieux de voir un nom de quelqu'un, qu'on le connaisse ou non
- contre : divulgue l'identité des agents 
- contre : n'est pas vraiment explicité dans la partie agent

après dicussion on a décidé que pour l'instant on enlevait cette info côté usager. On voudra peut-être la remettre plus tard mais il faudra y réfléchir à comment présenter ça côté agent et probablement en opt-in. 

J'ai refait un tour et on n'affiche le nom de l'agent ni dans le mail reçu par l'usager ni dans la vue du RDV une fois réservé.

## Captures

<img width="815" height="1089" alt="image" src="https://github.com/user-attachments/assets/016850ef-0ff0-4831-a46b-be55342dd23b" />

