### PR TITLE
Rendre les noms des fichiers ICS + lisible

### DIFF
--- a/app/models/concerns/ics_payloads/rdv.rb
+++ b/app/models/concerns/ics_payloads/rdv.rb
@@ -2,7 +2,7 @@ module IcsPayloads
   module Rdv
     def payload(action = nil, recipient = users.first)
       payload = {
-        name: "rdv-#{uuid}-#{starts_at.to_s.parameterize}.ics",
+        name: "rdv-#{motif&.name&.parameterize}-#{starts_at.strftime('%Y-%m-%d-%Hh%M')}.ics",
         starts_at: starts_at,
         ends_at: ends_at,
         ical_uid: uuid,

--- a/spec/models/concerns/ics_payloads/rdv_spec.rb
+++ b/spec/models/concerns/ics_payloads/rdv_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
       let(:user) { build(:user) }
       let(:rdv) { build(:rdv, users: [user], starts_at: Time.zone.parse("20201123 15h50")) }
 
-      it { expect(rdv.payload[:name]).to eq("rdv-#{rdv.uuid}-2020-11-23-15-50-00-0100.ics") }
+      it { expect(rdv.payload[:name]).to eq("rdv-#{rdv.motif.name.parameterize}-2020-11-23-15h50.ics") }
     end
 
     describe ":starts_at" do


### PR DESCRIPTION
# Contexte

Le nom du fichier ICS joint aux emails de RDV contenait l'UUID du RDV et un timestamp brut, ce qui donnait un nom peu lisible pour les usagers et les agents :
`rdv-123e4567-e89b-12d3-a456-426614174000-2025-03-15t10-00-00-0100.ics`

# Solution

On remplace l'UUID et le timestamp brut par le nom du motif et une date formatée lisiblement :
`rdv-consultation-medicale-2025-03-15-10h00.ics`

Ce changement n'affecte que le nom de la pièce jointe dans les mails.
