### PR TITLE
Corrige une flaky spec dans import_absences_from_caldav_job_spec.rb

### DIFF
--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
     response_breadcrumb = sentry_events.last.breadcrumbs.compact[1]
     expect(response_breadcrumb.data[:status_code]).to eq(500)
     expect(response_breadcrumb.data[:body]).to eq("ceci est mon corps")
-    expect(response_breadcrumb.data[:duration_ms]).to be_within(10).of(1)
+    expect(response_breadcrumb.data[:duration_ms]).to be_within(50).of(50) # entre 0 et 100ms
     expect(response_breadcrumb.data[:headers]["Set-Cookie"]).to eq("[FILTERED]")
   end
 

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
     response_breadcrumb = sentry_events.last.breadcrumbs.compact[1]
     expect(response_breadcrumb.data[:status_code]).to eq(500)
     expect(response_breadcrumb.data[:body]).to eq("ceci est mon corps")
-    expect(response_breadcrumb.data[:duration_ms]).to be_within(50).of(50) # entre 0 et 100ms
+    expect(response_breadcrumb.data[:duration_ms]).to be_between(0, 100)
     expect(response_breadcrumb.data[:headers]["Set-Cookie"]).to eq("[FILTERED]")
   end
 


### PR DESCRIPTION
On a eu une erreur parce que l'appel a mis plus de 10ms. Je ne sais pas trop pourquoi c'est si long alors que c'est stubbé. Quoi qu'il en soit, je propose de passer à 0-100ms. :shrug: 

```
  1) Caldav::ImportAbsencesFromCaldavJob enregistre la réponse dans Sentry si la récupération du token retourne un body inattendu
     Failure/Error: expect(response_breadcrumb.data[:duration_ms]).to be_within(10).of(1)
       expected 14 to be within 10 of 1
     # ./spec/jobs/caldav/import_absences_from_caldav_job_spec.rb:113:in 'block (2 levels) in <main>'
     # ./spec/rails_helper.rb:100:in 'block (2 levels) in <top (required)>'
```