### PR TITLE
Vérification de l’accès en lecture et en écriture agenda CalDAV

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -12,11 +12,13 @@ class Agents::CaldavSyncController < AgentAuthController
       caldav_username: params[:caldav_username],
       caldav_password: params[:caldav_password]
     )
-    if caldav_config_ok?
+
+    error = caldav_config_error
+    if error.nil?
       current_agent.save!
       Caldav::MassExportEventToCaldavJob.perform_later(current_agent)
     else
-      flash[:alert] = "La connexion au calendrier a échoué. Veuillez vérifier vos informations et réessayer."
+      flash[:alert] = error
     end
 
     redirect_to agents_calendar_sync_caldav_sync_path
@@ -31,13 +33,45 @@ class Agents::CaldavSyncController < AgentAuthController
 
   private
 
-  def caldav_config_ok?
-    # Pour vérifier la configuration Caldav, on tente de récupérer l'URL principale.
-    current_agent.caldav_client.principal_url
+  # Vérifie la configuration CalDAV en 3 étapes : authentification, lecture, écriture.
+  # Retourne nil si tout est OK, ou un message d’erreur décrivant l’étape qui a échoué.
+  def caldav_config_error
+    client = current_agent.caldav_client
+    agenda_url = params[:caldav_agenda_url]
 
-    true
-  rescue StandardError
-    false
+    begin
+      client.principal_url
+    rescue StandardError
+      return "L’authentification a échoué. Veuillez vérifier votre identifiant et votre mot de passe."
+    end
+
+    begin
+      client.calendars.find(agenda_url)
+    rescue StandardError
+      return "L’accès en lecture au calendrier a échoué. Veuillez vérifier l’URL de l’agenda."
+    end
+
+    begin
+      identifier = "rdvsp-connection-test-#{SecureRandom.uuid}.ics"
+      test_event = client.events.create(agenda_url, identifier, test_event_ics)
+      client.events.delete(test_event.url) # On nettoie l’événement de test qu’on vient de créer
+    rescue StandardError
+      return "L’accès en écriture au calendrier a échoué. Veuillez vérifier vos droits d’accès à l’agenda."
+    end
+
+    nil
+  end
+
+  def test_event_ics
+    cal = Icalendar::Calendar.new
+    cal.prodid = "RDV Service Public"
+    cal.event do |event|
+      event.uid = "rdvsp-connection-test-#{SecureRandom.uuid}"
+      event.dtstart = Icalendar::Values::DateTime.new(Time.now.change(hour: 0, min: 0, sec: 0).utc)
+      event.dtend = Icalendar::Values::DateTime.new(Time.now.change(hour: 1, min: 0, sec: 0).utc)
+      event.summary = "Test de connexion RDV Service Public"
+    end
+    cal.to_ical
   end
 
   def pundit_user

--- a/spec/controllers/agents/caldav_sync_controller_spec.rb
+++ b/spec/controllers/agents/caldav_sync_controller_spec.rb
@@ -1,0 +1,118 @@
+RSpec.describe Agents::CaldavSyncController, type: :controller do
+  let(:agent) { create(:agent) }
+  let(:caldav_client) { instance_double(Calendav::Client) }
+  let(:caldav_events) { instance_double(Calendav::Clients::EventsClient) }
+  let(:caldav_calendars) { instance_double(Calendav::Clients::CalendarsClient) }
+
+  let(:caldav_params) do
+    {
+      caldav_username: "user@example.fr",
+      caldav_password: "secret",
+      caldav_agenda_url: "https://caldav.example.fr/dav/calendars/user/default",
+    }
+  end
+
+  before do
+    sign_in agent
+    allow_any_instance_of(Agent).to receive(:caldav_client).and_return(caldav_client) # rubocop:disable RSpec/AnyInstance
+    allow(caldav_client).to receive(:principal_url).and_return("https://caldav.example.fr/dav/principals/user")
+    allow(caldav_client).to receive(:events).and_return(caldav_events)
+    allow(caldav_client).to receive(:calendars).and_return(caldav_calendars)
+    allow(caldav_calendars).to receive(:find).and_return(double)
+    allow(caldav_events).to receive(:create).and_return(instance_double(Calendav::Event, url: "https://caldav.example.fr/dav/calendars/user/default/test.ics"))
+    allow(caldav_events).to receive(:delete)
+  end
+
+  describe "#show" do
+    it "rend la page de configuration" do
+      get :show
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "#update" do
+    context "quand l’authentification, la lecture et l’écriture réussissent" do
+      it "enregistre les identifiants et lance l’export en masse" do
+        expect(Caldav::MassExportEventToCaldavJob).to receive(:perform_later).with(agent)
+
+        put :update, params: caldav_params
+
+        expect(response).to redirect_to(agents_calendar_sync_caldav_sync_path)
+        expect(agent.reload.caldav_username).to eq("user@example.fr")
+        expect(agent.reload.caldav_agenda_url).to eq("https://caldav.example.fr/dav/calendars/user/default")
+      end
+
+      it "ne met pas de message d’erreur en flash" do
+        put :update, params: caldav_params
+        expect(flash[:alert]).to be_nil
+      end
+    end
+
+    context "quand l’authentification échoue" do
+      before do
+        allow(caldav_client).to receive(:principal_url).and_raise(StandardError.new("401 Unauthorized"))
+      end
+
+      it "affiche un message d’erreur d’authentification" do
+        put :update, params: caldav_params
+
+        expect(response).to redirect_to(agents_calendar_sync_caldav_sync_path)
+        expect(flash[:alert]).to eq("L’authentification a échoué. Veuillez vérifier votre identifiant et votre mot de passe.")
+      end
+
+      it "ne sauvegarde pas les identifiants" do
+        put :update, params: caldav_params
+        expect(agent.reload.caldav_username).to be_nil
+      end
+    end
+
+    context "quand la lecture du calendrier échoue" do
+      before do
+        allow(caldav_calendars).to receive(:find).and_raise(StandardError.new("404 Not Found"))
+      end
+
+      it "affiche un message d’erreur de lecture" do
+        put :update, params: caldav_params
+
+        expect(response).to redirect_to(agents_calendar_sync_caldav_sync_path)
+        expect(flash[:alert]).to eq("L’accès en lecture au calendrier a échoué. Veuillez vérifier l’URL de l’agenda.")
+      end
+
+      it "ne sauvegarde pas les identifiants" do
+        put :update, params: caldav_params
+        expect(agent.reload.caldav_username).to be_nil
+      end
+    end
+
+    context "quand l’écriture dans le calendrier échoue" do
+      before do
+        allow(caldav_events).to receive(:create).and_raise(StandardError.new("403 Forbidden"))
+      end
+
+      it "affiche un message d’erreur d’écriture" do
+        put :update, params: caldav_params
+
+        expect(response).to redirect_to(agents_calendar_sync_caldav_sync_path)
+        expect(flash[:alert]).to eq("L’accès en écriture au calendrier a échoué. Veuillez vérifier vos droits d’accès à l’agenda.")
+      end
+
+      it "ne sauvegarde pas les identifiants" do
+        put :update, params: caldav_params
+        expect(agent.reload.caldav_username).to be_nil
+      end
+    end
+  end
+
+  describe "#destroy" do
+    let(:agent) { create(:agent, :with_caldav_config) }
+
+    it "active le flag de déconnexion et lance le job de nettoyage" do
+      expect(Caldav::MassDestroyEventsAndAbsencesJob).to receive(:perform_later).with(agent)
+
+      delete :destroy
+
+      expect(response).to redirect_to(agents_calendar_sync_caldav_sync_path)
+      expect(agent.reload.caldav_disconnect_in_progress).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
# Contexte

On s’aperçoit en regardant les Sentry que nous avons quelques agents qui ont essayé de mettre en place la synchro CalDAV mais que celle-ci n’a jamais fonctionné. 
Cela semble généralement dû à un problème de droit de lecture ou d’écriture de l’agenda.

# Solution

Je propose donc ici de tester la lecture et l’écriture dans l’agenda avant d’enregistrer les identifiants CalDAV.