### PR TITLE
protect_from_forgery with: :exception

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,8 @@ class ApplicationController < ActionController::Base
   include ExplicitPunditConcern
   include DomainDetection
 
-  protect_from_forgery with: :exception
+  # TODO: supprimer cette var d'env après le 23/03/2026 c'était une sécurité le temps de la release
+  protect_from_forgery with: ENV.fetch("PROTECT_FROM_FORGERY_STRATEGY", "exception").to_sym
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :store_user_location!, if: :storable_location?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,7 @@ class ApplicationController < ActionController::Base
   include ExplicitPunditConcern
   include DomainDetection
 
-  # TODO: supprimer cette var d'env après le 23/03/2026 c'était une sécurité le temps de la release
-  protect_from_forgery with: ENV.fetch("PROTECT_FROM_FORGERY_STRATEGY", "exception").to_sym
+  protect_from_forgery with: :exception
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :store_user_location!, if: :storable_location?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include ExplicitPunditConcern
   include DomainDetection
 
-  protect_from_forgery
+  protect_from_forgery with: :exception
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :store_user_location!, if: :storable_location?


### PR DESCRIPTION
# Contexte

On utilise pour l'instant `protect_from_forgery` avec la stratégie par défaut soit `null_session`. Ça nullifie la session en cas de token d'authenticité invalide mais ça n’empêche pas les requêtes. Je pense que ça signifie que l'effet est limité aux routes authentifiées. 



`protect_from_forgery with: :exception` est maintenant le défaut sur les apps Rails cf [le guide rails](https://guides.rubyonrails.org/security.html#required-security-token)

Une approche moderne devrait être proposée dans les prochaines versions de Rails [cf cette PR](https://github.com/rails/rails/pull/56350).  Elle se base sur un header HTTP nativement envoyé par les navigateurs pour identifier le domaine de la requête.

# Solution

je propose de passer toute l'appli à `protect_from_forgery with: :exception`.

## Review app et script externe

J'ai fait un petit script sur codesandbox.io avec un formulaire de demande de code de connexion usager nom-prénom-email : [live form ici](https://t8l4cq.csb.app/) – [code visible ici](https://codesandbox.io/p/sandbox/lingering-sea-t8l4cq)

<img width="838" height="631" alt="image" src="https://github.com/user-attachments/assets/fca9aa68-c585-4409-bf08-1fa50903b5da" />


On peut voir que : 
- quand on met en cible demo.rdv.anct.gouv.fr, on arrive à soumettre le formulaire, c'est le comportement actuel
-  quand on met en cible la review app de cette PR, on prend une 422 unprocessable content 

C'est bien le comportement de Rails pour les token d'authentification invalides lorsque la stratégie est le raise cf [le code de rails](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb#L21)
