### PR TITLE
Enregistrement du statut de l'export d'instance sans les batch

### DIFF
--- a/app/jobs/instance_exports/copy_planning_job.rb
+++ b/app/jobs/instance_exports/copy_planning_job.rb
@@ -22,8 +22,13 @@ class InstanceExports::CopyPlanningJob < ApplicationJob
 
     source_organisation = instance_export.source_organisation
 
+    instance_export.update(status: "copying_planning")
+
     instance_export.transaction do
       copy_planning_batch = GoodJob::Batch.new(instance_export_id: instance_export.id)
+
+      copy_planning_batch.properties = { instance_export_id: instance_export.id }
+      copy_planning_batch.on_success = "InstanceExports::PlanningCopiedJob"
 
       copy_planning_batch.enqueue do
         source_organisation.rdvs.future.not_cancelled.pluck(:id).each do |rdv_id|
@@ -44,11 +49,6 @@ class InstanceExports::CopyPlanningJob < ApplicationJob
           CopyPlageOuvertureJob.perform_later(instance_export.id, plage_ouverture_id)
         end
       end
-
-      instance_export.update(
-        good_job_batch_id: copy_planning_batch.id,
-        status: "copying_planning"
-      )
     end
   end
 

--- a/app/jobs/instance_exports/planning_copied_job.rb
+++ b/app/jobs/instance_exports/planning_copied_job.rb
@@ -1,0 +1,6 @@
+class InstanceExports::PlanningCopiedJob < ApplicationJob
+  def perform(batch, _context)
+    instance_export = InstanceExport.find(batch.properties[:instance_export_id])
+    instance_export.update!(status: "planning_copied")
+  end
+end

--- a/app/models/instance_export.rb
+++ b/app/models/instance_export.rb
@@ -7,10 +7,10 @@ class InstanceExport < ApplicationRecord
   encrypts :refresh_token
 
   scope :finished_exports_for_organisation, lambda { |source_organisation_id|
-    where(source_organisation_id: source_organisation_id, status: "motifs_archived")
+    where(source_organisation_id: source_organisation_id, status: %w[planning_copied motifs_archived])
   }
 
-  validates :status, inclusion: { in: %w[oauth_connected copying_configuration copying_planning motifs_archived] }
+  validates :status, inclusion: { in: %w[oauth_connected copying_configuration copying_planning planning_copied motifs_archived] }
 
   def new_instance_organisations
     @new_instance_organisations ||= api_client.get("organisations")["organisations"]
@@ -35,8 +35,8 @@ class InstanceExport < ApplicationRecord
 
   def copy_to_new_instance!(current_domain)
     transaction do
-      InstanceExports::CopyConfiguration.new(self).enqueue_batch(current_domain)
       update(status: "copying_configuration")
+      InstanceExports::CopyConfiguration.new(self).enqueue_batch(current_domain)
     end
   end
 end

--- a/app/views/admin/instance_exports/show.html.slim
+++ b/app/views/admin/instance_exports/show.html.slim
@@ -7,7 +7,7 @@
     .fr-col-8.fr-col-offset-2
       .card
         .card-body
-          - if @instance_export.good_job_batch && @instance_export.good_job_batch.jobs.where(finished_at: nil).none?
+          - if @instance_export.status == "planning_copied"
             - if current_organisation.motifs.active.any?
               p
                 = icon("fr-icon-checkbox-circle-fill", class: "fr-mr-1w color-scheme-green")

--- a/db/migrate/20260219101309_instance_exports_status_without_batches.rb
+++ b/db/migrate/20260219101309_instance_exports_status_without_batches.rb
@@ -1,0 +1,11 @@
+class InstanceExportsStatusWithoutBatches < ActiveRecord::Migration[8.0]
+  def change
+    up_only do
+      InstanceExport.where(status: "copying_planning").each do |instance_export|
+        if instance_export.good_job_batch && instance_export.good_job_batch.jobs.where(finished_at: nil).none?
+          instance_export.update(status: "planning_copied")
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_09_094348) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_19_101309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"


### PR DESCRIPTION
Cette PR permet de découpler un peu les instance exports de batches good jobs pour éviter que l'affichage de la migration soit cassé quand on supprime le batch.