### PR TITLE
Remove useless html_safe

### DIFF
--- a/config/initializers/field_with_errors.rb
+++ b/config/initializers/field_with_errors.rb
@@ -1,6 +1,4 @@
 # Par défaut, Rails ajoute une div avec une classe CSS "field_with_errors" aux champs de formulaire qui contiennent
 # des erreurs. Nous n’utilisons pas cette classe CSS dans notre design, et l’ajout de cette div rentre en conflit avec
 # certains éléments du DSFR. Nous désactivons ce comportement avec le code suivant.
-ActionView::Base.field_error_proc = proc do |html_tag, _|
-  html_tag.html_safe # rubocop:disable Rails/OutputSafety
-end
+ActionView::Base.field_error_proc = proc { |html_tag, _| html_tag }


### PR DESCRIPTION
# Contexte

On retire ce `html_safe` qui ne sert manifestement à rien. Testé en local sans problème et les tests tournent 
