### PR TITLE
Corrige une erreur JS en console

### DIFF
--- a/app/javascript/components/plage_ouverture.js
+++ b/app/javascript/components/plage_ouverture.js
@@ -2,6 +2,10 @@
 // des motifs sélectionnés sur le formulaire de plages d'ouverture.
 class PlageOuvertureLieuSelection {
   constructor() {
+    this.lieuSelectionField = $(".plage-ouverture-form .js-lieu-field");
+    if(!this.lieuSelectionField[0]) {
+      return;
+    }
 
     this.toggleLieuSelectionField(true);
     $(".plage-ouverture-form .form-check-input[name='plage_ouverture[motif_ids][]']").on("input", () => { this.toggleLieuSelectionField(); });
@@ -9,19 +13,19 @@ class PlageOuvertureLieuSelection {
 
   toggleLieuSelectionField(noTransition = false) {
     const selectedMotifsPublicOffice = $(".plage-ouverture-form .form-check-input.public_office[name='plage_ouverture[motif_ids][]']:checked");
-    const lieuSelectionField = $(".plage-ouverture-form .js-lieu-field").toggleClass("no-transition", noTransition);
-    const lieuOptions = Array.from(lieuSelectionField[0].querySelector("select").options).filter(o => o.value);
+    this.lieuSelectionField.toggleClass("no-transition", noTransition);
+    const lieuOptions = Array.from(this.lieuSelectionField[0].querySelector("select").options).filter(o => o.value);
 
     if (selectedMotifsPublicOffice.length > 0) {
-      lieuSelectionField.collapse("show");
+      this.lieuSelectionField.collapse("show");
 
       // Sélectionner automatiquement le lieu s'il n'y en a qu'un seul.
       if (lieuOptions.length === 1) {
-        $(lieuSelectionField).find(".select2-input").val(lieuOptions[0].value).trigger('change');
+        $(this.lieuSelectionField).find(".select2-input").val(lieuOptions[0].value).trigger('change');
       }
     } else {
-      $(lieuSelectionField).find(".select2-input").val(null).trigger('change');
-      lieuSelectionField.collapse("hide");
+      $(this.lieuSelectionField).find(".select2-input").val(null).trigger('change');
+      this.lieuSelectionField.collapse("hide");
     }
   }
 }


### PR DESCRIPTION
Dans #6111 j'ai introduit une erreur JS :

<img width="1160" height="416" alt="image" src="https://github.com/user-attachments/assets/84039329-3925-40b0-a954-a7a2a50cfdd2" />

Je propose ici de la corriger.

J'ai aussi essayé de faire en sorte que Playwright détecte ces erreurs, mais j'y ai passé du temps sans résultat, donc je propose de passer ceci d'abord, pour éviter que ce sujet vienne parasiter les expérimentations sur bun / esbuild.