### PR TITLE
Correctif d'un wording "RDV Solidarités" qui trainait

### DIFF
--- a/app/views/agents/preferences/show.html.slim
+++ b/app/views/agents/preferences/show.html.slim
@@ -43,6 +43,6 @@
   hr
 
   .fr-alert.fr-alert--info.fr-mb-2w
-    = t(".technical_email_explanation")
+    = t(".technical_email_explanation", domain_name: current_domain.name)
 
   .text-right= f.submit t("helpers.submit.submit"), class: "fr-btn"

--- a/config/locales/views/agents.fr.yml
+++ b/config/locales/views/agents.fr.yml
@@ -15,7 +15,7 @@ fr:
         rdv_notifications_header: "Être notifié·e de la création, modification et annulation d’un rendez-vous auquel je participe :"
         plage_ouverture_notifications_header: "Être notifié·e de la création, modification et annulation d’une de mes plages d'ouverture :"
         absence_notifications_header: "Être notifié·e de la création, modification et annulation d’une de mes indisponibilités :"
-        technical_email_explanation: Les emails de notification sont envoyés avec un fichier .ics qui vous permet de synchroniser votre calendrier (Outlook, zimbra, etc.) avec RDV Solidarités.
+        technical_email_explanation: Les emails de notification sont envoyés avec un fichier .ics qui vous permet de synchroniser votre calendrier (Outlook, zimbra, etc.) avec %{domain_name}.
       update:
         done: Préférences de notifications mises à jour.
     exports:


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="738" height="100" alt="Screenshot 2026-02-20 at 09 52 27" src="https://github.com/user-attachments/assets/7fc38940-3052-42ec-a56c-c68e7876bc37" />|<img width="754" height="115" alt="Screenshot 2026-02-20 at 09 51 52" src="https://github.com/user-attachments/assets/d740bc5d-2fe6-4624-ac1b-6e5e1e6c1da2" />

J'avais remarqué ce "RDV Solidarités" qui trainait en faisant un onboarding pour un agent des SPM