### PR TITLE
Déblocage des email Brevo lors d’une invitation via SuperAdmin

### DIFF
--- a/app/controllers/super_admins/agents_controller.rb
+++ b/app/controllers/super_admins/agents_controller.rb
@@ -42,6 +42,7 @@ module SuperAdmins
 
     def invite
       authorize(:agent, :invite?, policy_class: SuperAdmin::AgentPolicy)
+      UnblockBrevoTransactionalContact.new(requested_resource.email).call
       requested_resource.invited_by = current_super_admin
       requested_resource.invite!(nil, validate: false)
       redirect_to(


### PR DESCRIPTION
# Contexte

En discutant avec Teo ce matin, je me suis rendu compte que j’avais mis en place un système pour débloquer automatiquement des adresses email dans Brevo lors d’une réinvitation côté agent.
Mais, cela ne fonctionnait pas côté SuperAdmin. 

# Solution

Je rajoute l’appel à l’API Brevo pour débloquer une adresse email lorsqu’on clique sur le bouton « Inviter ».
