### PR TITLE
Suppression des colonnes `phone_number` et `phone_number_formatted` Territory

### DIFF
--- a/db/migrate/20260220095942_remove_phone_numbers_in_territory.rb
+++ b/db/migrate/20260220095942_remove_phone_numbers_in_territory.rb
@@ -1,0 +1,8 @@
+class RemovePhoneNumbersInTerritory < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :territories, :phone_number, :string
+      remove_column :territories, :phone_number_formatted, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -744,8 +744,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_20_101844) do
   create_table "territories", force: :cascade do |t|
     t.string "departement_number", default: "", null: false
     t.string "name"
-    t.string "phone_number"
-    t.string "phone_number_formatted"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.enum "sms_provider", enum_type: "sms_provider"


### PR DESCRIPTION
# Contexte

Suite à #5294, on supprime physiquement les colonnes de la base qui ne sont plus utilisées.