### PR TITLE
Clarifications de l'index des plages d'ouvertures

### DIFF
--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -17,13 +17,18 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
     all_plage_ouvertures = policy_scope(current_organisation.plage_ouvertures, policy_scope_class: Agent::PlageOuverturePolicy::Scope)
       .includes(:lieu, :organisation, :motifs, :agent)
       .where(agent: @agent)
-      .order(updated_at: :desc)
     @plage_ouvertures = all_plage_ouvertures
       .where(expired_cached: filter_params[:current_tab] == "expired")
       .page(page_number)
     @plage_ouvertures_before_text_search = @plage_ouvertures
 
     @plage_ouvertures = @plage_ouvertures.search_by_text(params[:search]) if params[:search].present?
+
+    if filter_params[:current_tab] == "expired"
+      @plage_ouvertures.order!(first_day: :desc)
+    else
+      @plage_ouvertures.order!(first_day: :asc)
+    end
     @display_tabs = all_plage_ouvertures.where(expired_cached: true).any? || params[:current_tab] == "expired"
   end
 

--- a/app/helpers/recurrence_helper.rb
+++ b/app/helpers/recurrence_helper.rb
@@ -9,22 +9,26 @@ module RecurrenceHelper
     [every_part, time_part, range_part]
   end
 
-  def display_every(recurrent_record)
+  def display_every(recurrent_record) # rubocop:disable Metrics/PerceivedComplexity
     recurrence_hash = recurrent_record.recurrence.to_hash
 
     interval = "#{recurrence_hash[:interval]} " if recurrence_hash[:interval]&.>(1)
 
     case recurrence_hash[:every]
     when :week
-      every_part = "Toutes les #{interval} semaines"
+      every_part = if recurrence_hash[:interval] == 1
+                     "Tous"
+                   else
+                     "Toutes les #{interval}semaines,"
+                   end
 
       if recurrence_hash[:on].present?
-        "#{every_part}, les #{recurrence_hash[:on].map { |d| "#{weekday_in_fr(d)}s" }.to_sentence}"
+        "#{every_part} les #{recurrence_hash[:on].map { |d| "#{weekday_in_fr(d)}s" }.to_sentence}"
       else
-        "#{every_part}, le #{I18n.l(recurrent_record.first_day, format: '%A')}"
+        "#{every_part} le #{I18n.l(recurrent_record.first_day, format: '%A')}"
       end
     when :month
-      "Tous les #{interval} mois, #{weekday_position_in_month(recurrence_hash[:day])}"
+      "Tous les #{interval}mois, #{weekday_position_in_month(recurrence_hash[:day])}"
     end
   end
 

--- a/app/javascript/components/plage_ouverture.js
+++ b/app/javascript/components/plage_ouverture.js
@@ -58,7 +58,7 @@ class PlageOuvertureSecondaryTimes {
       secondaryTimesEndsAtHours.required = true;
       secondaryTimesEndsAtMinutes.required = true;
 
-      // Lorsque le second créneau est activé, on propose par défaut
+      // Lorsque la seconde période est activée, on propose par défaut
       // de faire une pause d'une heure avant une après-midi de 4h.
       if(!secondaryTimesStartsAtHours.value && parseInt(primaryTimesEndsAtHours.value) < 15) {
         secondaryTimesStartsAtHours.value ||= String(parseInt(primaryTimesEndsAtHours.value) + 1).padStart(2, "0");

--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -3,9 +3,6 @@ tr
   td
     = link_to plage_ouverture.title_with_default, admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture), class: "fr-link"
     = exceptionnelle_tag(plage_ouverture)
-    br
-    small
-      | modifiée le #{l(plage_ouverture.updated_at, format: :short)}
   td
     ul.pl-2
       - plage_ouverture.motifs.each do |motif|

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -14,14 +14,14 @@
     .row.mb-2
       .col
         button.fr-btn.fr-btn--tertiary.fr-btn--sm.fr-btn--icon-left.fr-icon-add-line.js-plages-form-add-secondary-times-button[type="button" style="width: 100%"]
-          | Ajouter un second créneau à la plage
+          | Ajouter une seconde période à la plage
     .row.mb-2.hidden.js-plages-form-secondary-times-container
       .col = f.input :secondary_start_time, as: :time, ignore_date: true, minute_step: 5, include_blank: true
       .col = f.input :secondary_end_time,   as: :time, ignore_date: true, minute_step: 5, include_blank: true
     .row.mb-2
       .col
         button.fr-btn.fr-btn--tertiary.fr-btn--sm.fr-btn--icon-left.fr-icon-close-line.js-plages-form-remove-secondary-times-button.hidden[type="button" style="width: 100%"]
-          | Retirer le second créneau à la plage
+          | Retirer la seconde période de la plage
 
   = f.input :recurrence, as: :hidden, input_html: { value: model.recurrence ? model.recurrence.as_json.to_json : "", "data-target": "recurrence.recurrenceComputed", class: "js-recurrence-computed" }
 

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -17,7 +17,7 @@ html lang="fr"
           - if @beta_planning_layout
             = content_for :onboarding_banner
             = render partial: "admin/planning/planning_agents_select"
-            .p-3
+            .fr-p-2w
               = content_for(:fil_ariane)
               = yield
 

--- a/config/locales/models/plage_ouverture.fr.yml
+++ b/config/locales/models/plage_ouverture.fr.yml
@@ -24,7 +24,7 @@ fr:
               must_be_after_start_time: "L’heure de fin doit être après l'heure de début."
             secondary_start_time:
               format: "%{message}"
-              overlaps_primary_interval: "Le second créneau ne doit pas chevaucher le premier."
+              overlaps_primary_interval: "La seconde période ne doit pas chevaucher la première."
             secondary_end_time:
               format: "%{message}"
               must_be_after_secondary_start_time: "L'heure de fin doit être après l'heure de début."

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       select "12", from: "plage_ouverture_end_time_4i"
       select "00", from: "plage_ouverture_end_time_5i"
 
-      click_on "Ajouter un second créneau à la plage"
+      click_on "Ajouter une seconde période à la plage"
       # Set secondary start time at 09:30
       select "14", from: "plage_ouverture_secondary_start_time_4i"
       select "30", from: "plage_ouverture_secondary_start_time_5i"

--- a/spec/helpers/recurrence_helper_spec.rb
+++ b/spec/helpers/recurrence_helper_spec.rb
@@ -7,30 +7,35 @@ RSpec.describe RecurrenceHelper do
 
   describe "#display_recurrence" do
     it "with a weekly recurrence" do
-      plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week))
-      expect(display_recurrence(plage_ouverture)).to eq(["Toutes les  semaines, le mardi", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
+      plage_ouverture = build(:plage_ouverture, :weekly_on_monday)
+      expect(display_recurrence(plage_ouverture)).to eq(["Tous les lundis", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
     end
 
     it "with a weekly recurrence on wednesday" do
-      plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week, on: ["wednesday"]))
-      expect(display_recurrence(plage_ouverture)).to eq(["Toutes les  semaines, les mercredis", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
+      plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week, on: ["wednesday"], interval: 1))
+      expect(display_recurrence(plage_ouverture)).to eq(["Tous les mercredis", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
+    end
+
+    it "with a recurrence every other week" do
+      plage_ouverture = build(:plage_ouverture, :every_two_weeks)
+      expect(display_recurrence(plage_ouverture)).to eq(["Toutes les 2 semaines, les lundis", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
     end
 
     it "with a monthly recurrence" do
       plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:month, day: { 3 => [2] }))
-      expect(display_recurrence(plage_ouverture)).to eq(["Tous les  mois, le 2ème mercredi", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
+      expect(display_recurrence(plage_ouverture)).to eq(["Tous les mois, le 2ème mercredi", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
     end
 
     it "with a secondary time interval" do
       plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week), secondary_start_time: "14:00", secondary_end_time: "17:45")
-      expect(display_recurrence(plage_ouverture)).to eq(["Toutes les  semaines, le mardi", "de 08:00 à 12:00 et de 14:00 à 17:45", "à partir du mardi 28 décembre 2021"])
+      expect(display_recurrence(plage_ouverture)).to eq(["Toutes les semaines, le mardi", "de 08:00 à 12:00 et de 14:00 à 17:45", "à partir du mardi 28 décembre 2021"])
     end
   end
 
   describe "#occurrence_text" do
     it "returns occurrence text" do
       plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week))
-      expect(occurrence_text(plage_ouverture)).to eq("Toutes les  semaines, le mardi de 08:00 à 12:00 à partir du mardi 28 décembre 2021")
+      expect(occurrence_text(plage_ouverture)).to eq("Toutes les semaines, le mardi de 08:00 à 12:00 à partir du mardi 28 décembre 2021")
     end
 
     it "returns" do


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1420" height="773" alt="Screenshot 2026-02-20 at 11 33 23" src="https://github.com/user-attachments/assets/efca8313-a95a-4ee5-b6cb-e010c7ac4c36" />|<img width="1422" height="774" alt="Screenshot 2026-02-20 at 11 32 34" src="https://github.com/user-attachments/assets/9c0c51e0-b7f3-4802-aee7-3239aee924bd" />

# Contexte

Pendant un onboarding, on a appris que l'ordre des plages d'ouverture était en fonction de la date de modification la plus récente, et non pas par ordre chronologique comme on s'y serait attendu (ça a étonné l'agent qu'on onboardait aussi).

On a aussi certains agents qui comprennent mal le texte "Ajouter un second créneau à la plage", et qui se mettre à créer des blocs inutiles. On espère qu'en utilisant plutôt la formulation "Ajouter une seconde période à la plage" on évite la confusion

# Solution

Après discussion avec Mehdi et Nesserine, on fait plusieurs petits correctifs découpés par commit : 
- on commence par ordonner les plages d'ouverture par date de début : dans l'ordre chronologique pour celles en cours, et de la plus récente à la plus ancienne pour celles qui sont passées (similaire à ce qui a été fait récemment par françois sur l'index des rdvs côté usagé)
- La date de modification n'étant plus utilisée pour le tri, elle n'est plus nécessaire, et apporte plus de bruit qu'autre chose. On peut donc la supprimer de l'index
- On utilise un padding dsfr à la place de bootstrap, ce qui permet d'aligner le conteneur avec le flash
- On utilise la formulation "Tous les lundis" plutôt que "Toutes les semaines, les lundis", qui est à la fois plus consise, plus facile à comprendre et plus naturelle
- "créneau" signifie un intervalle de temps égal à la durée du rendez-vous, "période" nous semblait être un bon remplacement.

