### PR TITLE
Allègement de l'année de début dans les index des plages d'ouvertures et indisponibilités

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -18,4 +18,12 @@ module DateHelper
 
     [Date.current, Date.current + 1].include?(date.to_date)
   end
+
+  def human_date_format(date)
+    if date.year == Time.zone.now.year
+      I18n.l(date, format: :human_without_year)
+    else
+      I18n.l(date, format: :human)
+    end
+  end
 end

--- a/app/helpers/recurrence_helper.rb
+++ b/app/helpers/recurrence_helper.rb
@@ -44,16 +44,16 @@ module RecurrenceHelper
     if recurrent_record.recurring?
       display_recurrence(recurrent_record).join(" ")
     else
-      [I18n.l(recurrent_record.first_day, format: :human), display_time_range(recurrent_record)].join(" ")
+      [human_date_format(recurrent_record.first_day), display_time_range(recurrent_record)].join(" ")
     end
   end
 
   def display_recurrence_range(recurrent_record)
     recurrence_hash = recurrent_record.recurrence.to_hash
 
-    range_part = "à partir du #{I18n.l(recurrent_record.first_day, format: :human)}"
+    range_part = "à partir du #{human_date_format(recurrent_record.first_day)}"
 
-    range_part = "#{range_part}, jusqu'au #{I18n.l(recurrence_hash[:until].to_date, format: :human)}" if recurrence_hash[:until].present?
+    range_part = "#{range_part}, jusqu'au #{human_date_format(recurrence_hash[:until].to_date)}" if recurrence_hash[:until].present?
     range_part
   end
 

--- a/app/helpers/recurrence_helper.rb
+++ b/app/helpers/recurrence_helper.rb
@@ -1,4 +1,6 @@
 module RecurrenceHelper
+  include DateHelper
+
   def display_recurrence(recurrent_record)
     every_part = display_every(recurrent_record)
 

--- a/app/views/admin/planning/absences/_absence.html.slim
+++ b/app/views/admin/planning/absences/_absence.html.slim
@@ -9,7 +9,7 @@ tr
       - if absence.first_day != absence.end_day
         | Du #{l(absence.starts_at, format: :human)} au #{l(absence.first_occurrence_ends_at, format: :human)}
       - else
-        | Le #{l(absence.first_day, format: :human)} #{display_time_range(absence)}
+        | #{human_date_format(absence.first_day).capitalize} #{display_time_range(absence)}
 
   td
     .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline.rdv-gap-05rem

--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -13,7 +13,7 @@ tr
     - if plage_ouverture.recurrence.present?
       = sanitize(display_recurrence(plage_ouverture).join("<br/>"))
     - else
-      | Le #{l(plage_ouverture.first_day, format: :human)} #{display_time_range(plage_ouverture)}
+      | #{human_date_format(plage_ouverture.first_day).capitalize} #{display_time_range(plage_ouverture)}
     - if plage_ouverture.overlapping_plages_ouvertures?
       .alert.alert-warning.py-1.px-2.mt-1
         span ⚠️ Conflit de dates

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -106,6 +106,7 @@ fr:
       long: "%e %B %Y"
       short: "%-d %b"
       human: "%A %-d %B %Y"
+      human_without_year: "%A %-d %B"
     month_names:
     -
     - janvier
@@ -318,6 +319,7 @@ fr:
       short_sms: "%A %-d/%m %Hh%M"
       short_sms_approx: "%-d/%-m vers %Hh%M"
       human: "%A %-d %B %Y à %Hh%M"
+      human_without_year: "%A %-d %B à %Hh%M"
       human_approx: "%A %-d %B %Y vers %Hh%M"
       dense: "%-d/%m/%Y à %H:%M"
       dense_html: "%-d/%m/%Y&nbsp;à&nbsp;%H:%M"

--- a/spec/helpers/recurrence_helper_spec.rb
+++ b/spec/helpers/recurrence_helper_spec.rb
@@ -8,39 +8,39 @@ RSpec.describe RecurrenceHelper do
   describe "#display_recurrence" do
     it "with a weekly recurrence" do
       plage_ouverture = build(:plage_ouverture, :weekly_on_monday)
-      expect(display_recurrence(plage_ouverture)).to eq(["Tous les lundis", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
+      expect(display_recurrence(plage_ouverture)).to eq(["Tous les lundis", "de 08:00 à 12:00", "à partir du mardi 28 décembre"])
     end
 
     it "with a weekly recurrence on wednesday" do
       plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week, on: ["wednesday"], interval: 1))
-      expect(display_recurrence(plage_ouverture)).to eq(["Tous les mercredis", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
+      expect(display_recurrence(plage_ouverture)).to eq(["Tous les mercredis", "de 08:00 à 12:00", "à partir du mardi 28 décembre"])
     end
 
     it "with a recurrence every other week" do
       plage_ouverture = build(:plage_ouverture, :every_two_weeks)
-      expect(display_recurrence(plage_ouverture)).to eq(["Toutes les 2 semaines, les lundis", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
+      expect(display_recurrence(plage_ouverture)).to eq(["Toutes les 2 semaines, les lundis", "de 08:00 à 12:00", "à partir du mardi 28 décembre"])
     end
 
     it "with a monthly recurrence" do
       plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:month, day: { 3 => [2] }))
-      expect(display_recurrence(plage_ouverture)).to eq(["Tous les mois, le 2ème mercredi", "de 08:00 à 12:00", "à partir du mardi 28 décembre 2021"])
+      expect(display_recurrence(plage_ouverture)).to eq(["Tous les mois, le 2ème mercredi", "de 08:00 à 12:00", "à partir du mardi 28 décembre"])
     end
 
     it "with a secondary time interval" do
       plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week), secondary_start_time: "14:00", secondary_end_time: "17:45")
-      expect(display_recurrence(plage_ouverture)).to eq(["Toutes les semaines, le mardi", "de 08:00 à 12:00 et de 14:00 à 17:45", "à partir du mardi 28 décembre 2021"])
+      expect(display_recurrence(plage_ouverture)).to eq(["Toutes les semaines, le mardi", "de 08:00 à 12:00 et de 14:00 à 17:45", "à partir du mardi 28 décembre"])
     end
   end
 
   describe "#occurrence_text" do
     it "returns occurrence text" do
       plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week))
-      expect(occurrence_text(plage_ouverture)).to eq("Toutes les semaines, le mardi de 08:00 à 12:00 à partir du mardi 28 décembre 2021")
+      expect(occurrence_text(plage_ouverture)).to eq("Toutes les semaines, le mardi de 08:00 à 12:00 à partir du mardi 28 décembre")
     end
 
     it "returns" do
       plage_ouverture = build(:plage_ouverture)
-      expect(occurrence_text(plage_ouverture)).to eq("mardi 28 décembre 2021 de 08:00 à 12:00")
+      expect(occurrence_text(plage_ouverture)).to eq("mardi 28 décembre de 08:00 à 12:00")
     end
   end
 


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1129" height="490" alt="Screenshot 2026-02-20 at 15 43 34" src="https://github.com/user-attachments/assets/37039be9-35f1-43a1-933c-ba42ec29b33b" />|<img width="1131" height="504" alt="Screenshot 2026-02-20 at 15 43 50" src="https://github.com/user-attachments/assets/7a31c772-3ec9-405c-afbe-e129bdd10af8" />

Un autre petite allègement de l'index des dispos/indispos suite à https://github.com/betagouv/rdv-service-public/pull/6169 : on arrête d'afficher l'année lorsqu'il s'agit de l'année courante (c'est assez classique, Planity le fait pour les dates de rendez-vous par exemple).