### PR TITLE
Correctif de l'affichage des organisations par colonnes

### DIFF
--- a/app/views/admin/territories/organisations/index.html.slim
+++ b/app/views/admin/territories/organisations/index.html.slim
@@ -7,9 +7,9 @@
     .card
       .card-body
         h2.fr-h3 Organisations actives
-        .fr-grid-row
+        .fr-grid-row.fr-grid-row--gutters
           - @organisations.each do |organisation|
-            .fr-col-12.fr-col-md-6.fr-col-lg-4.fr-mb-2w.fr-mr-2w
+            .fr-col-12.fr-col-md-6.fr-col-lg-4.fr-mb-2w
               .fr-tile.fr-enlarge-link
                 .fr-tile__body
                   .fr-tile__content


### PR DESCRIPTION
On est vraiment sur du mini-fix avant départ en vacances.

Avant | Après
:- | -:
<img width="1246" height="774" alt="Screenshot 2026-02-20 at 15 56 49" src="https://github.com/user-attachments/assets/6492bdac-3563-45fa-944c-1adc77eeea30" />|<img width="1311" height="786" alt="Screenshot 2026-02-20 at 15 56 59" src="https://github.com/user-attachments/assets/c10b9aa9-b7d8-4af6-97d2-a0018869888c" />

Merci à Adrien de m'avoir rappelé l'existance de `.fr-grid-row--gutters` qui manquait cruellement à cette page.
