### PR TITLE
Ajout d’une étape de sélection agenda sync CalDAV

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,7 +153,7 @@ gem "icalendar-recurrence"
 # Ruby Date Recurrence Library - Allows easy creation of recurrence rules and fast querying
 gem "ice_cube", git: "https://github.com/ice-cube-ruby/ice_cube.git", ref: "32ff145"
 # Caldav client library
-gem "calendav", "~> 0.5"
+gem "calendav", "~> 0.6"
 # Base de données des fuseaux horaires
 # Au lieu d’utiliser la base de données système qui peut différer entre les environnements (local, CI, production)
 # on utilise cette gem pour avoir la même partout.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     bullet (8.0.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    calendav (0.5.1)
+    calendav (0.6.0)
       http
       icalendar
       nokogiri
@@ -793,7 +793,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   bullet
-  calendav (~> 0.5)
+  calendav (~> 0.6)
   capybara
   capybara-email
   capybara-playwright-driver
@@ -922,7 +922,7 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bullet (8.0.0) sha256=77f02fde19a1dfef028db42535e581b2b7b49906be5aa934494f1365a478de4d
   bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
-  calendav (0.5.1) sha256=c685eef12b6d70f3fb66a044c7156138cfd39c05acb4668415f79b2da2fbd7b9
+  calendav (0.6.0) sha256=4cd1bb8d19ca60f4c76b9a64b2a8c81f0fe6d2062b2235cf155acd960a7cf926
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-email (3.0.2) sha256=ab65dd9b15c096b1ebe24308d18d790eb08814f916883ebccbc1cf46f760696f
   capybara-playwright-driver (0.5.7) sha256=875a1928077d56be8b484f84674901a2374752d7842d93de2045bbede1aad242

--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -18,7 +18,7 @@ class Agents::CaldavSyncController < AgentAuthController
 
     begin
       calendars = client.calendars.list
-      preselected_url = calendars.any? { |c| c.url.chomp("/") == params[:caldav_agenda_url].to_s.chomp("/") }
+      preselected_url = params[:caldav_agenda_url].to_s.chomp("/")
       render locals: { calendars: calendars, preselected_url: preselected_url }
     rescue StandardError => e
       flash[:alert] = "L'authentification a échoué. Veuillez vérifier votre identifiant et votre mot de passe. #{e.message}"

--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -5,6 +5,27 @@ class Agents::CaldavSyncController < AgentAuthController
     skip_authorization
   end
 
+  def calendar_selection
+    skip_authorization
+    client = Calendav::Client.new(
+      Calendav::Credentials::Standard.new(
+        host: params[:caldav_agenda_url],
+        username: params[:caldav_username],
+        password: params[:caldav_password],
+        authentication: :basic_auth
+      )
+    )
+
+    begin
+      calendars = client.calendars.list
+      preselected_url = calendars.any? { |c| c.url.chomp("/") == params[:caldav_agenda_url].to_s.chomp("/") }
+      render locals: { calendars: calendars, preselected_url: preselected_url }
+    rescue StandardError => e
+      flash[:alert] = "L'authentification a échoué. Veuillez vérifier votre identifiant et votre mot de passe. #{e.message}"
+      redirect_to agents_calendar_sync_caldav_sync_path
+    end
+  end
+
   def update
     skip_authorization
     current_agent.assign_attributes(permitted_params)

--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -21,8 +21,19 @@ class Agents::CaldavSyncController < AgentAuthController
       calendars = client.calendars.list.select { |c| c.components.include?("VEVENT") }
       preselected_url = params[:caldav_agenda_url].to_s.chomp("/")
       render locals: { calendars: calendars, preselected_url: preselected_url }
+    rescue Calendav::RequestError => e
+      flash[:alert] = case e.response.status
+                      when 401, 403
+                        "L'authentification a échoué : #{e.message}. Veuillez vérifier votre identifiant et votre mot de passe."
+                      when 404
+                        "L'authentification a échoué : #{e.message}. Veuillez vérifier l'URL du serveur ou de l'agenda CalDAV."
+                      else
+                        "L'authentification a échoué : #{e.message}. Si l'erreur persiste veuillez contacter le support."
+                      end
+      redirect_to agents_calendar_sync_caldav_sync_path
     rescue StandardError => e
-      flash[:alert] = "L'authentification a échoué. Veuillez vérifier votre identifiant et votre mot de passe. #{e.message}"
+      Sentry.capture_exception(e)
+      flash[:alert] = "Une erreur inattendue a été rencontrée, l'équipe de développement a été prévenue. Si l'erreur persiste veuillez contacter le support."
       redirect_to agents_calendar_sync_caldav_sync_path
     end
   end

--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -17,7 +17,8 @@ class Agents::CaldavSyncController < AgentAuthController
     )
 
     begin
-      calendars = client.calendars.list
+      # CalDAV peut retourner des calendriers (VEVENT) et des listes de tâches (VTODO), on ne veut que les calendriers.
+      calendars = client.calendars.list.select { |c| c.components.include?("VEVENT") }
       preselected_url = params[:caldav_agenda_url].to_s.chomp("/")
       render locals: { calendars: calendars, preselected_url: preselected_url }
     rescue StandardError => e

--- a/app/views/agents/caldav_sync/calendar_selection.html.slim
+++ b/app/views/agents/caldav_sync/calendar_selection.html.slim
@@ -18,10 +18,13 @@ p Veuillez sélectionner ci-dessous l'agenda que vous souhaitez synchroniser ave
     legend.fr-fieldset__legend.fr-fieldset__legend--regular
       | Sélectionnez l'agenda à synchroniser
     - calendars.each do |calendar|
+      - writable = calendar.current_user_privilege_set&.include?("write")
       .fr-fieldset__element
-        .fr-radio-group
-          input type="radio" name="caldav_agenda_url" id="calendar_#{calendar.url.parameterize}" value=calendar.url required=true checked=(calendar.url.chomp("/") == preselected_url)
+        .fr-radio-group[class=("fr-radio-group--disabled" unless writable)]
+          input type="radio" name="caldav_agenda_url" id="calendar_#{calendar.url.parameterize}" value=calendar.url required=true checked=(calendar.url.chomp("/") == preselected_url) disabled=(!writable || nil)
           label.fr-label for="calendar_#{calendar.url.parameterize}"
             = calendar.display_name
+            - unless writable
+              span.fr-hint-text Vous n’avez pas les droits d’écriture sur cet agenda.
 
   = submit_tag "Valider", class: "fr-btn fr-mt-2w"

--- a/app/views/agents/caldav_sync/calendar_selection.html.slim
+++ b/app/views/agents/caldav_sync/calendar_selection.html.slim
@@ -1,0 +1,27 @@
+/# locals: (calendars:, preselected_url:)
+
+- content_for :title do
+  | Configuration de la synchronisation CalDAV
+
+- content_for :breadcrumbs do
+  = dsfr_breadcrumbs do |b|
+    = b.with_breadcrumb label: "Synchronisation d'agenda", href: agents_calendar_sync_path
+    = b.with_breadcrumb label: "Configuration de la synchronisation CalDAV"
+
+p Veuillez sélectionner ci-dessous l'agenda que vous souhaitez synchroniser avec RDV Service Public.
+
+= form_tag agents_calendar_sync_caldav_sync_path, method: :put do
+  = hidden_field_tag :caldav_username, params[:caldav_username]
+  = hidden_field_tag :caldav_password, params[:caldav_password]
+
+  fieldset.fr-fieldset
+    legend.fr-fieldset__legend.fr-fieldset__legend--regular
+      | Sélectionnez l'agenda à synchroniser
+    - calendars.each do |calendar|
+      .fr-fieldset__element
+        .fr-radio-group
+          input type="radio" name="caldav_agenda_url" id="calendar_#{calendar.url.parameterize}" value=calendar.url required=true checked=(calendar.url.chomp("/") == preselected_url)
+          label.fr-label for="calendar_#{calendar.url.parameterize}"
+            = calendar.display_name
+
+  = submit_tag "Valider", class: "fr-btn fr-mt-2w"

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -41,7 +41,7 @@ p
         = form_tag agents_calendar_sync_caldav_sync_path, method: :delete do
           = submit_tag "Supprimer la configuration CalDAV", class: "fr-btn fr-btn--tertiary", data: { confirm: "Êtes-vous sûr de vouloir supprimer vos identifiants CalDAV ?" }
 - else
-  = form_tag agents_calendar_sync_caldav_sync_path, method: :put do
+  = form_tag calendar_selection_agents_calendar_sync_caldav_sync_path, method: :post do
     .fr-input-group
       label.fr-label for="caldav_username"
         | Identifiant de l’agenda CalDAV
@@ -55,7 +55,7 @@ p
           = external_link_to "voir la documentation", "https://aide.rdv-service-public.fr/documentation-utilisateur/faq#synchronisation-avec-la-suite-numerique-caldav"
       input#caldav_password.fr-input type="password" name="caldav_password"
     .fr-input-group
-      label.fr-label for="caldav_agenda_url" URL de l’agenda CalDAV
+      label.fr-label for="caldav_agenda_url" URL du serveur ou de l’agenda CalDAV
       input#caldav_agenda_url.fr-input type="text" name="caldav_agenda_url"
     fieldset.fr-fieldset
       legend.fr-fieldset__legend--regular.fr-fieldset__legend

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,7 +141,9 @@ Rails.application.routes.draw do
       end
       resource :preferences, only: %i[show update]
       resource :calendar_sync, only: %i[show], controller: :calendar_sync do
-        resource :caldav_sync, only: %i[show update destroy], controller: :caldav_sync
+        resource :caldav_sync, only: %i[show update destroy], controller: :caldav_sync do
+          post :calendar_selection
+        end
         resource :webcal_sync, only: %i[show update], controller: :webcal_sync
         resource :outlook_sync, only: %i[show destroy], controller: :outlook_sync
       end


### PR DESCRIPTION
# Contexte

Nous avons de plus en plus d’agents qui utilisent RDV-SP avec la synchronisation CalDAV.
Pour les agents qui utilisent LaSuite Numérique (avec OX Suite) on les guide pour leur montrer comment nous envoyer directement le lien de l’agenda qu’ils veulent synchroniser, mais pour d’autres agents qui utilisent d’autres systèmes c’est moins évident. 
Ils ont souvent dans leur documentation que l’URL du serveur CalDAV mais pas l’URL de l’agenda.

# Solution

Je propose donc ici d’ajouter un écran pour la sélection de l’agenda.

## Captures d'écran

<img width="1047" height="973" alt="image" src="https://github.com/user-attachments/assets/2922074e-7ee5-4870-856d-d0e5d4dd574f" />

