### PR TITLE
Nouvelle var d'env pour mocker l'API ANTS

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -59,6 +59,7 @@ POSTGRES_PASSWORD=
 
 # Shared Secrets for external services
 ANTS_API_AUTH_TOKEN=fake_ants_api_auth_token
+ANTS_RDV_API_MOCK_RESPONSES="true" # par défaut, aucun appel n'est fait à l'API externe de l'ANTS
 ANTS_RDV_OPT_AUTH_TOKEN="voir https://vaultwarden.incubateur.net/#/vault?itemId=f5a2605f-f706-4560-a70d-8c4cdc4fe1fe"
 ANTS_RDV_API_URL="https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api"
 

--- a/app/validators/ants_pre_demande_number_status_validation.rb
+++ b/app/validators/ants_pre_demande_number_status_validation.rb
@@ -4,6 +4,21 @@
 # Cette validation fait des requêtes HTTP externes à l’API de l’ANTS
 #
 # cf /docs/interconnexions/ants.md
+#
+MOCK_RESPONSES = {
+  "RDVSPUB001" => { status: "validated", appointments: [] },
+  "RDVSPUB002" => { status: "validated", appointments: [] },
+  "RDVSPUB003" => { status: "validated", appointments: [] },
+  "RDVSPUB004" => { status: "consumed", appointments: [] },
+  "RDVSPUB005" => { status: "consumed", appointments: [] },
+  "RDVSPUB006" => { status: "consumed", appointments: [] },
+  "RDVSPUB007" => { status: "declared", appointments: [] },
+  "RDVSPUB008" => { status: "declared", appointments: [] },
+  "RDVSPUB009" => { status: "declared", appointments: [] },
+  "RDVSPUB010" => { status: "expired", appointments: [] },
+  "RDVSPUB011" => { status: "expired", appointments: [] },
+  "RDVSPUB012" => { status: "expired", appointments: [] },
+}.freeze
 
 class AntsPreDemandeNumberStatusValidation < ActiveModel::Validator
   include ActionView::Helpers::SanitizeHelper
@@ -17,11 +32,7 @@ class AntsPreDemandeNumberStatusValidation < ActiveModel::Validator
       record.ants_pre_demande_number.blank? ||
       !record.ants_pre_demande_number.upcase.match?(AntsPreDemandeNumberFormatValidator::REGEX)
 
-    status, appointments = AntsApi.status(
-      ants_pre_demande_number: record.ants_pre_demande_number.upcase,
-      meeting_point_id: get_meeting_point_id(record),
-      timeout: 4
-    ).values_at("status", "appointments")
+    status, appointments = fetch_ants_api_status(record).values_at("status", "appointments")
 
     return unless validate_status_validated(status, record)
 
@@ -35,6 +46,19 @@ class AntsPreDemandeNumberStatusValidation < ActiveModel::Validator
   end
 
   private
+
+  def fetch_ants_api_status(record)
+    if ENV["ANTS_RDV_API_MOCK_RESPONSES"] == "true"
+      MOCK_RESPONSES[record.ants_pre_demande_number.upcase]&.stringify_keys ||
+        { "status" => "unknown", "appointments" => [] }
+    else
+      AntsApi.status(
+        ants_pre_demande_number: record.ants_pre_demande_number.upcase,
+        meeting_point_id: get_meeting_point_id(record),
+        timeout: 4
+      )
+    end
+  end
 
   def get_meeting_point_id(record)
     meeting_point_id = record.respond_to?(:ants_meeting_point_id) ? record.ants_meeting_point_id : nil

--- a/docs/interconnexions/ants.md
+++ b/docs/interconnexions/ants.md
@@ -83,6 +83,10 @@ Pour mettre à jour ces tokens :
 
 ### Environnement de développement
 
+Sur vos machines locales et sur les review apps plusieurs solutions sont possibles :
+- par défaut la variable d'environnement `ANTS_RDV_API_MOCK_RESPONSES` est activée, aucun appel n'est fait
+- ou vous pouvez pointer vers un environnement d'API de développement, cf ci-dessous
+
 L’ANTS fournit un environnement de développement (aussi dit d’intégration) disponible sur [int.api-coordination.rendezvouspasseport.ants.gouv.fr](https://int.api-coordination.rendezvouspasseport.ants.gouv.fr).
 
 L’instance demo-rdv-solidarites (et donc le domaine demo.rdv.anct.gouv.fr) est configurée pour requêter cette API d’intégration.


### PR DESCRIPTION
# Contexte

Dans le cadre de la fusion des étapes de prise de RDV post-sign-in, j'ai envie de faire plus de tests ANTS des différents cas, en local et en review app.

On peut déjà mettre en variables d'env les credentials de l'API sandbox mais ça a des inconvénients : 
- appels externes faits
- les statuts des dossiers comme `RDVSPUB001` sont modifiés au fur et à mesure des tests

# Solution

Je propose de rajouter une var d'env `ANTS_RDV_API_MOCK_RESPONSES=true` par défaut dans le .env local

Lorsqu'elle est activée, l'API n'est pas consultée, les retours sont pré-enregistrées en fonction des codes passés