### PR TITLE
correctif Admins::RdvsCollectifs#update render edit

### DIFF
--- a/app/controllers/admin/rdvs_collectifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs_controller.rb
@@ -43,10 +43,8 @@ class Admin::RdvsCollectifsController < AgentAuthController
 
   def edit
     @rdv = Rdv.find(params[:id])
-
     @add_user_ids = params[:add_user].to_a + params[:user_ids].to_a
-    users_to_add = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.where(id: @add_user_ids)).resolve.distinct
-    @participations_to_add = users_to_add.ids.map { @rdv.participations.build(user_id: _1, created_by: current_agent) }
+    set_participations_to_add
 
     authorize(@rdv, policy_class: Agent::RdvPolicy)
   end
@@ -63,6 +61,8 @@ class Admin::RdvsCollectifsController < AgentAuthController
       flash[:success] = "Participants mis à jour"
       redirect_to edit_admin_organisation_rdvs_collectif_path(current_organisation, @rdv)
     else
+      @add_user_ids = update_users_params[:user_ids]
+      set_participations_to_add
       render :edit
     end
   end
@@ -89,5 +89,10 @@ class Admin::RdvsCollectifsController < AgentAuthController
       user_ids: [],
       participations_attributes: %i[user_id send_lifecycle_notifications send_reminder_notification id _destroy]
     )
+  end
+
+  def set_participations_to_add
+    users_to_add = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.where(id: @add_user_ids)).resolve.distinct
+    @participations_to_add = users_to_add.ids.map { @rdv.participations.build(user_id: _1, created_by: current_agent) }
   end
 end

--- a/spec/features/agents/rdvs_collectifs/agent_can_add_users_to_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_add_users_to_rdv_collectif_spec.rb
@@ -96,4 +96,20 @@ RSpec.describe "Un agent peut ajouter des usagers à un RDV Collectif", js: true
       expect(rdv.reload.participations.first.send_lifecycle_notifications).to be false
     end
   end
+
+  context "quand la mise à jour échoue" do
+    let!(:user) { create(:user, organisations: [organisation]) }
+
+    it "affiche le formulaire sans erreur 500" do
+      rdv = create(:rdv, :collectif, motif:, agents: [agent_noe], organisation:)
+      login_as(agent_noe, scope: :agent)
+      visit edit_admin_organisation_rdvs_collectif_path(organisation, rdv, add_user: [user.id])
+      allow(Rdv).to receive(:find).and_return(rdv)
+      allow(rdv).to receive(:update_and_notify).and_return(false)
+      rdv.errors.add(:base, "Une erreur est survenue")
+      click_button "Enregistrer"
+      expect(page).to have_content("Ajouter un participant")
+      expect(page).to have_content("Une erreur est survenue")
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

https://zammad10.ethibox.fr/#ticket/zoom/34429
https://sentry.incubateur.net/organizations/betagouv/issues/245019

Lorsqu'une erreur de validation se produit dans `Admins::RdvsCollectifs#update` , le template `edit` n'arrive pas à être rendu car il manque des variables d'instances.

# Solution

Dans cette PR je rajoute les variables d'instances rendues entre `edit` et la branche d'échec du `update`.
Je rajoute dans un premier commit une failing spec.

Je n'ai pas réussi à reproduire ce cas « naturellement », je stubbe donc `rdv` pour y insérer une erreur dans la spec 🤷