### PR TITLE
cacher élargir la recherche si le territory n'a pas de departement nu…

### DIFF
--- a/app/helpers/feature_helper.rb
+++ b/app/helpers/feature_helper.rb
@@ -3,6 +3,7 @@ module FeatureHelper
     # TODO: faire sauter ce return une fois que nous avons implémenté la saisie d'adresse
     return false if current_organisation.territory.sectorized? && !user_provided
     return false unless current_organisation.territory.any_motifs_opened_for_prescription?
+    return false if current_territory.departement_number.blank?
 
     true
   end


### PR DESCRIPTION
# Contexte

https://sentry.incubateur.net/organizations/betagouv/issues/193456
https://zammad10.ethibox.fr/#ticket/zoom/34467

Lorsqu'un agent essaie d'accéder à la prescription interne en cliquant sur élargir la recherche dans un territoire qui n'a pas de `departement_number`, une erreur 500 se produit : `Missing partial search/_address_selection`

En effet s'il n'y a pas de `departement_number`, la current_step est la sélection d'adresse hors ce partial est distinct par environnement et ne peut pas être chargé directement

# Solution

Je propose ici de désactiver cette feature de prescription interne pour ces territoires sans `departement_number` . ça évitera les 500 systématiques. 

Il faudrait corriger en profondeur la prescription interne mais je n'ai pas l'énergie de m'y plonger je pense que ça demande pas mal de boulot.