### PR TITLE
Correction des OU mal placés sur la connexion usagers

### DIFF
--- a/app/views/common/_franceconnect_button.html.slim
+++ b/app/views/common/_franceconnect_button.html.slim
@@ -12,5 +12,3 @@
 
     p
       = link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/", target: "_blank", class: "fr-link", title: "Qu’est-ce que FranceConnect ? - Nouvelle fenêtre"
-
-  p.fr-hr-or ou

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -6,6 +6,7 @@
   .card-body
     = form_for resource, as: :user, url: registration_path(resource_name), builder: Dsfr::FormBuilder, display_required_tags: false do |f|
       = render "common/franceconnect_button"
+      p.fr-hr-or ou
 
       h2 Se créer un compte avec un email
       p.fr-hint-text Sauf mention contraire, tous les champs sont obligatoires.

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -5,12 +5,13 @@
   .card-body
     - if @rdv_wizard.nil? || @rdv_wizard.rdv.motif.organisation.online_booking_for_particuliers
       = render "common/franceconnect_button", display_title: false
+      p.fr-hr-or ou
 
     / Contrairement à FranceConnect, on n'affiche pas le bouton ProConnect en dehors de la prise de rendez-vous
     - if display_pro_connect_button? && @rdv_wizard&.rdv&.motif&.organisation&.online_booking_for_professionnels
-      p.fr-hr-or ou
       .rdv-text-align-center
         = render "common/proconnect_button_dsfr", user_type: "user"
+      p.fr-hr-or ou
 
     - if params[:with_password].present? || params[:user].present?
       = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|


### PR DESCRIPTION
# Contexte

Signalé par Mehdi dans https://mattermost.incubateur.net/betagouv/pl/jwzf5kg717dnpb463gkdqzrqpw

<img width="1686" height="1216" alt="image" src="https://github.com/user-attachments/assets/e7fbadae-7ab2-4153-9564-144631d70c7b" />


# Solution

Je sors les `hr OU` des partial de boutons pour les mettre dans les templates appelants ces partials et bien mettre ces `hr` de séparation entre les différentes sections, ça devrait éviter les erreurs futures 😅 

## Captures

| FC seul | PC seul | les deux|
|-|-|-|
|<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/17639af4-809e-4f56-8c57-dfc96a8ec7b9" />|<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/68e7b0b3-8122-45bc-896c-43c8f798f303" />|<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/3437b5eb-20a1-4fd1-a839-0fcde7e4f377" />|