### PR TITLE
Nettoyage des ignored_columns non nécessaires

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -1,6 +1,4 @@
 class Absence < ApplicationRecord
-  self.ignored_columns += %w[caldav_url]
-
   # Mixins
   has_paper_trail
   include WebhookDeliverable

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,7 +1,6 @@
 class SoftDeleteError < StandardError; end
 
 class Agent < ApplicationRecord
-  self.ignored_columns += %w[connected_with_agent_connect]
   include Agent::CaldavConfiguration
   include Agent::FeatureFlags
   include Agent::PreloadRoles

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -1,6 +1,4 @@
 class OauthApplication < Doorkeeper::Application
-  self.ignored_columns += %w[default_service_id]
-
   def self.agent_is_verified_by_an_application?(agent)
     OauthApplication
       .joins(:access_tokens)

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -1,5 +1,4 @@
 class Territory < ApplicationRecord
-  self.ignored_columns += %w[phone_number phone_number_formatted]
   has_paper_trail
 
   DEPARTEMENTS_NAMES = CSV.read(Rails.root.join("lib/assets/departements_fr.csv"), headers: :first_row)

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -135,7 +135,6 @@ tables:
       - deleted_at
       - created_at
       - updated_at
-      - connected_with_agent_connect
       - proconnect_siret
       - feature_flags
       - caldav_disconnect_in_progress
@@ -228,7 +227,6 @@ tables:
   - table_name: absences
     anonymized_column_names:
       - title
-      - caldav_url
     non_anonymized_column_names:
       - created_at
       - updated_at
@@ -308,8 +306,6 @@ tables:
     non_anonymized_column_names:
       - departement_number
       - name
-      - phone_number
-      - phone_number_formatted
       - created_at
       - updated_at
       - sms_provider


### PR DESCRIPTION
# Contexte

Suite à : 
- https://github.com/betagouv/rdv-service-public/pull/6168
- https://github.com/betagouv/rdv-service-public/pull/6167
- https://github.com/betagouv/rdv-service-public/pull/6093

On peut supprimer les `ignored_columns` non nécessaire. J’en profite aussi pour retirer les entrées dans le fichier d’anonymiseur.