### PR TITLE
Ajout d’un test qui vérifie les colonnes supprimés dans le fichier d’anonymizer

### DIFF
--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -56,13 +56,11 @@ tables:
       - logement
       - ants_pre_demande_number
       - franceconnect_openid_sub
-      - pro_connect_idp_id
       - pro_connect_openid_sub
       - encrypted_password
       - confirmation_token
       - reset_password_token
       - invitation_token
-      - remember_created_at
       - rdv_invitation_token
     non_anonymized_column_names:
       - confirmed_at
@@ -94,7 +92,6 @@ tables:
       - encrypted_password
       - unconfirmed_email
       - uid
-      - external_id
       - calendar_uid
       - reset_password_token
       - confirmation_token
@@ -102,7 +99,6 @@ tables:
       - tokens
       - microsoft_graph_token
       - refresh_microsoft_graph_token
-      - remember_created_at
       - pro_connect_openid_sub
       - pro_connect_2fa_active
       - pro_connect_idp_id
@@ -155,7 +151,6 @@ tables:
       - motif_id
       - uuid
       - lieu_id
-      - old_location
       - created_by_id
       - created_by_type
       - ends_at
@@ -191,7 +186,6 @@ tables:
     non_anonymized_column_names:
       - created_at
       - updated_at
-      - participation_id
 
   - table_name: super_admins
     anonymized_column_names:
@@ -211,9 +205,7 @@ tables:
       - created_at
       - updated_at
       - name
-      - departement
       - horaires
-      - human_id
       - website
       - external_id
       - verticale
@@ -247,10 +239,8 @@ tables:
     non_anonymized_column_names:
       - created_at
       - updated_at
-      - old_address
       - latitude
       - longitude
-      - old_enabled
       - availability
       - code_postal
 
@@ -353,7 +343,6 @@ tables:
       - updated_at
       - allow_to_manage_access_rights
       - allow_to_invite_agents
-      - allow_to_download_metrics
 
   - table_name: teams
     non_anonymized_column_names:
@@ -367,7 +356,6 @@ tables:
       - created_at
       - updated_at
       - default_duration_in_min
-      - legacy_bookable_publicly
       - min_public_booking_delay
       - max_public_booking_delay
       - deleted_at
@@ -375,7 +363,6 @@ tables:
       - restriction_for_rdv
       - instruction_for_rdv
       - for_secretariat
-      - old_location_type
       - follow_up
       - visibility_type
       - sectorisation_level
@@ -423,7 +410,6 @@ tables:
 
   - table_name: sectors
     non_anonymized_column_names:
-      - departement
       - name
       - human_id
       - created_at
@@ -572,5 +558,4 @@ tables:
     non_anonymized_column_names:
       - used_at
       - created_at
-      - updated_at
       - domain_id

--- a/lib/anonymizer/lib/anonymizer/config.rb
+++ b/lib/anonymizer/lib/anonymizer/config.rb
@@ -37,6 +37,14 @@ module Anonymizer
     def truncated? = @data.fetch(:truncated, false)
     def anonymized_column_names = @data.fetch(:anonymized_column_names, [])
     def non_anonymized_column_names = @data.fetch(:non_anonymized_column_names, [])
+    def all_column_names = anonymized_column_names + non_anonymized_column_names
+
+    def non_existent_columns(connection)
+      return [] unless connection.table_exists?(table_name)
+
+      actual_columns = connection.columns(table_name).map(&:name)
+      all_column_names.reject { |col| actual_columns.include?(col) }
+    end
 
     private
 

--- a/spec/anonymizer_spec.rb
+++ b/spec/anonymizer_spec.rb
@@ -195,4 +195,26 @@ RSpec.describe Anonymizer do
       expect(errors).to eq([]), errors.join("\n")
     end
   end
+
+  describe "colonnes obsolètes" do
+    it "ne référence pas de colonnes qui n'existent plus en base de données" do
+      config = described_class.default_config
+      stale_columns = []
+
+      config.table_configs.each do |table_config|
+        next if table_config.truncated?
+        next unless described_class.db_connection.table_exists?(table_config.table_name)
+
+        actual_columns = described_class.db_connection.columns(table_config.table_name).map(&:name)
+
+        (table_config.anonymized_column_names + table_config.non_anonymized_column_names).each do |column_name|
+          unless actual_columns.include?(column_name)
+            stale_columns << "#{table_config.table_name}.#{column_name}"
+          end
+        end
+      end
+
+      expect(stale_columns).to eq([]), "Colonnes obsolètes dans la config anonymizer (supprimées de la base) :\n#{stale_columns.join("\n")}"
+    end
+  end
 end

--- a/spec/anonymizer_spec.rb
+++ b/spec/anonymizer_spec.rb
@@ -198,20 +198,8 @@ RSpec.describe Anonymizer do
 
   describe "colonnes obsolètes" do
     it "ne référence pas de colonnes qui n'existent plus en base de données" do
-      config = described_class.default_config
-      stale_columns = []
-
-      config.table_configs.each do |table_config|
-        next if table_config.truncated?
-        next unless described_class.db_connection.table_exists?(table_config.table_name)
-
-        actual_columns = described_class.db_connection.columns(table_config.table_name).map(&:name)
-
-        (table_config.anonymized_column_names + table_config.non_anonymized_column_names).each do |column_name|
-          unless actual_columns.include?(column_name)
-            stale_columns << "#{table_config.table_name}.#{column_name}"
-          end
-        end
+      stale_columns = described_class.default_config.table_configs.reject(&:truncated?).flat_map do |table_config|
+        table_config.non_existent_columns(described_class.db_connection).map { "#{table_config.table_name}.#{_1}" }
       end
 
       expect(stale_columns).to eq([]), "Colonnes obsolètes dans la config anonymizer (supprimées de la base) :\n#{stale_columns.join("\n")}"


### PR DESCRIPTION
# Contexte

Je me suis rendu compte qu’on avait pleins de colonnes qui étaient encore listés dans le fichier d’anonymizer.
Ce n’est pas forcément très grave, mais pour avoir un fichier un peu plus concis (et donc lisible) je propose d’ajouter un test qui vérifie les colonnes qui n’existent plus.

# Solution

- Ajout du test
- Suppression des colonnes inutiles dans `anonymizer.yml`