### PR TITLE
Mettre en place un timestamp pour caldav_disconnect_in_progress

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -26,7 +26,7 @@ class Agents::CaldavSyncController < AgentAuthController
 
   def destroy
     skip_authorization
-    current_agent.update!(caldav_disconnect_in_progress: true)
+    current_agent.update!(caldav_disconnect_in_progress: true, caldav_disconnect_in_progress_at: Time.current)
     Caldav::MassDestroyEventsAndAbsencesJob.perform_later(current_agent)
     redirect_to agents_calendar_sync_caldav_sync_path
   end

--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -26,7 +26,7 @@ class Agents::CaldavSyncController < AgentAuthController
 
   def destroy
     skip_authorization
-    current_agent.update!(caldav_disconnect_in_progress: true, caldav_disconnect_in_progress_at: Time.current)
+    current_agent.update!(caldav_disconnect_started_at: Time.current)
     Caldav::MassDestroyEventsAndAbsencesJob.perform_later(current_agent)
     redirect_to agents_calendar_sync_caldav_sync_path
   end

--- a/app/jobs/caldav/import_absences_from_caldav_job.rb
+++ b/app/jobs/caldav/import_absences_from_caldav_job.rb
@@ -19,7 +19,7 @@ module Caldav
     def perform(agent_id)
       agent = Agent.find(agent_id)
       Sentry.set_user({ id: agent.id, role: "Agent", email: agent.email })
-      return unless agent.caldav_configured? || agent.caldav_disconnect_in_progress?
+      return unless agent.caldav_configured? || agent.caldav_disconnect_started_at.present?
 
       if agent.caldav_sync_token
         updated_events, deleted_events, new_sync_token = changes_since_last_sync_of(agent:)

--- a/app/jobs/caldav/mass_destroy_events_and_absences_job.rb
+++ b/app/jobs/caldav/mass_destroy_events_and_absences_job.rb
@@ -12,7 +12,7 @@ module Caldav
 
       ExternalCalendarEvent.where(agent:).delete_all
 
-      agent.update!(caldav_username: nil, caldav_password: nil, caldav_agenda_url: nil, caldav_disconnect_in_progress: false, caldav_disconnect_in_progress_at: nil, caldav_sync_token: nil)
+      agent.update!(caldav_username: nil, caldav_password: nil, caldav_agenda_url: nil, caldav_disconnect_started_at: nil, caldav_sync_token: nil)
     end
 
     private

--- a/app/jobs/caldav/mass_destroy_events_and_absences_job.rb
+++ b/app/jobs/caldav/mass_destroy_events_and_absences_job.rb
@@ -12,7 +12,7 @@ module Caldav
 
       ExternalCalendarEvent.where(agent:).delete_all
 
-      agent.update!(caldav_username: nil, caldav_password: nil, caldav_agenda_url: nil, caldav_disconnect_in_progress: false, caldav_sync_token: nil)
+      agent.update!(caldav_username: nil, caldav_password: nil, caldav_agenda_url: nil, caldav_disconnect_in_progress: false, caldav_disconnect_in_progress_at: nil, caldav_sync_token: nil)
     end
 
     private

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,6 +1,7 @@
 class SoftDeleteError < StandardError; end
 
 class Agent < ApplicationRecord
+  self.ignored_columns += %w[caldav_disconnect_in_progress]
   include Agent::CaldavConfiguration
   include Agent::FeatureFlags
   include Agent::PreloadRoles

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -25,7 +25,7 @@ p
   = external_link_to("contacter le support", new_aide_demande_support_path(role: "agent", sujet: "Synchronisation CalDAV"))
   | .
 
-- if current_agent.caldav_disconnect_in_progress
+- if current_agent.caldav_disconnect_started_at.present?
     p
       |> Les événements qui avaient été importés dans votre agenda sont en cours de suppression. Cela peut prendre quelques minutes.
       | Vous pouvez revenir sur cette page plus tard pour reconfigurer vos identifiants CalDAV.

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -134,7 +134,7 @@ tables:
       - proconnect_siret
       - feature_flags
       - caldav_disconnect_in_progress
-      - caldav_disconnect_in_progress_at
+      - caldav_disconnect_started_at
       - blog_read_at
       - group_by_agent
 

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -134,6 +134,7 @@ tables:
       - proconnect_siret
       - feature_flags
       - caldav_disconnect_in_progress
+      - caldav_disconnect_in_progress_at
       - blog_read_at
       - group_by_agent
 

--- a/db/migrate/20260223104814_add_caldav_disconnect_in_progress_at_to_agents.rb
+++ b/db/migrate/20260223104814_add_caldav_disconnect_in_progress_at_to_agents.rb
@@ -1,18 +1,18 @@
 class AddCaldavDisconnectInProgressAtToAgents < ActiveRecord::Migration[8.0]
   def up
-    add_column :agents, :caldav_disconnect_in_progress_at, :datetime
+    add_column :agents, :caldav_disconnect_started_at, :datetime
 
     # rubocop:disable Rails/SkipsModelValidations
-    Agent.where(caldav_disconnect_in_progress: true).update_all(caldav_disconnect_in_progress_at: Time.current)
+    Agent.where(caldav_disconnect_in_progress: true).update_all(caldav_disconnect_started_at: Time.current)
     # rubocop:enable Rails/SkipsModelValidations
   end
 
   def down
     # rubocop:disable Rails/SkipsModelValidations
-    Agent.where.not(caldav_disconnect_in_progress_at: nil).update_all(caldav_disconnect_in_progress: true)
-    Agent.where(caldav_disconnect_in_progress_at: nil).update_all(caldav_disconnect_in_progress: false)
+    Agent.where.not(caldav_disconnect_started_at: nil).update_all(caldav_disconnect_in_progress: true)
+    Agent.where(caldav_disconnect_started_at: nil).update_all(caldav_disconnect_in_progress: false)
     # rubocop:enable Rails/SkipsModelValidations
 
-    remove_column :agents, :caldav_disconnect_in_progress_at
+    remove_column :agents, :caldav_disconnect_started_at
   end
 end

--- a/db/migrate/20260223104814_add_caldav_disconnect_in_progress_at_to_agents.rb
+++ b/db/migrate/20260223104814_add_caldav_disconnect_in_progress_at_to_agents.rb
@@ -1,0 +1,18 @@
+class AddCaldavDisconnectInProgressAtToAgents < ActiveRecord::Migration[8.0]
+  def up
+    add_column :agents, :caldav_disconnect_in_progress_at, :datetime
+
+    # rubocop:disable Rails/SkipsModelValidations
+    Agent.where(caldav_disconnect_in_progress: true).update_all(caldav_disconnect_in_progress_at: Time.current)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  def down
+    # rubocop:disable Rails/SkipsModelValidations
+    Agent.where.not(caldav_disconnect_in_progress_at: nil).update_all(caldav_disconnect_in_progress: true)
+    Agent.where(caldav_disconnect_in_progress_at: nil).update_all(caldav_disconnect_in_progress: false)
+    # rubocop:enable Rails/SkipsModelValidations
+
+    remove_column :agents, :caldav_disconnect_in_progress_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -155,7 +155,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_23_104814) do
     t.boolean "group_by_agent", default: false, null: false
     t.string "pro_connect_idp_id", comment: "Fournisseur d'identité ProConnect (identity provider)"
     t.boolean "sensitive_account", default: false, null: false
-    t.datetime "caldav_disconnect_in_progress_at"
+    t.datetime "caldav_disconnect_started_at"
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_20_101844) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_23_104814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -155,6 +155,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_20_101844) do
     t.boolean "group_by_agent", default: false, null: false
     t.string "pro_connect_idp_id", comment: "Fournisseur d'identité ProConnect (identity provider)"
     t.boolean "sensitive_account", default: false, null: false
+    t.datetime "caldav_disconnect_in_progress_at"
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true

--- a/spec/controllers/agents/caldav_sync_controller_spec.rb
+++ b/spec/controllers/agents/caldav_sync_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Agents::CaldavSyncController, type: :controller do
       delete :destroy
 
       expect(response).to redirect_to(agents_calendar_sync_caldav_sync_path)
-      expect(agent.reload.caldav_disconnect_in_progress).to be(true)
+      expect(agent.reload.caldav_disconnect_started_at.present?).to be(true)
     end
   end
 end


### PR DESCRIPTION
# Contexte

Aujourd’hui, nous avons un boolean pour savoir si la déconnexion CalDAV a été initialisé. Dans le futur, on va vouloir permettre à l’utilisateur de forcer cette déconnexion (sans supprimer les événements dans son agenda externe) si jamais on n'arrive pas à faire cette déconnexion, car ses identifiants ne sont plus valides.
Cela nous permettra également de débugguer des comptes pour lesquels la déconnexion est en cours depuis un moment.

# Solution

Afin d’avoir une migration zero downtime, on crée la nouvelle colonne, et on migre les données sans supprimer l’ancienne pour le moment.

Dans un second temps, on arrêtera d’utiliser la colonne `caldav_disconnect_in_progress` puis on la supprimera dans un troisième temps.