### PR TITLE
Remonter dans Sentry les erreurs InvalidAuthenticityToken

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,7 +9,7 @@ Sentry.init do |config|
 
   # cf docs/5-role-de-vigie.md
   # et https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/
-  config.excluded_exceptions -= ["ActiveRecord::RecordNotFound"]
+  config.excluded_exceptions -= ["ActiveRecord::RecordNotFound", "ActionController::InvalidAuthenticityToken"]
 
   # send_default_pii est désactivé par défaut
   # L’activer envoie par défaut pour toutes les requêtes HTTP : les params, le body, les cookies, l’IP.


### PR DESCRIPTION
# Contexte

Dans https://github.com/betagouv/rdv-service-public/pull/6159 on va potentiellement générer plus d'erreurs `InvalidAuthenticityToken` qu'aujourd'hui.

En testant en local j'ai cru comprendre qu'actuellement on ne remonte pas ces erreurs dans sentry.  

# Solution

je propose de remonter ces erreurs dans Sentry avant de changer la stratégie de `protect_from_forgery` 

ça permettra de se rendre compte de la différence de volumes 

j'ai testé en local sur la branche qui change la strategy avec ce changement de config sentry : https://sentry.incubateur.net/organizations/betagouv/issues/249683