### PR TITLE
Notifier les usagers d'un changement de lien de visio

### DIFF
--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -67,11 +67,15 @@ module Rdv::Updatable
   end
 
   def rdv_updated?
-    starts_at_changed? || lieu_changed?
+    starts_at_changed? || lieu_changed? || visio_url_custom_changed?
     # || agents_changed? désactivé pour l’instant cf https://github.com/betagouv/rdv-service-public/pull/5399
   end
 
   private
+
+  def visio_url_custom_changed?
+    collectif? && visio? && previous_changes["visio_url_custom"].present?
+  end
 
   def agents_changed?
     # we cannot use ActiveModel::Dirty methods here for this has_many association

--- a/spec/models/concerns/rdv/updatable_spec.rb
+++ b/spec/models/concerns/rdv/updatable_spec.rb
@@ -121,6 +121,26 @@ RSpec.describe Rdv::Updatable, type: :concern do
         rdv_co.update_and_notify(agent, context: "some context")
         expect_no_notifications
       end
+
+      it "notifies when visio_url_custom is set on an existing collective visio rdv" do
+        motif_visio_co = create(:motif, :collectif, location_type: :visio, organisation:)
+        rdv_visio_co = create(:rdv, motif: motif_visio_co, users: [user_co1, user_co2], agents: [agent], organisation:, lieu: nil)
+        rdv_visio_co.reload
+        rdv_visio_co.update_and_notify(agent, visio_url_custom: "https://teams.live.com/somemeeting")
+        expect_notifications_sent_for(rdv_visio_co, user_co1, :rdv_updated)
+        expect_notifications_sent_for(rdv_visio_co, user_co2, :rdv_updated)
+        expect_notifications_sent_for(rdv_visio_co, agent, :rdv_updated)
+      end
+
+      it "notifies when visio_url_custom changes to a new value for collective visio rdv" do
+        motif_visio_co = create(:motif, :collectif, location_type: :visio, organisation:)
+        rdv_visio_co = create(:rdv, motif: motif_visio_co, users: [user_co1, user_co2], agents: [agent], organisation:, lieu: nil, visio_url_custom: "https://teams.live.com/originalmeeting")
+        rdv_visio_co.reload
+        rdv_visio_co.update_and_notify(agent, visio_url_custom: "https://teams.live.com/newmeeting")
+        expect_notifications_sent_for(rdv_visio_co, user_co1, :rdv_updated)
+        expect_notifications_sent_for(rdv_visio_co, user_co2, :rdv_updated)
+        expect_notifications_sent_for(rdv_visio_co, agent, :rdv_updated)
+      end
     end
 
     it "call Notifiers::RdvCreated when reloaded status from cancelled status" do


### PR DESCRIPTION
## Review app : 

https://rdv-service-public-review-app-pr6184.osc-secnum-fr1.scalingo.io/admin/organisations/4/rdvs/8026

en tant que `martine@demo.rdv-solidarites.fr` : `Rdvservicepublictest1!`

🚨 emails activés, n'utilisez que des emails qui vous appartiennent

# Contexte

Actuellement les usagers ne sont pas prévenus lorsqu'un agent change l'URL de visio d'un RDV collectif.

# Solution

Envoyer des notifications aux usagers et aux agents dans ce cas. 

J'ai rajouté une spec pour ce cas. 

J’ai testé en review app, le mail arrive bien lors de la modif et l'ICS modifie l'URL ✅ 

Bémol : un SMS sera envoyé aux usagers dans ce cas de changement d'url de visio. or ces sms ne contiennent pas l'URL de visio donc ce n'est pas très clair ce qui a changé :/ je suppose qu'il ne faudrait pas envoyer de SMS du tout dans ce cas ?

Bémol 2 : on cache l'URL de la visio derrière un lien « rejoindre la visioconférence ». Pour l'usager c'est donc assez compliqué / impossible de comprendre que c'est ça qui a changé :/

<img width="583" height="639" alt="image" src="https://github.com/user-attachments/assets/e32ce1eb-05f5-4abc-9310-c6ce992e86b7" />
