### PR TITLE
Suppression de l’ancienne colonne caldav_disconnect_in_progress

### DIFF
--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -133,7 +133,6 @@ tables:
       - updated_at
       - proconnect_siret
       - feature_flags
-      - caldav_disconnect_in_progress
       - caldav_disconnect_started_at
       - blog_read_at
       - group_by_agent

--- a/db/migrate/20260224092756_remove_caldav_disconnect_in_progress_from_agents.rb
+++ b/db/migrate/20260224092756_remove_caldav_disconnect_in_progress_from_agents.rb
@@ -1,0 +1,7 @@
+class RemoveCaldavDisconnectInProgressFromAgents < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :agents, :caldav_disconnect_in_progress, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_23_104814) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_24_092756) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -147,7 +147,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_23_104814) do
     t.string "caldav_agenda_url"
     t.string "caldav_username"
     t.string "caldav_password"
-    t.boolean "caldav_disconnect_in_progress", default: false, null: false
     t.datetime "blog_read_at"
     t.string "pro_connect_openid_sub"
     t.string "caldav_sync_token"


### PR DESCRIPTION
# Contexte

Suite à #6179 
Maintenant qu’on a créé une nouvelle colonne avec un timestamp, mis l’ancienne colonne en ignoré et migré les données, nous pouvons supprimer cette ancienne colonne.

