### PR TITLE
Retrait d’un wording erroné sur la page de conctact RDVSP

### DIFF
--- a/app/views/aide/pages/aiguillage_usager.html.slim
+++ b/app/views/aide/pages/aiguillage_usager.html.slim
@@ -34,8 +34,9 @@
         li Identifiez-vous : la connexion se fait par la création d'un compte ou via France Connect.
         li Confirmez le rendez-vous : un SMS et/ou un email seront envoyés quelques minutes après la confirmation du rendez-vous. Pour les emails, pensez à vérifier vos spams si besoin.
 
-      .fr-mb-4w
-        = link_to "Faire une recherche de RDV depuis l’accueil", root_path, class: "fr-btn"
+      - unless current_domain == Domain::RDV_SERVICE_PUBLIC
+        .fr-mb-4w
+          = link_to "Faire une recherche de RDV depuis l’accueil", root_path, class: "fr-btn"
 
       .fr-callout.fr-mb-2w
         p Si vous ne trouvez pas de créneaux, nous vous invitons à contacter l’organisation avec laquelle vous souhaitez prendre RDV


### PR DESCRIPTION
# Contexte
Dans la page de contact on affiche un CTA qui invite les usagers à se rendre sur la page d’accueil pour prendre rendez-vous.
Cela a du sens sur RDV S et RDV Aide Numérique, mais pas sur RDV SP.
