### PR TITLE
seeds: ajout des categories de motifs ANTS sur l’espace RDV Mairie 

### DIFF
--- a/db/seeds/rdv_mairie.rb
+++ b/db/seeds/rdv_mairie.rb
@@ -20,9 +20,13 @@ service_titres = Service.create!(name: "Mairie", short_name: "Mairie")
 
 territory_val_doise.services << service_titres
 
-MotifCategory.create!(name: "Carte d'identité disponible sur le site de l'ANTS", short_name: "CNI")
-MotifCategory.create!(name: "Passeport disponible sur le site de l'ANTS", short_name: "PASSPORT")
-MotifCategory.create!(name: "Carte d'identité et passeport disponible sur le site de l'ANTS", short_name: "CNI-PASSPORT")
+motif_categories = [
+  MotifCategory.create!(name: "Carte d'identité disponible sur le site de l'ANTS", short_name: "CNI"),
+  MotifCategory.create!(name: "Passeport disponible sur le site de l'ANTS", short_name: "PASSPORT"),
+  MotifCategory.create!(name: "Carte d'identité et passeport disponible sur le site de l'ANTS", short_name: "CNI-PASSPORT"),
+]
+
+territory_val_doise.motif_categories = motif_categories
 
 # MOTIFS
 motif_passeport = Motif.create!(


### PR DESCRIPTION
Actuellement, dans les seeds permettant de tester le cas des mairies et des motifs ANTS, on : 
- créé bien les 3 catégories de motifs ANTS
- associe bien les motifs à ces catégories 

Mais on ne les ajoute pas à l'espace via `territory.motif_categories <<`

Ça a pour effet que nous ne voyons pas cette jolie partie de la config des motifs dans nos environnements locaux et review apps : 

<img width="677" height="313" alt="image" src="https://github.com/user-attachments/assets/8e31f47a-1408-4572-a649-f48de33a64ab" />

C'est pourtant très vieux cette histoire de `territory.motif_categories` 🤷  : #3304

On peut voir qu'on le fait bien lorsqu'on ouvre des comptes en prod depuis la super admin ici : https://github.com/betagouv/rdv-service-public/blob/271387e67a68b7069fd8d464cae584862faa9e86/app/form_models/compte.rb#L120-L124
