### PR TITLE
Bouton « Ajouter à mon agenda » sur l’écran de confirmation

### DIFF
--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -1,5 +1,5 @@
 class Users::RdvsController < UserAuthController
-  before_action :verify_user_name_initials, :set_rdv, :set_can_see_rdv_motif, only: %i[show creneaux edit cancel update]
+  before_action :verify_user_name_initials, :set_rdv, :set_can_see_rdv_motif, only: %i[show creneaux ics edit cancel update]
   before_action :set_can_see_rdv_motif, only: %i[show edit index]
   before_action :set_geo_search, only: [:create]
   before_action :set_lieu, only: %i[edit update]
@@ -88,6 +88,15 @@ class Users::RdvsController < UserAuthController
       flash[:error] = "Impossible d'annuler le RDV."
     end
     redirect_to users_rdv_path(@rdv, invitation_token: @rdv.participation_token(current_user.id))
+  end
+
+  def ics
+    payload = @rdv.payload(nil, current_user)
+    cal = IcalFormatters::Ics.from_payload(payload)
+    send_data cal.to_ical,
+              filename: payload[:attachement_filename],
+              type: "text/calendar",
+              disposition: "attachment"
   end
 
   def creneaux

--- a/app/policies/user/rdv_policy.rb
+++ b/app/policies/user/rdv_policy.rb
@@ -50,6 +50,7 @@ class User::RdvPolicy < ApplicationPolicy
       !record.in_the_past?
   end
 
+  alias ics? show?
   alias creneaux? edit?
   alias update? edit?
 

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -80,10 +80,14 @@ ul.list-group.list-group-flush.fr-mb-3w.fr-mt-0
     span.fr-icon-close-circle-fill.fr-mr-1w[aria-hidden="true"]
     | Ce rendez-vous n'est pas annulable en ligne. Prenez contact avec le secrétariat.
 
-ul.fr-btns-group.fr-btns-group--inline.fr-mb-0
+ul.fr-btns-group.fr-btns-group--inline.fr-btns-group--icon-left.fr-mb-0
+  - unless rdv.cancelled? || rdv.in_the_past?
+    li
+      = link_to ics_users_rdv_path(rdv), class: "fr-btn fr-btn--secondary fr-icon-calendar-line" do
+        | Ajouter à mon agenda
   - if policy(rdv, policy_class: User::RdvPolicy).edit?
     li
-      = link_to "Déplacer le RDV", creneaux_users_rdv_path(rdv), class: "fr-btn fr-btn--secondary"
+      = link_to "Déplacer le RDV", creneaux_users_rdv_path(rdv), class: "fr-btn fr-btn--tertiary"
   - if policy(rdv, policy_class: User::RdvPolicy).cancel?
     li
       button.fr-btn.fr-btn--tertiary[data-fr-opened="false" aria-controls="js-cancel-rdv-modal-#{rdv.id}"] Annuler le RDV

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
       put "participations/cancel", to: "participations#cancel"
       member do
         get :creneaux
+        get :ics
         put :cancel
       end
     end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6190.osc-secnum-fr1.scalingo.io/)

# Contexte

Suite à différents retours d’« agents usagers », on ajoute un bouton « Ajouter à mon calendrier » sur l’écran de confirmation de RDV. Ce bouton permet simplement le téléchargement de l’ICS qu’on envoit aussi par email.

À terme, il faudra peut-être faire évoluer ça comme certains autres systèmes de prise de RDV avec un bouton spécifique par provider pour faciliter la vie des usagers.

# Solution

## Captures d'écran

<img width="676" height="668" alt="image" src="https://github.com/user-attachments/assets/fc9a237e-e162-4555-8189-ad2c7a764e47" />

