### PR TITLE
Revert "protect_from_forgery with: :exception"

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include ExplicitPunditConcern
   include DomainDetection
 
-  protect_from_forgery with: :exception
+  protect_from_forgery
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :store_user_location!, if: :storable_location?


### PR DESCRIPTION
Reverts betagouv/rdv-service-public#6159

malheureusement l'erreur a été levée sur la route de sign_in d'api version devise_token (sur RDVS) 

on rollbacke le temps de corriger