### PR TITLE
protect_from_forgery with: :exception 2e tentative

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include ExplicitPunditConcern
   include DomainDetection
 
-  protect_from_forgery
+  protect_from_forgery with: :exception
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :store_user_location!, if: :storable_location?

--- a/app/views/admin/agents/edit.html.slim
+++ b/app/views/admin/agents/edit.html.slim
@@ -55,7 +55,7 @@
           .row
             - if policy(@agent, policy_class: Agent::AgentPolicy).destroy?
               .col.text-left
-                = link_to @agent_removal_presenter.button_value, \
+                = button_to @agent_removal_presenter.button_value, \
                   admin_organisation_agent_path(current_organisation, @agent), \
                   data: { confirm: @agent_removal_presenter.confirm_message }, \
                   method: :delete, \

--- a/app/views/admin/agents/edit.html.slim
+++ b/app/views/admin/agents/edit.html.slim
@@ -52,22 +52,21 @@
                 .col-md-6
                   = f.input :last_name, required: true, input_html: { value: "" }, disabled: true
 
-          .row
-            - if policy(@agent, policy_class: Agent::AgentPolicy).destroy?
-              .col.text-left
-                = button_to @agent_removal_presenter.button_value, \
-                  admin_organisation_agent_path(current_organisation, @agent), \
-                  data: { confirm: @agent_removal_presenter.confirm_message }, \
-                  method: :delete, \
-                  class: "btn btn-outline-danger"
-            .col.text-right
-              - if AgentRole.find(@agent_role.id).access_level == "intervenant"
+          .text-right
+            - if AgentRole.find(@agent_role.id).access_level == "intervenant"
+              = f.button :submit
+            - else
+              .js_agent_role_form__agent_with_account_fields
                 = f.button :submit
-              - else
-                .js_agent_role_form__agent_with_account_fields
-                  = f.button :submit
-                .js_agent_role_form__intervenant_fields[style="display:none;"]
-                  = f.button :submit, data: { confirm: "Cet agent ne pourra plus se connecter à son compter. Êtes vous sûr de vouloir continuer ?" }
+              .js_agent_role_form__intervenant_fields[style="display:none;"]
+                = f.button :submit, data: { confirm: "Cet agent ne pourra plus se connecter à son compter. Êtes vous sûr de vouloir continuer ?" }
+        - if policy(@agent, policy_class: Agent::AgentPolicy).destroy?
+          .mt-2
+            = button_to @agent_removal_presenter.button_value, \
+              admin_organisation_agent_path(current_organisation, @agent), \
+              data: { confirm: @agent_removal_presenter.confirm_message }, \
+              method: :delete, \
+              class: "btn btn-outline-danger"
 
 .row.justify-content-center
   .col-md-12.col-lg-8

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -24,14 +24,14 @@
           h2.fr-h6 Ce lieu est ouvert aux nouveaux rendez-vous
           p Vous pouvez fermer ce lieu pour empêcher que de nouveaux rendez-vous ou des nouvelles plages d'ouvertures y soient associées.
           p Il sera ensuite possible de rouvrir ce lieu dès que vous le souhaitez.
-          = link_to "Fermer ce lieu", close_admin_organisation_lieu_path(current_organisation, @lieu), method: :post, class: "fr-btn fr-btn--secondary"
+          = button_to "Fermer ce lieu", close_admin_organisation_lieu_path(current_organisation, @lieu), method: :post, class: "fr-btn fr-btn--secondary"
 
         - else
           h2.fr-h6 Ce lieu est fermé aux nouveaux rendez-vous
 
           p Il n'est pas possible d'ajouter des rendez-vous ou des plages d'ouverture pour ce lieu.
           p Si vous le souhaitez, vous pouvez le rouvrir
-          = link_to "Réouvrir ce lieu", reopen_admin_organisation_lieu_path(current_organisation, @lieu), method: :post, class: "fr-btn fr-btn--secondary"
+          = button_to "Réouvrir ce lieu", reopen_admin_organisation_lieu_path(current_organisation, @lieu), method: :post, class: "fr-btn fr-btn--secondary"
 
 - if @lieu.disabled?
   .row.justify-content-center
@@ -54,7 +54,7 @@
             = button_tag t("helpers.delete"), type: "button", disabled: true, class: "btn btn-outline-danger"
           - else
             p Vous pouvez supprimer ce lieu
-            = link_to t("helpers.delete"), admin_organisation_lieu_path(@lieu.organisation, @lieu), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce lieu ?" }
+            = button_to t("helpers.delete"), admin_organisation_lieu_path(@lieu.organisation, @lieu), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce lieu ?" }
 
 .row.justify-content-center
   .col-md-12.col-lg-8

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -20,8 +20,5 @@ ul#motif_tabs.nav.nav-tabs.mt-3[role="tablist"]
         = render "admin/motifs/form/notifs_et_instructions", f: f, motif: motif, rdvi_mode: rdvi_mode
 
     .row.mb-5
-      - if motif.persisted?
-        .col.text-left
-          = button_to t("admin.motifs.actions.destroy"), admin_organisation_motif_path(motif.organisation, motif), method: :delete, class: "fr-btn fr-btn--tertiary", data: { confirm: t("admin.motifs.actions.destroy_confirm") }
       .col.text-right
         = f.submit((motif.new_record? ? "Créer le motif" : "Enregistrer"), class: "fr-btn")

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -22,6 +22,6 @@ ul#motif_tabs.nav.nav-tabs.mt-3[role="tablist"]
     .row.mb-5
       - if motif.persisted?
         .col.text-left
-          = link_to t("admin.motifs.actions.destroy"), admin_organisation_motif_path(motif.organisation, motif), method: :delete, class: "fr-btn fr-btn--tertiary", data: { confirm: t("admin.motifs.actions.destroy_confirm") }
+          = button_to t("admin.motifs.actions.destroy"), admin_organisation_motif_path(motif.organisation, motif), method: :delete, class: "fr-btn fr-btn--tertiary", data: { confirm: t("admin.motifs.actions.destroy_confirm") }
       .col.text-right
         = f.submit((motif.new_record? ? "Créer le motif" : "Enregistrer"), class: "fr-btn")

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -39,13 +39,13 @@ tr
 
       - if motif.archived?
         - if motif_policy.unarchive?
-          = link_to "", unarchive_admin_organisation_motif_path(current_organisation, motif),
+          = button_to "", unarchive_admin_organisation_motif_path(current_organisation, motif),
                   class: "fr-btn fr-btn--tertiary fr-icon-upload-fill",
                   method: :post,
                   title: t("admin.motifs.actions.unarchive")
         - if motif_policy.destroy?
           - if motif.destroyable?
-            = link_to "", admin_organisation_motif_path(current_organisation, motif),
+            = button_to "", admin_organisation_motif_path(current_organisation, motif),
                     class: "fr-btn fr-btn--tertiary fr-icon-delete-fill",
                     method: :delete,
                     title: t("admin.motifs.actions.destroy"), data: { confirm: t("admin.motifs.actions.destroy_confirm") }
@@ -53,7 +53,7 @@ tr
             button.fr-btn.fr-btn--tertiary.fr-icon-delete-fill [disabled="disabled" title=t("admin.motifs.actions.not_destroyable_explanation")]
       - else
         - if motif_policy.archive?
-          = link_to "", archive_admin_organisation_motif_path(current_organisation, motif),
+          = button_to "", archive_admin_organisation_motif_path(current_organisation, motif),
                   class: "fr-btn fr-btn--tertiary fr-icon-archive-fill",
                   method: :post,
                   title: t("admin.motifs.actions.archive"),

--- a/app/views/admin/motifs/edit.html.slim
+++ b/app/views/admin/motifs/edit.html.slim
@@ -13,3 +13,7 @@
     = form_for @motif, url: admin_organisation_motif_path, builder: Dsfr::FormBuilder, html: { "data-controller": "motif-form" } do |f|
       = render "model_errors", model: @motif, f: f
       = render "admin/motifs/form", motif: @motif, f: f, rdvi_mode: current_organisation.rdv_insertion?
+
+    - if policy(@motif, policy_class: Agent::MotifPolicy).destroy?
+      .mt-2
+        = button_to t("admin.motifs.actions.destroy"), admin_organisation_motif_path(@motif.organisation, @motif), method: :delete, class: "fr-btn fr-btn--tertiary", data: { confirm: t("admin.motifs.actions.destroy_confirm") }

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -101,13 +101,13 @@
           .d-flex.justify-content-end.flex-gap-1em
             - if @motif.archived?
               - if @motif_policy.unarchive?
-                div= link_to t("admin.motifs.actions.unarchive"), unarchive_admin_organisation_motif_path(current_organisation, @motif), method: :post, class: "btn btn-light w-100"
+                div= button_to t("admin.motifs.actions.unarchive"), unarchive_admin_organisation_motif_path(current_organisation, @motif), method: :post, class: "btn btn-light w-100"
             - else
               - if @motif_policy.archive?
-                div= link_to t("admin.motifs.actions.archive"), archive_admin_organisation_motif_path(current_organisation, @motif), method: :post, data: { confirm: t("admin.motifs.actions.archive_confirm") }, class: "btn btn-light w-100"
+                div= button_to t("admin.motifs.actions.archive"), archive_admin_organisation_motif_path(current_organisation, @motif), method: :post, data: { confirm: t("admin.motifs.actions.archive_confirm") }, class: "btn btn-light w-100"
 
             - if @motif_policy.destroy?
-              div= link_to t("admin.motifs.actions.destroy"), admin_organisation_motif_path(current_organisation, @motif), method: :delete, data: { confirm: t("admin.motifs.actions.destroy_confirm") }, class: "btn btn-danger w-100"
+              div= button_to t("admin.motifs.actions.destroy"), admin_organisation_motif_path(current_organisation, @motif), method: :delete, data: { confirm: t("admin.motifs.actions.destroy_confirm") }, class: "btn btn-danger w-100"
 
             - unless @motif.archived?
               - if @motif_policy.duplicate?

--- a/app/views/admin/planning/absences/_absence.html.slim
+++ b/app/views/admin/planning/absences/_absence.html.slim
@@ -19,7 +19,7 @@ tr
       = link_to "", new_admin_organisation_planning_absence_path(current_organisation, agent_id: absence.agent, duplicate_absence_id: absence),
               title: t("helpers.clone"),
               class: "fr-btn fr-btn--tertiary fr-icon-clipboard-fill"
-      = link_to "", admin_organisation_planning_absence_path(current_organisation, absence),
+      = button_to "", admin_organisation_planning_absence_path(current_organisation, absence),
               method: :delete,
               title: t("helpers.delete"),
               data: { confirm: t(".confirm_delete_absence")},

--- a/app/views/admin/planning/absences/_form.html.slim
+++ b/app/views/admin/planning/absences/_form.html.slim
@@ -10,6 +10,6 @@
   .row
     - if absence.persisted?
       .col.text-left
-        = link_to "Supprimer", admin_organisation_planning_absence_path(current_organisation, absence), method: :delete, class: "btn btn-outline-danger", data: { confirm: t(".confirm_delete_absence")}
+        = button_to "Supprimer", admin_organisation_planning_absence_path(current_organisation, absence), method: :delete, class: "btn btn-outline-danger", data: { confirm: t(".confirm_delete_absence")}
     .col.text-right
       = f.submit class: "fr-btn"

--- a/app/views/admin/planning/absences/_form.html.slim
+++ b/app/views/admin/planning/absences/_form.html.slim
@@ -8,8 +8,5 @@
   = render partial: "common/recurrence", locals: { f: f, model: absence }
 
   .row
-    - if absence.persisted?
-      .col.text-left
-        = button_to "Supprimer", admin_organisation_planning_absence_path(current_organisation, absence), method: :delete, class: "btn btn-outline-danger", data: { confirm: t(".confirm_delete_absence")}
     .col.text-right
       = f.submit class: "fr-btn"

--- a/app/views/admin/planning/absences/edit.html.slim
+++ b/app/views/admin/planning/absences/edit.html.slim
@@ -34,6 +34,10 @@
       .card-body
         = render "form", absence: @absence, agent: @agent
 
+        - if policy(@absence, policy_class: Agent::AbsencePolicy).destroy?
+          .mt-2
+            = button_to "Supprimer", admin_organisation_planning_absence_path(current_organisation, @absence), method: :delete, class: "btn btn-outline-danger", data: { confirm: t("admin.planning.absences.form.confirm_delete_absence") }
+
 .row.justify-content-center
   .col-md-12.col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: policy(@absence, policy_class: Agent::AbsencePolicy), resource: @absence

--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -30,7 +30,7 @@ tr
       = link_to "", new_admin_organisation_planning_plage_ouverture_path(organisation, agent_id: plage_ouverture.agent, duplicate_plage_ouverture_id: plage_ouverture),
               title: "Dupliquer",
               class: "fr-btn fr-btn--tertiary fr-icon-clipboard-fill"
-      = link_to "", admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture),
+      = button_to "", admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture),
               method: :delete,
               title: "Supprimer",
               class: "fr-btn fr-btn--tertiary fr-icon-delete-fill",

--- a/app/views/admin/planning/plage_ouvertures/show.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/show.html.slim
@@ -57,7 +57,7 @@
 
       .card-footer.d-flex.justify-content-between
         div
-          = link_to( \
+          = button_to( \
             "Supprimer", \
             admin_organisation_planning_plage_ouverture_path(current_organisation, @plage_ouverture), \
             method: :delete, \

--- a/app/views/admin/referent_assignations/_referent_assignation_row.html.slim
+++ b/app/views/admin/referent_assignations/_referent_assignation_row.html.slim
@@ -6,6 +6,6 @@ tr id="agent_#{agent.id}"
   td.text-right
     div.mr-3
       - if action == :remove
-        = link_to "Retirer", admin_organisation_user_referent_assignation_path(current_organisation, @user, agent), method: :delete, class: "fr-btn fr-btn--secondary", data: { confirm: "Voulez-vous vraiment retirer ce référent ?"}
+        = button_to "Retirer", admin_organisation_user_referent_assignation_path(current_organisation, @user, agent), method: :delete, class: "fr-btn fr-btn--secondary", data: { confirm: "Voulez-vous vraiment retirer ce référent ?"}
       - elsif action == :add
-        = link_to "Ajouter", admin_organisation_user_referent_assignations_path(current_organisation, @user, agent_id: agent.id),  method: :post, class: "fr-btn", data: { disable_with: "Veuillez patienter…"}
+        = button_to "Ajouter", admin_organisation_user_referent_assignations_path(current_organisation, @user, agent_id: agent.id), method: :post, class: "fr-btn", data: { disable_with: "Veuillez patienter…"}

--- a/app/views/admin/territories/motifs/_motifs_table.html.slim
+++ b/app/views/admin/territories/motifs/_motifs_table.html.slim
@@ -59,13 +59,13 @@ table.table.table-centered.table-bordered.table-sm.mb-0[class=(display_checkboxe
                         target: :_blank
               - if motif.archived?
                 - if motif_policy.unarchive?
-                  = link_to "", unarchive_admin_territory_motif_path(current_territory, motif),
+                  = button_to "", unarchive_admin_territory_motif_path(current_territory, motif),
                           class: "fr-btn fr-btn--tertiary fr-icon-upload-fill",
                           method: :post,
                           title: "Réactiver"
                 - if motif_policy.destroy?
                   - if motif.destroyable?
-                    = link_to "", admin_territory_motif_path(current_territory, motif),
+                    = button_to "", admin_territory_motif_path(current_territory, motif),
                             class: "fr-btn fr-btn--tertiary fr-icon-delete-fill",
                             method: :delete,
                             title: "Supprimer", data: { confirm: "Confirmez-vous la suppression de ce motif ?" }
@@ -73,7 +73,7 @@ table.table.table-centered.table-bordered.table-sm.mb-0[class=(display_checkboxe
                     button.fr-btn.fr-btn--tertiary.fr-icon-delete-line [disabled="disabled" title=t("admin.motifs.actions.not_destroyable_explanation")]
               - else
                 - if motif_policy.archive?
-                  = link_to "", archive_admin_territory_motif_path(current_territory, motif),
+                  = button_to "", archive_admin_territory_motif_path(current_territory, motif),
                           class: "fr-btn fr-btn--tertiary fr-icon-archive-fill",
                           method: :post,
                           title: "Archiver",

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -29,7 +29,7 @@ ruby:
               - if @user.invitation_sent_at
                 p.small.m-0 Invitation envoyée il y a #{distance_of_time_in_words_to_now(@user.invitation_sent_at)}
             .col-md-4.text-right
-              = link_to "Inviter", invite_admin_organisation_user_path(current_organisation, @user), method: :post, class: "btn btn-outline-white", data: { disable_with: "Veuillez patienter…"}
+              = button_to "Inviter", invite_admin_organisation_user_path(current_organisation, @user), method: :post, class: "btn btn-outline-white", data: { disable_with: "Veuillez patienter…"}
 
         - if @user.invited_through == "external" && @user.invitation_accepted_at.nil?
           .row.bg-info.text-white.p-2.mb-3

--- a/app/views/agents/_preferences_menu.html.slim
+++ b/app/views/agents/_preferences_menu.html.slim
@@ -16,5 +16,5 @@ ruby:
           = link_to(item[2], class: "px-1 py-2 side-menu__item #{'active' if @active_agent_preferences_menu_item == item[0]}") do
             span.ml-1 = item[1]
       li
-        = link_to destroy_agent_session_path, method: :delete, class: "px-1 py-2 side-menu__item" do
+        = button_to destroy_agent_session_path, method: :delete, class: "px-1 py-2 side-menu__item" do
           span.ml-1 = "Se déconnecter"

--- a/app/views/agents/outlook_sync/show.html.slim
+++ b/app/views/agents/outlook_sync/show.html.slim
@@ -10,7 +10,7 @@
   p Attention, cela aura pour effect de supprimer tous vos rendez-vous #{current_domain.name} de votre agenda Outlook (Microsoft 365).
 
   div.rdv-text-align-center
-    = link_to "Déconnecter votre compte Outlook", agents_calendar_sync_outlook_sync_path, class: "btn btn-primary m-2 #{'disabled' if current_agent.outlook_disconnect_in_progress?}", method: :delete
+    = button_to "Déconnecter votre compte Outlook", agents_calendar_sync_outlook_sync_path, method: :delete, class: "btn btn-primary m-2 #{'disabled' if current_agent.outlook_disconnect_in_progress?}"
 
 - else
 
@@ -18,7 +18,7 @@
     | Vous pouvez synchroniser automatiquement et en temps réel vos rendez-vous sur votre agenda Microsoft Office 365 en connectant votre compte grâce au bouton ci-dessous :
 
   div.rdv-text-align-center
-    = link_to "/omniauth/microsoft_graph?login_hint=#{current_agent.email}", class: "mb-4", method: :post do
+    = button_to "/omniauth/microsoft_graph?login_hint=#{current_agent.email}", method: :post, class: "mb-4" do
       = image_tag("sign_in_with_microsoft.svg", alt: "S'identifier avec Microsoft")
 
   p

--- a/app/views/common/_modal_confirmation.html.slim
+++ b/app/views/common/_modal_confirmation.html.slim
@@ -15,6 +15,6 @@ dialog id="#{id}" class="fr-modal" aria-labelledby="#{id}-title"
               = body_message
           .fr-modal__footer
             .fr-btns-group.fr-btns-group--right.fr-btns-group--inline-reverse.fr-btns-group--inline-lg.fr-btns-group--icon-left
-              = link_to confirm_message, confirm_path, class: "fr-btn", **confirm_link_options
+              = button_to confirm_message, confirm_path, class: "fr-btn", **confirm_link_options
               button type='button' class='fr-btn fr-btn--secondary' aria-controls="#{id}"
                 = cancel_message

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -30,7 +30,7 @@ header.header.bg-white
                 span.fr-icon--sm.fr-mr-2v.fr-icon-settings-5-line[aria-hidden="true"]
                 | Paramètres de #{territory.name_for_agent}
             li.dropdown-divider.my-1[aria-hidden="true"]
-            li = link_to destroy_agent_session_path, method: :delete, class: "dropdown-item-dsfr dropdown-item" do
+            li = button_to destroy_agent_session_path, method: :delete, class: "dropdown-item-dsfr dropdown-item" do
               span.fr-icon--sm.fr-mr-2v.fr-icon-logout-box-r-line[aria-hidden="true"]
               | Se déconnecter
         - if current_domain == Domain::RDV_SERVICE_PUBLIC && current_agent.lagaufre_access?

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -38,7 +38,9 @@ html lang="fr"
           header.with_tool_link title: "Vos rendez-vous", path: users_rdvs_path, html_attributes: { class: "fr-icon-calendar-fill" }
           header.with_tool_link title: "Vos informations", path: users_informations_path
           header.with_tool_link title: "Votre compte", path: edit_user_registration_path
-          header.with_tool_link title: "Déconnexion", path: destroy_user_session_path, html_attributes: { "data-method": "delete", class: "fr-icon-lock-fill" }
+          header.with_custom_tool_link do
+            button_to("Déconnexion", destroy_user_session_path, method: :delete, class: "fr-btn fr-icon-lock-fill")
+          end
         elsif current_agent
           header.with_tool_link title: "Espace Agent", path: root_path
           header.with_tool_link title: current_agent.full_name, path: edit_agent_registration_path

--- a/app/views/prescripteur_rdv_wizard/_rdv.html.slim
+++ b/app/views/prescripteur_rdv_wizard/_rdv.html.slim
@@ -40,7 +40,7 @@ ul.list-group.list-group-flush.fr-mt-0
         | Vous n’avez pas renseigné de numéro de téléphone pour l’usager. En cas d’annulation, il ne recevra pas de notification automatique.
     ul.fr-btns-group.fr-btns-group--inline
       li
-        = link_to "Annuler le rendez-vous", prescripteur_cancel_rdv_path, class: "fr-btn fr-btn--secondary", data: { confirm: prescripteur.user.phone_number.blank? ? "Attention ! L’usager ne recevera pas notification d’annulation. Êtes-vous sûr de vouloir annuler ce rendez-vous ?" : "Êtes-vous sûr de vouloir annuler ce rendez-vous ?", method: :delete }
+        = button_to "Annuler le rendez-vous", prescripteur_cancel_rdv_path, method: :delete, class: "fr-btn fr-btn--secondary", data: { confirm: prescripteur.user.phone_number.blank? ? "Attention ! L’usager ne recevera pas notification d’annulation. Êtes-vous sûr de vouloir annuler ce rendez-vous ?" : "Êtes-vous sûr de vouloir annuler ce rendez-vous ?" }
 p
   |> Besoin de corriger un détail ?
   = link_to "Contactez-nous", new_aide_demande_support_path(role: :agent,

--- a/app/views/users/rdv_wizard_steps/step3.html.slim
+++ b/app/views/users/rdv_wizard_steps/step3.html.slim
@@ -9,6 +9,6 @@
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard, show_user_info: true
       .card-body.rdv-text-align-right
         - if @rdv_wizard.rdv.collectif?
-          = link_to "Confirmer ma participation", users_rdv_participations_path(@rdv_wizard.rdv, user_id: @rdv_wizard.users.first.id), method: :post, class: "fr-btn", data: { disable_with: "Veuillez patienter…"}
+          = button_to "Confirmer ma participation", users_rdv_participations_path(@rdv_wizard.rdv, user_id: @rdv_wizard.users.first.id), method: :post, class: "fr-btn", data: { disable_with: "Veuillez patienter…"}
         - else
-          = link_to "Confirmer mon RDV", users_rdvs_path(@rdv_wizard.to_query), method: :post, class: "fr-btn", data: { disable_with: "Veuillez patienter…"}
+          = button_to "Confirmer mon RDV", users_rdvs_path(@rdv_wizard.to_query), method: :post, class: "fr-btn", data: { disable_with: "Veuillez patienter…"}

--- a/app/views/users/rdvs/edit.html.slim
+++ b/app/views/users/rdvs/edit.html.slim
@@ -12,4 +12,4 @@
       .col
         = link_to "Retour à la liste des créneaux", creneaux_users_rdv_path(@rdv)
       .col.rdv-text-align-right
-        = link_to "Confirmer le nouveau créneau", users_rdv_path(@rdv, starts_at: @starts_at.to_s), class: "btn btn-primary", method: :put, data: { disable_with: "Veuillez patienter…"}
+        = button_to "Confirmer le nouveau créneau", users_rdv_path(@rdv, starts_at: @starts_at.to_s), class: "btn btn-primary", method: :patch, data: { disable_with: "Veuillez patienter…"}

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  config.action_controller.allow_forgery_protection = true
 
   # Store uploaded files on the local file system in a temporary directory.
   # config.active_storage.service = :test

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Admin can configure the organisation" do
       click_link "Modifier"
     end
 
-    click_link("Fermer ce lieu")
+    click_on("Fermer ce lieu")
     expect_page_title("Lieux")
 
     expect(nouveau_lieu.reload).to have_attributes(availability: "disabled")
@@ -40,14 +40,14 @@ RSpec.describe "Admin can configure the organisation" do
     click_on("Le nouveau lieu")
     expect(page).to have_content("Ce lieu est fermé")
 
-    click_link("Réouvrir ce lieu")
+    click_on("Réouvrir ce lieu")
     expect(page).to have_content("Le lieu a été rouvert.")
     expect(nouveau_lieu.reload).to have_attributes(availability: "enabled")
 
     nouveau_lieu.update!(availability: :disabled)
 
     click_on("Le nouveau lieu")
-    click_link("Supprimer")
+    click_on("Supprimer")
 
     expect_page_title("Lieux")
     expect(page).to have_content("Vous n'avez pas encore ajouté de lieu de consultation.")

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Agent can CRUD absences" do
       expect_page_title("Vos indisponibilités")
       click_link "La belle indisponibilité"
 
-      click_link("Supprimer")
+      click_on("Supprimer")
       expect_page_title("Vos indisponibilités")
       expect(page).to have_content("Vous n’avez pas encore créé d’indisponibilité")
 
@@ -65,7 +65,7 @@ RSpec.describe "Agent can CRUD absences" do
       expect_page_title("Indisponibilités de Jane FAROU (PMI)")
       click_link "La belle indisponibilité"
 
-      click_link("Supprimer")
+      click_on("Supprimer")
       expect_page_title("Indisponibilités de Jane FAROU (PMI)")
       expect(page).to have_content("Jane FAROU n’a pas encore créé d’indisponibilité")
 
@@ -113,7 +113,7 @@ RSpec.describe "Agent can CRUD absences" do
 
     it "works" do
       click_link "Indisponibilités"
-      expect { click_link("Supprimer") }.to change(enqueued_jobs, :size).by(1)
+      expect { click_on("Supprimer") }.to change(enqueued_jobs, :size).by(1)
       expect { perform_enqueued_jobs }.to change { emails_sent_to(absence.agent.email).size }.by(1)
       open_email(absence.agent.email)
       expect(current_email.subject).to eq("RDV Service Public - Indisponibilité supprimée - #{absence.title}")

--- a/spec/features/agents/agent_can_crud_intervenants_spec.rb
+++ b/spec/features/agents/agent_can_crud_intervenants_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Agent can CRUD intervenants" do
     click_link "FICTIF"
     expect_page_title("Modifier le niveau de permission de l'agent FICTIF")
     accept_alert do
-      click_link("Supprimer le compte")
+      click_on("Supprimer le compte")
     end
     expect_page_title("Agents de Organisation n°1")
     expect(page).to have_no_content("FICTIF")

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
 
       expect_page_title("Plages d’ouverture")
       click_on("La belle plage")
-      accept_alert { click_link("Supprimer") }
+      accept_alert { click_on("Supprimer") }
 
       expect { perform_enqueued_jobs }.to change { emails_sent_to(agent.email).size }.by(1)
       open_email(agent.email)
@@ -156,7 +156,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       click_on("La belle plage")
       expect(page).to have_content("La belle plage")
       accept_confirm do
-        click_link("Supprimer")
+        click_on("Supprimer")
       end
 
       expect_page_title("Plages d’ouverture de Jane FAROU (PMI)")
@@ -194,7 +194,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
 
         expect_page_title("Plages d’ouverture de Jane FAROU (PMI)")
         click_on("La belle plage")
-        click_link("Supprimer")
+        click_on("Supprimer")
 
         expect_page_title("Plages d’ouverture de Jane FAROU (PMI)")
         expect(page).to have_content("Jane FAROU n'a pas encore créé de plage d'ouverture")
@@ -215,7 +215,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
     let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], agent: agent, organisation: organisation, start_time: Tod::TimeOfDay.new(8, 30), end_time: Tod::TimeOfDay.new(9, 30)) }
 
     it "works" do
-      expect { click_link("Supprimer") }.to change(enqueued_jobs, :size).by(1)
+      expect { click_on("Supprimer") }.to change(enqueued_jobs, :size).by(1)
       expect { perform_enqueued_jobs }.to change { emails_sent_to(plage_ouverture.agent.email).size }.by(1)
       open_email(plage_ouverture.agent.email)
       expect(current_email.subject).to eq("RDV Service Public - Plage d’ouverture supprimée - #{plage_ouverture.title_with_default}")

--- a/spec/features/agents/agent_can_sync_his_account_to_outlook_spec.rb
+++ b/spec/features/agents/agent_can_sync_his_account_to_outlook_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Agent can sync his account to outlook" do
 
     expect(client_double).to receive(:create_event!)
     perform_enqueued_jobs do
-      find(:xpath, "//a/img[@alt=\"S'identifier avec Microsoft\"]").find(:xpath, "..").click
+      find(:xpath, "//button/img[@alt=\"S'identifier avec Microsoft\"]").find(:xpath, "..").click
 
       expect(agent.reload.microsoft_graph_token).to eq("super_token")
       expect(agent.reload.refresh_microsoft_graph_token).to eq("super_refresh_token")

--- a/spec/features/agents/agent_can_unsync_his_account_to_outlook_spec.rb
+++ b/spec/features/agents/agent_can_unsync_his_account_to_outlook_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Agent can unsync his account to outlook" do
   before do
     login_as(agent, scope: :agent)
     visit agents_calendar_sync_outlook_sync_path
-    click_link "Déconnecter votre compte Outlook"
+    click_on "Déconnecter votre compte Outlook"
   end
 
   it "unsyncs the account" do

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
       expect(page).to have_content("Administrateur", count: 2)
 
       click_link "PATRICK Tony"
-      click_link("Supprimer le compte")
+      click_on("Supprimer le compte")
 
       expect_page_title("Agents de Organisation n°1")
       expect(page).to have_no_content("Tony PATRICK")

--- a/spec/features/agents/motifs/crud_spec.rb
+++ b/spec/features/agents/motifs/crud_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe "Agent can CRUD motifs" do
       click_button("Enregistrer")
 
       expect(page).to have_content("Suivi bonsoir (PMI)")
-      click_link("Archiver")
+      click_on("Archiver")
       expect(page).to have_content("Suivi bonsoir (PMI) (archivé)")
-      click_link("Supprimer")
+      click_on("Supprimer")
 
       expect_page_title("Motifs de rendez-vous")
       expect(page).to have_content("Vous n'avez pas encore créé de motif.")
@@ -70,9 +70,9 @@ RSpec.describe "Agent can CRUD motifs" do
       click_button("Enregistrer")
 
       expect(page).to have_content("Renouvellement de permis de construire")
-      click_link("Archiver")
+      click_on("Archiver")
       expect(page).to have_content("Renouvellement de permis de construire (archivé)")
-      click_link("Supprimer")
+      click_on("Supprimer")
     end
 
     context "when the territory doesn't have any services" do

--- a/spec/features/agents/oauth_provider_spec.rb
+++ b/spec/features/agents/oauth_provider_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "OAuth provider", js: true do
   around do |example|
     pid = Process.fork do
       OmniAuth.config.test_mode = false
+      OmniAuth.config.request_validation_phase = nil # Sinatra ne dispose pas d'un token CSRF Rails
 
       `touch log/test_sinatra.log`
       $stdout.reopen("log/test_sinatra.log", "r+") # Pour ne pas logger sur stdout

--- a/spec/features/agents/users/agent_can_create_user_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Agent can create user" do
     within("#spec-primary-user-card") { click_link "Modifier" }
     fill_in "Email", with: "marco@lebreton.bzh"
     click_button "Enregistrer"
-    click_link "Inviter"
+    click_on "Inviter"
     open_email("marco@lebreton.bzh")
     expect(current_email.subject).to eq("Vous avez été invité sur RDV Aide Numérique")
   end

--- a/spec/features/agents/users/agent_can_display_user_spec.rb
+++ b/spec/features/agents/users/agent_can_display_user_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Agent can display user" do
 
     it "prompts the agent to invite the user" do
       expect(page).to have_content("Cet usager ne s'est pas encore créé de compte RDV Solidarités.")
-      expect(page).to have_link("Inviter", href: invite_admin_organisation_user_path(id: user.id, organisation_id: organisation.id))
+      expect(page).to have_button("Inviter")
     end
   end
 

--- a/spec/features/agents/users/agent_can_update_user_spec.rb
+++ b/spec/features/agents/users/agent_can_update_user_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Agent can update user" do
       within("#spec-primary-user-card") { click_link "Modifier" }
       fill_in "Email", with: "jean@legende.com"
       click_button "Enregistrer"
-      click_link "Inviter"
+      click_on "Inviter"
       open_email("jean@legende.com")
       expect(current_email.subject).to eq "Vous avez été invité sur RDV Solidarités"
     end

--- a/spec/features/prescripteurs/can_cancel_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_cancel_rdv_for_a_user_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "un prescripteur peut annuler un rendez-vous qu’il a pris pour 
     expect(page).to have_content("Rendez-vous confirmé")
 
     # Sur la page de confirmation, le prescripteur doit pouvoir annuler le rdv
-    click_link "Annuler le rendez-vous"
+    click_on "Annuler le rendez-vous"
 
     expect(page).to have_content("Le rendez-vous a bien été annulé.")
 
@@ -52,7 +52,7 @@ RSpec.describe "un prescripteur peut annuler un rendez-vous qu’il a pris pour 
 
     visit prescripteur_show_path(token: prescripteur.token)
 
-    click_link "Annuler le rendez-vous"
+    click_on "Annuler le rendez-vous"
 
     expect(page).to have_content("Le rendez-vous a bien été annulé.")
 

--- a/spec/features/users/account/logout_spec.rb
+++ b/spec/features/users/account/logout_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Déconnexion" do
 
     click_button("Continuer")
     click_button("Continuer")
-    click_link("Confirmer mon RDV")
+    click_on("Confirmer mon RDV")
     expect(page).to have_content("Votre RDV")
 
     click_on "Déconnexion"

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "User signs up and signs in" do
       click_on "Valider"
       expect(page).to have_content("Connexion réussie")
       expect(invited_user.reload).to be_confirmed
-      click_link "Déconnexion"
+      click_on "Déconnexion"
       expect(page).to have_current_path(root_path, ignore_query: true)
     end
   end

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -403,7 +403,7 @@ RSpec.describe "User can search for rdvs" do
       expect(page).to have_content("Choix de l’usager")
       click_button("Continuer")
       expect(page).to have_content("Confirmation")
-      click_link("Confirmer mon RDV")
+      click_on("Confirmer mon RDV")
 
       expect(page).to have_content("Votre RDV")
       expect(page).to have_content(lieu.address)
@@ -640,7 +640,7 @@ RSpec.describe "User can search for rdvs" do
   def confirm_rdv(motif, lieu = nil)
     expect(page).to have_content("Informations de contact")
     expect(page).to have_content("Mathieu LAPIN")
-    click_link("Confirmer mon RDV")
+    click_on("Confirmer mon RDV")
 
     expect(page).to have_content("Votre RDV")
     expect(page).to have_content(lieu.address) if lieu.present?

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
       click_button("Confirmer en ignorant les avertissements")
 
       click_button("Continuer")
-      click_link("Confirmer mon RDV")
+      click_on("Confirmer mon RDV")
       expect(page).to have_content("Votre rendez vous a été confirmé.")
       expect(user.reload.ants_pre_demande_number).to eq("1122334455")
     end
@@ -213,7 +213,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
       check("Alain MAIRIE", allow_label_click: true)
       click_button "Continuer"
 
-      click_link "Confirmer mon RDV"
+      click_on "Confirmer mon RDV"
       expect(page).to have_content("Votre rendez vous a été confirmé.")
       expect(page).to have_content("Alain MAIRIE")
       expect(page).to have_content("Marco POLO")
@@ -266,7 +266,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
       check("Alain MAIRIE", allow_label_click: true)
       click_button "Continuer"
 
-      click_link "Confirmer mon RDV"
+      click_on "Confirmer mon RDV"
       expect(page).to have_content("Votre rendez vous a été confirmé.")
       expect(page).to have_content("Alain MAIRIE")
       expect(page).to have_content("Marco POLO")
@@ -310,7 +310,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         fill_in("user_ants_pre_demande_number", with: "abcd1234ef")
         click_button("Continuer")
         click_button("Continuer")
-        expect { click_link("Confirmer mon RDV") }.to change(Rdv, :count).by(1)
+        expect { click_on("Confirmer mon RDV") }.to change(Rdv, :count).by(1)
         expect(user.reload.ants_pre_demande_number).to eq("ABCD1234EF")
         expect(call_to_status_with_upcased_number).to have_been_requested.at_least_once
       end
@@ -546,11 +546,8 @@ RSpec.describe "User can search rdv on rdv mairie" do
         expect(page).to have_content("Étape 3 sur 3")
         expect(page).to have_content("Confirmer mon RDV")
         page.execute_script(%{
-          elt = document.querySelector("a.fr-btn[data-disable-with='Veuillez patienter…']");
-          elt.setAttribute(
-            "href",
-            elt.getAttribute("href").replace("ants_pre_demandes_count=2", "ants_pre_demandes_count=100")
-          )
+          elt = document.querySelector("button[data-disable-with='Veuillez patienter…']").closest("form");
+          elt.action = elt.action.replace("ants_pre_demandes_count=2", "ants_pre_demandes_count=100");
         })
         expect { click_on "Confirmer mon RDV" }.not_to change(Rdv, :count)
         expect(page).to have_content("Veuillez choisir un nombre de pré-demandes entre 1 et 6")

--- a/spec/features/users/online_booking/on_rdv_service_public_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_service_public_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "User can search rdv on rdv service public" do
 
     click_button("Continuer")
     click_button("Continuer")
-    click_link("Confirmer mon RDV")
+    click_on("Confirmer mon RDV")
     expect(page).to have_content("Votre rendez vous a été confirmé.")
   end
 

--- a/spec/features/users/online_booking/with_invitation_spec.rb
+++ b/spec/features/users/online_booking/with_invitation_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "User can be invited" do
       expect(page).to have_content("Informations de contact")
       expect(page).to have_content("johndoe@gmail.com")
       expect(page).to have_content("0682605955")
-      click_link("Confirmer mon RDV")
+      click_on("Confirmer mon RDV")
 
       # RDV page
       expect(page).to have_content("Votre RDV")
@@ -220,7 +220,7 @@ RSpec.describe "User can be invited" do
       expect(page).to have_content("Informations de contact")
       expect(page).to have_content("johndoe@gmail.com")
       expect(page).to have_content("0682605955")
-      click_link("Confirmer mon RDV")
+      click_on("Confirmer mon RDV")
 
       # RDV page
       expect(page).to have_content("Votre RDV")
@@ -285,7 +285,7 @@ RSpec.describe "User can be invited" do
         expect(page).to have_content("Informations de contact")
         expect(page).to have_content("johndoe@gmail.com")
         expect(page).to have_content("0682605955")
-        click_link("Confirmer mon RDV")
+        click_on("Confirmer mon RDV")
 
         # RDV page
         expect(page).to have_content("Votre RDV")

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Adding a user to a collective RDV" do
     expect do
       expect(page).to have_content(/À venir/i)
       click_on("Annuler votre participation")
-      click_link("Oui, annuler votre participation", match: :first)
+      click_on("Oui, annuler votre participation", match: :first)
       expect(page).to have_content("Participation annulée")
       expect(page).to have_content(/Annulé/i)
     end

--- a/spec/features/users/user_can_manage_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_rdv_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "User can manage their rdvs" do
         expect(page).to have_content(rdv.motif_name)
         click_on("Annuler le RDV")
         expect(page).to have_content("Confirmation")
-        click_link("Oui, annuler le rendez-vous")
+        click_on("Oui, annuler le rendez-vous")
         expect(page).to have_selector(".fr-badge", text: "ANNULÉ")
       end
     end
@@ -76,7 +76,7 @@ RSpec.describe "User can manage their rdvs" do
           click_link("Déplacer le RDV")
           first(:link, "11:00").click
           expect(page).to have_content("Vous allez modifier votre RDV #{motif.name} qui a lieu le #{I18n.l(rdv.starts_at, format: :human)}")
-          click_link("Confirmer le nouveau créneau")
+          click_on("Confirmer le nouveau créneau")
           expect(rdv.reload.starts_at).not_to eq(original_date)
 
           # Check Notifications

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,14 @@ RSpec.configure do |config|
   config.include DeviseRequestSpecHelpers, type: :request
   config.include NotificationsHelper
 
+  config.around(:each, type: :request) do |example|
+    original = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = false
+    example.run
+  ensure
+    ActionController::Base.allow_forgery_protection = original
+  end
+
   # Permet d'avoir des données générées de manière déterministe pour les specs swagger
   if ENV["FAKER_SEED"]
     Faker::Config.random = Random.new(ENV["FAKER_SEED"].to_i)


### PR DESCRIPTION
# Contexte

Fait suite à #6159 qui a du être revert. La route d'api `api/v1/auth/sign_in` qui accepte un email et un mot de passe d'agent sur RDVS plantait. Elle ne devrait pas vérifier les `authenticity_token`. Il y a pourtant des specs mais en fait il semble que rails désactive le protect_from_forgery en test.

# Solution

on doit remplacer pas mal de `link_to method: :post` par des `button_to method: :post` 

ça a plusieurs avantages : 
- ça marche sans JS 
- c’est sémantiquement plus correct que les liens ne fassent pas de modifs
- ça inclut le `authenticity_token` nativement dans le form HTML 


# Leg :

- [ ] 1. vérifier l'affichage des nested forms extraits
- [ ] 2. déployer les commits qui changent les link_to en button_to
- [ ] 3. déployer les commits qui un-nest les forms
- [ ] 4. déployer le changement de stratégie `protect_from_forgery: true`