### PR TITLE
Retrait des liens vers l’accueil et uniformisation header

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
-    dsfr-view-components (4.1.1)
+    dsfr-view-components (4.1.2)
       dsfr-assets (>= 1.13.2, < 1.15)
       html-attributes-utils (~> 1)
       view_component (~> 3)
@@ -925,7 +925,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   dsfr-assets (1.14.3) sha256=132dae8bbe8ddbcc2cf90f598c0112f3956453cd3c40bcd58442427b4215d9f1
   dsfr-form_builder (0.0.7) sha256=16165ee281de4645617fdb79c4fc03384f9125cbbdf6a149daa1ef2bb367ffde
-  dsfr-view-components (4.1.1) sha256=b9e3c502222fc270b1567f10d7fa1ddd6a0a002ed2bf193be7e573f68db39830
+  dsfr-view-components (4.1.2) sha256=5b7b0b0027f84dd6db7e3a3f04bd731a488dd013f9631e7d76a9d3bf547a79ed
   erb (5.1.3) sha256=566e53057b6ba48699f824b578473b391fa8aef100aa14afad1c46725fae0e67
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.2.11) sha256=d26e868cc21db88280a9ec1a50aa3da5d267eb9b2037ba7b831d6c2731f5df64

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -1,3 +1,5 @@
+/# locals: (home_path: root_path)
+
 footer.fr-footer.main-footer.fr-pb-12w#footer[role="contentinfo"]
   .fr-container
     .fr-footer__body
@@ -6,8 +8,12 @@ footer.fr-footer.main-footer.fr-pb-12w#footer[role="contentinfo"]
           | République
           br
           | Française
-        = link_to root_path, title: "aller à l'accueil #{current_domain.name}", class: "fr-footer__brand-link" do
-          = image_tag current_domain.dark_logo_path, alt: current_domain.name, class: "fr-footer__logo", width: "150"
+        - if home_path.present?
+          = link_to root_path, title: "aller à l'accueil #{current_domain.name}", class: "fr-footer__brand-link" do
+            = image_tag current_domain.dark_logo_path, alt: current_domain.name, class: "fr-footer__logo", width: "150"
+        - else
+          .fr-footer__brand-link
+            = image_tag current_domain.dark_logo_path, alt: current_domain.name, class: "fr-footer__logo", width: "150"
       .fr-footer__content
         p.fr-footer__content-desc
           |> #{current_domain.name} est un service porté par la

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -20,9 +20,20 @@ html lang="fr"
     = render "layouts/rdv_solidarites_instance_name"
     = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
 
+    ruby:
+      home_path = root_path
+
+      # Sur RDV Service Public, la page d’accueil n’est pas à destination des usagers qui prennent rendez-vous
+      # On veut donc éviter d’avoir un lien qui mène vers la page d’accueil pendant la prise de rendez-vous
+      if current_domain == Domain::RDV_SERVICE_PUBLIC
+        if current_page?("/prendre_rdv") || @rdv_wizard
+          home_path = nil
+        end
+      end
+
     = dsfr_header logo_text: sanitize("République<br>Française"), html_attributes: {id: "header"} do |header|
       ruby:
-        header.with_operator_image title: "", src: asset_path(current_domain.dark_logo_path), alt: "Accueil - #{current_domain.name}"
+        header.with_operator_image title: "", src: asset_path(current_domain.dark_logo_path), alt: "Accueil - #{current_domain.name}", href: home_path
         if current_user.present? && !current_user.signed_in_with_invitation_token?
           header.with_tool_link title: "Vos rendez-vous", path: users_rdvs_path, html_attributes: { class: "fr-icon-calendar-fill" }
           header.with_tool_link title: "Vos informations", path: users_informations_path
@@ -55,4 +66,4 @@ html lang="fr"
 
     #modal-holder
 
-    = render "layouts/footer"
+    = render "layouts/footer", home_path:

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -36,8 +36,8 @@ html lang="fr"
           header.with_tool_link title: "Connexion Agent", path: new_agent_session_path, html_attributes: { class: "fr-icon-admin-line" }
           header.with_tool_link title: "Connexion Usager", path: new_user_session_path, html_attributes: { class: "fr-icon-account-line" }
         else
-          header.with_tool_link title: "Espace Agent", path: new_agent_session_path
-          header.with_tool_link title: "Se connecter", path: new_user_session_path,html_attributes: { class: "fr-fi-account-fill" }
+          header.with_tool_link title: "Connexion Agent", path: new_agent_session_path, html_attributes: { class: "fr-icon-admin-line" }
+          header.with_tool_link title: "Connexion Usager", path: new_user_session_path, html_attributes: { class: "fr-icon-account-line" }
         end
 
         if current_domain == Domain::RDV_SERVICE_PUBLIC  && @site_vitrine_page

--- a/spec/features/agents/oauth_provider_spec.rb
+++ b/spec/features/agents/oauth_provider_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "OAuth provider", js: true do
 
     # La fois suivante, il y a uniquement besoin de se connecter, pas de reconfirmer qu'on donne la permission à l'appli
     # Et on peut se connecter avant de faire l'oauth
-    click_on "Espace Agent"
+    click_on "Connexion Agent"
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "User signs up and signs in" do
 
     it "ne permet pas de créer un compte en arrivant depuis la page de connexion" do
       visit "http://www.rdv-solidarites-test.localhost/"
-      click_link "Se connecter"
+      click_link "Connexion Usager"
       expect(page).not_to have_content("Inscription")
       fill_in "Adresse email", with: user.email
       click_on "Recevoir un code de connexion"
@@ -17,7 +17,7 @@ RSpec.describe "User signs up and signs in" do
 
     it "can login via 6-digit code and gets confirmed" do
       visit "http://www.rdv-solidarites-test.localhost/"
-      click_link "Se connecter"
+      click_link "Connexion Usager"
       fill_in "Adresse email", with: invited_user.email
       click_on "Recevoir un code de connexion"
       fill_in "Code à 6 chiffres", with: LoginCode.most_recent_usable_for(email: invited_user.email).code
@@ -34,7 +34,7 @@ RSpec.describe "User signs up and signs in" do
 
     it "logs them in and confirms their account" do
       visit "http://www.rdv-aide-numerique-test.localhost/"
-      click_link "Se connecter"
+      click_link "Connexion Usager"
       fill_in "Adresse email", with: unconfirmed_user.email
       click_on "Recevoir un code de connexion"
       fill_in "Code à 6 chiffres", with: LoginCode.most_recent_usable_for(email: unconfirmed_user.email).code
@@ -50,7 +50,7 @@ RSpec.describe "User signs up and signs in" do
 
     it "redirige vers la page de connexion agent" do
       visit "http://www.rdv-solidarites-test.localhost/"
-      click_link "Se connecter"
+      click_link "Connexion Usager"
       within("form") do
         fill_in "Adresse email", with: "dulce@agent.fr"
         click_on "Recevoir un code de connexion"


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6196.osc-secnum-fr1.scalingo.io/)

# Contexte

Nous avons des usagers qui semblent durant leur prise de rendez-vous cliquer sur le lien qui est dans l’en-tête et mène vers la page d’accueil.
Or, sur l’instance RDV Service Public, la landing page est à destination des agents de service public et non des usagers.

# Solution

On supprime les liens vers la page d’accueil quand on est sur la route `prendre_rdv` ou qu’on a un `@rdv_wizard`.

Je mets à jour `dsfr-view-components` car j’ai ajouté la possiblité de customisé le lien du header, ce qui n’était pas possible jusque ici. Voir : https://github.com/betagouv/dsfr-view-components/pull/255

J’en ai profité pour uniformiser les boutons de connexion dans l’en-tête qui était parfois différents en fonction de la page sur laquelle on était ou de l’instance. 
Maintenant un utilisateur non connecté verra toujours : 
<img width="417" height="138" alt="image" src="https://github.com/user-attachments/assets/32278df5-5256-47b5-aa87-d30d90072689" />

