### PR TITLE
retrait infos prescripteurs doublons dépréciées

### DIFF
--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -46,30 +46,6 @@
     br
     .fr-ml-4w.fr-pl-1w.text-muted.border-left= simple_format(rdv.context, {}, wrapper_tag: :span)
 
-- rdv.participations.select(&:prescription?).each do |participation|
-  - author = participation.created_by
-  .d-flex.card-text.mt-1
-    = icon("fr-icon-user-add-fill", class: "text-primary-blue fr-mr-1w")
-    div
-      |> Rendez-vous pris par
-      a href="#prescripteur-explanation#{participation.id}" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="collapseExample"
-        = author.full_name
-  .collapse.alert-info.p-2.m-2 id="prescripteur-explanation#{participation.id}"
-    p
-      |> La réservation a été faite par un prescripteur qui ne participera pas au rendez-vous (agent d'accueil, conseiller).
-    p
-      |> Ce rendez-vous a été pris sur un créneau ouvert au public.
-    p.mb-0
-      |> Si vous pensez qu'il y a eu une erreur lors de la prise de rendez-vous, vous pouvez contacter
-      strong => author.full_name
-      - if author.is_a?(Prescripteur) && author.phone_number.present?
-        |> au
-        strong => phone_to(author.phone_number)
-        |> ou
-      |> à l'adresse
-      strong = mail_to(author.email)
-      | .
-
 - if rdv.public_office? && rdv.overlapping_plages_ouvertures?
   div.my-3
     .alert.alert-warning.mt-1.mb-0


### PR DESCRIPTION
# Contexte

dans https://github.com/betagouv/rdv-service-public/pull/6124/changes j'ai supprimé ce bloc

<img width="882" height="376" alt="image" src="https://github.com/user-attachments/assets/f6d1b101-3648-40ec-9942-9374b17b006b" />

en faveur d'infos dans le tableau directement

<img width="536" height="212" alt="image" src="https://github.com/user-attachments/assets/7a53d892-b9dc-44e2-a378-16ff0cdf28f6" />

malheureusement on bossait simultanément sur cette page `admin/rdvs#show` avec Victor et un merge malheureux a fait réapparaitre ce bloc dans https://github.com/betagouv/rdv-service-public/pull/6107/changes#diff-08d756e8c24f0a90f14d3b40f15d3a4ae4dd5d1081541dee385f20c1c0fc8760R49-R72

# Solution

re-supprimer ce bloc

## captures

<img width="569" height="681" alt="image" src="https://github.com/user-attachments/assets/cefb8bc6-7e09-47ae-8408-e45184b700ca" />
