### PR TITLE
Orienteur pour les prospects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
-    dsfr-view-components (4.1.2)
+    dsfr-view-components (4.1.3)
       dsfr-assets (>= 1.13.2, < 1.15)
       html-attributes-utils (~> 1)
       view_component (~> 3)
@@ -925,7 +925,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   dsfr-assets (1.14.3) sha256=132dae8bbe8ddbcc2cf90f598c0112f3956453cd3c40bcd58442427b4215d9f1
   dsfr-form_builder (0.0.7) sha256=16165ee281de4645617fdb79c4fc03384f9125cbbdf6a149daa1ef2bb367ffde
-  dsfr-view-components (4.1.2) sha256=5b7b0b0027f84dd6db7e3a3f04bd731a488dd013f9631e7d76a9d3bf547a79ed
+  dsfr-view-components (4.1.3) sha256=70cce072c391fc39b09e9189127ebc0bcd36744048fe9510d1fec3cfb2d1d11a
   erb (5.1.3) sha256=566e53057b6ba48699f824b578473b391fa8aef100aa14afad1c46725fae0e67
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.2.11) sha256=d26e868cc21db88280a9ec1a50aa3da5d267eb9b2037ba7b831d6c2731f5df64

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -1,0 +1,19 @@
+class OnboardingController < ApplicationController
+  layout "application_base"
+
+  def show
+    render "step_1"
+  end
+
+  def step_1; end
+
+  def step_2; end
+
+  def step_3; end
+
+  def usager; end
+
+  def webinaire; end
+
+  def help_needed; end
+end

--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -389,6 +389,8 @@ $pagination-active-border-color: $pagination-active-bg;
 $card-spacer-x: $spacer;
 $card-border-color: $gray-200;
 $card-cap-bg: $white;
+$card-border-radius: 8px;
+$card-inner-border-radius: 8px;
 
 // Tooltips
 

--- a/app/services/annuaire_service_public.rb
+++ b/app/services/annuaire_service_public.rb
@@ -36,6 +36,6 @@ class AnnuaireServicePublic
   end
 
   def response
-    @response ||= Faraday.get("https://api-lannuaire.service-public.fr/api/explore/v2.1/catalog/datasets/api-lannuaire-administration/records?where=siret%3D%22#{@siret}%22")
+    @response ||= Faraday.get("https://api-lannuaire.service-public.gouv.fr/api/explore/v2.1/catalog/datasets/api-lannuaire-administration/records?where=siret%3D%22#{@siret}%22")
   end
 end

--- a/app/views/aide/demandes_support/new.html.slim
+++ b/app/views/aide/demandes_support/new.html.slim
@@ -39,7 +39,7 @@
         .fr-callout.fr-my-2w
           p
             |> Pour toute demande de prise de RDV ou d’annulation, de disponibilités, ou de transmission de documents, veuillez contactez directement l’organisation concernée via
-            = link_to "l’annuaire du Service Public", "https://lannuaire.service-public.fr/", target: "_blank"
+            = link_to "l’annuaire du Service Public", "https://lannuaire.service-public.gouv.fr/", target: "_blank"
             |. Par contre, si vous rencontrez un problème technique lors de la prise de RDV, vous êtes au bon endroit, n’hésitez à nous en parler ici !
 
       = f.dsfr_text_area :message, rows: 5, label: "Votre message", required: true

--- a/app/views/aide/pages/aiguillage_usager.html.slim
+++ b/app/views/aide/pages/aiguillage_usager.html.slim
@@ -44,7 +44,7 @@
       p
         ' Vous pouvez chercher les coordonnées de l’organisation avec laquelle vous souhaitez prendre RDV dans l’annuaire des services publics :
       .fr-mb-8w
-        = link_to "Consulter l’annuaire du Service Public", "https://lannuaire.service-public.fr/", class: "fr-btn fr-btn--secondary", target: "_blank"
+        = link_to "Consulter l’annuaire du Service Public", "https://lannuaire.service-public.gouv.fr/", class: "fr-btn fr-btn--secondary", target: "_blank"
 
     - if @form.raison_annuler?
       - content_for :subtitle, "Annuler votre RDV"

--- a/app/views/dsfr/rdv_mairie/homepage.html.slim
+++ b/app/views/dsfr/rdv_mairie/homepage.html.slim
@@ -17,7 +17,7 @@
           | Évitez les rendez-vous non honorés, gagnez du temps au quotidien et améliorez la relation entre les agents et les usagers
         .fr-btns-group.fr-btns-group--inline-md.fr-btns-group--center
           = link_to "Ouvrir mon espace", presentation_agent_path, class: "fr-btn"
-          = link_to "Participer au prochain webinaire", "https://rdv.anct.gouv.fr/motif/J87KGT9b/webinaire-rdv-service-public", title: "Accéder à l'inscription au prochain webinaire - nouvel onglet", class: "fr-btn fr-btn--secondary", rel: "noreferrer", target: "_blank"
+          = link_to "S’inscrire à une démo", onboarding_path, class: "fr-btn fr-btn--secondary"
 
 .fr-py-8w.rdv-background-color-alt-grey
   .fr-container
@@ -34,7 +34,7 @@
             li Renseignez vos disponibilités, vos absences
             li Consultez les plannings de vos collègues
         .fr-btns-group.fr-btns-group--inline-md
-          = link_to "Demander une démo", contact_team_url, class: "fr-btn fr-btn--secondary fr-mt-3w"
+          = link_to "Être accompagné pour la mise en place", onboarding_path, class: "fr-btn fr-btn--secondary fr-mt-3w"
 
 .fr-container.fr-py-8w
   .fr-grid-row.fr-grid-row--gutters.fr-grid-row--center
@@ -486,5 +486,5 @@ section.fr-py-8w.rdv-text-align-center
     h2 Plus de RDV, moins de lapins
     p
       | Votre agenda vous remerciera.
-    .fr-my-4w= link_to "Demander une démo", contact_team_url, class: "fr-btn"
+    .fr-my-4w= link_to "S’inscrire à une démo", onboarding_path, class: "fr-btn"
     = link_to "Revenir en haut de la page", "#header", class: "fr-link fr-icon-arrow-up-line fr-link--icon-left"

--- a/app/views/onboarding/help_needed.html.slim
+++ b/app/views/onboarding/help_needed.html.slim
@@ -1,0 +1,14 @@
+.rdv-background-color-alt-blue-ecume.fr-py-6v
+  .fr-container
+    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+      | Retour à l’accueil
+
+    .fr-grid-row.justify-content-md-center
+      .card.fr-mt-6v.fr-mb-12v.fr-p-12v.fr-col-lg-6
+        = dsfr_svg "artwork/pictograms/system/information"
+        h1.fr-h2 Votre projet nécessite un accompagnement personnalisé.
+        p Compte tenu de vos besoins, nous vous proposons d’organiser un moment d’échange avec notre équipe afin de vous présenter la solution et d’étudier ensemble vos cas d’usage, pour un accompagnement optimal.
+
+        = link_to "Plannifier un échange", Agents::PagesController::CONTACT_TEAM_URL, class: "fr-btn fr-btn--primary"
+
+        = link_to "Précédent", request.referer || root_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line fr-mt-6v"

--- a/app/views/onboarding/help_needed.html.slim
+++ b/app/views/onboarding/help_needed.html.slim
@@ -1,6 +1,6 @@
 .rdv-background-color-alt-blue-ecume.fr-py-6v
   .fr-container
-    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+    = link_to root_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
       | Retour à l’accueil
 
     .fr-grid-row.justify-content-md-center

--- a/app/views/onboarding/step_1.html.slim
+++ b/app/views/onboarding/step_1.html.slim
@@ -1,0 +1,23 @@
+.rdv-background-color-alt-blue-ecume.fr-py-6v
+  .fr-container
+    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+      | Retour à l’accueil
+
+    .fr-grid-row.justify-content-md-center
+      .card.fr-mt-6v.fr-mb-12v.fr-p-12v.fr-col-lg-8
+        .fr-container
+          h1 Découvrir RDV Service Public
+          p Afin de vous orienter vers l'accompagnement le plus adapté, parlez-nous de vous et de votre besoin.
+
+          h2 Vous êtes :
+          .fr-grid-row.fr-grid-row--gutters
+            .fr-col-12.fr-col-md-6
+              = dsfr_tile title: "Un particulier",
+                      url: usager_onboarding_path,
+                      description: "Vous cherchez à prendre ou modifier un rendez-vous avec un service public",
+                      image_src: "/assets/artwork/pictograms/digital/self-training.svg"
+            .fr-col-12.fr-col-md-6
+              = dsfr_tile title: "Un agent public",
+                      url: step_2_onboarding_path,
+                      description: "Vous cherchez à découvrir la solution ou obtenir des informations supplémentaires",
+                      image_src: "/assets/artwork/pictograms/digital/avatar.svg"

--- a/app/views/onboarding/step_1.html.slim
+++ b/app/views/onboarding/step_1.html.slim
@@ -1,6 +1,6 @@
 .rdv-background-color-alt-blue-ecume.fr-py-6v
   .fr-container
-    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+    = link_to root_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
       | Retour à l’accueil
 
     .fr-grid-row.justify-content-md-center

--- a/app/views/onboarding/step_2.html.slim
+++ b/app/views/onboarding/step_2.html.slim
@@ -1,0 +1,24 @@
+.rdv-background-color-alt-blue-ecume.fr-py-6v
+  .fr-container
+    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+      | Retour à l’accueil
+
+    .fr-grid-row.justify-content-md-center
+      .card.fr-mt-6v.fr-mb-12v.fr-p-12v.fr-col-lg-8
+        .fr-container
+          = dsfr_stepper title: "Votre administration", value: 2, max: 3, next_title: "Vos effectifs", header_level: 1
+
+          h2.fr-h4 Quelle est l’envergure de votre administration ?
+          .fr-grid-row.fr-grid-row--gutters
+            .fr-col-12.fr-col-md-6
+              = dsfr_tile title: "Un seul service et/ou une seule structure",
+                      url: step_3_onboarding_path,
+                      description: "Déploiement simple comme une mairie d’une petite commune etc.",
+                      image_src: "/assets/artwork/pictograms/buildings/city-hall.svg"
+            .fr-col-12.fr-col-md-6
+              = dsfr_tile title: "Plusieurs services et/ou structures",
+                      url: help_needed_onboarding_path,
+                      description: "Déploiement à grande échelle comme un département, une agglomération, gestion de plusieurs services etc.",
+                      image_src: "/assets/artwork/pictograms/digital/ecosystem.svg"
+
+          = link_to "Précédent", step_1_onboarding_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line fr-mt-6v"

--- a/app/views/onboarding/step_2.html.slim
+++ b/app/views/onboarding/step_2.html.slim
@@ -1,6 +1,6 @@
 .rdv-background-color-alt-blue-ecume.fr-py-6v
   .fr-container
-    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+    = link_to root_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
       | Retour à l’accueil
 
     .fr-grid-row.justify-content-md-center

--- a/app/views/onboarding/step_2.html.slim
+++ b/app/views/onboarding/step_2.html.slim
@@ -13,12 +13,12 @@
             .fr-col-12.fr-col-md-6
               = dsfr_tile title: "Un seul service et/ou une seule structure",
                       url: step_3_onboarding_path,
-                      description: "Déploiement simple comme une mairie d’une petite commune etc.",
+                      description: "Déploiement ciblé pour un agent individuel, un bureau de l'État ou la mairie d'une petite commune etc.",
                       image_src: "/assets/artwork/pictograms/buildings/city-hall.svg"
             .fr-col-12.fr-col-md-6
               = dsfr_tile title: "Plusieurs services et/ou structures",
                       url: help_needed_onboarding_path,
-                      description: "Déploiement à grande échelle comme un département, une agglomération, gestion de plusieurs services etc.",
+                      description: "Déploiement à grande échelle pour un ministère, un département ou une agglomération etc.",
                       image_src: "/assets/artwork/pictograms/digital/ecosystem.svg"
 
           = link_to "Précédent", step_1_onboarding_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line fr-mt-6v"

--- a/app/views/onboarding/step_3.html.slim
+++ b/app/views/onboarding/step_3.html.slim
@@ -1,0 +1,22 @@
+.rdv-background-color-alt-blue-ecume.fr-py-6v
+  .fr-container
+    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+      | Retour à l’accueil
+
+    .fr-grid-row.justify-content-md-center
+      .card.fr-mt-6v.fr-mb-12v.fr-p-12v.fr-col-lg-8
+        .fr-container
+          = dsfr_stepper title: "Votre administration", value: 3, max: 3, header_level: 1
+
+          h2.fr-h4 Combien d’agents seront amenés à utiliser la solution ?
+          .fr-grid-row.fr-grid-row--gutters
+            .fr-col-12.fr-col-md-6
+              = dsfr_tile title: "Moins de 10 agents",
+                      url: webinaire_onboarding_path,
+                      image_src: "/assets/artwork/pictograms/buildings/city-hall.svg"
+            .fr-col-12.fr-col-md-6
+              = dsfr_tile title: "Plus de 10 agents",
+                      url: help_needed_onboarding_path,
+                      image_src: "/assets/artwork/pictograms/buildings/city-hall.svg"
+
+          = link_to "Précédent", step_2_onboarding_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line fr-mt-6v"

--- a/app/views/onboarding/step_3.html.slim
+++ b/app/views/onboarding/step_3.html.slim
@@ -1,6 +1,6 @@
 .rdv-background-color-alt-blue-ecume.fr-py-6v
   .fr-container
-    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+    = link_to root_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
       | Retour à l’accueil
 
     .fr-grid-row.justify-content-md-center

--- a/app/views/onboarding/usager.html.slim
+++ b/app/views/onboarding/usager.html.slim
@@ -8,7 +8,7 @@
         = dsfr_svg "artwork/pictograms/system/information"
         h1.fr-h2 Vous cherchez à prendre un rendez-vous avec un service public ?
         p
-          |> RDV Service Public est un outil utilisé par les administrations pour créer leurs agendas.
+          |> RDV Service Public est un service permettant aux administrations et aux collectivités de vous proposer des créneaux de rendez-vous.
           b Notre équipe n'a pas accès à vos dossiers, ni aux plannings des services qui vous accompagnent.
 
         p Pour toute demande de rendez-vous, vous pouvez vous adresser directement au service concerné :

--- a/app/views/onboarding/usager.html.slim
+++ b/app/views/onboarding/usager.html.slim
@@ -1,6 +1,6 @@
 .rdv-background-color-alt-blue-ecume.fr-py-6v
   .fr-container
-    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+    = link_to root_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
       | Retour à l’accueil
 
     .fr-grid-row.justify-content-md-center

--- a/app/views/onboarding/usager.html.slim
+++ b/app/views/onboarding/usager.html.slim
@@ -17,4 +17,4 @@
           li
             = external_link_to "Trouver les coordonnées d’un service public", "https://lannuaire.service-public.gouv.fr/", class: "fr-link"
           li
-            = external_link_to "Consulter l'aide aux usagers pour la prise de RDV", "#", class: "fr-link"
+            = external_link_to "Consulter l'aide aux usagers pour la prise de RDV", aide_aiguillage_usager_path(raison: "creneaux"), class: "fr-link"

--- a/app/views/onboarding/usager.html.slim
+++ b/app/views/onboarding/usager.html.slim
@@ -1,0 +1,20 @@
+.rdv-background-color-alt-blue-ecume.fr-py-6v
+  .fr-container
+    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+      | Retour à l’accueil
+
+    .fr-grid-row.justify-content-md-center
+      .card.fr-mt-6v.fr-mb-12v.fr-p-12v.fr-col-lg-6
+        = dsfr_svg "artwork/pictograms/system/information"
+        h1.fr-h2 Vous cherchez à prendre un rendez-vous avec un service public ?
+        p
+          |> RDV Service Public est un outil utilisé par les administrations pour créer leurs agendas.
+          b Notre équipe n'a pas accès à vos dossiers, ni aux plannings des services qui vous accompagnent.
+
+        p Pour toute demande de rendez-vous, vous pouvez vous adresser directement au service concerné :
+
+        ul
+          li
+            = external_link_to "Trouver les coordonnées d’un service public", "https://lannuaire.service-public.gouv.fr/", class: "fr-link"
+          li
+            = external_link_to "Consulter l'aide aux usagers pour la prise de RDV", "#", class: "fr-link"

--- a/app/views/onboarding/webinaire.html.slim
+++ b/app/views/onboarding/webinaire.html.slim
@@ -14,6 +14,6 @@
 
         p Si toutefois vous souhaitez en savoir plus sur notre outil avant de vous lancer, vous pouvez vous inscrire à un de nos prochains webinaires.
 
-        = link_to "S’inscrire au webinaire", "https://rdv.anct.gouv.fr/motif/J87KGT9b/webinaire-rdv-service-public", class: "fr-btn fr-btn--secondary"
+        = link_to "S’inscrire au webinaire", "https://rdv.anct.gouv.fr/motif/J87KGT9b/webinaire-rdv-service-public", class: "fr-btn"
 
         = link_to "Précédent", request.referer || root_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line fr-mt-6v"

--- a/app/views/onboarding/webinaire.html.slim
+++ b/app/views/onboarding/webinaire.html.slim
@@ -1,0 +1,19 @@
+.rdv-background-color-alt-blue-ecume.fr-py-6v
+  .fr-container
+    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+      | Retour à l’accueil
+
+    .fr-grid-row.justify-content-md-center
+      .card.fr-mt-6v.fr-mb-12v.fr-p-12v.fr-col-lg-6
+        = dsfr_svg "artwork/pictograms/system/success"
+        h1.fr-h2 Bonne nouvelle !
+        p
+          |> Compte tenu de vos besoins, vous pouvez commencer à utiliser l’outil dès maintenant en
+          = link_to "ouvrant votre espace", new_agents_territory_path, class: "fr-link"
+          | .
+
+        p Si toutefois vous souhaitez en savoir plus sur notre outil avant de vous lancer, vous pouvez vous inscrire à un de nos prochains webinaires.
+
+        = link_to "S’inscrire au webinaire", "https://rdv.anct.gouv.fr/motif/J87KGT9b/webinaire-rdv-service-public", class: "fr-btn fr-btn--secondary"
+
+        = link_to "Précédent", request.referer || root_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line fr-mt-6v"

--- a/app/views/onboarding/webinaire.html.slim
+++ b/app/views/onboarding/webinaire.html.slim
@@ -1,6 +1,6 @@
 .rdv-background-color-alt-blue-ecume.fr-py-6v
   .fr-container
-    = link_to root_path, class: "fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
+    = link_to root_path, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-btn--icon-left fr-icon-arrow-left-line" do
       | Retour à l’accueil
 
     .fr-grid-row.justify-content-md-center

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -438,6 +438,15 @@ Rails.application.routes.draw do
   get "accueil_mds", to: redirect("presentation_agent", status: 307)
   get "presentation_agent" => "static_pages#presentation_for_agents"
 
+  resource :onboarding, controller: :onboarding do
+    get "step_1"
+    get "step_2"
+    get "step_3"
+    get "usager"
+    get "webinaire"
+    get "help_needed"
+  end
+
   root "search#home"
 
   get "/prendre_rdv", to: "search#search_rdv"

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -52,6 +52,6 @@ description:
       - notifier les usagers des RDV pris
 fundedBy:
   - name: Direction interministérielle du numérique
-    url: https://lannuaire.service-public.fr/gouvernement/d1a97841-b4bf-46df-a089-1003e4e266b4
+    url: https://lannuaire.service-public.gouv.fr/gouvernement/d1a97841-b4bf-46df-a089-1003e4e266b4
   - name: Agence Nationale de Cohésion des Territoires
-    url: https://lannuaire.service-public.fr/gouvernement/da837b24-afa7-46ab-b56a-427dd4bcc159
+    url: https://lannuaire.service-public.gouv.fr/gouvernement/da837b24-afa7-46ab-b56a-427dd4bcc159

--- a/spec/fixtures/files/annuaire_service_public/anct.json
+++ b/spec/fixtures/files/annuaire_service_public/anct.json
@@ -48,7 +48,7 @@
       "code_insee_commune": null,
       "statut_de_diffusion": "true",
       "adresse": "[{\"type_adresse\": \"Adresse\", \"complement1\": \"\", \"complement2\": \"\", \"numero_voie\": \"20 avenue de Ségur\", \"service_distribution\": \"\", \"code_postal\": \"75007\", \"nom_commune\": \"Paris\", \"pays\": \"\", \"continent\": \"\", \"longitude\": \"2.308339\", \"latitude\": \"48.850518\"}, {\"type_adresse\": \"Adresse postale\", \"complement1\": \"\", \"complement2\": \"\", \"numero_voie\": \"\", \"service_distribution\": \"TSA 10717\", \"code_postal\": \"75334\", \"nom_commune\": \"Paris Cedex 07\", \"pays\": \"\", \"continent\": \"\", \"longitude\": \"\", \"latitude\": \"\"}]",
-      "url_service_public": "https://lannuaire.service-public.fr/gouvernement/da837b24-afa7-46ab-b56a-427dd4bcc159",
+      "url_service_public": "https://lannuaire.service-public.gouv.fr/gouvernement/da837b24-afa7-46ab-b56a-427dd4bcc159",
       "information_complementaire": null,
       "date_diffusion": null
     }

--- a/spec/fixtures/files/annuaire_service_public/mairie.json
+++ b/spec/fixtures/files/annuaire_service_public/mairie.json
@@ -48,7 +48,7 @@
       "code_insee_commune": "60669",
       "statut_de_diffusion": "true",
       "adresse": "[{\"type_adresse\": \"Adresse\", \"complement1\": \"\", \"complement2\": \"\", \"numero_voie\": \"13 rue de l'Église\", \"service_distribution\": \"\", \"code_postal\": \"60140\", \"nom_commune\": \"Verderonne\", \"pays\": \"\", \"continent\": \"\", \"longitude\": \"2.49821996689\", \"latitude\": \"49.3306999207\"}]",
-      "url_service_public": "https://lannuaire.service-public.fr/hauts-de-france/oise/000e1df5-ae69-4a43-a52b-f6061bcc3707",
+      "url_service_public": "https://lannuaire.service-public.gouv.fr/hauts-de-france/oise/000e1df5-ae69-4a43-a52b-f6061bcc3707",
       "information_complementaire": null,
       "date_diffusion": null
     }

--- a/spec/support/annuaire_service_public_stubs.rb
+++ b/spec/support/annuaire_service_public_stubs.rb
@@ -1,11 +1,11 @@
 module AnnuaireServicePublicStubs
   def self.stub_siret_as_anct(siret, context)
-    context.stub_request(:get, "https://api-lannuaire.service-public.fr/api/explore/v2.1/catalog/datasets/api-lannuaire-administration/records?where=siret=%22#{siret}%22")
+    context.stub_request(:get, "https://api-lannuaire.service-public.gouv.fr/api/explore/v2.1/catalog/datasets/api-lannuaire-administration/records?where=siret=%22#{siret}%22")
       .to_return(status: 200, body: context.file_fixture("annuaire_service_public/anct.json"), headers: {})
   end
 
   def self.stub_siret_as_mairie(_siret, context)
-    context.stub_request(:get, "https://api-lannuaire.service-public.fr/api/explore/v2.1/catalog/datasets/api-lannuaire-administration/records?where=siret=%2221600660100019%22")
+    context.stub_request(:get, "https://api-lannuaire.service-public.gouv.fr/api/explore/v2.1/catalog/datasets/api-lannuaire-administration/records?where=siret=%2221600660100019%22")
       .to_return(status: 200, body: context.file_fixture("annuaire_service_public/mairie.json"), headers: {})
   end
 end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6199.osc-secnum-fr1.scalingo.io/)

# Contexte

On souhaite faciliter l’orientation des agents qui souhaitent de l’aide pour commencer à utiliser notre service.
En fonction du type d’organisation, on souhaite les orienter soit vers le webinaire, soit vers un accompagnement personnalisé.

# Solution

llannuaire.service-public.fr devient lannuaire.service-public.gouv.fr j’ai donc fait un gros find and replace

## Captures d'écran

<img width="1278" height="960" alt="image" src="https://github.com/user-attachments/assets/0df7536b-fc66-42fe-a75e-7917729f1274" />

<img width="1235" height="890" alt="image" src="https://github.com/user-attachments/assets/7f6a1d02-af29-4e8e-8e69-451c0b0c6b52" />

<img width="1233" height="967" alt="image" src="https://github.com/user-attachments/assets/d0717585-161a-49e1-b4a3-a5216289c855" />

<img width="1217" height="970" alt="image" src="https://github.com/user-attachments/assets/17055dde-ce29-4828-bab3-d858002191e4" />


