### PR TITLE
Adaptations de `.slugignore` (820 MB -> 388 MB)

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,5 +1,6 @@
 spec
 docs
 /tmp/cache
+/node_modules
 /scripts/devtools
 /.cache/yarn

--- a/.slugignore
+++ b/.slugignore
@@ -3,5 +3,5 @@ docs
 /tmp/cache
 /node_modules
 /scripts/devtools
-/.cache/yarn
+/.yarn/cache
 /app/assets/builds

--- a/.slugignore
+++ b/.slugignore
@@ -1,7 +1,7 @@
 spec
 docs
 /tmp/cache
-/node_modules
 /scripts/devtools
+/node_modules
 /.yarn/berry/cache
 /app/assets/builds

--- a/.slugignore
+++ b/.slugignore
@@ -4,4 +4,3 @@ docs
 /node_modules
 /scripts/devtools
 /.cache/yarn
-/app/assets/builds

--- a/.slugignore
+++ b/.slugignore
@@ -1,6 +1,5 @@
 spec
 docs
 /tmp/cache
-/node_modules
 /scripts/devtools
 /.cache/yarn

--- a/.slugignore
+++ b/.slugignore
@@ -4,3 +4,4 @@ docs
 /node_modules
 /scripts/devtools
 /.cache/yarn
+/app/assets/builds

--- a/.slugignore
+++ b/.slugignore
@@ -3,5 +3,5 @@ docs
 /tmp/cache
 /node_modules
 /scripts/devtools
-/.yarn/cache
+/.yarn/berry/cache
 /app/assets/builds

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,3 +9,6 @@ enableScripts: false
 # On ajoute un temps de quarantaine pour éviter d’installer des paquets trop rapidement après leur publication dans
 # le but de réduire les risques liés à des paquets malveillants (comme avec Shai Hulud).
 npmMinimalAgeGate: 5760 # 4 jours
+
+enableGlobalCache: false
+cacheFolder: .yarn/cache

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,6 +9,3 @@ enableScripts: false
 # On ajoute un temps de quarantaine pour éviter d’installer des paquets trop rapidement après leur publication dans
 # le but de réduire les risques liés à des paquets malveillants (comme avec Shai Hulud).
 npmMinimalAgeGate: 5760 # 4 jours
-
-enableGlobalCache: false
-cacheFolder: .yarn/cache


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6200.osc-secnum-fr1.scalingo.io/)

# Contexte

Dans #6013, on a retiré `/node_modules` du `.slugignore`. Cela signifie donc que ce répertoire était conservé dans l'image docker déployée par Scalingo.

Depuis le passage à yarn v4 dans #6064, la taille de l'image est passée de ~400 MB à 641 MB car le cache a changé de place et n'est donc plus nettoyé.

Depuis le passage à esbuild dans #6163, l'image est passée de 641 MB à 858 MB car esbuild doit prendre plus de place que webpack sur le disque.

# Solution

- rétablir `/node_modules` dans `.slugignore`
- corriger le chemin du cache yarn dans `.slugignore`

Au passage j'ajoute aussi `/app/assets/builds` car ces fichiers sont utilisés par sprockets pour générer les assets dans `/public/assets`, et ne sont ensuite plus nécessaires. :shrug: 

J'ai fait un tour en bash du système de fichier de la review app, et le gros du poids qui reste, ce sont les gems ruby (162 Mo).

# Impact

On peut voir l'impact de ces changements sur la liste des deploys de la review app : 
https://dashboard.scalingo.com/apps/osc-secnum-fr1/rdv-service-public-review-app-pr6200/deploy/list

On passe de 820 MB à 388 MB ! :tada: :feather: 
