### PR TITLE
Corrige la couleur du texte des modales

### DIFF
--- a/app/views/agents/blog/posts/index.html.slim
+++ b/app/views/agents/blog/posts/index.html.slim
@@ -1,5 +1,5 @@
-- content_for(:title) do
-  h2.h4 Nouveautés
+- content_for(:title, "Nouveautés")
+
 - if @posts.any?
   - @posts.each do |post|
     .m-2

--- a/app/views/layouts/modal.html.slim
+++ b/app/views/layouts/modal.html.slim
@@ -2,7 +2,7 @@
   .modal-dialog class=(content_for(:modal_class) || "modal-md")
     .modal-content
       .modal-header.modal-colored-header.rdv-background-color-flat-blue-ecume
-        #mainModalLabel.modal-title.m-0.rdv-text-align-center.w-100
+        #mainModalLabel.modal-title.m-0.rdv-text-align-center.w-100.rdv-color-white
           = yield :title if content_for? :title
         button.close aria-hidden="true" data-dismiss="modal" type="button"  ×
       .modal-body


### PR DESCRIPTION
Le fond étant bleu foncé, je suppose qu'il fallait faire en sorte que le texte soit blanc.

# Avant

<img width="1210" height="305" alt="image" src="https://github.com/user-attachments/assets/b5c6e10d-accf-4b0e-8901-34a126489af7" />

<img width="1210" height="305" alt="image" src="https://github.com/user-attachments/assets/610c041b-4c97-4ad5-801f-d0a199cfc09c" />

# Après

<img width="1210" height="305" alt="image" src="https://github.com/user-attachments/assets/ad3a7921-c634-41e0-941c-f452c4221a72" />

<img width="1210" height="305" alt="image" src="https://github.com/user-attachments/assets/89f20376-fa58-4900-88e5-9a2653c931e1" />

