### PR TITLE
Correction des timezones des RDV dans l’API

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -1,7 +1,7 @@
 class RdvBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :uuid, :status, :starts_at, :ends_at, :duration_in_min, :address, :context, :cancelled_at,
+  fields :uuid, :status, :duration_in_min, :address, :context, :cancelled_at,
          :max_participants_count, :users_count, :name, :collectif, :created_by_type, :created_by_id, :created_at,
          :visio_url
 
@@ -19,6 +19,22 @@ class RdvBlueprint < Blueprinter::Base
 
   field :url_for_agents do |rdv, _options|
     Rails.application.routes.url_helpers.agents_rdv_url(rdv, host: rdv.domain.host_name)
+  end
+
+  field :starts_at do |rdv, _options|
+    if rdv.motif.organisation.time_zone
+      rdv.starts_at.in_time_zone(rdv.motif.organisation.time_zone)
+    else
+      rdv.starts_at
+    end
+  end
+
+  field :ends_at do |rdv, _options|
+    if rdv.motif.organisation.time_zone
+      rdv.ends_at.in_time_zone(rdv.motif.organisation.time_zone)
+    else
+      rdv.ends_at
+    end
   end
 
   # On permet des associations optionnelles, mais on les charge toutes si le paramètre `include` n'est pas utilisé

--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -22,19 +22,11 @@ class RdvBlueprint < Blueprinter::Base
   end
 
   field :starts_at do |rdv, _options|
-    if rdv.motif.organisation.time_zone
-      rdv.starts_at.in_time_zone(rdv.motif.organisation.time_zone)
-    else
-      rdv.starts_at
-    end
+    rdv.starts_at_in_time_zone
   end
 
   field :ends_at do |rdv, _options|
-    if rdv.motif.organisation.time_zone
-      rdv.ends_at.in_time_zone(rdv.motif.organisation.time_zone)
-    else
-      rdv.ends_at
-    end
+    rdv.ends_at_in_time_zone
   end
 
   # On permet des associations optionnelles, mais on les charge toutes si le paramètre `include` n'est pas utilisé

--- a/app/blueprints/rdv_plan_blueprint.rb
+++ b/app/blueprints/rdv_plan_blueprint.rb
@@ -17,7 +17,7 @@ class RdvPlanBlueprint < Blueprinter::Base
     {
       id: rdv.id,
       status: rdv.status,
-      starts_at: rdv.starts_at,
+      starts_at: rdv.starts_at_in_time_zone,
       location_type: rdv.motif.location_type,
     }
   end

--- a/app/controllers/api/v1/rdv_plans_controller.rb
+++ b/app/controllers/api/v1/rdv_plans_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::RdvPlansController < Api::V1::AgentAuthBaseController
   end
 
   def show
-    rdv_plan = policy_scope(RdvPlan, policy_scope_class: Agent::RdvPlanPolicy::Scope).find(params[:id])
+    rdv_plan = policy_scope(RdvPlan, policy_scope_class: Agent::RdvPlanPolicy::Scope).includes(rdv: :organisation).find(params[:id])
 
     render_record rdv_plan
   end

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
     if params[:include].nil?
       rdvs = rdvs.includes(:organisation, :lieu, :agents, :users, participations: [:user], motif: [:motif_category])
     elsif params[:include].is_a?(Array)
-      rdvs.includes!(:organisation) if "organisation".in?(params[:include])
+      rdvs.includes!(:organisation) # Nous avons besoin de l’organisation pour renvoyer les RDV sur le bon fuseau horaire
 
       rdvs.includes!(:lieu) if "lieu".in?(params[:include])
 

--- a/app/models/concerns/rdv/timezone_concern.rb
+++ b/app/models/concerns/rdv/timezone_concern.rb
@@ -1,0 +1,26 @@
+# Nous stockons en base de données les dates de début et de fin sur la timezone Europe/Paris même si les RDV sont organisés
+# dans des organisations qui peuvent être dans d'autres fuseaux horaires.
+# Cela ne pose pas de problème pour la prise de RDV, car nous considérons toujours que les RDV sont effectués en heure locale.
+# Cependant, lors de l’envoi de ces données à des systèmes externes (par API ou via les ICS), nous devons envoyer les dates
+# dans le fuseau horaire de l’organisation.
+# Ce concern permet donc de renvoyer les dates sur le bon fuseau horaire pour les réponses d’API.
+# Pour les ICS, il nous suffit de spécifier le bon TZID dans le fichier ICS, et les clients de calendrier feront la conversion automatiquement.
+module Rdv::TimezoneConcern
+  extend ActiveSupport::Concern
+
+  def starts_at_in_time_zone
+    if organisation.time_zone.nil?
+      starts_at
+    else
+      starts_at.change(zone: organisation.time_zone)
+    end
+  end
+
+  def ends_at_in_time_zone
+    if organisation.time_zone.nil?
+      ends_at
+    else
+      ends_at.change(zone: organisation.time_zone)
+    end
+  end
+end

--- a/app/models/concerns/rdv/timezone_concern.rb
+++ b/app/models/concerns/rdv/timezone_concern.rb
@@ -9,7 +9,7 @@ module Rdv::TimezoneConcern
   extend ActiveSupport::Concern
 
   def starts_at_in_time_zone
-    if organisation.time_zone.nil?
+    if organisation.time_zone == "Europe/Paris"
       starts_at
     else
       starts_at.change(zone: organisation.time_zone)
@@ -17,7 +17,7 @@ module Rdv::TimezoneConcern
   end
 
   def ends_at_in_time_zone
-    if organisation.time_zone.nil?
+    if organisation.time_zone == "Europe/Paris"
       ends_at
     else
       ends_at.change(zone: organisation.time_zone)

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -12,6 +12,7 @@ class Rdv < ApplicationRecord
   include Rdv::Updatable
   include Rdv::UsingWaitingRoom
   include Rdv::HardcodedAttributeNamesConcern
+  include Rdv::TimezoneConcern
   include IcsPayloads::Rdv
   include Ants::AppointmentSerializerAndListener
   include CreatedByConcern

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -194,5 +194,27 @@ RSpec.describe "RDV Plan API" do
         expect(response.status).to eq 404
       end
     end
+
+    describe "utilise la bonne timezone" do
+      let(:organisation) { create(:organisation, time_zone: "America/Guadeloupe") }
+      let(:rdv) { create(:rdv, organisation: organisation) }
+      let(:rdv_plan) { create(:rdv_plan, planning_agent: agent, rdv: rdv) }
+
+      context "lorsque la timezone de l'organisation est la timezone par défaut (Europe/Paris)" do
+        let(:organisation) { create(:organisation) }
+
+        it "utilise la timezone de l'instance" do
+          get "/api/v1/rdv_plans/#{rdv_plan.id}", headers: headers, params: {}, as: :json
+          expect(parsed_response_body.dig("rdv_plan", "rdv", "starts_at")).to eq rdv.starts_at.to_s
+        end
+      end
+
+      context "lorsque la timezone de l'organisation est définie" do
+        it "utilise la timezone de l'organisation" do
+          get "/api/v1/rdv_plans/#{rdv_plan.id}", headers: headers, params: {}, as: :json
+          expect(parsed_response_body.dig("rdv_plan", "rdv", "starts_at")).to eq rdv.starts_at.change(zone: "America/Guadeloupe").to_s
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -210,9 +210,11 @@ RSpec.describe "RDV Plan API" do
       end
 
       context "lorsque la timezone de l'organisation est définie" do
+        let(:rdv) { create(:rdv, organisation: organisation, starts_at: Time.zone.parse("2025-01-15 10:00:00")) }
+
         it "utilise la timezone de l'organisation" do
           get "/api/v1/rdv_plans/#{rdv_plan.id}", headers: headers, params: {}, as: :json
-          expect(parsed_response_body.dig("rdv_plan", "rdv", "starts_at")).to eq rdv.starts_at.change(zone: "America/Guadeloupe").to_s
+          expect(parsed_response_body.dig("rdv_plan", "rdv", "starts_at")).to eq "2025-01-15 10:00:00 -0400"
         end
       end
     end

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -116,11 +116,15 @@ RSpec.describe "RDV API" do
 
       context "lorsque la timezone de l'organisation est définie" do
         let(:organisation) { create(:organisation, time_zone: "America/Guadeloupe") }
+        let!(:rdv_with_user_and_agent) do
+          create(:rdv, organisation: organisation, motif: motif, users: [user], agents: [agent],
+                       starts_at: Time.zone.parse("2025-01-15 10:00:00"))
+        end
 
         it "utilise la timezone de l'organisation" do
           get "/api/v1/rdvs", headers: headers, params: { user_id: user.id, agent_id: agent.id }, as: :json
-          expect(parsed_response_body["rdvs"].first["starts_at"]).to eq rdv_with_user_and_agent.starts_at.change(zone: "America/Guadeloupe").to_s
-          expect(parsed_response_body["rdvs"].first["ends_at"]).to eq rdv_with_user_and_agent.ends_at.change(zone: "America/Guadeloupe").to_s
+          expect(parsed_response_body["rdvs"].first["starts_at"]).to eq "2025-01-15 10:00:00 -0400"
+          expect(parsed_response_body["rdvs"].first["ends_at"]).to eq "2025-01-15 10:45:00 -0400"
         end
       end
     end

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -119,7 +119,8 @@ RSpec.describe "RDV API" do
 
         it "utilise la timezone de l'organisation" do
           get "/api/v1/rdvs", headers: headers, params: { user_id: user.id, agent_id: agent.id }, as: :json
-          expect(parsed_response_body["rdvs"].first["ends_at"]).to eq rdv_with_user_and_agent.ends_at.in_time_zone("America/Guadeloupe").to_s
+          expect(parsed_response_body["rdvs"].first["starts_at"]).to eq rdv_with_user_and_agent.starts_at.change(zone: "America/Guadeloupe").to_s
+          expect(parsed_response_body["rdvs"].first["ends_at"]).to eq rdv_with_user_and_agent.ends_at.change(zone: "America/Guadeloupe").to_s
         end
       end
     end

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -104,6 +104,25 @@ RSpec.describe "RDV API" do
         expect(rdv).not_to have_key("organisation")
       end
     end
+
+    describe "utilise la bonne timezone" do
+      context "lorsque la timezone de l'organisation n'est pas définie" do
+        it "utilise la timezone de l'instance" do
+          get "/api/v1/rdvs", headers: headers, params: { user_id: user.id, agent_id: agent.id }, as: :json
+          expect(parsed_response_body["rdvs"].first["starts_at"]).to eq rdv_with_user_and_agent.starts_at.to_s
+          expect(parsed_response_body["rdvs"].first["ends_at"]).to eq rdv_with_user_and_agent.ends_at.to_s
+        end
+      end
+
+      context "lorsque la timezone de l'organisation est définie" do
+        let(:organisation) { create(:organisation, time_zone: "America/Guadeloupe") }
+
+        it "utilise la timezone de l'organisation" do
+          get "/api/v1/rdvs", headers: headers, params: { user_id: user.id, agent_id: agent.id }, as: :json
+          expect(parsed_response_body["rdvs"].first["ends_at"]).to eq rdv_with_user_and_agent.ends_at.in_time_zone("America/Guadeloupe").to_s
+        end
+      end
+    end
   end
 
   describe "#create" do

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "RDV API" do
     end
 
     describe "utilise la bonne timezone" do
-      context "lorsque la timezone de l'organisation n'est pas définie" do
+      context "lorsque la timezone de l'organisation est la timezone par défaut (Europe/Paris)" do
         it "utilise la timezone de l'instance" do
           get "/api/v1/rdvs", headers: headers, params: { user_id: user.id, agent_id: agent.id }, as: :json
           expect(parsed_response_body["rdvs"].first["starts_at"]).to eq rdv_with_user_and_agent.starts_at.to_s


### PR DESCRIPTION
Closes #6202 

# Contexte

Le contexte complet est dans l’issue ci-dessus ☝🏻 

# Solution

@francois-ferrandis, je sais que cette PR va nous ramener à notre fameuse discussion sur comment on stocke les fuseaux horaires en base. Je sais ce que tu penses, et je te comprends, mais j’ai l’impression qu’ici, on peut fournir une solution simple à nos agents guadeloupéens.
Qu’en penses-tu ?