### PR TITLE
Clarifier les dépendances de `BusyTimePreloader`

### DIFF
--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -146,8 +146,6 @@ module CreneauxSearch::Calculator
       start_loading!
     end
 
-    attr_reader :range
-
     # On charge les absences en asynchrone et les rdvs en synchrone
     def self.start_loading_busy_times_for(range, agent, work_on_off_days:)
       new(range, agent, work_on_off_days)
@@ -176,7 +174,7 @@ module CreneauxSearch::Calculator
       # TODO : Peut-être cacher la récupération de l'ensemble des RDV et absences concernées (pour n'avoir que deux requêtes) puis faire des selections dessus pour le filtre sur le range
       #        Le problème potentiel de cette approche est qu'il serait difficile d'éviter de charger des rdv et absences qui sont en dehors des ocurrences des plages d'ouverture
 
-      @absences = @agent.absences.not_expired.in_range(range).load_async
+      @absences = @agent.absences.not_expired.in_range(@range).load_async
 
       @rdvs_starts_and_ends_at = optimized_rdv_request.pluck(:calculator_rdv_starts_at, :calculator_rdv_ends_at)
     end
@@ -185,14 +183,14 @@ module CreneauxSearch::Calculator
       # Cet requête est censée utiliser l'index "calculator_index"
       AgentsRdv
         .where(agent_id: @agent.id, calculator_rdv_not_cancelled_and_in_the_future: true)
-        .where("tsrange(calculator_rdv_starts_at, calculator_rdv_ends_at, '[)') && tsrange(?, ?)", range.begin, range.end)
+        .where("tsrange(calculator_rdv_starts_at, calculator_rdv_ends_at, '[)') && tsrange(?, ?)", @range.begin, @range.end)
         .select(:calculator_rdv_starts_at, :calculator_rdv_ends_at)
     end
 
     def busy_times_from_absences
       busy_times = []
       @absences.each do |absence|
-        absence.occurrences_for(range).each do |absence_occurrence|
+        absence.occurrences_for(@range).each do |absence_occurrence|
           next if absence_out_of_range?(absence_occurrence)
 
           busy_times << BusyTime.new(absence_occurrence.starts_at, absence_occurrence.ends_at)
@@ -202,15 +200,15 @@ module CreneauxSearch::Calculator
     end
 
     def absence_out_of_range?(absence)
-      absence.ends_at < range.begin || range.end < absence.starts_at
+      absence.ends_at < @range.begin || @range.end < absence.starts_at
     end
 
     def busy_times_from_external_calendar
       return [] unless @agent.caldav_configured?
 
       external_calendar_occurrences = []
-      ExternalCalendarEvent.where(agent_id: @agent.id).within_range(range).each do |event|
-        event.all_occurrences_within(range).each do |occurrence|
+      ExternalCalendarEvent.where(agent_id: @agent.id).within_range(@range).each do |event|
+        event.all_occurrences_within(@range).each do |occurrence|
           external_calendar_occurrences << BusyTime.new(occurrence.starts_at, occurrence.ends_at)
         end
       end
@@ -218,7 +216,7 @@ module CreneauxSearch::Calculator
     end
 
     def busy_times_from_off_days
-      OffDays.all_in_date_range(range).map do |off_day|
+      OffDays.all_in_date_range(@range).map do |off_day|
         BusyTime.new(off_day.beginning_of_day, off_day.end_of_day)
       end
     end

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -43,7 +43,7 @@ module CreneauxSearch::Calculator
       return [] if ranges.empty?
 
       ranges.map do |range|
-        [range, BusyTimePreloader.start_loading_busy_times_for(range, plage_ouverture, work_on_off_days:)]
+        [range, BusyTimePreloader.start_loading_busy_times_for(range, plage_ouverture.agent, work_on_off_days:)]
       end.flat_map do |range, busy_times_preloader|
         busy_times = busy_times_preloader.busy_times
         split_range_recursively(range, busy_times)
@@ -139,18 +139,18 @@ module CreneauxSearch::Calculator
   end
 
   class BusyTimePreloader
-    def initialize(range, plage_ouverture, work_on_off_days)
+    def initialize(range, agent, work_on_off_days)
       @range = range
-      @plage_ouverture = plage_ouverture
+      @agent = agent
       @work_on_off_days = work_on_off_days
       start_loading!
     end
 
-    attr_reader :range, :plage_ouverture
+    attr_reader :range
 
     # On charge les absences en asynchrone et les rdvs en synchrone
-    def self.start_loading_busy_times_for(range, plage_ouverture, work_on_off_days:)
-      new(range, plage_ouverture, work_on_off_days)
+    def self.start_loading_busy_times_for(range, agent, work_on_off_days:)
+      new(range, agent, work_on_off_days)
     end
 
     def busy_times
@@ -176,7 +176,7 @@ module CreneauxSearch::Calculator
       # TODO : Peut-être cacher la récupération de l'ensemble des RDV et absences concernées (pour n'avoir que deux requêtes) puis faire des selections dessus pour le filtre sur le range
       #        Le problème potentiel de cette approche est qu'il serait difficile d'éviter de charger des rdv et absences qui sont en dehors des ocurrences des plages d'ouverture
 
-      @absences = plage_ouverture.agent.absences.not_expired.in_range(range).load_async
+      @absences = @agent.absences.not_expired.in_range(range).load_async
 
       @rdvs_starts_and_ends_at = optimized_rdv_request.pluck(:calculator_rdv_starts_at, :calculator_rdv_ends_at)
     end
@@ -184,7 +184,7 @@ module CreneauxSearch::Calculator
     def optimized_rdv_request
       # Cet requête est censée utiliser l'index "calculator_index"
       AgentsRdv
-        .where(agent_id: plage_ouverture.agent_id, calculator_rdv_not_cancelled_and_in_the_future: true)
+        .where(agent_id: @agent.id, calculator_rdv_not_cancelled_and_in_the_future: true)
         .where("tsrange(calculator_rdv_starts_at, calculator_rdv_ends_at, '[)') && tsrange(?, ?)", range.begin, range.end)
         .select(:calculator_rdv_starts_at, :calculator_rdv_ends_at)
     end
@@ -206,11 +206,10 @@ module CreneauxSearch::Calculator
     end
 
     def busy_times_from_external_calendar
-      agent = plage_ouverture.agent
-      return [] unless agent.caldav_configured?
+      return [] unless @agent.caldav_configured?
 
       external_calendar_occurrences = []
-      ExternalCalendarEvent.where(agent:).within_range(range).each do |event|
+      ExternalCalendarEvent.where(agent_id: @agent.id).within_range(range).each do |event|
         event.all_occurrences_within(range).each do |occurrence|
           external_calendar_occurrences << BusyTime.new(occurrence.starts_at, occurrence.ends_at)
         end

--- a/spec/services/creneaux_search/calculator/busy_time_preloader_spec.rb
+++ b/spec/services/creneaux_search/calculator/busy_time_preloader_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
   subject(:busy_times) do
-    described_class.start_loading_busy_times_for(range, plage_ouverture, work_on_off_days: false).busy_times
+    described_class.start_loading_busy_times_for(range, agent, work_on_off_days: false).busy_times
   end
 
   let(:monday) { Time.zone.parse("20211025 10:00") }
   let(:range) { Time.zone.parse("2021-10-26 8:00")..Time.zone.parse("2021-10-29 12:00") }
-  let(:plage_ouverture) { create(:plage_ouverture) }
+  let(:agent) { create(:agent) }
 
   before { travel_to(monday) }
 
@@ -15,7 +15,7 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
 
   context "with a RDV" do
     it "returns a BusyTime with the correct attributes" do
-      create(:rdv, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00"), ends_at: Time.zone.parse("20211027 9:40"))
+      create(:rdv, agents: [agent], starts_at: Time.zone.parse("20211027 9:00"), ends_at: Time.zone.parse("20211027 9:40"))
 
       busy_time = busy_times.first
       expect(busy_time).to have_attributes(
@@ -27,18 +27,18 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
 
   context "with an absence without recurrence" do
     it "returns BusyTime starts_at as absence first_day and start_time" do
-      create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9))
+      create(:absence, agent: agent, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9))
       expect(busy_times.first.starts_at).to eq(Time.zone.parse("20211027 9:00"))
     end
 
     it "returns BusyTime ends_at as absence first_day and end_time when end_day is nil" do
-      create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9), end_day: nil,
+      create(:absence, agent: agent, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9), end_day: nil,
                        end_time: Tod::TimeOfDay.new(9, 40))
       expect(busy_times.first.ends_at).to eq(Time.zone.parse("20211027 9:40"))
     end
 
     it "returns BusyTime ends_at as absence end_day and end_time" do
-      create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9),
+      create(:absence, agent: agent, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9),
                        end_day: Date.new(2021, 10, 28), end_time: Tod::TimeOfDay.new(12))
       expect(busy_times.first.ends_at).to eq(Time.zone.parse("20211028 12"))
     end
@@ -47,7 +47,7 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
       let(:range) { Time.zone.parse("2021-10-26 9:00")..Time.zone.parse("2021-10-29 11:00") }
 
       it "doesn't return BusyTime" do
-        create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 29), start_time: Tod::TimeOfDay.new(14),
+        create(:absence, agent: agent, first_day: Date.new(2021, 10, 29), start_time: Tod::TimeOfDay.new(14),
                          end_day: Date.new(2021, 10, 29), end_time: Tod::TimeOfDay.new(15))
         expect(busy_times).to be_empty
       end
@@ -56,20 +56,20 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
 
   context "with an absence with recurrence" do
     it "returns starts_at first occurrence in range" do
-      create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 19), start_time: Tod::TimeOfDay.new(9),
+      create(:absence, agent: agent, first_day: Date.new(2021, 10, 19), start_time: Tod::TimeOfDay.new(9),
                        recurrence: Montrose.every(:week, on: ["tuesday"], starts: Time.zone.parse("20211019 9:00"), until: nil, interval: 1))
       expect(busy_times.first.starts_at).to eq(Time.zone.parse("20211026 9:00"))
     end
 
     it "returns ends_at occurrence in range" do
-      create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 19), start_time: Tod::TimeOfDay.new(9),
+      create(:absence, agent: agent, first_day: Date.new(2021, 10, 19), start_time: Tod::TimeOfDay.new(9),
                        end_time: Tod::TimeOfDay.new(9, 45), recurrence: Montrose.every(:week, on: ["tuesday"], starts: Time.zone.parse("20211019 9:00"), until: nil, interval: 1))
       expect(busy_times.first.ends_at).to eq(Time.zone.parse("20211026 9:45"))
     end
 
     it "returns a busy_time for each occurrence in range" do
       create(:absence,
-             agent: plage_ouverture.agent,
+             agent: agent,
              first_day: Date.new(2021, 10, 19),
              start_time: Tod::TimeOfDay.new(9),
              end_time: Tod::TimeOfDay.new(9, 45),
@@ -81,7 +81,7 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
       let(:range) { Time.zone.parse("2021-10-29 9:00")..Time.zone.parse("2021-10-29 11:00") }
 
       it "doesn't return BusyTime" do
-        create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 22),
+        create(:absence, agent: agent, first_day: Date.new(2021, 10, 22),
                          start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(15),
                          recurrence: Montrose.every(:week, on: %w[tuesday friday], starts: Date.new(2021, 10, 22), until: nil, interval: 1))
         expect(busy_times).to be_empty
@@ -93,28 +93,28 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
     context "with a range on a single day" do
       it "returns off_day from beginning of day to end of day" do
         christmas_morning = Time.zone.parse("2024-12-25 8:00")..Time.zone.parse("2024-12-25 12:00")
-        busy_time = described_class.start_loading_busy_times_for(christmas_morning, plage_ouverture, work_on_off_days: false).busy_times.first
+        busy_time = described_class.start_loading_busy_times_for(christmas_morning, agent, work_on_off_days: false).busy_times.first
         expect(busy_time.starts_at).to eq(Time.zone.parse("2024-12-25 0:00"))
         expect(busy_time.ends_at).to be_within(1.second).of(Time.zone.parse("2024-12-25 23:59:59"))
       end
 
       it "returns off_day that in given range only" do
         regular_monday_morning =  Time.zone.parse("2021-12-13 8:00")..Time.zone.parse("2021-12-13 12:00")
-        expect(described_class.start_loading_busy_times_for(regular_monday_morning, plage_ouverture, work_on_off_days: false).busy_times).to be_empty
+        expect(described_class.start_loading_busy_times_for(regular_monday_morning, agent, work_on_off_days: false).busy_times).to be_empty
       end
     end
 
     context "with a range spanning several days" do
       it "returns off_day from beginning of day to end of day" do
         christmas_week = Time.zone.parse("2024-12-20 8:00")..Time.zone.parse("2024-12-26 12:00")
-        busy_time = described_class.start_loading_busy_times_for(christmas_week, plage_ouverture, work_on_off_days: false).busy_times.first
+        busy_time = described_class.start_loading_busy_times_for(christmas_week, agent, work_on_off_days: false).busy_times.first
         expect(busy_time.starts_at).to eq(Time.zone.parse("2024-12-25 0:00"))
         expect(busy_time.ends_at).to be_within(1.second).of(Time.zone.parse("2024-12-25 23:59:59"))
       end
 
       it "returns off_day that in given range only" do
         all_work_week = Time.zone.parse("2021-12-13 8:00")..Time.zone.parse("2021-12-19 12:00")
-        expect(described_class.start_loading_busy_times_for(all_work_week, plage_ouverture, work_on_off_days: false).busy_times).to be_empty
+        expect(described_class.start_loading_busy_times_for(all_work_week, agent, work_on_off_days: false).busy_times).to be_empty
       end
     end
   end
@@ -122,12 +122,12 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
   describe "request to fetch rdvs" do
     it "est optimisée pour utiliser l'index 'calculator_index'. Décommentez le test suivant si celui-ci échoue." do
       # Voir https://www.postgresql.org/docs/current/indexes-index-only-scans.html
-      request = described_class.new(range, plage_ouverture, work_on_off_days: false).send(:optimized_rdv_request)
+      request = described_class.new(range, agent, work_on_off_days: false).send(:optimized_rdv_request)
       expect(request.select(:calculator_rdv_starts_at, :calculator_rdv_ends_at).to_sql.squish).to eq <<~SQL.squish
         SELECT "agents_rdvs"."calculator_rdv_starts_at",
                "agents_rdvs"."calculator_rdv_ends_at"
         FROM "agents_rdvs"
-        WHERE "agents_rdvs"."agent_id" = #{plage_ouverture.agent_id}
+        WHERE "agents_rdvs"."agent_id" = #{agent.id}
           AND "agents_rdvs"."calculator_rdv_not_cancelled_and_in_the_future" = TRUE
           AND (tsrange(calculator_rdv_starts_at, calculator_rdv_ends_at, '[)') && tsrange('2021-10-26 06:00:00', '2021-10-29 10:00:00'))
       SQL
@@ -139,13 +139,13 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
     #   # Il faut créer un minimum de données pour que l'index soit utilisé (le query planner prend des décisions en fonction de la taille des tables et des indexes)
     #   100.times do |i|
     #     create(:rdv, starts_at: Time.zone.parse("20211027 9:00") + (i * 30.minutes), ends_at: Time.zone.parse("20211027 9:40") + (i * 30.minutes))
-    #     create(:rdv, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00") + (i * 30.minutes), ends_at: Time.zone.parse("20211027 9:40") + (i * 30.minutes))
+    #     create(:rdv, agents: [agent], starts_at: Time.zone.parse("20211027 9:00") + (i * 30.minutes), ends_at: Time.zone.parse("20211027 9:40") + (i * 30.minutes))
     #   end
     # end
     #
     # it "is optimized to use an index only scan" do
     #   # Voir https://www.postgresql.org/docs/current/indexes-index-only-scans.html
-    #   request = described_class.new(range, plage_ouverture).send(:optimized_rdv_request)
+    #   request = described_class.new(range, agent).send(:optimized_rdv_request)
     #   expect(request.select(:calculator_rdv_starts_at, :calculator_rdv_ends_at).explain.inspect).to include "Index Only Scan using calculator_index"
     # end
   end


### PR DESCRIPTION
Deux changements quasi-cosmétiques : 
- on passe un `agent` plutôt qu'une `plage_ouverture`, car `BusyTimePreloader` n'utilise la plage que pour récupérer l'agent
- on fait de `BusyTimePreloader#range` une variable interne à la classe puisqu'elle n'est jamais utilisée à l'extérieur