### PR TITLE
Calculateur : charger les busy times pour l'ensemble des ranges d'une plage

### DIFF
--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -42,10 +42,9 @@ module CreneauxSearch::Calculator
       ranges = ranges_for(plage_ouverture, datetime_range)
       return [] if ranges.empty?
 
-      ranges.map do |range|
-        [range, BusyTimePreloader.start_loading_busy_times_for(range, plage_ouverture.agent, work_on_off_days:)]
-      end.flat_map do |range, busy_times_preloader|
-        busy_times = busy_times_preloader.busy_times
+      global_range = ranges.map(&:begin).min..ranges.map(&:end).max
+      busy_times = BusyTimePreloader.start_loading_busy_times_for(global_range, plage_ouverture.agent, work_on_off_days:).busy_times
+      ranges.flat_map do |range|
         split_range_recursively(range, busy_times)
       end
     end

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -174,7 +174,7 @@ module CreneauxSearch::Calculator
       # TODO : Peut-être cacher la récupération de l'ensemble des RDV et absences concernées (pour n'avoir que deux requêtes) puis faire des selections dessus pour le filtre sur le range
       #        Le problème potentiel de cette approche est qu'il serait difficile d'éviter de charger des rdv et absences qui sont en dehors des ocurrences des plages d'ouverture
 
-      @absences = @agent.absences.not_expired.in_range(@range).load_async
+      @absences = @agent.absences.not_expired.in_range(@range).load
 
       @rdvs_starts_and_ends_at = optimized_rdv_request.pluck(:calculator_rdv_starts_at, :calculator_rdv_ends_at)
     end

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -43,8 +43,8 @@ module CreneauxSearch::Calculator
       return [] if ranges.empty?
 
       # On récupère les busy times sur l'ensemble des ranges de la plage d'ouverture.
-      # Auparavant, nous calculions les busy times pour chacun des occurrences, ce qui avait pour effet
-      # de générer 5 fois plus de requêtes pour une plage ayant lieu 5 fois par semaine par exemple.
+      # Le but est d'éviter de lancer des requêtes en base pour chacun des occurrences,
+      # même si cela a pour effet de parfois charger des busy_times qui sont en dehors des ranges.
       global_range = ranges.map(&:begin).min..ranges.map(&:end).max
       busy_times = BusyTimePreloader.start_loading_busy_times_for(global_range, plage_ouverture.agent, work_on_off_days:).busy_times
 

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -42,8 +42,12 @@ module CreneauxSearch::Calculator
       ranges = ranges_for(plage_ouverture, datetime_range)
       return [] if ranges.empty?
 
+      # On récupère les busy times sur l'ensemble des ranges de la plage d'ouverture.
+      # Auparavant, nous calculions les busy times pour chacun des occurrences, ce qui avait pour effet
+      # de générer 5 fois plus de requêtes pour une plage ayant lieu 5 fois par semaine par exemple.
       global_range = ranges.map(&:begin).min..ranges.map(&:end).max
       busy_times = BusyTimePreloader.start_loading_busy_times_for(global_range, plage_ouverture.agent, work_on_off_days:).busy_times
+
       ranges.flat_map do |range|
         split_range_recursively(range, busy_times)
       end
@@ -142,7 +146,7 @@ module CreneauxSearch::Calculator
       @range = range
       @agent = agent
       @work_on_off_days = work_on_off_days
-      start_loading!
+      load_absences_and_rdvs!
     end
 
     # On charge les absences en asynchrone et les rdvs en synchrone
@@ -168,11 +172,7 @@ module CreneauxSearch::Calculator
 
     private
 
-    def start_loading!
-      # c'est là que l'on execute le SQL
-      # TODO : Peut-être cacher la récupération de l'ensemble des RDV et absences concernées (pour n'avoir que deux requêtes) puis faire des selections dessus pour le filtre sur le range
-      #        Le problème potentiel de cette approche est qu'il serait difficile d'éviter de charger des rdv et absences qui sont en dehors des ocurrences des plages d'ouverture
-
+    def load_absences_and_rdvs!
       @absences = @agent.absences.not_expired.in_range(@range).load
 
       @rdvs_starts_and_ends_at = optimized_rdv_request.pluck(:calculator_rdv_starts_at, :calculator_rdv_ends_at)

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -173,7 +173,7 @@ module CreneauxSearch::Calculator
     private
 
     def load_absences_and_rdvs!
-      @absences = @agent.absences.not_expired.in_range(@range).load
+      @absences = @agent.absences.not_expired.in_range(@range).load_async
 
       @rdvs_starts_and_ends_at = optimized_rdv_request.pluck(:calculator_rdv_starts_at, :calculator_rdv_ends_at)
     end


### PR DESCRIPTION
Actuellement, dans le calculateur de créneaux, nous chargeons, pour chaque plage d'ouverture trouvée, nous chargeons depuis Postgres, **pour chacune des occurrences de la plage sur la semaine courante** :
- les RDV sur ce range
- les absences sur ce range
- les événements caldav sur ce range

Cela signifie que, pour une plage ayant lieu chaque jour de la semaine, nous avons 5 occurrences (lun-mar-mer-jeu-ven), et donc nous faisons 5 fois les 3 appels ci-dessus. Si cette plage est découpé en matin / après-midi, on double encore le nombre d'itérations (et on fait donc 10 fois les 3 appels) !

Cette PR propose plutôt de ne faire les 3 appels ci dessus qu'une seule fois, sur un seul range global qui couvre toutes les occurrences (dans l'exemple ci dessus, ce range global va du lundi matin au vendredi soir).

Cela va donc avoir pour effet de charger parfois des éléments qui sont en dehors des ranges, mais de réduire parfois considérablement le nombre de requêtes en base. Nous faisons le pari que cela nous fera globalement gagner en performance car la majorité des busytimes sont bel et bien contenus dans les ranges.

Ce changement est proposé dans un contexte dans lequel nous avons des soucis d’exhaustion de connection dans la pool, et nous suspectons très fortement l'usage de `load_async` dans le calculator d'en être la cause. C'est donc la suite de #6095, #4725 et #4695.