### PR TITLE
Redémarrer les apps de prod une fois toutes les 2 heures

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,7 +1,7 @@
 {
   "jobs": [
     {
-      "command": "0 6 * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart"
+      "command": "0 * * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart"
     }
   ]
 }

--- a/cron.json
+++ b/cron.json
@@ -1,7 +1,7 @@
 {
   "jobs": [
     {
-      "command": "0 * * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart"
+      "command": "0 */2 * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart"
     }
   ]
 }


### PR DESCRIPTION
Depuis la semaine dernière nous avons énormément de swap sur `production-rdv-mairie` : 

<img width="1045" height="485" alt="image" src="https://github.com/user-attachments/assets/16165dc5-658b-4f9e-9d68-006c4b8a433d" />

Cela a provoqué de très gros ralentissements ce matin, et donc je propose ce palliatif temporaire un peu radical : redémarrer les serveurs une fois toutes les deux heures.

## Edit : metrics 24h après le merge

On peut voir que malheureusement c'était nécessaire, voire limite car on swappe toujours un petit peu : 

<img width="1038" height="993" alt="image" src="https://github.com/user-attachments/assets/3fec5bc1-172a-461e-8dc7-c5b41f40f44b" />
