### PR TITLE
Retirer le lien vers l'inscription

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,6 +7,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   layout "application"
   layout "application_narrow", only: %i[new create update edit]
 
+  def new
+    redirect_to root_path
+  end
+
   def destroy
     authorize(resource, policy_class: User::UserPolicy)
     # users from rdv-insertion have to be monitored wether they want it or not, so we don't allow them to destroy themselves

--- a/app/views/common/form/_current_password_input.html.slim
+++ b/app/views/common/form/_current_password_input.html.slim
@@ -1,4 +1,4 @@
-/# locals: (f:, name: :password, hint: nil, password_label: nil, forgotten_password_link: false, forgotten_password_link_label: "Mot de passe oublié ?")
+/# locals: (f:, name: :password, hint: nil, password_label: nil, forgotten_password_link: false)
 
 = f.dsfr_input_group name, class: "fr-password fr-mt-2w"
   = f.dsfr_label_with_hint name, class: "fr-label", for: "password", hint: hint, label: password_label
@@ -9,4 +9,4 @@
     input type="checkbox" aria-label="Afficher le mot de passe" id="password-show"
     label for="password-show" class="fr-password__checkbox fr-label" Afficher
   - if forgotten_password_link
-    = link_to forgotten_password_link_label, new_password_path(resource_name), class: "fr-link"
+    = link_to "Mot de passe oublié ?", new_password_path(resource_name), class: "fr-link"

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "Mot de passe oublié ou première connexion ?"
+- content_for :title, "Mot de passe oublié ?"
 
 .card
   .card-body
@@ -16,9 +16,5 @@
     hr
     .rdv-text-align-center
       p.rdv-color-text-mention-grey
-        | Vous avez un compte ?&nbsp;
+        | Vous pouvez également vous connecter par code magique ?&nbsp;
         = link_to "Se connecter", new_session_path(resource_name), class: "fr-link"
-
-      p.rdv-color-text-mention-grey
-        | Vous n'avez pas de compte ?&nbsp;
-        = link_to "Je m’inscris", new_registration_path(resource_name), class: "fr-link"

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -15,6 +15,6 @@
 
     hr
     .rdv-text-align-center
-      p.rdv-color-text-mention-grey
-        | Vous pouvez également vous connecter par code magique ?&nbsp;
-        = link_to "Se connecter", new_session_path(resource_name), class: "fr-link"
+      .fr-mb-2w.fr-text--sm
+        |> Vous pouvez aussi vous
+        = link_to "connecter via code à 6 chiffres", new_user_session_path

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -28,7 +28,7 @@
         = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
           = render "devise/shared/error_messages", resource: resource
           = f.dsfr_email_field :email, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email", autocomplete: "email"
-          = render "common/form/current_password_input", f:, forgotten_password_link: true, forgotten_password_link_label: @rdv_wizard.present? ? "Mot de passe oublié ?" : "Mot de passe oublié ou première connexion ?"
+          = render "common/form/current_password_input", f:, forgotten_password_link: true
           .rdv-text-align-center
             = f.submit "Se connecter", class: "fr-mt-2v fr-btn"
             .fr-mt-4w.fr-mb-2w.fr-text--sm

--- a/spec/features/accessibility/users_pages_spec.rb
+++ b/spec/features/accessibility/users_pages_spec.rb
@@ -39,8 +39,4 @@ RSpec.describe "users pages", js: true do
   it "new_user_password_path is accessible" do
     expect_page_to_be_axe_clean(new_user_password_path)
   end
-
-  it "new_user_registration_path is accessible" do
-    expect_page_to_be_axe_clean(new_user_registration_path)
-  end
 end

--- a/spec/features/agents/account/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/account/agent_can_reset_his_password_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Un agent peut réinitialiser son mot de passe" do
 
   it "fonctionne via le formulaire de réinitialisation utilisateur" do
     visit new_user_password_path
-    expect(page).to have_content("Mot de passe oublié ou première connexion ?")
+    expect(page).to have_content("Mot de passe oublié ?")
     expect(page).to have_link("Se connecter")
 
     fill_in "user_email", with: agent.email

--- a/spec/features/agents/account/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/account/agent_can_reset_his_password_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe "Un agent peut réinitialiser son mot de passe" do
     end
   end
 
-  it "fonctionne via le formulaire de réinitialisation utilisateur" do
+  it "fonctionne via le formulaire de réinitialisation utilisateur", js: true do
     visit new_user_password_path
     expect(page).to have_content("Mot de passe oublié ?")
-    expect(page).to have_link("Se connecter")
+    expect(page).to have_content("connecter via code à 6 chiffres")
 
     fill_in "user_email", with: agent.email
     expect { click_on "Envoyer" }.to change { emails_sent_to(agent.email).size }.by(1)

--- a/spec/features/users/account/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/account/user_can_reset_his_password_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "User resets his password spec" do
 
   it "works by sending a reset email" do
     visit new_user_password_path
-    expect(page).to have_content("Mot de passe oublié ou première connexion ?")
+    expect(page).to have_content("Mot de passe oublié ?")
     expect(page).to have_link("Se connecter")
 
     fill_in "user_email", with: user.email

--- a/spec/features/users/account/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/account/user_can_reset_his_password_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "User resets his password spec" do
   it "works by sending a reset email" do
     visit new_user_password_path
     expect(page).to have_content("Mot de passe oublié ?")
-    expect(page).to have_link("Se connecter")
+    expect(page).to have_link("connecter via code à 6 chiffres")
 
     fill_in "user_email", with: user.email
     expect { click_on "Envoyer" }.to change { emails_sent_to(user.email).size }.by(1)


### PR DESCRIPTION
Discussion Mattermost : 
https://mattermost.incubateur.net/betagouv/pl/orjisj8qwiffbew4bkda7j5mey

# Contexte

Depuis #6203, l'inscription [déclenche une 500](https://sentry.incubateur.net/organizations/betagouv/issues/251861). Cela nous a permis de constater que beaucoup d'usagers tentent de se créer des comptes. Nous suspectons fortement que ces créations soient contextuelles à l'usage de notre outil par une préfecture pour la délivrance de titres de séjour, contexte dans lequel les usagers tentent d'accéder à un RDV par tous les moyens. 

Nous avons prévu de supprimer l'inscription usager très prochainement dans le cadre de #5481.

# Solution

Nous proposons ici de faire simple dans l'urgence et de retirer le lien vers le formulaire d'inscription et de rediriger `/users/sign_up` vers le `root_path`.

Cela permet aussi de récupérer au plus tôt des retours du terrain face au retrait de l'inscription.