### PR TITLE
Donner plus d'infos en cas d'échec de axe (accessibilité)

### DIFF
--- a/spec/controllers/admin/planning/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/planning/plage_ouvertures_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Admin::Planning::PlageOuverturesController, type: :controller do
         expect(assigns(:plage_ouvertures)).to eq([plage_ouverture])
       end
 
-      it "dispay tab when any expired plage" do
+      it "display tab when any expired plage" do
         now = Time.zone.parse("2020-11-23 13h30")
         travel_to(now)
         create(:plage_ouverture, organisation: organisation, agent: agent, first_day: now + 3.days)

--- a/spec/support/accessibility_spec_matchers.rb
+++ b/spec/support/accessibility_spec_matchers.rb
@@ -3,14 +3,18 @@
 class AxeRunner
   attr_reader :page
 
-  Violation = Data.define(:id, :impact, :tags, :description, :help, :helpUrl) do
+  Violation = Data.define(:id, :impact, :tags, :description, :help, :helpUrl, :nodes) do
     def to_s
+      node_details = nodes.map { |node| "  - #{node['target'].join(', ')}\n    #{node['html']}\n    #{node['failureSummary']}" }.join("\n")
+
       <<~MSG
         # #{description}
 
         impact #{impact} · #{help}
         #{id} · #{tags.join(', ')}
         #{helpUrl}
+        Nodes:
+        #{node_details}
       MSG
     end
   end
@@ -26,7 +30,7 @@ class AxeRunner
   def violations
     @violations ||= raw_results
       .fetch("violations")
-      .map { Violation.new(**_1.except("nodes")) } # nodes clutters up the output
+      .map { Violation.new(**_1.slice("id", "impact", "tags", "description", "help", "helpUrl", "nodes")) }
   end
 
   # inject the axe JS into the page, wait for the results to be logged, parse the results, and return them


### PR DESCRIPTION
Je constate que lors d'un échec de Axe (l'outil qui vérifie automatiquement l'accessibilité de nos pages dans notre suite de tests), nous n'avons aucune info sur quel nœud du DOM est en cause. Cette PR ajoute dans des infos de nœud au message d'erreur.

# Avant

```
Expected no axe violations, found 1 :

# Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds

impact serious · Elements must meet minimum color contrast ratio thresholds
color-contrast · cat.color, wcag2aa, wcag143, TTv5, TT13.c, EN-301-549, EN-9.1.4.3, ACT, RGAAv4, RGAA-3.2.1
https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI
```

# Après

```
Expected no axe violations, found 1 :

# Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds

impact serious · Elements must meet minimum color contrast ratio thresholds
color-contrast · cat.color, wcag2aa, wcag143, TTv5, TT13.c, EN-301-549, EN-9.1.4.3, ACT, RGAAv4, RGAA-3.2.1
https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI
Nodes:
  - .fc-timegrid-event-harness.fc-timegrid-event-harness-inset:nth-child(1) > .fc-event.fc-event-start.fc-event-end > .fc-event-main > .fc-event-main-frame > .fc-event-time
    <div class="fc-event-time">13:00 - 13:45</div>
    Fix any of the following:
  Element has insufficient color contrast of 3.78 (foreground color: #cce0fc, background color: #0066ee, font size: 7.6pt (10.2px), font weight: normal). Expected contrast ratio of 4.5:1
```