### PR TITLE
Bugfix: crash sur l'agenda des rdv plans (RDV via intégration)

### DIFF
--- a/app/javascript/rdv_plan.js
+++ b/app/javascript/rdv_plan.js
@@ -7,3 +7,8 @@ Stimulus.register('rdv-plan', RdvPlanController)
 // Il est nécessaire d'importer le CSS après le JS pour
 // que nos customisations FullCalendar fonctionnent.
 import './stylesheets/rdv_plan';
+
+// Ces tooltips sont utilisées sur l'agenda via les appels à $(...).tooltip()
+import 'bootstrap/js/dist/tooltip'
+import { Tooltips } from "./components/tooltips";
+Tooltips()

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     expect(page).to have_content("Retour sur Démarches Simplifiées")
   end
 
+  it "displays existing RDVs and absences", js: true do
+    existing_rdv_this_week = create(:rdv, starts_at: Time.zone.now.beginning_of_week + 8.hours, agents: [agent], motif:, organisation:)
+    existing_absence_next_week = create(:absence, first_day: Time.zone.now.beginning_of_week.to_date + 1.week, agent:)
+    visit agents_rdv_plan_path(rdv_plan.id)
+    expect(page).to have_content(existing_rdv_this_week.users.first.full_name)
+    click_on("Semaine suivante")
+    expect(page).to have_content(existing_absence_next_week.title)
+  end
+
   context "quand l'usager avait déjà une adresse email dans la colonne email et pas notification_email" do
     let(:rdv_plan) do
       create(:rdv_plan, user: user, motif: motif, location_type: :public_office, duration_in_minutes: 30,


### PR DESCRIPTION
Ticket Zammad : https://zammad10.ethibox.fr/#ticket/zoom/35511

Un conseiller numérique nous remonte qu'il ne peut plus cliquer sur les flèches de son agenda lors d'une prise de RDV en via l'intégration coop.

> Uncaught (in promise) TypeError: $el.tooltip is not a function

J'ai cassé ça dans #6198 car les tooltips bootstrap sont une dépendance non explicite à notre code FullCalendar.

J'ai ajouté une spec qui échoue sur `production` et passe au vert avec le fix JS. 

## Capture d'écran du crash


<img width="2174" height="1134" alt="image" src="https://github.com/user-attachments/assets/0e87a898-a3a0-4a15-84a9-8ebce4ca59a6" />