### PR TITLE
Enregistrer l'heure de dernier login pour un User

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
   private
 
   def email_change_not_allowed?
-    @user.confirmed? && user_params.key?(:email) && @user.email != user_params[:email]
+    @user.already_logged_in? && user_params.key?(:email) && @user.email != user_params[:email]
   end
 
   def set_organisation

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -7,7 +7,7 @@ class Users::PasswordsController < Devise::PasswordsController
 
   def create
     user = User.find_by(email: resource_params[:email])
-    if user && !user&.confirmed?
+    if user && !user&.already_logged_in?
       self.resource = resource_class.send_confirmation_instructions(resource_params)
       if successfully_sent?(resource)
         respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -292,6 +292,10 @@ class User < ApplicationRecord
     super
   end
 
+  def confirmed?
+    latest_login_at.present? || super
+  end
+
   def set_email_to_null_if_blank
     self.email = nil if email.blank?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -264,7 +264,7 @@ class User < ApplicationRecord
   end
 
   def already_logged_in?
-    encrypted_password.present? || confirmed_at.present? || latest_login_at.present?
+    confirmed_at.present? || latest_login_at.present?
   end
 
   protected

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -263,8 +263,8 @@ class User < ApplicationRecord
     (franceconnect_openid_sub || pro_connect_openid_sub).present?
   end
 
-  def confirmed?
-    latest_login_at.present? || super
+  def already_logged_in?
+    encrypted_password.present? || confirmed_at.present? || latest_login_at.present?
   end
 
   protected

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -263,6 +263,10 @@ class User < ApplicationRecord
     (franceconnect_openid_sub || pro_connect_openid_sub).present?
   end
 
+  def confirmed?
+    latest_login_at.present? || super
+  end
+
   protected
 
   def generate_rdv_invitation_token
@@ -290,10 +294,6 @@ class User < ApplicationRecord
     return false if signed_in_with_invitation_token?
 
     super
-  end
-
-  def confirmed?
-    latest_login_at.present? || super
   end
 
   def set_email_to_null_if_blank

--- a/app/services/notifiers/rdv_created.rb
+++ b/app/services/notifiers/rdv_created.rb
@@ -18,7 +18,7 @@ class Notifiers::RdvCreated < Notifiers::RdvBase
   end
 
   def self.should_send_sms_to_user?(user:, rdv:, author:)
-    author != user || !user.confirmed? || rdv.starts_at < 2.days.from_now
+    author != user || !user.already_logged_in? || rdv.starts_at < 2.days.from_now
   end
 
   protected

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -16,6 +16,7 @@ class Users::LoginService
   def perform
     if matching_login_code&.usable?
       @user = upsert_user
+      user.confirm
       user.update!(latest_login_at: Time.zone.now)
       sign_in_user_lambda.call(user)
       matching_login_code.update!(used_at: Time.zone.now)

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -17,6 +17,7 @@ class Users::LoginService
     if matching_login_code&.usable?
       @user = upsert_user
       user.confirm
+      user.update!(latest_login_at: Time.zone.now)
       sign_in_user_lambda.call(user)
       matching_login_code.update!(used_at: Time.zone.now)
       true

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -16,7 +16,6 @@ class Users::LoginService
   def perform
     if matching_login_code&.usable?
       @user = upsert_user
-      user.confirm
       user.update!(latest_login_at: Time.zone.now)
       sign_in_user_lambda.call(user)
       matching_login_code.update!(used_at: Time.zone.now)

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -26,14 +26,14 @@
   div= f.input( \
     :notify_by_email,  \
     wrapper: false, \
-    **input_opts.deep_merge(user.confirmed? ? { disabled: true, input_html: { class: "js-force-disabled" } } : {}) \
+    **input_opts.deep_merge(user.already_logged_in? ? { disabled: true, input_html: { class: "js-force-disabled" } } : {}) \
   )
   div= f.input( \
     :notify_by_sms,  \
     wrapper: false, \
-    **input_opts.deep_merge(user.confirmed? ? { disabled: true, input_html: { class: "js-force-disabled" } } : {}) \
+    **input_opts.deep_merge(user.already_logged_in? ? { disabled: true, input_html: { class: "js-force-disabled" } } : {}) \
   )
-- if user.confirmed?
+- if user.already_logged_in?
   .mt-1.text-muted
     | L'usager ayant validé son compte, vous ne pouvez plus modifier ses préférences
 

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -82,6 +82,7 @@ tables:
       - notify_by_sms
       - logged_once_with_franceconnect
       - rdv_invitation_token_updated_at
+      - latest_login_at
 
   - table_name: agents
     anonymized_column_names:

--- a/db/migrate/20260304111613_add_latest_login_at_to_users.rb
+++ b/db/migrate/20260304111613_add_latest_login_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLatestLoginAtToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :latest_login_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_02_081619) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_04_111613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -864,6 +864,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_02_081619) do
     t.string "notification_email", comment: "Used for notifications only, multiple users can share the same email notification address"
     t.virtual "text_search_terms_with_notification_email", type: :tsvector, as: "((((((setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(last_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(first_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(birth_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'C'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(notification_email, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(email, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(phone_number_formatted, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text)), 'D'::\"char\"))", stored: true
     t.string "pro_connect_openid_sub"
+    t.datetime "latest_login_at"
     t.index ["ants_pre_demande_number"], name: "index_users_on_ants_pre_demande_number", where: "(ants_pre_demande_number IS NOT NULL)"
     t.index ["birth_date"], name: "index_users_on_birth_date"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/spec/services/users/login_service_spec.rb
+++ b/spec/services/users/login_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Users::LoginService, type: :service do
     specify do
       expect(sign_in_user_lambda).to receive(:call).with(user)
       expect(service.perform).to be true
-      expect(user.reload.confirmed?).to be true
+      expect(user.reload.already_logged_in?).to be true
       expect(login_code.reload.used?).to be true
     end
   end


### PR DESCRIPTION
# Contexte

Nous avons plusieurs endroits dans le code où l'on appelle `User#confirmed?` pour déterminer si un usager s'est déjà connecté via invitation ou mot de passe, et en conséquence empêcher qu'un agent modifie son e-mail. La pertinence de ce comportement n'est pas le sujet de cette PR.

Le sujet de cette PR, c'est d'ajouter une colonne `users.latest_login_at` qui sera écrite à chaque connexion à via code à 6 chiffres. En effet, nous avions hésité dans #6204 à réutiliser `confirmed_at`, mais cela pose deux problèmes : 
- la sémantique est mauvaise : on ne "confirme" pas un user quand il se connecte via code à 6 chiffre
- ça ne permet pas de distinguer les logins via password ou via login code, comme remarqué par @aminedhobb dans https://github.com/betagouv/rdv-service-public/pull/6204#discussion_r2882967700

# Solution

Ajouter la colonne `users.latest_login_at`, l'écrire lors d'un login à 6 chiffre, et la prendre en compte dans nos logiques de `confirmed?`.