### PR TITLE
Fix CVE-2026-29063

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -956,9 +956,9 @@ __metadata:
   linkType: hard
 
 "immutable@npm:^5.0.2":
-  version: 5.1.4
-  resolution: "immutable@npm:5.1.4"
-  checksum: 10c0/f1c98382e4cde14a0b218be3b9b2f8441888da8df3b8c064aa756071da55fbed6ad696e5959982508456332419be9fdeaf29b2e58d0eadc45483cc16963c0446
+  version: 5.1.5
+  resolution: "immutable@npm:5.1.5"
+  checksum: 10c0/8017ece1578e3c5939ba3305176aee059def1b8a90c7fa2a347ef583ebbd38cbe77ce1bbd786a5fab57e2da00bbcb0493b92e4332cdc4e1fe5cfb09a4688df31
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
J'ai lancé `YARN_NPM_MINIMAL_AGE_GATE=0 yarn up -R immutable`.

Alerte dependabot : https://github.com/betagouv/rdv-service-public/security/dependabot/159