### PR TITLE
Bugfix: en-têtes d'agenda erronés dans les timezones en UTC-XX:XX

### DIFF
--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -18,8 +18,9 @@ const CUSTOM_HEADER_FORMATS = {
   resourceTimeGridWeek: { weekday: "short", day: "numeric" },
 };
 export const dayHeaderContent = ({ date, view }) => {
-  if (CUSTOM_HEADER_FORMATS[view.type]) {
-    return new Intl.DateTimeFormat('fr-FR', CUSTOM_HEADER_FORMATS[view.type]).format(date);
+  const customFormat = CUSTOM_HEADER_FORMATS[view.type];
+  if (customFormat) {
+    return new Intl.DateTimeFormat('fr-FR', { timeZone: "Europe/Paris", ...customFormat }, ).format(date);
   }
   return true; // v6 : retourner true pour afficher le contenu par défaut
 };


### PR DESCRIPTION
# Le problème

Nous avons un agent en Guadeloupe qui nous signale que, depuis le déploiement du nouvel agenda, les en-têtes de l'agenda sont erronées : la colonne affichant les RDV du lundi 2 mars a pour en-tête "dim. 1", celle affichant les RDV du mardi 3 mars a pour en-tête "lun. 2", bref, les en-têtes affichent le nom du jour de la veille. Le contenu de l'agenda est correct hormis ce souci d'en-tête.

J'ai bien reproduit le problème en définissant la timezone de mon Fedora à en Guadeloupe et en ouvrant l'agenda sous Firefox (voir captures avant / après).

# Pourquoi

La raison, c'est que le formateur d'en-tête reçoit un object `Date` qui représente le début du premier jour de l'agenda à 00:00 UTC. 

Dans la timezone de Paris (CEST), qui est +01:00 / +02:00, cette date correspond bien au lundi : 

> Mon Mar 02 2026 01:00:00 GMT+0100 (Central European Standard Time)

Mais dans les timezones qui sont à "gauche" d'UTC, c'est à dire -01:00, -02:00, ou -04:00 comme la Guadeloupe, à minuit UTC, on est encore le jour d'avant !

> Sun Mar 01 2026 20:00:00 GMT-0400 (Atlantic Standard Time)

# La solution

En précisant la timezone `"Europe/Paris"` lors de la génération des en-têtes custom, on corrige le problème car on formate bien au même jour que le jour UTC.

#### Pourquoi le bug est-il apparu avec le nouveau planning ?

Avec l'ancien code, nous n'utilisions pas de formatage custom `dayHeaderContent`, et donc c'est FullCalendar qui effectuait le formatage, en utilisant comme timezone ce que nous passons au global : `timeZone: "Europe/Paris"`. C'est donc puisque nous utilisons désormais un formateur custom qu'il faut re-expliciter quelle timezone est à utiliser.

## Avant

<img width="1830" height="1038" alt="image" src="https://github.com/user-attachments/assets/b75a2db5-588d-4a30-b498-512b81404027" />


## Après

<img width="1830" height="1038" alt="image" src="https://github.com/user-attachments/assets/6b3846d6-3339-49f6-955f-f0582ad05aff" />