### PR TITLE
Ajoute une spec pour #6226

### DIFF
--- a/spec/features/agents/planning/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/planning/agent_has_a_calendar_spec.rb
@@ -211,4 +211,23 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       expect(page).to have_content("Nouveau RDV pour le #{I18n.l(monday_next_week, format: '%-d/%m/%Y')} à 08:30")
     end
   end
+
+  describe "apparence de l'agenda" do
+    let!(:organisation) { create(:organisation) }
+    let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+    before do
+      login_as(agent, scope: :agent)
+    end
+
+    it "affiche chaque jour", js: true do
+      Capybara.using_driver(:playwright_guadeloupe) do
+        page.driver.with_playwright_page { _1.clock.pause_at(Time.zone.parse("2026-03-15 08:00")) }
+        visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+        expected_header = ["lun. 9", "mar. 10", "mer. 11", "jeu. 12", "ven. 13"]
+        actual_headers = find_all(".fc-col-header-cell-cushion").map(&:text)
+        expect(actual_headers).to eq(expected_header)
+      end
+    end
+  end
 end

--- a/spec/features/agents/planning/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/planning/agent_has_a_calendar_spec.rb
@@ -220,11 +220,19 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       login_as(agent, scope: :agent)
     end
 
-    it "affiche chaque jour", js: true do
+    it "affiche le nom des jour en en-tête", js: true do
       Capybara.using_driver(:playwright_guadeloupe) do
         page.driver.with_playwright_page { _1.clock.pause_at(Time.zone.parse("2026-03-15 08:00")) }
         visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+
+        # vue semaine
         expected_header = ["lun. 9", "mar. 10", "mer. 11", "jeu. 12", "ven. 13"]
+        actual_headers = find_all(".fc-col-header-cell-cushion").map(&:text)
+        expect(actual_headers).to eq(expected_header)
+
+        # vue mois
+        click_on("Mois")
+        expected_header = %w[lundi mardi mercredi jeudi vendredi]
         actual_headers = find_all(".fc-col-header-cell-cushion").map(&:text)
         expect(actual_headers).to eq(expected_header)
       end

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -4,14 +4,21 @@ WebMock.disable_net_connect!(allow: [
                                "www.rdv-solidarites-test.localhost",
                              ])
 
+playwright_config = {
+  browser_type: ENV["PLAYWRIGHT_BROWSER"]&.to_sym || :chromium,
+  headless: ENV["HEADLESS"] != "false",
+  timeout: 5,
+  timezoneId: "Europe/Paris",
+}
+
 Capybara.register_driver(:playwright) do |app|
-  Capybara::Playwright::Driver.new(
-    app,
-    browser_type: ENV["PLAYWRIGHT_BROWSER"]&.to_sym || :chromium,
-    headless: ENV["HEADLESS"] != "false",
-    timeout: 5
-  )
+  Capybara::Playwright::Driver.new(app, **playwright_config)
 end
+
+Capybara.register_driver(:playwright_guadeloupe) do |app|
+  Capybara::Playwright::Driver.new(app, **playwright_config, timezoneId: "America/Guadeloupe")
+end
+
 Capybara.javascript_driver = :playwright
 
 Capybara.configure do |config|


### PR DESCRIPTION
Lorsque j'ai implémenté un fix dans #6226, j'ai cru qu'il était impossible de modifier la timezone dans un test Playwright.

En réalité j'ai découvert qu'il était possible et même facile dans un test JS Playwright :
- d'utiliser une autre timezone :earth_americas: 
- de faire un équivalent du `travel_to` :watch: 

Je suis super content, ça me permet donc d'ajouter cette spec. En la lançant sans le fix de #6226, elle échoue bien ainsi : 

```
expected: ["lun. 9", "mar. 10", "mer. 11", "jeu. 12", "ven. 13"]
     got: ["dim. 8", "lun. 9", "mar. 10", "mer. 11", "jeu. 12"]
```

# Ceci est une révolution

En effet, ça signifie qu'on va pouvoir ajouter des test JS qui vérifient que tout fonctionne sur un navigateur qui est dans une autre timezone, ce qui va beaucoup nous aider à implémenter une gestion correcte des timezone (le jour on enfin on priorise le sujet).

:woman_dancing: 