### PR TITLE
Ne pas faire d'appel FullCalendar pour les événements Caldav si l'agent n'a pas Caldav

### DIFF
--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -135,12 +135,12 @@ class Agents::RdvPlansController < AgentAuthController
     organisation = agent.organisations.first
 
     event_sources = [
-      { id: "Rdv",                    url: admin_api_agenda_rdvs_path(agent_id: agent.id, organisation_id: organisation.id, format: :json) },
-      { id: "Absence",                url: admin_api_agenda_absences_path(agent_id: agent.id, organisation_id: organisation.id, format: :json) },
-      { id: "ExternalCalendarEvent",  url: admin_api_agenda_external_calendar_events_path(agent_id: agent.id, format: :json) },
-      { id: "PlageOuverture",         url: admin_api_agenda_plage_ouvertures_path(agent_id: agent.id, organisation_id: organisation.id, mixed_with_rdvs: true, format: :json) },
+      { id: "Rdv",            url: admin_api_agenda_rdvs_path(agent_id: agent.id, organisation_id: organisation.id, format: :json) },
+      { id: "Absence",        url: admin_api_agenda_absences_path(agent_id: agent.id, organisation_id: organisation.id, format: :json) },
+      { id: "PlageOuverture", url: admin_api_agenda_plage_ouvertures_path(agent_id: agent.id, organisation_id: organisation.id, mixed_with_rdvs: true, format: :json) },
       OffDays.to_full_calendar_array,
     ]
+    event_sources.push({ id: "ExternalCalendarEvent", url: admin_api_agenda_external_calendar_events_path(agent_id: agent.id, format: :json) }) if agent.caldav_configured?
 
     if @rdv_plan.starts_at
       event_sources << [

--- a/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
+++ b/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
@@ -4,12 +4,14 @@
 
 ruby:
   event_sources = [
-    { id: "Rdv",                    url: admin_api_agenda_rdvs_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, format: :json) },
-    { id: "Absence",                url: admin_api_agenda_absences_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, format: :json) },
-    { id: "ExternalCalendarEvent",  url: admin_api_agenda_external_calendar_events_path(agent_id: @agents.map(&:id), format: :json) },
-    { id: "PlageOuverture",         url: admin_api_agenda_plage_ouvertures_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, mixed_with_rdvs: true, format: :json) },
+    { id: "Rdv",            url: admin_api_agenda_rdvs_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, format: :json) },
+    { id: "Absence",        url: admin_api_agenda_absences_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, format: :json) },
+    { id: "PlageOuverture", url: admin_api_agenda_plage_ouvertures_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, mixed_with_rdvs: true, format: :json) },
   ]
+
+  event_sources.push({ id: "ExternalCalendarEvent", url: admin_api_agenda_external_calendar_events_path(agent_id: @agents.map(&:id), format: :json) }) if @agents.any(&:caldav_configured?)
   event_sources.push(OffDays.to_full_calendar_array) unless current_territory.work_on_sunday?
+
   resources = @agents.map { { id: _1.id, title: _1.full_name_or_email } }
 
 = render partial: "admin/planning/agendas/disconnected_warning"

--- a/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
+++ b/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
@@ -9,7 +9,7 @@ ruby:
     { id: "PlageOuverture", url: admin_api_agenda_plage_ouvertures_path(agent_id: @agents.map(&:id), organisation_id: current_organisation.id, mixed_with_rdvs: true, format: :json) },
   ]
 
-  event_sources.push({ id: "ExternalCalendarEvent", url: admin_api_agenda_external_calendar_events_path(agent_id: @agents.map(&:id), format: :json) }) if @agents.any(&:caldav_configured?)
+  event_sources.push({ id: "ExternalCalendarEvent", url: admin_api_agenda_external_calendar_events_path(agent_id: @agents.map(&:id), format: :json) }) if @agents.any?(&:caldav_configured?)
   event_sources.push(OffDays.to_full_calendar_array) unless current_territory.work_on_sunday?
 
   resources = @agents.map { { id: _1.id, title: _1.full_name_or_email } }

--- a/app/views/admin/planning/agendas/show.html.slim
+++ b/app/views/admin/planning/agendas/show.html.slim
@@ -10,11 +10,12 @@
 
 ruby:
   event_sources = [
-    { id: "Rdv",                    url: admin_api_agenda_rdvs_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json) },
-    { id: "Absence",                url: admin_api_agenda_absences_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json) },
-    { id: "ExternalCalendarEvent",  url: admin_api_agenda_external_calendar_events_path(agent_id: @agent, format: :json) },
-    { id: "PlageOuverture",         url: admin_api_agenda_plage_ouvertures_path(agent_id: @agent, organisation_id: current_organisation.id, mixed_with_rdvs: true, format: :json) },
+    { id: "Rdv",            url: admin_api_agenda_rdvs_path(agent_id: @agent.id, organisation_id: current_organisation.id, format: :json) },
+    { id: "Absence",        url: admin_api_agenda_absences_path(agent_id: @agent.id, organisation_id: current_organisation.id, format: :json) },
+    { id: "PlageOuverture", url: admin_api_agenda_plage_ouvertures_path(agent_id: @agent.id, organisation_id: current_organisation.id, mixed_with_rdvs: true, format: :json) },
   ]
+
+  event_sources.push({ id: "ExternalCalendarEvent", url: admin_api_agenda_external_calendar_events_path(agent_id: @agent.id, format: :json) }) if @agent.caldav_configured?
   event_sources.push(OffDays.to_full_calendar_array) unless current_territory.work_on_sunday?
 
 = render partial: "admin/planning/agendas/disconnected_warning"


### PR DESCRIPTION
Nous avons beaucoup d'appels inutiles vers `Admin::Api::Agenda::ExternalCalendarEventsController#index`.

Avec ce nouveau code, on n'ajoute ce flux aux sources FullCalendar que si l'un des agents a un synchro Caldav. Ça devrait diminuer le nombre d'appels ajax vers cet endpoint de facilement 95%.