### PR TITLE
Ajout d’un client pour requêter l’API ANCT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ docs/domain_model.svg
 
 # Fichiers créés quand on fait un gem build sur une des gems définies dans lib
 lib/**/*.gem
+
+# Added by ggshield
+.cache_ggshield

--- a/app/controllers/api/anct/metrics_controller.rb
+++ b/app/controllers/api/anct/metrics_controller.rb
@@ -2,13 +2,13 @@
 # Cette API est appelée par la cartographie du déploiement de la suite territoriale.
 # Voir docs/interconnexions/carto_anct.md
 #
-class Api::Anct::MetricsController < ActionController::Base # rubocop:disable Rails/ApplicationController
+class Api::ANCT::MetricsController < ActionController::Base # rubocop:disable Rails/ApplicationController
   before_action :authorize_via_shared_secret
 
   rescue_from StandardError, with: :render_json_error
 
   def index
-    all_metrics = CartoAnct.cached_metrics
+    all_metrics = CartoANCT.cached_metrics
 
     paginated_results = all_metrics.drop(params[:offset].presence.to_i || 0)
     paginated_results = paginated_results.take(params[:limit].to_i) if params[:limit].present?

--- a/app/jobs/cron_job/refresh_carto_anct_stats_job.rb
+++ b/app/jobs/cron_job/refresh_carto_anct_stats_job.rb
@@ -1,5 +1,5 @@
-class CronJob::RefreshCartoAnctStatsJob < CronJob
+class CronJob::RefreshCartoANCTStatsJob < CronJob
   def perform
-    CartoAnct.write_cache
+    CartoANCT.write_cache
   end
 end

--- a/app/lib/carto_anct.rb
+++ b/app/lib/carto_anct.rb
@@ -1,7 +1,7 @@
 #
 # Voir docs/interconnexions/carto_anct.md
 #
-module CartoAnct
+module CartoANCT
   CACHE_KEY = "carto_anct_metrics".freeze
 
   def self.cached_metrics

--- a/app/services/espace_operateur_anct.rb
+++ b/app/services/espace_operateur_anct.rb
@@ -1,0 +1,60 @@
+class EspaceOperateurANCT
+  ESPACE_OPERATEUR_SERVICE_ID = "49".freeze
+
+  def initialize(siret, account_email, account_type = "user")
+    raise "Ce service n’est pas utilisable dans cet environnement." unless ENV.fetch("ESPACE_OPERATEUR_ANCT_AUTH_TOKEN", nil)
+
+    @siret = siret
+    @account_email = account_email
+    @account_type = account_type
+  end
+
+  def organization
+    parsed_response&.fetch("organization", nil)
+  end
+
+  def operator
+    parsed_response&.fetch("operator", nil)
+  end
+
+  def can_access?
+    return false unless entitlements
+
+    Rails.logger.debug entitlements
+
+    entitlements["can_access"]
+  end
+
+  def admin?
+    return false unless entitlements
+
+    entitlements["is_admin"]
+  end
+
+  def entitlements
+    parsed_response&.fetch("entitlements", nil)
+  end
+
+  private
+
+  def parsed_response
+    @parsed_response ||= JSON.parse(response.body) if response.success?
+  end
+
+  def client
+    @client ||= Faraday.new(url: "https://operateurs.suite.anct.gouv.fr/api/v1.0/") do |faraday|
+      faraday.headers = {
+        "X-Service-Auth": ENV.fetch("ESPACE_OPERATEUR_ANCT_AUTH_TOKEN", nil),
+      }
+    end
+  end
+
+  def response
+    @response ||= client.get("entitlements/") do |request|
+      request.params["service_id"] = ESPACE_OPERATEUR_SERVICE_ID
+      request.params["siret"] = @siret
+      request.params["account_email"] = @account_email
+      request.params["account_type"] = @account_type
+    end
+  end
+end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -108,7 +108,7 @@ Rails.application.configure do
     },
     refresh_carto_anct_stats: {
       cron: "every day at 06:30 Europe/Paris",
-      class: "CronJob::RefreshCartoAnctStatsJob",
+      class: "CronJob::RefreshCartoANCTStatsJob",
     },
     refresh_cached_stats: {
       cron: "every day at 08:00 Europe/Paris",

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -15,6 +15,7 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.uncountable "created_by"
   inflect.irregular "demande_support", "demandes_support"
   inflect.acronym "IGN"
+  inflect.acronym "ANCT"
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_admin.yml
+++ b/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_admin.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://operateurs.suite.anct.gouv.fr/api/v1.0/entitlements/?account_email=test-admin@example.com&account_type=user&service_id=49&siret=21550050500015
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Service-Auth:
+      - Bearer fake-token
+      User-Agent:
+      - Faraday v2.14.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Authorization: "[Filtered in vcr.rb -> before_record]"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Mar 2026 17:05:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '250'
+      Connection:
+      - keep-alive
+      X-Request-Id:
+      - 98fe3dbf-3bf9-4805-86d8-f42c844ba10d
+      Vary:
+      - Accept, origin, Accept-Language, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Language:
+      - fr-fr
+      Strict-Transport-Security:
+      - max-age=60; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Set-Cookie: "[Filtered in vcr.rb -> before_record]"
+    body:
+      encoding: UTF-8
+      string: '{"organization":{"type":"other","name":"Bezonvaux","oidc_valid":null},"operator":{"id":"f33e9b4b-213f-4db9-8b39-ab17558f2931","name":"TEST","url":null,"config":{}},"entitlements":{"can_access":true,"is_admin":true,"is_admin_resolve_level":"service"}}'
+  recorded_at: Mon, 09 Mar 2026 17:05:01 GMT
+recorded_with: VCR 6.4.0

--- a/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_api_error.yml
+++ b/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_api_error.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://operateurs.suite.anct.gouv.fr/api/v1.0/entitlements/?account_email=contact@mairie-nantes.fr&account_type=aienrustesr&service_id=49&siret=21550050500015
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Service-Auth:
+      - Bearer fake-token
+      User-Agent:
+      - Faraday v2.14.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Authorization: "[Filtered in vcr.rb -> before_record]"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 09 Mar 2026 17:08:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '58'
+      Connection:
+      - keep-alive
+      X-Request-Id:
+      - 92b5d296-3413-451d-9f87-78fe4e1940fc
+      Www-Authenticate:
+      - Bearer realm="api"
+      Vary:
+      - Accept, origin, Accept-Language, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Language:
+      - fr-fr
+      Strict-Transport-Security:
+      - max-age=60; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Set-Cookie: "[Filtered in vcr.rb -> before_record]"
+    body:
+      encoding: UTF-8
+      string: '{"detail":"Informations d''authentification non fournies."}'
+  recorded_at: Mon, 09 Mar 2026 17:08:29 GMT
+recorded_with: VCR 6.4.0

--- a/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_no_access.yml
+++ b/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_no_access.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://operateurs.suite.anct.gouv.fr/api/v1.0/entitlements/?account_email=contact@mairie-nantes.fr&account_type=user&service_id=49&siret=21350238800019
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Service-Auth:
+      - Bearer fake-token
+      User-Agent:
+      - Faraday v2.14.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Authorization: "[Filtered in vcr.rb -> before_record]"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Mar 2026 17:05:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      X-Request-Id:
+      - 2b30ff67-f462-466b-826c-e55b9179fab7
+      Vary:
+      - Accept, origin, Accept-Language, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Language:
+      - fr-fr
+      Strict-Transport-Security:
+      - max-age=60; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Set-Cookie: "[Filtered in vcr.rb -> before_record]"
+    body:
+      encoding: UTF-8
+      string: '{"organization":{"type":"commune","name":"Rennes","oidc_valid":null},"operator":null,"entitlements":{"can_access":false,"can_access_reason":"not_activated"}}'
+  recorded_at: Mon, 09 Mar 2026 17:05:01 GMT
+recorded_with: VCR 6.4.0

--- a/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_success.yml
+++ b/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_success.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://operateurs.suite.anct.gouv.fr/api/v1.0/entitlements/?account_email=contact@mairie-nantes.fr&account_type=user&service_id=49&siret=21550050500015
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Service-Auth:
+      - Bearer fake-token
+      User-Agent:
+      - Faraday v2.14.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Authorization: "[Filtered in vcr.rb -> before_record]"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Mar 2026 17:05:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '247'
+      Connection:
+      - keep-alive
+      X-Request-Id:
+      - 6a54bd02-f959-4b63-ae24-123dcf70e249
+      Vary:
+      - Accept, origin, Accept-Language, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Language:
+      - fr-fr
+      Strict-Transport-Security:
+      - max-age=60; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Set-Cookie: "[Filtered in vcr.rb -> before_record]"
+    body:
+      encoding: UTF-8
+      string: '{"organization":{"type":"other","name":"Bezonvaux","oidc_valid":null},"operator":{"id":"f33e9b4b-213f-4db9-8b39-ab17558f2931","name":"TEST","url":null,"config":{}},"entitlements":{"can_access":true,"is_admin":false,"is_admin_reason":"no_account"}}'
+  recorded_at: Mon, 09 Mar 2026 17:05:01 GMT
+recorded_with: VCR 6.4.0

--- a/spec/lib/carto_anct_spec.rb
+++ b/spec/lib/carto_anct_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe CartoAnct do
+RSpec.describe CartoANCT do
   describe ".fetch_and_merge_metrics" do
     it "merges siret and insee" do
       stub_request(:post, /#{MetabaseApi::HOST_URL}/)

--- a/spec/requests/api/anct/metrics_controller_spec.rb
+++ b/spec/requests/api/anct/metrics_controller_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe "/api/anct/metrics" do
   end
 
   it "works when cached is warmed up" do
-    allow(CartoAnct).to receive(:cached_metrics).and_return(valid_cached_metrics)
+    allow(CartoANCT).to receive(:cached_metrics).and_return(valid_cached_metrics)
     get "/api/anct/metrics", headers: auth_headers
     expect(response.parsed_body["results"].size).to eq(4)
   end
 
   it "allows for offset-based pagination" do
     # On simule 1400 résultats
-    allow(CartoAnct).to receive(:cached_metrics).and_return(1400.times.map { |i| { insee: i.to_s.rjust(5, "0"), metrics: { tu: i * 2 } } })
+    allow(CartoANCT).to receive(:cached_metrics).and_return(1400.times.map { |i| { insee: i.to_s.rjust(5, "0"), metrics: { tu: i * 2 } } })
 
     get "/api/anct/metrics", headers: auth_headers, params: { limit: 800 }
     expect(response.parsed_body["results"].size).to eq(800)
@@ -34,7 +34,7 @@ RSpec.describe "/api/anct/metrics" do
   end
 
   it "returns a 500 with JSON body on error" do
-    allow(CartoAnct).to receive(:cached_metrics).and_raise("boom")
+    allow(CartoANCT).to receive(:cached_metrics).and_raise("boom")
     get "/api/anct/metrics", headers: auth_headers
     expect(response).to have_http_status(:internal_server_error)
     expect(response.body).to eq("{\"error\":\"Erreur interne du serveur\"}")
@@ -42,7 +42,7 @@ RSpec.describe "/api/anct/metrics" do
 
   describe "authentication" do
     before do
-      allow(CartoAnct).to receive(:cached_metrics).and_return(valid_cached_metrics)
+      allow(CartoANCT).to receive(:cached_metrics).and_return(valid_cached_metrics)
     end
 
     context "when providing the correct shared secret" do

--- a/spec/services/espace_operateur_anct_spec.rb
+++ b/spec/services/espace_operateur_anct_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe EspaceOperateurANCT do
+  let(:siret) { "21550050500015" }
+  let(:account_email) { "contact@mairie-nantes.fr" }
+
+  stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: "Bearer fake-token")
+
+  describe "#organization, #operator, #entitlements" do
+    subject(:service) { described_class.new(siret, account_email) }
+
+    around do |example|
+      VCR.use_cassette("espace_operateur_anct/entitlements_success") { example.run }
+    end
+
+    it "retourne l'organisation" do
+      expect(service.organization).to be_present
+    end
+
+    it "retourne l'opérateur" do
+      expect(service.operator).to be_present
+    end
+
+    it "retourne les entitlements" do
+      expect(service.entitlements).to be_present
+    end
+
+    it "n'appelle l'API qu'une fois pour plusieurs méthodes" do
+      service.organization
+      service.operator
+      service.entitlements
+      expect(WebMock).to have_requested(:get, /entitlements/).once
+    end
+  end
+
+  describe "#can_access?" do
+    subject { described_class.new(siret, account_email).can_access? }
+
+    context "quand l'utilisateur a accès" do
+      around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_success") { ex.run } }
+
+      it { is_expected.to be true }
+    end
+
+    context "quand l'utilisateur n'a pas accès" do
+      let(:siret) { "21350238800019" }
+
+      around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_no_access") { ex.run } }
+
+      it { is_expected.to be false }
+    end
+
+    context "quand l'API retourne une erreur" do
+      subject { described_class.new(siret, account_email, "aienrustesr").can_access? }
+
+      around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_api_error") { ex.run } }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#admin?" do
+    subject { described_class.new(siret, account_email).admin? }
+
+    context "quand l'utilisateur est admin" do
+      around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_admin") { ex.run } }
+
+      let(:account_email) { "test-admin@example.com" }
+
+      it { is_expected.to be true }
+    end
+
+    context "quand l'utilisateur n'est pas admin" do
+      around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_success") { ex.run } }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "initialize" do
+    context "sans token d'authentification configuré" do
+      stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: nil)
+
+      it "lève une exception" do
+        expect { described_class.new(siret, account_email) }
+          .to raise_error("Ce service n’est pas utilisable dans cet environnement.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Contexte

Nous allons nous intégrer prochainement avec l’espace opérateur de l’ANCT. Pour cela, nous devons requêter le point d’API `entitlements`. Je propose donc une première PR pour faire un petit service minimaliste permettant de requêter cette API.

Spec de l’API ici : https://docs.numerique.gouv.fr/docs/181ba88b-a1fb-45b0-9a7c-97f12886212b/

Nous n’avons pas d’environnement de test sur l’espace opérateur. On doit alors utiliser la prod pour faire des tests en local. La clef se trouve dans le coffre-fort habituel.

# Solution

- Je me suis inspiré du travail fait sur l’appel API à l’annuaire
- J’en profite au passage pour ajouter l’acronym ANCT (et faire un bon renommage en conséquence)


