### PR TITLE
Correction date relative mail agent

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -4,11 +4,24 @@ module DateHelper
 
     date = date.to_date
     if date == Date.current
-      I18n.t "date.helpers.today"
+      "aujourd’hui"
     elsif date == Date.current + 1
-      I18n.t "date.helpers.tomorrow"
+      "demain"
     else
       I18n.l(date, format: fallback_format)
+    end
+  end
+
+  def relative_date_with_preposition(date, fallback_format = :short)
+    return if date.nil?
+
+    date_obj = date.to_date
+    if date_obj == Date.current
+      "d'aujourd'hui"
+    elsif date_obj == Date.current + 1
+      "de demain"
+    else
+      "du #{I18n.l(date_obj, format: fallback_format)}"
     end
   end
 

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -8,7 +8,7 @@ module DateHelper
     elsif date == Date.current + 1
       "demain"
     else
-      I18n.l(date, format: fallback_format)
+      "le #{I18n.l(date, format: fallback_format)}"
     end
   end
 

--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -27,7 +27,7 @@ class Agents::RdvMailer < ApplicationMailer
   end
 
   def rdv_cancelled(old_starts_at: nil)
-    date = relative_date(old_starts_at || @rdv.starts_at)
+    date = old_starts_at || @rdv.starts_at
     self.ics_payload = @rdv.payload(:destroy, @agent)
     subject = "RDV #{relative_date_with_preposition(date)} annulé"
     mail(subject: subject)

--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -13,7 +13,7 @@ class Agents::RdvMailer < ApplicationMailer
 
   def rdv_created
     self.ics_payload = @rdv.payload(:create, @agent)
-    subject = "Nouveau RDV ajouté sur votre agenda #{domain.name} pour #{relative_date(@rdv.starts_at)}"
+    subject = "Nouveau RDV ajouté pour #{relative_date(@rdv.starts_at)} sur votre agenda #{domain.name}"
     mail(subject: subject)
   end
 
@@ -22,14 +22,14 @@ class Agents::RdvMailer < ApplicationMailer
     @user = @participation.user
     @rdv = @participation.rdv
     self.ics_payload = @rdv.payload(:create, @agent)
-    subject = "Nouvelle participation au RDV collectif sur votre agenda #{domain.name} pour #{relative_date(@rdv.starts_at)}"
+    subject = "Nouvelle participation au RDV collectif #{relative_date_with_preposition(@rdv.starts_at)} sur votre agenda #{domain.name}"
     mail(subject: subject)
   end
 
   def rdv_cancelled(old_starts_at: nil)
     date = relative_date(old_starts_at || @rdv.starts_at)
     self.ics_payload = @rdv.payload(:destroy, @agent)
-    subject = "RDV annulé #{date}"
+    subject = "RDV #{relative_date_with_preposition(date)} annulé"
     mail(subject: subject)
   end
 
@@ -38,7 +38,7 @@ class Agents::RdvMailer < ApplicationMailer
     @user = @participation.user
     @rdv = @participation.rdv
     self.ics_payload = @rdv.payload(:create, @agent)
-    subject = "Participation au RDV collectif annulée sur votre agenda #{domain.name} pour #{relative_date(@rdv.starts_at)}"
+    subject = "Participation au RDV collectif #{relative_date_with_preposition(@rdv.starts_at)} annulée sur votre agenda #{domain.name}"
     mail(subject: subject)
   end
 
@@ -46,7 +46,7 @@ class Agents::RdvMailer < ApplicationMailer
     @old_starts_at = old_starts_at
     @address_name = Lieu.find(lieu_id).full_name if lieu_id
     self.ics_payload = @rdv.payload(:update, @agent)
-    subject = "RDV du #{relative_date(@old_starts_at)} modifié"
+    subject = "RDV #{relative_date_with_preposition(@old_starts_at)} modifié"
     mail(subject: subject)
   end
 

--- a/app/mailers/agents/reply_transfer_mailer.rb
+++ b/app/mailers/agents/reply_transfer_mailer.rb
@@ -12,7 +12,7 @@ class Agents::ReplyTransferMailer < ApplicationMailer
     @reply_subject = source_mail.subject
     @reply_body = reply_body
     @attachment_names = source_mail.attachments.map(&:filename).join(", ")
-    @date = relative_date(@rdv.starts_at)
+    @date = relative_date_with_preposition(@rdv.starts_at)
 
     mail(to: agents.map(&:email), subject: t(".title", date: @date))
   end
@@ -27,9 +27,9 @@ class Agents::ReplyTransferMailer < ApplicationMailer
     @reply_subject = source_mail.subject
     @reply_body = reply_body
     @attachment_names = source_mail.attachments.map(&:filename).join(", ")
-    @date = relative_date(@rdv.starts_at)
+    @date = relative_date_with_preposition(@rdv.starts_at)
 
-    mail(to: organisation.email, subject: "Message d'usager⋅e au sujet d’un RDV du #{@date}")
+    mail(to: organisation.email, subject: "Message d'usager⋅e au sujet d’un RDV #{@date}")
   end
 
   # @param [String] reply_body

--- a/app/views/mailers/agents/rdv_mailer/participation_cancelled.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/participation_cancelled.html.slim
@@ -1,7 +1,6 @@
 div
   p= t("mailers.common.hello")
   p
-    - date = relative_date(@rdv.starts_at)
     - author = @author.full_name
     - if @author == @agent
       | Vous avez annulé la participation de #{@participation.user} au RDV collectif le #{l(@rdv.starts_at, format: :short)}.

--- a/app/views/mailers/agents/rdv_mailer/rdv_updated.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_updated.html.slim
@@ -1,7 +1,7 @@
 div
   p Bonjour,
   p
-    | Un de vos RDV qui devait avoir lieu le #{relative_date @old_starts_at} à #{l(@old_starts_at, format: "%H:%M")}
+    | Un de vos RDV qui devait avoir lieu #{relative_date @old_starts_at} à #{l(@old_starts_at, format: "%H:%M")}
     = " à l'adresse #{@address_name}" if @address_name
     |  a été modifié par #{@author.full_name}.
   p Veuillez prendre note des nouvelles informations.

--- a/app/views/mailers/agents/reply_transfer_mailer/notify_organisation.html.slim
+++ b/app/views/mailers/agents/reply_transfer_mailer/notify_organisation.html.slim
@@ -2,7 +2,7 @@ div
   p
     | Bonjour,
   p
-    | Dans le cadre du RDV du #{@date} avec #{@rdv.agents.map(&:short_name).sort.to_sentence}, l'usager⋅e #{@author} a envoyé la réponse suivante par e-mail :
+    | Dans le cadre du RDV #{@date} avec #{@rdv.agents.map(&:short_name).sort.to_sentence}, l'usager⋅e #{@author} a envoyé la réponse suivante par e-mail :
   blockquote
     h4 = @reply_subject
     div = simple_format(@reply_body)

--- a/app/views/mailers/users/rdv_mailer/rdv_updated.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_updated.html.slim
@@ -1,7 +1,7 @@
 div
   p Bonjour,
   p
-    | Votre RDV qui devait avoir lieu le #{relative_date @old_starts_at} à #{l(@old_starts_at, format: "%H:%M")}
+    | Votre RDV qui devait avoir lieu #{relative_date @old_starts_at} à #{l(@old_starts_at, format: "%H:%M")}
     = " à l'adresse #{@address_name}" if @address_name
     |  a été modifié.
   p Veuillez prendre note des nouvelles informations.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -68,8 +68,6 @@ fr:
           subject: Export des RDVs par usager du %{date}
   date:
     helpers:
-      tomorrow: demain
-      today: aujourd’hui
       yesterday: hier
     abbr_day_names:
     - dim

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -40,7 +40,7 @@ fr:
     reply_transfer_mailer:
       notify_agent_of_user_reply:
         title: Message d'usager⋅e au sujet de votre RDV %{date}
-        intro: "Dans le cadre du RDV du %{date}, l'usager⋅e %{author} a envoyé la réponse suivante par e-mail :"
+        intro: "Dans le cadre du RDV %{date}, l'usager⋅e %{author} a envoyé la réponse suivante par e-mail :"
         instructions: Merci de ne pas répondre à cet e-mail. Vous pouvez contacter l'usager⋅e à l'aide des informations inclues dans le RDV.
       forward_to_default_mailbox:
         title: Message d'usager⋅e en réponse à un e-mail de notification
@@ -68,4 +68,4 @@ fr:
         title: Participation annulée au RDV du %{date} avec %{organisation}
   prescripteurs_mailer:
     rdv_created:
-      title: RDV confirmé le %{date}
+      title: RDV confirmé pour %{date}

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     emails = ActionMailer::Base.deliveries
     expect(emails.size).to eq(2)
     expect(emails.map { [_1.to, _1.subject] }).to include([["newaddress@exemple.com"], a_string_matching(/RDV confirmé le/)])
-    expect(emails.map { [_1.to, _1.subject] }).to include([[agent.email], a_string_matching(/Nouveau RDV ajouté sur votre agenda/)])
+    expect(emails.map { [_1.to, _1.subject] }).to include([[agent.email], a_string_matching(/Nouveau RDV ajouté pour .+ sur votre agenda/)])
 
     expect(page).to have_content("Retour sur Démarches Simplifiées")
   end

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Agent can create a Rdv collectif from the agenda" do
     sleep 1
     perform_enqueued_jobs
     open_email("alain@tiptop.fr")
-    expect(current_email.subject).to include("Nouveau RDV ajouté sur votre agenda RDV Service Public")
+    expect(current_email.subject).to match(/Nouveau RDV ajouté pour .+ sur votre agenda RDV Service Public/)
 
     rdv = Rdv.last
     expect(rdv.users.count).to eq(0)

--- a/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
+++ b/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "prescripteur can add a user to a RDV collectif" do
     )
 
     perform_enqueued_jobs(only: ApplicationMailerDeliveryJob)
-    expect(first_email_sent_to(agent.email).subject).to include("Nouvelle participation au RDV collectif sur votre agenda RDV Service Public")
+    expect(first_email_sent_to(agent.email).subject).to match(/Nouvelle participation au RDV collectif .+ sur votre agenda RDV Service Public/)
     expect(first_email_sent_to("alex@prescripteur.fr").subject).to include("RDV confirmé")
     expect(first_email_sent_to("alex@prescripteur.fr").body).to include("RDV Aide Numérique")
 

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "un prescripteur peut prendre rendez-vous pour un usager" do
     expect(created_rdv.versions.first.whodunnit).to eq("[Prescripteur] Alex PRESCRIPTEUR")
 
     perform_enqueued_jobs(only: ApplicationMailerDeliveryJob)
-    expect(first_email_sent_to(agent.email).subject).to include("Nouveau RDV ajouté sur votre agenda RDV Service Public")
+    expect(first_email_sent_to(agent.email).subject).to match(/Nouveau RDV ajouté pour .+ sur votre agenda RDV Service Public/)
     expect(first_email_sent_to("alex@prescripteur.fr").subject).to include("RDV confirmé")
     expect(first_email_sent_to("alex@prescripteur.fr").body).to include("RDV Aide Numérique")
 

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe "Adding a user to a collective RDV" do
 
         perform_enqueued_jobs
 
-        expect_notifications_sent_for(user, :rdv_created, :mail) # pas de SMS car le RDV est dans plus de 48h
+        expect_notifications_sent_for(rdv, user, :rdv_created, :mail) # pas de SMS car le RDV est dans plus de 48h
 
         expect_webhooks_for(user)
       end

--- a/spec/features/users/user_can_manage_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_rdv_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe "User can manage their rdvs" do
           # Check Notifications
           perform_enqueued_jobs
           deliveries = ActionMailer::Base.deliveries
-          expect(deliveries.any? { |mail| mail.to == [agent1.email] && mail.subject == "RDV annulé #{relative_date(original_date)}" }).to be true
+          expect(deliveries.any? { |mail| mail.to == [agent1.email] && mail.subject == "RDV #{relative_date_with_preposition(original_date)} annulé" }).to be true
           expect(deliveries.any? do |mail|
-                   mail.to == [agent2.email] && mail.subject == "Nouveau RDV ajouté sur votre agenda RDV Service Public pour #{relative_date(rdv.reload.starts_at)}"
+                   mail.to == [agent2.email] && mail.subject == "Nouveau RDV ajouté pour #{relative_date(rdv.reload.starts_at)} sur votre agenda RDV Service Public"
                  end).to be true
           expect(deliveries.any? { |mail| mail.to == [user.email] && mail.subject == "RDV du #{I18n.l(original_date, format: :human)} modifié" }).to be true
         end

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe DateHelper do
     end
   end
 
+  describe "#relative_date_with_preposition" do
+    it "returns du 23 déc." do
+      date = Time.zone.parse("2021-12-23 15:30")
+      expect(relative_date_with_preposition(date)).to eq("du 23 déc.")
+    end
+
+    it "returns d'aujourd'hui" do
+      expect(relative_date_with_preposition(Time.zone.now)).to eq("d'aujourd'hui")
+    end
+
+    it "returns de demain" do
+      expect(relative_date_with_preposition(Time.zone.tomorrow)).to eq("de demain")
+    end
+  end
+
   describe "#soon_date?" do
     it "return false" do
       date = Time.zone.parse("2021-12-23 15:30")

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe DateHelper do
     # def relative_date(date, fallback_format = :short)
     it "returns 23 déc." do
       date = Time.zone.parse("2021-12-23 15:30")
-      expect(relative_date(date)).to eq("23 déc.")
+      expect(relative_date(date)).to eq("le 23 déc.")
     end
     # def relative_date(date, fallback_format = :short)
 

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
       let(:rdv) { create(:rdv, starts_at: t + 10.minutes, agents: [agent]) }
 
       it "has a correct subject" do
-        expect(mail.subject).to eq("Nouveau RDV ajouté sur votre agenda RDV Service Public pour aujourd’hui")
+        expect(mail.subject).to eq("Nouveau RDV ajouté pour aujourd’hui sur votre agenda RDV Service Public")
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
       let(:rdv) { create(:rdv, starts_at: t + 1.day, agents: [agent]) }
 
       it "has a correct subject" do
-        expect(mail.subject).to eq("Nouveau RDV ajouté sur votre agenda RDV Service Public pour demain")
+        expect(mail.subject).to eq("Nouveau RDV ajouté pour demain sur votre agenda RDV Service Public")
       end
     end
 
@@ -110,7 +110,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
 
     specify do
       mail = described_class.with(agent:, participation:, author: agent_author).participation_cancelled
-      expect(mail.subject).to eq("Participation au RDV collectif annulée sur votre agenda RDV Service Public pour 13 nov.")
+      expect(mail.subject).to eq("Participation au RDV collectif du 13 nov. annulée sur votre agenda RDV Service Public")
       expect(mail.html_part.body.to_s).to include("La participation de Marcia LOPEZ au RDV collectif le jeudi 13/11 à 10h30 a été annulée par Paola NORI")
     end
   end

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
       end
     end
 
+    context "in 3 days" do
+      let(:rdv) { create(:rdv, starts_at: t + 3.days, agents: [agent]) }
+
+      it "has a correct subject" do
+        expect(mail.subject).to eq("Nouveau RDV ajouté pour le 4 mar. sur votre agenda RDV Service Public")
+      end
+    end
+
     describe "using the agent domain's branding" do
       context "when agent's service is not conseiller_numerique" do
         let(:agent) { build(:agent, service: build(:service, :social)) }

--- a/spec/support/notifications_helper.rb
+++ b/spec/support/notifications_helper.rb
@@ -78,13 +78,13 @@ module NotificationsHelper
   def email_title_for_agent(rdv, person, event)
     case event
     when :participation_created
-      "Nouvelle participation au RDV collectif sur votre agenda #{person.domain.name} pour #{relative_date(rdv.starts_at)}"
+      "Nouvelle participation au RDV collectif #{relative_date_with_preposition(rdv.starts_at)} sur votre agenda #{person.domain.name}"
     when :rdv_created
-      "Nouveau RDV ajouté sur votre agenda #{person.domain.name} pour #{relative_date(rdv.starts_at)}"
+      "Nouveau RDV ajouté pour #{relative_date(rdv.starts_at)} sur votre agenda #{person.domain.name}"
     when :rdv_cancelled
-      "RDV annulé #{relative_date(rdv.starts_at)}"
+      "RDV #{relative_date_with_preposition(rdv.starts_at)} annulé"
     when :participation_cancelled
-      "Participation au RDV collectif annulée sur votre agenda #{person.domain.name} pour #{relative_date(rdv.starts_at)}"
+      "Participation au RDV collectif #{relative_date_with_preposition(rdv.starts_at)} annulée sur votre agenda #{person.domain.name}"
     when :rdv_updated
       # Maybe not enough precision here (because specific design choice), the date used for agents rdv update is the previsous date of the rdv
       "modifié"


### PR DESCRIPTION
# Contexte

Suite à un retour d’Eva, je me suis rendu compte que les dates relatives dans l’objet de courriel côté agent étaient incorrectes : 

<img width="796" height="186" alt="image" src="https://github.com/user-attachments/assets/2a81a80d-ab7b-4887-aa0b-6dd1b0e1a132" />

Les objets des mails de notification aux agents contenaient des tournures incorrectes en français. Par exemple, "RDV du demain modifié" ou "RDV annulé demain" au lieu de "RDV de demain modifié". On avait également des « RDV confirmé le demain » ou « RDV ajouté pour 24 mars ».

Plus généralement, l'ordre des mots et les prépositions n'étaient pas cohérents selon que la date était relative ("demain", "aujourd'hui") ou absolue ("15 mar.").

# Solution

**Modification de `relative_date` dans `DateHelper`**

Les dates absolues retournent désormais `"le 15 mar."` au lieu de `"15 mar."`, ce qui permet une insertion directe dans une phrase sans avoir à gérer l'article à l'extérieur du helper.

**Ajout de `relative_date_with_preposition` dans `DateHelper`**

Nouveau helper qui retourne la date précédée de la bonne préposition selon le contexte :
- `"d'aujourd'hui"` pour aujourd'hui (élision devant voyelle)
- `"de demain"` pour demain
- `"du 15 mar."` pour une date absolue

**Mise à jour des sujets des mails agents (`Agents::RdvMailer`)**

Les sujets utilisent désormais ce helper pour produire des formulations correctes :
- `"RDV de demain modifié"` / `"RDV du 15 mar. modifié"`
- `"RDV de demain annulé"` / `"RDV du 15 mar. annulé"`
- `"Nouveau RDV ajouté pour demain sur votre agenda …"`
- `"Nouvelle participation au RDV collectif de demain sur votre agenda …"`
- `"Participation au RDV collectif de demain annulée sur votre agenda …"`
