### PR TITLE
Retire de la CSP "*.bootstrapcdn.com"

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,8 +12,6 @@ tiles_etalab = "etalab-tiles.fr"
 unpkg_cdn = "unpkg.com"
 tiles_osm = "tile.openstreetmap.org"
 tiles_data_gouv = "openmaptiles.data.gouv.fr"
-# Utilisé sur nos pages statiques (404.html, 500.html)
-bootstrap_cdn = "*.bootstrapcdn.com"
 # Metabase permet d’embedder des rapports dans l’application
 metabase = "rdv-service-public-metabase.osc-secnum-fr1.scalingo.io"
 # La suite (pour afficher les services dans la gaufre)
@@ -39,7 +37,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.child_src :blob, :self
   policy.frame_src :self, metabase
   policy.img_src :self, :data, :blob, tiles_osm, tiles_data_gouv, lasuite
-  policy.style_src :self, :unsafe_inline, bootstrap_cdn, unpkg_cdn
+  policy.style_src :self, :unsafe_inline, unpkg_cdn
   policy.connect_src :self, api_adresse_ign, tiles_etalab, tiles_data_gouv, lasuite
 
   policy.script_src :self, mapbox_js_sha, maplibre_js_sha, *swagger_shas


### PR DESCRIPTION
Ce domaine aurait dû être retiré dans #4480 car il était uniquement utilisé par nos anciennes pages d'erreur, sous cette forme : 

```html
  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
```

https://github.com/betagouv/rdv-service-public/pull/4480/changes#diff-610a13470dd84dcd7e487bc1a574c58f428a826c40bbeaadabb49f69af08b95eL8