### PR TITLE
On réduit un peu la place du nom des services dans le menu

### DIFF
--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -21,7 +21,7 @@ nav.left-side-menu-wrapper
                 div.d-flex.flex-column
                   = current_organisation.name
                   - if navigation_scoped_by_agent_services?(current_agent, current_organisation)
-                    span= current_agent.services_short_names
+                    span.fr-text--xs.fr-mb-0= current_agent.services_short_names
               - if current_agent.organisations_count > 1
                 div.d-flex.align-items-center
                   = icon("fr-icon-arrow-down-s-line", class: "menu-arrow")


### PR DESCRIPTION
# Contexte

On s'aperçoit que pour certains agents, les noms des services qui sont présents dans le menu de gauche prennent beaucoup de place. Comme discuté avec Victor, il s'agit d'un élément important de contexte pour beaucoup d'organisations. On ne peut donc pas se séparer de celui-ci.

Avec Mehdi, on propose donc de garder le sujet du positionnement de cet élément pour plus tard, lorsque nous repenserons la navigation latérale. Mais en attendant, on souhaite quand même proposer un quick win.
 
# Solution

Je propose donc d'utiliser une typo plus petite pour les services.

## Captures d'écran

Avant | Après
:- | -:
<img width="514" height="335" alt="image" src="https://github.com/user-attachments/assets/f57671e1-cff3-4a40-9075-318f2a979979" /> | <img width="486" height="317" alt="image" src="https://github.com/user-attachments/assets/c522a188-0c72-49b7-802c-ed70ff0bc528" />
