### PR TITLE
Permettre aux espaces de désactiver les stats publiques (1/2)

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -6,8 +6,6 @@ class StatsController < ApplicationController
 
   def lieux_map_data
     render(json: Rails.cache.fetch("stats.both_instances.lieux_map_data") || [])
-  rescue MetabaseApi::Error => e
-    render(json: { error: e.message }, status: :internal_server_error)
   end
 
   def territories

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -9,14 +9,17 @@ class StatsController < ApplicationController
   end
 
   def territories
+    raise "listing territories"
     @territories = Territory.where(public_stats: true)
   end
 
   def territory
+    raise "seeing territory"
     @stats = Stat.new(agents: @agents, organisations: @organisations, rdvs: @rdvs, users: @users, receipts: @receipts)
   end
 
   def territory_rdvs
+    raise "seeing territory rdv"
     cache_key = ["stats_rdvs", request.query_parameters, Time.zone.today]
     chart_json = Rails.cache.fetch(cache_key, expires_in: 24.hours) do
       stats = Stat.new(rdvs: @rdvs)

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -9,7 +9,7 @@ class StatsController < ApplicationController
   end
 
   def territories
-    @territories = Territory.all
+    @territories = Territory.where(public_stats: true)
   end
 
   def territory
@@ -39,7 +39,7 @@ class StatsController < ApplicationController
   private
 
   def set_territory_and_records
-    @territory = Territory.find(params[:territory])
+    @territory = Territory.where(public_stats: true).find(params[:territory])
     @rdvs = @territory.rdvs
     @users = @territory.users
     @organisations = @territory.organisations

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -9,17 +9,14 @@ class StatsController < ApplicationController
   end
 
   def territories
-    raise "listing territories"
     @territories = Territory.where(public_stats: true)
   end
 
   def territory
-    raise "seeing territory"
     @stats = Stat.new(agents: @agents, organisations: @organisations, rdvs: @rdvs, users: @users, receipts: @receipts)
   end
 
   def territory_rdvs
-    raise "seeing territory rdv"
     cache_key = ["stats_rdvs", request.query_parameters, Time.zone.today]
     chart_json = Rails.cache.fetch(cache_key, expires_in: 24.hours) do
       stats = Stat.new(rdvs: @rdvs)

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -318,6 +318,7 @@ tables:
       - category
       - work_on_sunday
       - operator_id
+      - public_stats
 
   # Tables sans données personnelles
   - table_name: agent_territorial_roles

--- a/db/migrate/20260313100202_add_public_stats_to_territories.rb
+++ b/db/migrate/20260313100202_add_public_stats_to_territories.rb
@@ -1,0 +1,5 @@
+class AddPublicStatsToTerritories < ActiveRecord::Migration[8.0]
+  def change
+    add_column :territories, :public_stats, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260313100202_add_public_stats_to_territories.rb
+++ b/db/migrate/20260313100202_add_public_stats_to_territories.rb
@@ -1,5 +1,5 @@
 class AddPublicStatsToTerritories < ActiveRecord::Migration[8.0]
   def change
-    add_column :territories, :public_stats, :boolean, default: false, null: false
+    add_column :territories, :public_stats, :boolean, default: true, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -774,7 +774,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_13_100202) do
     t.boolean "enable_address_field", default: false
     t.boolean "work_on_sunday", default: false
     t.bigint "operator_id"
-    t.boolean "public_stats", default: false, null: false
+    t.boolean "public_stats", default: true, null: false
     t.index ["departement_number"], name: "index_territories_on_departement_number", where: "((departement_number)::text <> ''::text)"
     t.index ["operator_id"], name: "index_territories_on_operator_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_04_145918) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_13_100202) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -535,8 +535,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_04_145918) do
     t.boolean "ants_connectable", default: false, null: false, comment: "Autorise l'organisation à être branchée sur le moteur de recherche de l'ANTS sur https://rendezvouspasseport.ants.gouv.fr/. Pour éviter de brancher n'importe qui sur ce moteur de recherche, cette option n'est pas activable par les agents.\n"
     t.boolean "online_booking_for_particuliers", default: true, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des particuliers, et donc qu'on propose le bouton FranceConnect lors de la prise de rendez-vous en ligne.\n"
     t.boolean "online_booking_for_professionnels", default: false, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des professionnels, et donc qu'on propose le bouton ProConnect lors de la prise de rendez-vous en ligne.\n"
-    t.string "time_zone", default: "Europe/Paris", null: false
     t.datetime "disabled_at", comment: "Date de fermeture de l'organisation"
+    t.string "time_zone", default: "Europe/Paris", null: false
     t.string "public_link_id", null: false
     t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["name", "territory_id"], name: "index_organisations_on_name_and_territory_id", unique: true
@@ -774,6 +774,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_04_145918) do
     t.boolean "enable_address_field", default: false
     t.boolean "work_on_sunday", default: false
     t.bigint "operator_id"
+    t.boolean "public_stats", default: false, null: false
     t.index ["departement_number"], name: "index_territories_on_departement_number", where: "((departement_number)::text <> ''::text)"
     t.index ["operator_id"], name: "index_territories_on_operator_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -535,8 +535,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_13_100202) do
     t.boolean "ants_connectable", default: false, null: false, comment: "Autorise l'organisation à être branchée sur le moteur de recherche de l'ANTS sur https://rendezvouspasseport.ants.gouv.fr/. Pour éviter de brancher n'importe qui sur ce moteur de recherche, cette option n'est pas activable par les agents.\n"
     t.boolean "online_booking_for_particuliers", default: true, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des particuliers, et donc qu'on propose le bouton FranceConnect lors de la prise de rendez-vous en ligne.\n"
     t.boolean "online_booking_for_professionnels", default: false, null: false, comment: "Indique que l'organisation gère des rendez-vous avec des professionnels, et donc qu'on propose le bouton ProConnect lors de la prise de rendez-vous en ligne.\n"
-    t.datetime "disabled_at", comment: "Date de fermeture de l'organisation"
     t.string "time_zone", default: "Europe/Paris", null: false
+    t.datetime "disabled_at", comment: "Date de fermeture de l'organisation"
     t.string "public_link_id", null: false
     t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["name", "territory_id"], name: "index_organisations_on_name_and_territory_id", unique: true

--- a/spec/features/anybody/anybody_can_see_stats_spec.rb
+++ b/spec/features/anybody/anybody_can_see_stats_spec.rb
@@ -21,6 +21,19 @@ RSpec.describe "Anybody can see stats" do
     end
 
     it "lists the territories that are willing to publish public stats" do
+      visit stats_territories_path
+
+      expect(page).to have_content "Territoire public"
+      expect(page).not_to have_content "Territoire secret"
+
+      click_on "Territoire public"
+      expect(page).to have_content "Nombre de RDV par statut"
+    end
+
+    it "doesn't allow seeing the stats of a territory that has disabled public stats" do
+      expect do
+        visit stats_territory_path(territory: territory_without_stats.id)
+      end.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/features/anybody/anybody_can_see_stats_spec.rb
+++ b/spec/features/anybody/anybody_can_see_stats_spec.rb
@@ -10,4 +10,17 @@ RSpec.describe "Anybody can see stats" do
     # cette page contient l’iframe metabase
     expect(page).to have_css("iframe")
   end
+
+  describe "stats by territories" do
+    let!(:territory_with_stats) do
+      create(:territory, public_stats: true, name: "Territoire public")
+    end
+
+    let!(:territory_without_stats) do
+      create(:territory, public_stats: false, name: "Territoire secret")
+    end
+
+    it "lists the territories that are willing to publish public stats" do
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

Dans certains contextes où l'information est sensible, les agents nous demandent de ne pas publier les informations sur leur structure. Ça a été identifié comme le dernier obstacle à la généralisation dans le cas d'un service d'un ministère.

# Solution

Après discussion avec Téo, on s'est dit que le compromis le plus raisonnable était d'ajouter la fonctionnalité pour ce cas sans l'exposer dans l'interface, mais de se garder cette option pour plus tard.

Il faudra aussi modifier la requête metabase pour prendre en compte ce nouveau flag une fois que l'etl aura tourné (prévu dans la pr suivante : https://github.com/betagouv/rdv-service-public/pull/6248)

# Implémentation

au passage je me suis rendu compte qu'on n'avait pas du tout de spec pour ces deux pages donc je les ai ajoutées

