### PR TITLE
Faciliter la suppression d'organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -21,7 +21,7 @@ class Organisation < ApplicationRecord
   has_many :sector_attributions, dependent: :destroy
   has_many :plage_ouvertures, dependent: :destroy
   has_many :agent_roles, dependent: :delete_all # skips last admin validation
-  has_many :user_profiles, dependent: :restrict_with_error
+  has_many :user_profiles, dependent: :destroy
   has_many :external_references, as: :item, dependent: :destroy
 
   # Through relations


### PR DESCRIPTION
# Contexte

On a eu un cas particulier d'agent qui nous a demandé de supprimer une organisation via le support. Cette règle a empêché la suppression normale via le super admin, et a nécessité une interventio nd'un dev en console.

Elle a été ajoutée à une époque où on avait beaucoup plus d'informations sur les user_profiles, et maintenant c'est safe de la supprimer.
Ça permettra de faire cette opération plus facilement la prochaine fois.

J'ai hésité à changer aussi la règle sur les rdvs, mais je me dis que c'est mieux que pour une organisation avec des rendez-vous, on ai un peu plus de friction pour éviter des suppressions par erreur.

