### PR TITLE
Bugfix: crash du job CalDAV quand un RDV est supprimé

### DIFF
--- a/app/jobs/caldav/export_rdv_to_caldav_job.rb
+++ b/app/jobs/caldav/export_rdv_to_caldav_job.rb
@@ -10,32 +10,41 @@ module Caldav
     def perform(agents_rdv_id, agent_id, caldav_event_url: nil)
       @agents_rdv_id = agents_rdv_id
       @agent_id = agent_id
-
-      return unless agent
+      return unless agent&.caldav_configured?
 
       Sentry.set_user({ id: agent.id, role: "Agent", email: agent.email })
 
-      return unless agent.caldav_configured?
-
-      if caldav_event_url.present?
-        if agents_rdv
-          ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(:update, agents_rdv.agent)).to_ical
-          agent.caldav_client.events.update(caldav_event_url, ics)
+      if agents_rdv
+        if agents_rdv.caldav_url
+          update_event
         else
-          agent.caldav_client.events.delete(caldav_event_url)
+          create_event
         end
-      else
-        ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(:create, agents_rdv.agent)).to_ical
-        identifier = "agents_rdv-#{agents_rdv.id}.ics"
-        event = agent.caldav_client.events.create(agent.caldav_agenda_url, identifier, ics)
-        # Le provider Caldav n’utilise pas forcément l’identifiant qu’on lui donne pour créer l’event
-        # on stocke donc l’url complète de l’event créé pour être sûr de pouvoir le retrouver.
-        # On utilise update_columns pour éviter de déclencher des callbacks
-        agents_rdv.update_columns(caldav_url: event.url) # rubocop:disable Rails/SkipsModelValidations
+      elsif caldav_event_url
+        delete_event(caldav_event_url)
       end
     end
 
     private
+
+    def create_event
+      ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(:create, agents_rdv.agent)).to_ical
+      identifier = "agents_rdv-#{agents_rdv.id}.ics"
+      event = agent.caldav_client.events.create(agent.caldav_agenda_url, identifier, ics)
+      # Le provider Caldav n’utilise pas forcément l’identifiant qu’on lui donne pour créer l’event
+      # on stocke donc l’url complète de l’event créé pour être sûr de pouvoir le retrouver.
+      # On utilise update_columns pour éviter de déclencher des callbacks
+      agents_rdv.update_columns(caldav_url: event.url) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    def update_event
+      ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(:update, agents_rdv.agent)).to_ical
+      agent.caldav_client.events.update(agents_rdv.caldav_url, ics)
+    end
+
+    def delete_event(caldav_event_url)
+      agent.caldav_client.events.delete(caldav_event_url)
+    end
 
     def agent
       @agent ||= Agent.find_by_id(@agent_id)

--- a/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
+++ b/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe Caldav::ExportRdvToCaldavJob do
+  let(:agent) { create(:agent, :with_caldav_config) }
+  let(:agents_rdv) { create(:agents_rdv, agent:) }
+  let(:caldav_client) { instance_double(Calendav::Client, events: caldav_events) }
+  let(:caldav_events) { instance_double(Calendav::Clients::EventsClient) }
+  let(:ics_formatter) { instance_double(Icalendar::Calendar, to_ical: "BEGIN:VCALENDAR...") }
+
+  before do
+    allow_any_instance_of(Agent).to receive(:caldav_client).and_return(caldav_client) # rubocop:disable RSpec/AnyInstance
+    allow(IcalFormatters::Ics).to receive(:from_payload).and_return(ics_formatter)
+  end
+
+  context "quand l'agent n'existe pas" do
+    it "ne fait rien" do
+      expect(caldav_events).not_to receive(:create)
+      described_class.new.perform(agents_rdv.id, -1)
+    end
+  end
+
+  context "quand l'agent n'a pas de config caldav" do
+    let(:agent) { create(:agent) }
+
+    it "ne fait rien" do
+      expect(caldav_client).not_to receive(:events)
+      described_class.new.perform(agents_rdv.id, agent.id)
+    end
+  end
+
+  context "quand l'agents_rdv existe sans caldav_url (création)" do
+    let(:created_event) { instance_double(Calendav::Event, url: "https://caldav.example.com/event.ics") }
+
+    before { allow(caldav_events).to receive(:create).and_return(created_event) }
+
+    it "crée l'événement sur le serveur caldav" do
+      expect(caldav_events).to receive(:create).with(agent.caldav_agenda_url, "agents_rdv-#{agents_rdv.id}.ics", "BEGIN:VCALENDAR...")
+      described_class.new.perform(agents_rdv.id, agent.id)
+    end
+
+    it "enregistre l'url de l'événement créé sur l'agents_rdv" do
+      described_class.new.perform(agents_rdv.id, agent.id)
+      expect(agents_rdv.reload.caldav_url).to eq("https://caldav.example.com/event.ics")
+    end
+  end
+
+  context "quand l'agents_rdv existe avec une caldav_url (mise à jour)" do
+    let(:agents_rdv) { create(:agents_rdv, agent:, caldav_url: "https://caldav.example.com/event.ics") }
+
+    before { allow(caldav_events).to receive(:update) }
+
+    it "met à jour l'événement sur le serveur caldav" do
+      expect(caldav_events).to receive(:update).with("https://caldav.example.com/event.ics", "BEGIN:VCALENDAR...")
+      described_class.new.perform(agents_rdv.id, agent.id)
+    end
+  end
+
+  context "quand l'agents_rdv n'existe plus et qu'un caldav_event_url est fourni (suppression)" do
+    let(:caldav_event_url) { "https://caldav.example.com/event.ics" }
+
+    before { allow(caldav_events).to receive(:delete) }
+
+    it "supprime l'événement sur le serveur caldav" do
+      expect(caldav_events).to receive(:delete).with(caldav_event_url)
+      described_class.new.perform(-1, agent.id, caldav_event_url:)
+    end
+  end
+
+  context "quand l'agents_rdv n'existe plus et qu'aucun caldav_event_url n'est fourni" do
+    it "ne fait rien" do
+      expect(caldav_client).not_to receive(:events)
+      described_class.new.perform(-1, agent.id)
+    end
+  end
+end


### PR DESCRIPTION
Erreur Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/242538

# Contexte

Lorsqu'on a enqueue un job `Caldav::ExportRdvToCaldavJob` puis que le `Rdv` et / ou le `AgentsRdv` est supprimé avant que le job ne soit exécuté, on rencontre cette erreur : 

```
undefined method 'rdv' for nil (NoMethodError)

        ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(:create, agents_rdv.agent)).to_ical
                                                         ^^^^
```

En effet, on était dans un cas où on n'avais pas passer de `caldav_event_url` au job. Or, on interprète l'abesnce de ce paramètre comme une indication de besoin de créer l'événement distant. 

Ceci semble être une erreur de logique, car ma compréhension de ce paramètre, c'est qu'il nous sert uniquement dans le cas d'une suppression, quand on doit supprimer l'événement distant via son URL mais qu'on a plus de RDV en base. J'en arrive à cette conclusion car je me dis que, si on a bel et bien un `AgentsRdv` en base, alors il vaut mieux se baser sur la valeur de son `caldav_url` qui est une source de vérité, plutôt que sur le paramètre de job `caldav_event_url`, qui peut devenir obsolète.

# Solution

Je propose donc de changer la logique du job en 

```ruby
if agents_rdv
  if agents_rdv.caldav_url
    update_event
  else
    create_event
  end
elsif caldav_event_url
  delete_event(caldav_event_url)
end
```

alors qu'avant c'était

```ruby
if caldav_event_url
  if agents_rdv
    update_event
  else
    delete_event
  end
else
  create_event
end
```

Au passage j'ajoute une spec sur le job. 