### PR TITLE
Correctif du calcul de créneaux pour les plages d'ouverture où le deuxième bloc est avant le premier

### DIFF
--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -148,7 +148,7 @@ module RecurrenceConcern
     occurrences = []
     occurrences << occurrence_in_range(starts_at, ends_at, inclusive_datetime_range)
     occurrences << occurrence_in_range(secondary_starts_at, secondary_end_time.on(first_day), inclusive_datetime_range) if secondary_times_present?
-    occurrences.compact
+    occurrences.compact.sort
   end
 
   def compute_occurrences_for(montrose_recurrence, duration, inclusive_datetime_range)

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -21,6 +21,7 @@ class CreneauxSearch::Calculator
 
     @datetime_range = CreneauxSearch::Range.ensure_date_range_with_time(@date_range)
 
+    work_on_off_days = @motif.organisation.territory.work_on_sunday? # La colonne `work_on_sunday` indique aussi que les agents travaillent les jours fériés
     plage_ouvertures.map do |plage_ouverture|
       # Convention de nommage:
       #
@@ -35,7 +36,7 @@ class CreneauxSearch::Calculator
       free_times = FreeTimesFromPlageOuvertureAndBusyTimes.new(
         @datetime_range,
         plage_ouverture,
-        work_on_off_days: @motif.organisation.territory.work_on_sunday? # La colonne `work_on_sunday` indique aussi que les agents travaillent les jours fériés
+        work_on_off_days:
       ).perform
 
       SplitFreeTimeRangesIntoCreneaux.new(free_times, @motif, plage_ouverture, duration_in_min: @duration_in_min).perform(@datetime_range)

--- a/spec/services/creneaux_search/calculator/free_times_from_plage_ouverture_and_busy_times_spec.rb
+++ b/spec/services/creneaux_search/calculator/free_times_from_plage_ouverture_and_busy_times_spec.rb
@@ -334,4 +334,16 @@ RSpec.describe CreneauxSearch::Calculator::FreeTimesFromPlageOuvertureAndBusyTim
       end
     end
   end
+
+  context "when a plage d'ouverture has a secondary start time before its main start time" do
+    let(:plage_ouverture) do
+      build(:plage_ouverture, first_day: starts_at.to_date, agent: agent,
+                              start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(15),
+                              secondary_start_time: Tod::TimeOfDay.new(9), secondary_end_time: Tod::TimeOfDay.new(11))
+    end
+
+    it "still returns the proper ranges in the correct order" do
+      expect(free_times).to eq([])
+    end
+  end
 end

--- a/spec/services/creneaux_search/calculator/free_times_from_plage_ouverture_and_busy_times_spec.rb
+++ b/spec/services/creneaux_search/calculator/free_times_from_plage_ouverture_and_busy_times_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe CreneauxSearch::Calculator::FreeTimesFromPlageOuvertureAndBusyTim
     end
 
     it "still returns the proper ranges in the correct order" do
-      expect(free_times).to eq([])
+      expect(free_times.map(&:begin)).to eq([Time.zone.parse("2021-10-27 09:00:00"), Time.zone.parse("2021-10-27 14:00:00")])
     end
   end
 end


### PR DESCRIPTION
Fix pour https://sentry.incubateur.net/organizations/betagouv/issues/256445 et https://sentry.incubateur.net/organizations/betagouv/issues/256421

Le test et le fix expliquent assez bien le bug.

En bonus dans le troisième commit je corrige un petit bout de perfs que j'avais dégradé sans faire exprès dans le gros refacto.
