### PR TITLE
Permettre d’afficher le calendrier sur 24h

### DIFF
--- a/app/controllers/admin/planning/agendas_controller.rb
+++ b/app/controllers/admin/planning/agendas_controller.rb
@@ -29,6 +29,6 @@ class Admin::Planning::AgendasController < AgentAuthController
   private
 
   def permitted_agent_params
-    params.require(:agent).permit(:display_saturdays, :display_cancelled_rdv, :group_by_agent)
+    params.require(:agent).permit(:display_saturdays, :display_cancelled_rdv, :group_by_agent, :display_extended_hours)
   end
 end

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -13,6 +13,7 @@ import {
   dayHeaderContent,
   preferencesModalToggle,
   hiddenDays,
+  calendarTimeRange,
 } from './calendar/utils'
 
 import Bowser from "bowser";
@@ -37,6 +38,7 @@ export class AgendaMonoAgent {
 
   initFullCalendar = () => {
     const options = {
+      ...calendarTimeRange(this.data),
       plugins: [dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin],
       eventSources: JSON.parse(this.data.eventSourcesJson),
       eventSourceFailure: handleAjaxError,

--- a/app/javascript/components/calendar/agenda-multi-agent.js
+++ b/app/javascript/components/calendar/agenda-multi-agent.js
@@ -10,6 +10,7 @@ import {
   weekTitleFormat,
   preferencesModalToggle,
   hiddenDays,
+  calendarTimeRange,
 } from "./utils";
 
 class AgendaMultiAgent {
@@ -27,6 +28,7 @@ class AgendaMultiAgent {
   }
   initFullCalendar = () => {
     const options = {
+      ...calendarTimeRange(this.data),
       plugins: [resourceTimegridPlugin, interactionPlugin],
       schedulerLicenseKey: "GPL-My-Project-Is-Open-Source",
       resources: this.resources,

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -87,8 +87,6 @@ const defaultFullCalendarConfig = () => ({
       startTime: '07:00',
       endTime: '20:00',
   },
-  slotMinTime: '07:00:00',
-  slotMaxTime: '20:00:00',
   selectAllow: canSelectOnlyOneDay,
   eventClassNames: eventClassNames,
   eventMouseLeave: (info) => $(info.el).tooltip('hide'), // extra security
@@ -283,6 +281,13 @@ const handleAjaxError = (error) => {
       alert(`Le chargement du calendrier a échoué, probablement car votre connexion internet a été coupée.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
     }, 5000);
   }
+};
+
+export const calendarTimeRange = ({ displayExtendedHours }) => {
+  if (displayExtendedHours === "true") {
+    return { slotMinTime: '00:00:00', slotMaxTime: '24:00:00', scrollTime: '07:00:00', height: 700 };
+  }
+  return { slotMinTime: '07:00:00', slotMaxTime: '20:00:00' };
 };
 
 export { defaultFullCalendarConfig, eventRenderer, setupRealtimeRefresh, handleAjaxError }

--- a/app/views/admin/planning/agendas/_preferences_modal.html.slim
+++ b/app/views/admin/planning/agendas/_preferences_modal.html.slim
@@ -26,5 +26,7 @@ dialog#agenda-preferences-modal.fr-modal[aria-labelledby="agenda-preferences-mod
                 - if group_by_agent
                   = f.dsfr_check_box :group_by_agent, label: "Grouper par agent"
 
+                = f.dsfr_check_box :display_extended_hours, label: "Afficher l'amplitude horaire complète (00h–24h)"
+
               / .mt-2
               = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
+++ b/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
@@ -21,6 +21,7 @@ ruby:
   data-resources-json="#{resources.to_json}"
   data-display-saturdays="#{current_agent.display_saturdays}"
   data-display-sundays="#{current_territory.work_on_sunday? && current_agent.display_saturdays}"
+  data-display-extended-hours="#{current_agent.display_extended_hours}"
   data-group-by-agent="#{current_agent.group_by_agent}"
   data-organisation-id="#{current_organisation.id}"
 ]

--- a/app/views/admin/planning/agendas/show.html.slim
+++ b/app/views/admin/planning/agendas/show.html.slim
@@ -27,6 +27,7 @@ ruby:
   data-organisation-id="#{@organisation.id}"
   data-display-saturdays="#{current_agent.display_saturdays}"
   data-display-sundays="#{current_territory.work_on_sunday? && current_agent.display_saturdays}"
+  data-display-extended-hours="#{current_agent.display_extended_hours}"
   data-event-sources-json="#{event_sources.to_json}"
 ]
 

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -125,6 +125,7 @@ tables:
       - unknown_past_rdv_count
       - display_saturdays
       - display_cancelled_rdv
+      - display_extended_hours
       - plage_ouverture_notification_level
       - absence_notification_level
       - outlook_disconnect_in_progress

--- a/db/migrate/20260316144148_add_display_extended_hours_to_agents.rb
+++ b/db/migrate/20260316144148_add_display_extended_hours_to_agents.rb
@@ -1,0 +1,5 @@
+class AddDisplayExtendedHoursToAgents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :agents, :display_extended_hours, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_13_100202) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_16_144148) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -155,6 +155,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_13_100202) do
     t.string "pro_connect_idp_id", comment: "Fournisseur d'identité ProConnect (identity provider)"
     t.boolean "sensitive_account", default: false, null: false
     t.datetime "caldav_disconnect_started_at"
+    t.boolean "display_extended_hours", default: false, null: false
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true

--- a/spec/controllers/admin/planning/agendas_controller_spec.rb
+++ b/spec/controllers/admin/planning/agendas_controller_spec.rb
@@ -51,5 +51,18 @@ RSpec.describe Admin::Planning::AgendasController, type: :controller do
         expect(agent.reload.display_cancelled_rdv).to be(true)
       end
     end
+
+    context "pour l'amplitude horaire étendue" do
+      it "active l'affichage de l'amplitude horaire étendue pour l'agent courant" do
+        put :toggle_displays, params: { id: agent.id, organisation_id: organisation.id, agent: { display_extended_hours: true } }
+        expect(agent.reload.display_extended_hours).to be(true)
+      end
+
+      it "désactive l'affichage de l'amplitude horaire étendue pour l'agent courant" do
+        agent.update!(display_extended_hours: true)
+        put :toggle_displays, params: { id: agent.id, organisation_id: organisation.id, agent: { display_extended_hours: false } }
+        expect(agent.reload.display_extended_hours).to be(false)
+      end
+    end
   end
 end

--- a/spec/features/agents/planning/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/planning/agent_has_a_calendar_spec.rb
@@ -212,6 +212,39 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
     end
   end
 
+  describe "amplitude horaire étendue" do
+    let!(:organisation) { create(:organisation) }
+    let!(:user_matinal) { create(:user, first_name: "Jean", last_name: "MATINAL") }
+
+    it "ne montre pas les RDV hors de la plage 7h-20h quand l'amplitude étendue est désactivée", js: true do
+      agent = create(:agent, basic_role_in_organisations: [organisation], display_extended_hours: false)
+      # RDV à 5h du matin, hors de la plage par défaut 7h–20h
+      create(:rdv, :no_service, agents: [agent], organisation:, users: [user_matinal], starts_at: Time.zone.now.beginning_of_week.change(hour: 5))
+      # RDV à 14h dans la plage visible, pour confirmer que les événements AJAX sont bien chargés
+      create(:rdv, :no_service, agents: [agent], organisation:, users: [create(:user, last_name: "VISIBLE")], starts_at: Time.zone.now.beginning_of_week.change(hour: 14))
+
+      login_as(agent, scope: :agent)
+      visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+      expect(page).to have_selector(".fc-event", text: "VISIBLE")
+      expect(page).to have_no_selector(".fc-event", text: "Jean MATINAL")
+    end
+
+    it "montre les RDV hors de la plage 7h-20h quand l'amplitude étendue est activée", js: true do
+      agent = create(:agent, basic_role_in_organisations: [organisation], display_extended_hours: true)
+      create(:rdv, :no_service, agents: [agent], organisation:, users: [user_matinal], starts_at: Time.zone.now.beginning_of_week.change(hour: 5))
+      # RDV de référence dans la plage visible pour confirmer que les événements AJAX sont chargés
+      create(:rdv, :no_service, agents: [agent], organisation:, users: [create(:user, last_name: "VISIBLE")], starts_at: Time.zone.now.beginning_of_week.change(hour: 14))
+
+      login_as(agent, scope: :agent)
+      visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+      expect(page).to have_selector(".fc-event", text: "VISIBLE") # on vérifie que les événements sont bien chargés
+      # Avec l'amplitude étendue, le calendrier affiche les créneaux à partir de 0h (au lieu de 7h)
+      expect(page).to have_selector('.fc-timegrid-slot-lane[data-time="05:00:00"]')
+      # Le RDV de 5h est rendu dans le DOM
+      expect(page).to have_selector(".fc-event", text: "Jean MATINAL")
+    end
+  end
+
   describe "apparence de l'agenda" do
     let!(:organisation) { create(:organisation) }
     let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6252.osc-secnum-fr1.scalingo.io/)

Suite à https://zammad10.ethibox.fr/#ticket/zoom/36016

# Contexte

Nous avons des agents en administration centrale qui font des rendez-vous avec des personnes qui ne sont pas sur le même fuseau horaire. Il leur arrive donc d'avoir des rendez-vous en visioconférence ou par téléphone après 20 heures. Aujourd'hui, FullCalendar affiche les rendez-vous qu'entre 7 h et 20 h.

La seule option pour ces agents est aujourd'hui d’utiliser l’option planning de FullCalendar.

# Solution

Je propose alors que nous ajoutions une option permettant aux agents de voir leur agenda en entier.

L'affichage continue de se faire par défaut entre 7 h et 20 h, mais il est possible de scroller pour voir les rendez-vous avant 7 h et après 20 h.

## Captures d'écran

<img width="671" height="513" alt="image" src="https://github.com/user-attachments/assets/4ae6c73e-6ccb-4f8b-98ac-07ebb2a3402e" />

<img width="1181" height="735" alt="image" src="https://github.com/user-attachments/assets/dfdfa5b0-4b67-40d0-949a-603fa335da3c" />


