### PR TITLE
Fix YWH-PGM14753-12 (login agent via formulaire usager)

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,7 +2,6 @@ class Users::SessionsController < Devise::SessionsController
   layout "application_narrow"
 
   include CanHaveRdvWizardContext
-  include Admin::WeakPasswordControllerConcern
   include Users::DeviseOrSsoLogout
 
   def new
@@ -17,22 +16,6 @@ class Users::SessionsController < Devise::SessionsController
         last_name: form_params[:last_name]
       )
     )
-
-    super
-  end
-
-  def create
-    if auth_options[:scope] == :user && (self.resource = Agent.find_by(email: params[:user]["email"])) && resource.valid_password?(params[:user]["password"])
-      return if reset_current_agent_password_if_weak!(params[:user][:password])
-
-      set_flash_message!(:notice, :signed_in)
-      sign_in(:agent, resource)
-
-      yield resource if block_given?
-      respond_with resource, location: after_sign_in_path_for(resource)
-    else
-      super
-    end
   end
 
   def destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,6 @@ Rails.application.routes.draw do
 
   devise_scope :user do
     get    "users/sign_in",  to: "users/sessions#new",          as: "new_user_session"
-    post   "users/sign_in",  to: "users/sessions#create",       as: "user_session"
     delete "users/sign_out", to: "users/sessions#destroy",      as: "destroy_user_session"
     get    "users/edit",     to: "users/registrations#edit",    as: "edit_user_registration"
     patch  "users",          to: "users/registrations#update",  as: "user_registration"

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -1,7 +1,18 @@
 RSpec.describe Users::SessionsController do
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:user] # d'après la doc de Devise
+  end
+
+  describe "#create" do
+    it "does not allow to login an agent anymore" do
+      existing_agent = create(:agent, password: "CorrectH0rse!")
+      post :create, params: { user: { email: existing_agent.email, password: "CorrectH0rse!" } }
+      expect(controller.current_agent).to be_nil
+    end
+  end
+
   describe "#destroy" do
     before do
-      request.env["devise.mapping"] = Devise.mappings[:user] # d'après la doc de Devise
       sign_in create(:user)
     end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Users::SessionsController do
   end
 
   describe "#create" do
-    it "does not allow to login an agent anymore" do
-      existing_agent = create(:agent, password: "CorrectH0rse!")
-      post :create, params: { user: { email: existing_agent.email, password: "CorrectH0rse!" } }
-      expect(controller.current_agent).to be_nil
+    it "does not allow to login an agent anymore", type: :request do
+      expect do
+        post "/users/sign_in", params: { user: { email: existing_agent.email, password: "CorrectH0rse!" } }
+      end.to raise_error(ActionController::RoutingError)
     end
   end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -1,10 +1,7 @@
 RSpec.describe Users::SessionsController do
-  before do
-    request.env["devise.mapping"] = Devise.mappings[:user] # d'après la doc de Devise
-  end
-
   describe "#create" do
     it "does not allow to login an agent anymore", type: :request do
+      existing_agent = create(:agent, password: "CorrectH0rse!")
       expect do
         post "/users/sign_in", params: { user: { email: existing_agent.email, password: "CorrectH0rse!" } }
       end.to raise_error(ActionController::RoutingError)
@@ -13,6 +10,7 @@ RSpec.describe Users::SessionsController do
 
   describe "#destroy" do
     before do
+      request.env["devise.mapping"] = Devise.mappings[:user] # d'après la doc de Devise
       sign_in create(:user)
     end
 


### PR DESCRIPTION
Rapport YesWeHack : https://yeswehack.com/vulnerability-center/reports/721332

# Contexte

Tout est dans le rapport ci-dessus.

# Solution

Le champ "mot de passe" a déjà été retiré dans #6204, donc le code supprimé ici ne sert à rien niveau produit, mais permet toujours de bypass le 2FA pour les agents connectés avec ProConnect. 

J'ai fait le choix d'ajouter une spec mais si vous pensez qu'elle pollue plus qu'autre chose, on peut s'en passer.