### PR TITLE
Rafraichir l’agenda quand l’usager est mis en salle d’attente

### DIFF
--- a/app/models/concerns/rdv/using_waiting_room.rb
+++ b/app/models/concerns/rdv/using_waiting_room.rb
@@ -20,6 +20,10 @@ module Rdv::UsingWaitingRoom
     Redis.with_connection do |redis|
       redis.sadd?(REDIS_WAITING_ROOM_KEY, id)
     end
+
+    agent_ids_from_db.each do |agent_id|
+      AgendaChannel.broadcast_to(agent_id, model: "Rdv", refresh_periods: [[starts_at, ends_at]])
+    end
   end
 
   class_methods do

--- a/spec/channels/application_cable/agenda_channel_spec.rb
+++ b/spec/channels/application_cable/agenda_channel_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe AgendaChannel do
       end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class)
     end
 
+    it "fires on User in Waiting Room status change" do
+      rdv_agent = create(:agent)
+      rdv = create(:rdv, agents: [rdv_agent])
+
+      expect do
+        rdv.set_user_in_waiting_room!
+      end.to have_broadcasted_to(rdv_agent.id).from_channel(described_class)
+    end
+
     it "fires when adding, updating or removing a participation" do
       rdv_agent = create(:agent)
       rdv = create(:rdv, agents: [rdv_agent])


### PR DESCRIPTION
Suite à : https://zammad10.ethibox.fr/#ticket/zoom/35916

# Contexte

Depuis que nous avons mis en place la mise à jour automatique du calendrier lorsqu'un rendez-vous change, le statut du rendez-vous usager en salle d'attente ne s'affiche plus automatiquement. Cela s'explique par le fait qu'avant, nous rafraîchissions le calendrier toutes les 30 secondes. Et maintenant, nous rafraîchissons le calendrier lorsqu'un rendez-vous est commit en base. Or, la logique de celle d'attente n'utilise pas la base de données PG mais Redis.

# Solution

J'ajoute donc le broadcast quand on ajoute l’usager en salle d’attente.
