### PR TITLE
Strip email dans la recherche d’agent/user Zammad Augmenter

### DIFF
--- a/app/services/zammad_customer.rb
+++ b/app/services/zammad_customer.rb
@@ -10,4 +10,8 @@ class ZammadCustomer
   attribute :note, :string
   attribute :rdvsp_role, :string
   attribute :instance, :string, default: Domain.default_domain_for_current_instance.to_s
+
+  def email
+    super&.strip
+  end
 end

--- a/spec/services/zammad_customer_spec.rb
+++ b/spec/services/zammad_customer_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe ZammadCustomer do
         end
       end
 
+      context "agent trouvé par email avec un email contenant des espaces" do
+        let!(:agent) { create(:agent, email: "agent@example.com") }
+        let(:args) { {} }
+
+        specify do
+          zammad_customer = ZammadCustomer.new(email: "  agent@example.com  ", phone: nil)
+          described_class.new(zammad_customer).run
+          expect(zammad_customer.note).to eq "Agent trouvé avec l'email agent@example.com"
+          expect(zammad_customer.super_admin_url).to eq "http://www.rdv-service-public-test.localhost/super_admins/agents/#{agent.id}"
+        end
+      end
+
       context "usager trouvé par numéro de téléphone" do
         let!(:user) { create(:user, phone_number: "0612345678", phone_number_formatted: "+33612345678") }
 


### PR DESCRIPTION
# Contexte

Lorsque j'ai traité certains Zammad, je me suis aperçu que la recherche automatique d'usagers/agents n'avait pas fonctionné, car l'agent avait mis un espace à la fin de son mail.

# Solution

Je propose donc de rajouter un petit strip sur l'email afin que cela ne se reproduise plus.