### PR TITLE
Gestion des VTODO qui peuvent arriver pendant le sync Caldav

### DIFF
--- a/app/jobs/caldav/import_absences_from_caldav_job.rb
+++ b/app/jobs/caldav/import_absences_from_caldav_job.rb
@@ -40,6 +40,9 @@ module Caldav
       collection = agent.caldav_client.calendars.sync(agent.caldav_agenda_url, agent.caldav_sync_token)
       new_sync_token = collection.sync_token
 
+      # On rejette les changements qui ne sont pas des événements (c’est notamment le cas des VTODO qui peuvent être mélangées avec les VEVENT dans certains serveurs Caldav)
+      collection.changes.reject! { _1.send(:inner_event).nil? }
+
       # On met à jour les événements modifiés qui sont « OPAQUE » (considérés comme occupés)
       updated_events = collection.changes.select(&:calendar_data).select { |event| consider_busy?(event) }
 
@@ -57,7 +60,7 @@ module Caldav
 
     def all_events_for(agent:)
       new_sync_token = agent.caldav_client.calendars.find(agent.caldav_agenda_url, sync: true).sync_token
-      updated_events = agent.caldav_client.events.list(agent.caldav_agenda_url)
+      updated_events = agent.caldav_client.events.list(agent.caldav_agenda_url) # Cette méthode ne récupère que les événements et rejette bien les VTODO
       deleted_events = []
       [updated_events, deleted_events, new_sync_token]
     end

--- a/spec/fixtures/vcr_cassettes/caldav/sync_with_vtodos.yml
+++ b/spec/fixtures/vcr_cassettes/caldav/sync_with_vtodos.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: report
+    uri: https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <caldav:calendar-query xmlns:dav="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:apple="http://apple.com/ns/ical/">
+          <dav:prop>
+            <dav:getetag/>
+            <caldav:calendar-data/>
+          </dav:prop>
+          <caldav:filter>
+            <caldav:comp-filter name="VCALENDAR">
+              <caldav:comp-filter name="VEVENT"/>
+            </caldav:comp-filter>
+          </caldav:filter>
+        </caldav:calendar-query>
+    headers:
+      Authorization: "[Filtered in vcr.rb -> before_record]"
+      Depth:
+      - '1'
+      Content-Type:
+      - application/xml; charset=utf-8
+      Connection:
+      - close
+      Host:
+      - ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 26 Jan 2026 09:22:56 GMT
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie: "[Filtered in vcr.rb -> before_record]"
+      X-Robots-Tag:
+      - none
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <D:multistatus xmlns:D="DAV:" xmlns:APPLE="http://apple.com/ns/ical/" xmlns:CAL="urn:ietf:params:xml:ns:caldav" xmlns:CS="http://calendarserver.org/ns/">
+          <D:response>
+            <D:href>/dav/caldav/1234_calendar_id/vtodo_event.ics</D:href>
+            <D:propstat>
+              <D:prop>
+                <D:getetag>2-193694-1769419251161</D:getetag>
+                <calendar-data xmlns="urn:ietf:params:xml:ns:caldav">BEGIN:VCALENDAR
+        VERSION:2.0
+        PRODID:-//Open-Xchange//8.43.61//EN
+        BEGIN:VTIMEZONE
+        TZID:Europe/Paris
+        LAST-MODIFIED:20250410T142247Z
+        TZURL:https://www.tzurl.org/zoneinfo-outlook/Europe/Paris
+        X-LIC-LOCATION:Europe/Paris
+        BEGIN:DAYLIGHT
+        TZNAME:CEST
+        TZOFFSETFROM:+0100
+        TZOFFSETTO:+0200
+        DTSTART:19700329T020000
+        RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+        END:DAYLIGHT
+        BEGIN:STANDARD
+        TZNAME:CET
+        TZOFFSETFROM:+0200
+        TZOFFSETTO:+0100
+        DTSTART:19701025T030000
+        RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+        END:STANDARD
+        END:VTIMEZONE
+        BEGIN:VTODO
+        UID:2bff9852-2384-4106-848e-c6cae0aaa714
+        DTSTAMP:20260317T110223Z
+        SUMMARY:CA COFI 02/04/2026 17h15
+        DTSTART;TZID=Europe/Paris:20260317T130500
+        CREATED:20260317T110223Z
+        LAST-MODIFIED:20260317T110223Z
+        PERCENT-COMPLETE:0
+        BEGIN:VALARM
+        DESCRIPTION:Description par d\xC3\xA9faut Mozilla
+        ACTION:DISPLAY
+        TRIGGER:-PT30M
+        END:VALARM
+        END:VTODO
+        END:VCALENDAR</calendar-data>
+              </D:prop>
+              <D:status>HTTP/1.1 200 OK</D:status>
+            </D:propstat>
+          </D:response>
+        </D:multistatus>
+  recorded_at: Mon, 26 Jan 2026 09:22:56 GMT
+recorded_with: VCR 6.4.0

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -91,6 +91,15 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
         expect(ExternalCalendarEvent.where(url: "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/c766aa62-c76e-48eb-a6a1-c5a496ec740b.ics")).to be_empty
       end
     end
+
+    context "quand le serveur Caldav retourne des VTODO dans l’appelle de sync" do
+      it "ignore les VTODO et ne plante pas" do
+        VCR.use_cassette("caldav/sync_with_vtodos") do
+          expect { described_class.new.perform(agent.id) }.not_to raise_error
+          expect(ExternalCalendarEvent.where(url: "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/vtodo_event.ics")).to be_empty
+        end
+      end
+    end
   end
 
   it "enregistre la réponse dans Sentry si la récupération du token retourne un body inattendu" do


### PR DESCRIPTION
Suite à : https://sentry.incubateur.net/organizations/betagouv/issues/257024

# Contexte

Je me suis rendu compte en enquêtant sur ce Sentry que certains serveurs Caldav mélangeaient les ToDo et les événements de calendrier dans le cadre du sync. 
De ma compréhension du RFC 6578 (sync-collection), il n’est pas possible de requêter que les VEVENT.

# Solution

Je propose donc un fix qui rejette tous les objets qui n’ont pas d’`inner_event`
Le call `events.list` n’est pas concerné car il retourne déjà que des `VEVENT`.
