### PR TITLE
Permettre de configurer la couleur d'une plage

### DIFF
--- a/app/blueprints/plage_ouverture_blueprint.rb
+++ b/app/blueprints/plage_ouverture_blueprint.rb
@@ -1,7 +1,7 @@
 class PlageOuvertureBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :ical_uid, :title, :first_day, :start_time, :end_time
+  fields :ical_uid, :title, :first_day, :start_time, :end_time, :hex_color
   association :agent, blueprint: AgentBlueprint
   association :organisation, blueprint: OrganisationBlueprint
   association :lieu, blueprint: LieuBlueprint

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -139,7 +139,7 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
 
   def plage_ouverture_params
     params.require(:plage_ouverture).permit(
-      :title, :agent_id, :first_day, :start_time, :end_time, :secondary_start_time, :secondary_end_time, :lieu_id, :recurrence, :ignore_benign_errors, motif_ids: []
+      :title, :agent_id, :first_day, :start_time, :end_time, :secondary_start_time, :secondary_end_time, :lieu_id, :hex_color, :recurrence, :ignore_benign_errors, motif_ids: []
     )
   end
 

--- a/app/controllers/api/v1/plage_ouvertures_controller.rb
+++ b/app/controllers/api/v1/plage_ouvertures_controller.rb
@@ -64,6 +64,6 @@ class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
 
     params[:agent_id] ||= current_agent.id
 
-    params.permit(:agent_id, :title, :first_day, :start_time, :end_day, :end_time, :organisation_id)
+    params.permit(:agent_id, :title, :first_day, :start_time, :end_day, :end_time, :organisation_id, :hex_color)
   end
 end

--- a/app/views/admin/api/agenda/plage_ouvertures/index.json.jb
+++ b/app/views/admin/api/agenda/plage_ouvertures/index.json.jb
@@ -3,7 +3,7 @@
     title: sanitize(plage_ouverture.title_with_default),
     start: occurrence.starts_at.as_json,
     end: occurrence.ends_at.as_json,
-    backgroundColor: plage_ouverture.organisation == @organisation ? "#6fceff80" : "grey",
+    backgroundColor: plage_ouverture.organisation == @organisation ? plage_ouverture.hex_color : "grey",
     textColor: "#313131",
     display: @display_in_background ? "background" : nil,
     url: admin_organisation_planning_plage_ouverture_path(@organisation, plage_ouverture),

--- a/app/views/admin/planning/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_form.html.slim
@@ -54,6 +54,7 @@
         .card
           .card-body
             = f.input :title, label: "Libellé (facultatif)", placeholder: "ex: Permanence hebdo", hint: "Ce libellé sera affiché aux agents mais jamais aux usagers"
+            = f.input :hex_color, as: :color, label: "Couleur", hint: "Cette couleur peut vous aider à distinguer vos plages sur votre agenda."
 
     .row.justify-content-center
       .col-md-6

--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -1,8 +1,9 @@
 - organisation = plage_ouverture.organisation
 
 tr
+  td.pr-0
+    span.badge.badge-pill style="background: #{plage_ouverture.hex_color};" &nbsp;
   td
-    span.badge.badge-pill.ml-0.mr-1 style="background: #{plage_ouverture.hex_color};" &nbsp;
     = link_to plage_ouverture.title_with_default, admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture), class: "fr-link"
     = exceptionnelle_tag(plage_ouverture)
   td

--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -1,9 +1,8 @@
 - organisation = plage_ouverture.organisation
 
 tr
-  td.pr-0.text-right
-    span.badge.badge-pill.ml-0.mr-2 style="background: #{plage_ouverture.hex_color};" &nbsp;
   td
+    span.badge.badge-pill.ml-0.mr-1 style="background: #{plage_ouverture.hex_color};" &nbsp;
     = link_to plage_ouverture.title_with_default, admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture), class: "fr-link"
     = exceptionnelle_tag(plage_ouverture)
   td

--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -1,5 +1,8 @@
+- organisation = plage_ouverture.organisation
+
 tr
-  - organisation = plage_ouverture.organisation
+  td.pr-0.text-right
+    span.badge.badge-pill.ml-0.mr-2 style="background: #{plage_ouverture.hex_color};" &nbsp;
   td
     = link_to plage_ouverture.title_with_default, admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture), class: "fr-link"
     = exceptionnelle_tag(plage_ouverture)

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -40,7 +40,6 @@
     table.table
       thead
         tr
-          th
           th = t(".title")
           th = t(".motifs")
           th = t(".place")

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -40,6 +40,7 @@
     table.table
       thead
         tr
+          td
           th = t(".title")
           th = t(".motifs")
           th = t(".place")

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -40,6 +40,7 @@
     table.table
       thead
         tr
+          th
           th = t(".title")
           th = t(".motifs")
           th = t(".place")

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -281,6 +281,7 @@ tables:
       - recurrence
       - expired_cached
       - recurrence_ends_at
+      - hex_color
 
   - table_name: webhook_endpoints
     anonymized_column_names:

--- a/db/migrate/20260318152217_add_hex_color_to_plages.rb
+++ b/db/migrate/20260318152217_add_hex_color_to_plages.rb
@@ -1,0 +1,5 @@
+class AddHexColorToPlages < ActiveRecord::Migration[8.0]
+  def change
+    add_column :plage_ouvertures, :hex_color, :string, null: false, default: "#c6ecff", limit: 7
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_16_144148) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_18_152217) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -589,6 +589,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_16_144148) do
     t.datetime "recurrence_ends_at"
     t.time "secondary_start_time"
     t.time "secondary_end_time"
+    t.string "hex_color", limit: 7, default: "#c6ecff", null: false
     t.index "tsrange((first_day)::timestamp without time zone, recurrence_ends_at, '[]'::text)", name: "index_plage_ouvertures_on_tsrange_first_day_recurrence_ends_at", using: :gist
     t.index ["agent_id"], name: "index_plage_ouvertures_on_agent_id"
     t.index ["expired_cached"], name: "index_plage_ouvertures_on_expired_cached"

--- a/spec/controllers/admin/api/agenda/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/api/agenda/plage_ouvertures_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Admin::Api::Agenda::PlageOuverturesController, type: :controller 
               "start" => plage_ouverture.starts_at.as_json,
               "end" => plage_ouverture.ends_at.as_json,
               "resourceIds" => [plage_ouverture.agent.id],
-              "backgroundColor" => "#6fceff80",
+              "backgroundColor" => "#c6ecff",
               "textColor" => "#313131",
               "display" => nil,
               "url" => "/admin/organisations/#{organisation.id}/planning/plage_ouvertures/#{plage_ouverture.id}",


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6261.osc-secnum-fr1.scalingo.io/)

Nous avons reçu à de nombreuses reprises des demandes où les agents exprimaient le besoin de modifier la couleur d'affichage d'une plage. Cela permet notamment de distinguer les plages quand l'agent en utilise plusieurs pour des motifs distincts. Il peut ainsi fazire correspondre (ou pas) la couleur de la plage et celle du motif.

# Solution

1. On ajoute un picker natif de couleur sur le formulaire
2. On met à jour l'affichage sur l'agenda et la liste des plages
3. On se demande pourquoi on repousse depuis des mois un truc qui prend 10 minutes à faire

# Captures d'écran

<img width="1844" height="1221" alt="image" src="https://github.com/user-attachments/assets/ce13437d-6f1a-40e2-96b8-e0e543b37290" />

<img width="2178" height="1597" alt="image" src="https://github.com/user-attachments/assets/4da88f3b-8617-456a-955c-790a409e2465" />


<img width="1021" height="565" alt="image" src="https://github.com/user-attachments/assets/bf8d4f5e-c373-417f-9e37-d2491735c758" />

## Picker (Firefox)

<img width="725" height="501" alt="image" src="https://github.com/user-attachments/assets/04af01fa-22f4-4861-9e1b-e68844fbeb2d" />

## Picker (Chrome)

<img width="338" height="393" alt="image" src="https://github.com/user-attachments/assets/d51a9336-7eed-46d1-bbf4-b6d3b823484b" />
