### PR TITLE
Suppression du nom des services dans les fils d’arianes

### DIFF
--- a/app/views/admin/planning/absences/edit.html.slim
+++ b/app/views/admin/planning/absences/edit.html.slim
@@ -13,7 +13,7 @@
             current_page_title: yield(:title)
   - else
     = render "common/fil_ariane",
-            titles_and_paths: [["Indisponibilités de #{@absence.agent.full_name_and_service}", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
+            titles_and_paths: [["Indisponibilités de #{@absence.agent.full_name_or_email}", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
             current_page_title: yield(:title)
 
 - content_for :right_of_page_title do

--- a/app/views/admin/planning/absences/new.html.slim
+++ b/app/views/admin/planning/absences/new.html.slim
@@ -13,7 +13,7 @@
               current_page_title: yield(:title)
     - else
       = render "common/fil_ariane",
-              titles_and_paths: [["Indisponibilités de #{@absence.agent.full_name_and_service}", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
+              titles_and_paths: [["Indisponibilités de #{@absence.agent.full_name_or_email}", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
               current_page_title: yield(:title)
 
 .row.justify-content-center

--- a/app/views/admin/planning/plage_ouvertures/edit.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/edit.html.slim
@@ -10,6 +10,6 @@
   - if current_agent == @plage_ouverture.agent
     = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
   - else
-    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
+    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture de #{@plage_ouverture.agent.full_name_or_email}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 = render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/planning/plage_ouvertures/new.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/new.html.slim
@@ -10,6 +10,6 @@
   - if current_agent == @plage_ouverture.agent
     = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
   - else
-    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
+    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture de #{@plage_ouverture.agent.full_name_or_email}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 = render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/planning/plage_ouvertures/show.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/show.html.slim
@@ -7,7 +7,7 @@
   - if current_agent == @plage_ouverture.agent
     = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
   - else
-    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
+    = render "common/fil_ariane", titles_and_paths: [["Plages d’ouverture de #{@plage_ouverture.agent.full_name_or_email}", admin_organisation_planning_plage_ouvertures_path(@plage_ouverture.organisation, agent_id: @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 .row.justify-content-center
   .col-md-6.mb-3


### PR DESCRIPTION
# Contexte

Suite aux discussions que nous avons eues ici : https://mattermost.incubateur.net/betagouv/pl/qunnzywtbid88mr14zgiz4a9za

L’affichage des services dans le fil d’ariane prend parfois beaucoup de place (quand l’agent à beaucoup de services) et n’est pas utile.

# Solution

## Captures d'écran

Avant | Après
:- | -:
<img width="563" height="305" alt="image" src="https://github.com/user-attachments/assets/a07d4964-90dc-4bb1-8316-817d0e7b5be1" /> | <img width="561" height="304" alt="image" src="https://github.com/user-attachments/assets/847164d8-f506-4e6a-92e9-a86914b8c3bf" />
