### PR TITLE
Télécharger les participants à un RDV collectif (en CSV)

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -75,6 +75,24 @@ class Admin::RdvsController < AgentAuthController
     authorize(@rdv, policy_class: Agent::RdvPolicy)
   end
 
+  def download_participants
+    authorize(@rdv, policy_class: Agent::RdvPolicy)
+
+    csv_data = CSV.generate(headers: true) do |csv|
+      csv << %w[full_name email status]
+      @rdv.participations.includes(:user).each do |participation|
+        csv << [
+          participation.user.full_name,
+          participation.user.email,
+          Rdv.human_attribute_value(:status, participation.temporal_status, disable_cast: true),
+        ]
+      end
+    end
+
+    filename = "participants-rdv-collectif-#{@rdv.starts_at.to_date}.csv"
+    send_data csv_data, filename:, type: "text/csv"
+  end
+
   def edit
     add_user_ids = params[:add_user].to_a + params[:user_ids].to_a
     users_to_add = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.where(id: add_user_ids)).resolve.distinct

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -77,20 +77,8 @@ class Admin::RdvsController < AgentAuthController
 
   def download_participants
     authorize(@rdv, policy_class: Agent::RdvPolicy)
-
-    csv_data = CSV.generate(headers: true) do |csv|
-      csv << %w[full_name email status]
-      @rdv.participations.includes(:user).each do |participation|
-        csv << [
-          participation.user.full_name,
-          participation.user.email,
-          Rdv.human_attribute_value(:status, participation.temporal_status, disable_cast: true),
-        ]
-      end
-    end
-
-    filename = "participants-rdv-collectif-#{@rdv.starts_at.to_date}.csv"
-    send_data csv_data, filename:, type: "text/csv"
+    generator = ParticipantsCsv.new(@rdv)
+    send_data generator.generate_csv, filename: generator.filename, type: "text/csv"
   end
 
   def edit

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -21,6 +21,7 @@ class Agent::RdvPolicy < ApplicationPolicy
     same_agent_or_has_access?
   end
   alias versions? show?
+  alias download_participants? show?
 
   def destroy?
     current_agent.admin_in_organisation?(@record.organisation)

--- a/app/services/participants_csv.rb
+++ b/app/services/participants_csv.rb
@@ -5,7 +5,7 @@ class ParticipantsCsv
 
   def generate_csv
     CSV.generate(headers: true) do |csv|
-      csv << %w[full_name email status]
+      csv << ["nom complet", "adresse e-mail", "statut"]
       @rdv.participations.includes(:user).order(created_at: :asc).each do |participation|
         csv << [
           participation.user.full_name,

--- a/app/services/participants_csv.rb
+++ b/app/services/participants_csv.rb
@@ -1,0 +1,22 @@
+class ParticipantsCsv
+  def initialize(rdv)
+    @rdv = rdv
+  end
+
+  def generate_csv
+    CSV.generate(headers: true) do |csv|
+      csv << %w[full_name email status]
+      @rdv.participations.includes(:user).order(created_at: :asc).each do |participation|
+        csv << [
+          participation.user.full_name,
+          participation.user.email,
+          Rdv.human_attribute_value(:status, participation.temporal_status, disable_cast: true),
+        ]
+      end
+    end
+  end
+
+  def filename
+    "participants-rdv-collectif-#{@rdv.starts_at.to_date}.csv"
+  end
+end

--- a/app/views/admin/rdvs/_users_table.html.slim
+++ b/app/views/admin/rdvs/_users_table.html.slim
@@ -1,5 +1,10 @@
 /# locals: (rdv:, contextual_agents:)
 
+- if rdv.collectif?
+  .float-right.mb-2
+    - download_url = download_participants_admin_organisation_rdv_path(organisation_id: current_organisation.id, id: rdv.id)
+    = link_to("Télécharger la liste des participants", download_url, class: "fr-btn fr-btn--secondary")
+
 .table-responsive.users-table[style="overflow: inherit"]
   table.table.light-gray-table
     thead

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -291,6 +291,7 @@ Rails.application.routes.draw do
           resources :participations, only: %i[update destroy]
           resource :user_in_waiting_room, only: [:create]
           member do
+            get :download_participants
             post :send_reminder_manually
           end
           collection do

--- a/spec/features/agents/rdvs/agent_can_download_participants_csv_spec.rb
+++ b/spec/features/agents/rdvs/agent_can_download_participants_csv_spec.rb
@@ -1,11 +1,7 @@
 RSpec.describe "agent can download a RDV's participants in CSV" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-  let!(:user1) { create(:user, first_name: "Alice", last_name: "Martin", email: "alice@example.com", organisations: [organisation]) }
-  let!(:user2) { create(:user, first_name: "Bob", last_name: "Dupont", email: "bob@example.com", organisations: [organisation]) }
-  let!(:rdv) do
-    create(:rdv, :collectif, organisation: organisation, agents: [agent], users: [user1, user2], starts_at: 3.days.from_now)
-  end
+  let!(:rdv) { create(:rdv, :collectif, organisation: organisation, agents: [agent], starts_at: 3.days.from_now) }
 
   before { login_as(agent, scope: :agent) }
 
@@ -14,34 +10,14 @@ RSpec.describe "agent can download a RDV's participants in CSV" do
     expect(page).to have_link("Télécharger la liste des participants")
   end
 
-  it "downloads a CSV with the participants' information" do
-    visit admin_organisation_rdv_path(organisation, rdv)
-    click_link "Télécharger la liste des participants"
+  it "downloads the CSV produced by ParticipantsCsv" do
+    generator = instance_double(ParticipantsCsv, generate_csv: "full_name,email,status\n", filename: "participants-rdv-collectif-2025-06-15.csv")
+    allow(ParticipantsCsv).to receive(:new).with(rdv).and_return(generator)
+
+    visit download_participants_admin_organisation_rdv_path(organisation, rdv)
 
     expect(response_headers["Content-Type"]).to include("text/csv")
-    expected_filename = "participants-rdv-collectif-#{rdv.starts_at.to_date}.csv"
-    expect(response_headers["Content-Disposition"]).to include(expected_filename)
-
-    expected_csv = <<~CSV
-      full_name,email,status
-      Alice MARTIN,alice@example.com,Rendez-vous à venir
-      Bob DUPONT,bob@example.com,Rendez-vous à venir
-    CSV
-    expect(page.body).to eq(expected_csv)
-  end
-
-  context "when a participation has a non-default status" do
-    before { rdv.participations.find_by!(user: user1).update!(status: "seen") }
-
-    it "reflects the correct status for each participant" do
-      visit download_participants_admin_organisation_rdv_path(organisation, rdv)
-
-      expected_csv = <<~CSV
-        full_name,email,status
-        Alice MARTIN,alice@example.com,Rendez-vous honoré
-        Bob DUPONT,bob@example.com,Rendez-vous à venir
-      CSV
-      expect(page.body).to eq(expected_csv)
-    end
+    expect(response_headers["Content-Disposition"]).to include("participants-rdv-collectif-2025-06-15.csv")
+    expect(page.body).to eq("full_name,email,status\n")
   end
 end

--- a/spec/features/agents/rdvs/agent_can_download_participants_csv_spec.rb
+++ b/spec/features/agents/rdvs/agent_can_download_participants_csv_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe "agent can download a RDV's participants in CSV" do
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let!(:user1) { create(:user, first_name: "Alice", last_name: "Martin", email: "alice@example.com", organisations: [organisation]) }
+  let!(:user2) { create(:user, first_name: "Bob", last_name: "Dupont", email: "bob@example.com", organisations: [organisation]) }
+  let!(:rdv) do
+    create(:rdv, :collectif, organisation: organisation, agents: [agent], users: [user1, user2], starts_at: 3.days.from_now)
+  end
+
+  before { login_as(agent, scope: :agent) }
+
+  it "shows the download link on the RDV page" do
+    visit admin_organisation_rdv_path(organisation, rdv)
+    expect(page).to have_link("Télécharger la liste des participants")
+  end
+
+  it "downloads a CSV with the participants' information" do
+    visit admin_organisation_rdv_path(organisation, rdv)
+    click_link "Télécharger la liste des participants"
+
+    expect(response_headers["Content-Type"]).to include("text/csv")
+    expected_filename = "participants-rdv-collectif-#{rdv.starts_at.to_date}.csv"
+    expect(response_headers["Content-Disposition"]).to include(expected_filename)
+
+    expected_csv = <<~CSV
+      full_name,email,status
+      Alice MARTIN,alice@example.com,Rendez-vous à venir
+      Bob DUPONT,bob@example.com,Rendez-vous à venir
+    CSV
+    expect(page.body).to eq(expected_csv)
+  end
+
+  context "when a participation has a non-default status" do
+    before { rdv.participations.find_by!(user: user1).update!(status: "seen") }
+
+    it "reflects the correct status for each participant" do
+      visit download_participants_admin_organisation_rdv_path(organisation, rdv)
+
+      expected_csv = <<~CSV
+        full_name,email,status
+        Alice MARTIN,alice@example.com,Rendez-vous honoré
+        Bob DUPONT,bob@example.com,Rendez-vous à venir
+      CSV
+      expect(page.body).to eq(expected_csv)
+    end
+  end
+end

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     let(:rdv) { create(:rdv, organisation: organisation, agents: [agent], motif: motif) }
     let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
 
-    it_behaves_like "permit actions", :rdv, :show?, :edit?, :update?
+    it_behaves_like "permit actions", :rdv, :show?, :download_participants?, :edit?, :update?
     it_behaves_like "not permit actions", :rdv, :destroy?
     it_behaves_like "included in scope"
   end
@@ -35,13 +35,13 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service_agent) }
     let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
 
-    it_behaves_like "not permit actions", :rdv, :show?, :edit?, :update?, :destroy?
+    it_behaves_like "not permit actions", :rdv, :show?, :download_participants?, :edit?, :update?, :destroy?
     it_behaves_like "not included in scope"
 
     context "for secretariat" do
       let(:service_agent) { build(:service, :secretariat) }
 
-      it_behaves_like "permit actions", :rdv, :show?, :edit?, :update?
+      it_behaves_like "permit actions", :rdv, :show?, :download_participants?, :edit?, :update?
       it_behaves_like "not permit actions", :rdv, :destroy?
       it_behaves_like "included in scope"
     end
@@ -49,14 +49,14 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     context "for admin" do
       let(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service_agent) }
 
-      it_behaves_like "permit actions", :rdv, :show?, :edit?, :update?, :destroy?
+      it_behaves_like "permit actions", :rdv, :show?, :download_participants?, :edit?, :update?, :destroy?
       it_behaves_like "included in scope"
     end
 
     context "except if the rdv concerns the connected agent" do
       let(:rdv) { create(:rdv, motif: motif, organisation: organisation, agents: [agent]) }
 
-      it_behaves_like "permit actions", :rdv, :show?, :edit?, :update?
+      it_behaves_like "permit actions", :rdv, :show?, :download_participants?, :edit?, :update?
       it_behaves_like "not permit actions", :rdv, :destroy?
       it_behaves_like "included in scope"
     end
@@ -69,7 +69,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     let(:rdv) { create(:rdv, agents: [agents[0]], motif: motif, organisation: organisation) }
     let(:pundit_context) { AgentOrganisationContext.new(agents[1], organisation) }
 
-    it_behaves_like "permit actions", :rdv, :show?, :edit?, :update?
+    it_behaves_like "permit actions", :rdv, :show?, :download_participants?, :edit?, :update?
     it_behaves_like "not permit actions", :rdv, :destroy?
     it_behaves_like "included in scope"
   end
@@ -82,7 +82,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     let(:rdv) { create(:rdv, agents: [agents[0]], motif: motif, organisation: organisation) }
     let(:pundit_context) { AgentOrganisationContext.new(agents[1], organisation) }
 
-    it_behaves_like "permit actions", :rdv, :show?, :edit?, :update?
+    it_behaves_like "permit actions", :rdv, :show?, :download_participants?, :edit?, :update?
     it_behaves_like "not permit actions", :rdv, :destroy?
     it_behaves_like "included in scope"
   end
@@ -97,20 +97,20 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     let(:rdv) { create(:rdv, agents: [agent1], motif: motif1, organisation: organisation1) }
     let(:pundit_context) { AgentOrganisationContext.new(agent2, organisation2) }
 
-    it_behaves_like "not permit actions", :rdv, :show?, :edit?, :update?, :destroy?
+    it_behaves_like "not permit actions", :rdv, :show?, :download_participants?, :edit?, :update?, :destroy?
     it_behaves_like "not included in scope"
 
     context "for secretariat" do
       let(:agent2) { create(:agent, basic_role_in_organisations: [organisation2], service: create(:service, :secretariat)) }
 
-      it_behaves_like "not permit actions", :rdv, :show?, :edit?, :update?, :destroy?
+      it_behaves_like "not permit actions", :rdv, :show?, :download_participants?, :edit?, :update?, :destroy?
       it_behaves_like "not included in scope"
     end
 
     context "for admin" do
       let(:agent2) { create(:agent, admin_role_in_organisations: [organisation2], service: service) }
 
-      it_behaves_like "not permit actions", :rdv, :show?, :edit?, :update?, :destroy?
+      it_behaves_like "not permit actions", :rdv, :show?, :download_participants?, :edit?, :update?, :destroy?
       it_behaves_like "not included in scope"
     end
   end
@@ -156,7 +156,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
       rdv.participations.build(user_id: user_from_other_territory.id, created_by: agent)
     end
 
-    it_behaves_like "permit actions", :rdv, :show?, :destroy?
+    it_behaves_like "permit actions", :rdv, :show?, :download_participants?, :destroy?
     it_behaves_like "not permit actions", :rdv, :new?, :create?, :edit?, :update?
     it_behaves_like "included in scope"
   end
@@ -176,7 +176,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     let(:rdv) { create(:rdv, organisation: organisation, agents: [live_agent, soft_deleted_agent], users: [live_user, soft_deleted_user], motif: motif) }
     let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
 
-    it_behaves_like "permit actions", :rdv, :new?, :create?, :show?, :edit?, :update?, :destroy?
+    it_behaves_like "permit actions", :rdv, :new?, :create?, :show?, :download_participants?, :edit?, :update?, :destroy?
     it_behaves_like "not permit actions", :rdv
     it_behaves_like "included in scope"
   end
@@ -196,7 +196,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
       user.user_profiles.destroy_all
     end
 
-    it_behaves_like "permit actions", :rdv, :new?, :create?, :show?, :edit?, :update?, :destroy?
+    it_behaves_like "permit actions", :rdv, :new?, :create?, :show?, :download_participants?, :edit?, :update?, :destroy?
     it_behaves_like "not permit actions", :rdv
     it_behaves_like "included in scope"
   end

--- a/spec/services/participants_csv_spec.rb
+++ b/spec/services/participants_csv_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe ParticipantsCsv, type: :service do
+  before { travel_to Time.zone.parse("2026-03-19 08:00") }
+
+  let(:organisation) { create(:organisation) }
+  let(:rdv) do
+    create(:rdv, :collectif, :without_users, organisation: organisation, starts_at: Time.zone.parse("2027-06-15 10:00"))
+  end
+
+  describe "#filename" do
+    it "includes the RDV date" do
+      expect(described_class.new(rdv).filename).to eq("participants-rdv-collectif-2027-06-15.csv")
+    end
+  end
+
+  describe "#generate_csv" do
+    let!(:user1) { create(:user, first_name: "Alice", last_name: "Martin", email: "alice@example.com", organisations: [organisation]) }
+    let!(:user2) { create(:user, first_name: "Bob", last_name: "Dupont", email: "bob@example.com", organisations: [organisation]) }
+
+    before do
+      create(:participation, rdv: rdv, user: user1, created_at: 2.minutes.ago)
+      create(:participation, rdv: rdv, user: user2, created_at: 1.minute.ago)
+    end
+
+    it "returns a CSV with headers and one row per participation, ordered by creation date" do
+      expected_csv = <<~CSV
+        full_name,email,status
+        Alice MARTIN,alice@example.com,Rendez-vous à venir
+        Bob DUPONT,bob@example.com,Rendez-vous à venir
+      CSV
+      expect(described_class.new(rdv).generate_csv).to eq(expected_csv)
+    end
+
+    it "uses the participation's temporal status, not the RDV's" do
+      rdv.participations.find_by!(user: user1).update!(status: "seen")
+
+      expected_csv = <<~CSV
+        full_name,email,status
+        Alice MARTIN,alice@example.com,Rendez-vous honoré
+        Bob DUPONT,bob@example.com,Rendez-vous à venir
+      CSV
+      expect(described_class.new(rdv).generate_csv).to eq(expected_csv)
+    end
+  end
+end

--- a/spec/services/participants_csv_spec.rb
+++ b/spec/services/participants_csv_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ParticipantsCsv, type: :service do
 
     it "returns a CSV with headers and one row per participation, ordered by creation date" do
       expected_csv = <<~CSV
-        full_name,email,status
+        nom complet,adresse e-mail,statut
         Alice MARTIN,alice@example.com,Rendez-vous à venir
         Bob DUPONT,bob@example.com,Rendez-vous à venir
       CSV
@@ -34,7 +34,7 @@ RSpec.describe ParticipantsCsv, type: :service do
       rdv.participations.find_by!(user: user1).update!(status: "seen")
 
       expected_csv = <<~CSV
-        full_name,email,status
+        nom complet,adresse e-mail,statut
         Alice MARTIN,alice@example.com,Rendez-vous honoré
         Bob DUPONT,bob@example.com,Rendez-vous à venir
       CSV


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6263.osc-secnum-fr1.scalingo.io/)

# Contexte

Beaucoup d'agents qui organisent des ateliers et webinaires nous demandent à pouvoir exporter la liste des participants pour l'un des besoins suivants :
- créer une fiche d'émargement
- les contacter par e-mail

# Solution

Ajouter un bouton d'export : 

<img width="1400" height="894" alt="image" src="https://github.com/user-attachments/assets/af5c0017-22eb-48e1-a7bc-b14c100a4bb0" />
