### PR TITLE
Fix: gestion de l’absence de calendar_data lors de la sync CalDAV

### DIFF
--- a/app/jobs/caldav/import_absences_from_caldav_job.rb
+++ b/app/jobs/caldav/import_absences_from_caldav_job.rb
@@ -43,9 +43,9 @@ module Caldav
       # Dans les deux cas suivants, on rejette les changements qui ne sont pas des événements
       # (c’est notamment le cas des VTODO qui peuvent être mélangées avec les VEVENT dans certains serveurs Caldav)
       # On met à jour les événements modifiés qui sont « OPAQUE » (considérés comme occupés)
-      updated_events = collection.changes.select(&:calendar_data).reject { _1.send(:inner_event).nil? }.select { |event| consider_busy?(event) }
+      updated_events = collection.changes.select { _1.calendar_data && _1.send(:inner_event) }.select { |event| consider_busy?(event) }
       # On supprime les événements modifiés qui sont « TRANSPARENT » (considérés comme libres)
-      deleted_events = collection.changes.select(&:calendar_data).reject { _1.send(:inner_event).nil? }.reject { |event| consider_busy?(event) }.map(&:url)
+      deleted_events = collection.changes.select { _1.calendar_data && _1.send(:inner_event) }.reject { |event| consider_busy?(event) }.map(&:url)
 
       # Le serveur Caldav de la Suite Numérique signale une suppression à travers un calendar_data vide.
       deleted_events += collection.changes.reject(&:calendar_data).map(&:url)

--- a/app/jobs/caldav/import_absences_from_caldav_job.rb
+++ b/app/jobs/caldav/import_absences_from_caldav_job.rb
@@ -40,14 +40,12 @@ module Caldav
       collection = agent.caldav_client.calendars.sync(agent.caldav_agenda_url, agent.caldav_sync_token)
       new_sync_token = collection.sync_token
 
-      # On rejette les changements qui ne sont pas des événements (c’est notamment le cas des VTODO qui peuvent être mélangées avec les VEVENT dans certains serveurs Caldav)
-      collection.changes.reject! { _1.send(:inner_event).nil? }
-
+      # Dans les deux cas suivants, on rejette les changements qui ne sont pas des événements
+      # (c’est notamment le cas des VTODO qui peuvent être mélangées avec les VEVENT dans certains serveurs Caldav)
       # On met à jour les événements modifiés qui sont « OPAQUE » (considérés comme occupés)
-      updated_events = collection.changes.select(&:calendar_data).select { |event| consider_busy?(event) }
-
+      updated_events = collection.changes.select(&:calendar_data).reject { _1.send(:inner_event).nil? }.select { |event| consider_busy?(event) }
       # On supprime les événements modifiés qui sont « TRANSPARENT » (considérés comme libres)
-      deleted_events = collection.changes.select(&:calendar_data).reject { |event| consider_busy?(event) }.map(&:url)
+      deleted_events = collection.changes.select(&:calendar_data).reject { _1.send(:inner_event).nil? }.reject { |event| consider_busy?(event) }.map(&:url)
 
       # Le serveur Caldav de la Suite Numérique signale une suppression à travers un calendar_data vide.
       deleted_events += collection.changes.reject(&:calendar_data).map(&:url)

--- a/spec/fixtures/vcr_cassettes/caldav/sync_with_empty_calendar_data.yml
+++ b/spec/fixtures/vcr_cassettes/caldav/sync_with_empty_calendar_data.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: report
+    uri: https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <caldav:calendar-query xmlns:dav="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:apple="http://apple.com/ns/ical/">
+          <dav:prop>
+            <dav:getetag/>
+            <caldav:calendar-data/>
+          </dav:prop>
+          <caldav:filter>
+            <caldav:comp-filter name="VCALENDAR">
+              <caldav:comp-filter name="VEVENT"/>
+            </caldav:comp-filter>
+          </caldav:filter>
+        </caldav:calendar-query>
+    headers:
+      Authorization: "[Filtered in vcr.rb -> before_record]"
+      Depth:
+      - '1'
+      Content-Type:
+      - application/xml; charset=utf-8
+      Connection:
+      - close
+      Host:
+      - ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 26 Jan 2026 09:22:56 GMT
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie: "[Filtered in vcr.rb -> before_record]"
+      X-Robots-Tag:
+      - none
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <D:multistatus xmlns:D="DAV:" xmlns:APPLE="http://apple.com/ns/ical/" xmlns:CAL="urn:ietf:params:xml:ns:caldav" xmlns:CS="http://calendarserver.org/ns/">
+          <D:response>
+            <D:href>/dav/caldav/1234_calendar_id/event_signaled_as_deleted.ics</D:href>
+            <D:propstat>
+              <D:prop>
+                <D:getetag>3-193694-1769419251999</D:getetag>
+                <CAL:calendar-data/>
+              </D:prop>
+              <D:status>HTTP/1.1 200 OK</D:status>
+            </D:propstat>
+          </D:response>
+        </D:multistatus>
+  recorded_at: Mon, 26 Jan 2026 09:22:56 GMT
+recorded_with: VCR 6.4.0

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -100,6 +100,23 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
         end
       end
     end
+
+    context "quand le serveur Caldav signale une suppression via un calendar_data vide (Suite Numérique)" do
+      it "supprime l’événement local correspondant" do
+        ExternalCalendarEvent.create(
+          agent:,
+          url: "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/event_signaled_as_deleted.ics",
+          starts_at: Time.zone.tomorrow.change(hour: 9, min: 0),
+          ends_at: Time.zone.tomorrow.change(hour: 10, min: 0)
+        )
+
+        VCR.use_cassette("caldav/sync_with_empty_calendar_data") do
+          expect { described_class.new.perform(agent.id) }.to change(ExternalCalendarEvent, :count).by(-1)
+        end
+
+        expect(ExternalCalendarEvent.where(url: "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/event_signaled_as_deleted.ics")).to be_empty
+      end
+    end
   end
 
   it "enregistre la réponse dans Sentry si la récupération du token retourne un body inattendu" do


### PR DESCRIPTION
# Contexte

Lorsque j’ai implémenté le fix #6260, j’ai un peu oublié que certaines infos reçues par le serveur CalDAV notamment celui de LaSuite, ne contient pas de `calendar_data`. Cela a entraîné un problème de synchronisation pour certains agents : https://sentry.incubateur.net/organizations/betagouv/issues/258095

# Solution

Je déplace le reject, pour le faire que quand il y a un `calendar_data`.


