### PR TITLE
Ajout du SIRET pour les Opérateurs

### DIFF
--- a/app/dashboards/operator_dashboard.rb
+++ b/app/dashboards/operator_dashboard.rb
@@ -4,6 +4,7 @@ class OperatorDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     name: Field::String,
+    siret: Field::String,
     territories: Field::HasMany,
     operator_managers: Field::HasMany,
   }.freeze
@@ -11,17 +12,20 @@ class OperatorDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     name
+    siret
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     name
+    siret
     territories
     operator_managers
   ].freeze
 
   FORM_ATTRIBUTES = %i[
     name
+    siret
   ].freeze
 
   def display_resource(operator)

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -532,9 +532,9 @@ tables:
       - source_organisation_id
       - status
   - table_name: operators
-    anonymized_column_names:
-      - name
     non_anonymized_column_names:
+      - name
+      - siret
       - created_at
       - updated_at
   - table_name: operator_managers

--- a/db/migrate/20260319000001_add_siret_to_operators.rb
+++ b/db/migrate/20260319000001_add_siret_to_operators.rb
@@ -1,0 +1,5 @@
+class AddSiretToOperators < ActiveRecord::Migration[8.0]
+  def change
+    add_column :operators, :siret, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_16_144148) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_19_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -520,6 +520,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_16_144148) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "siret"
   end
 
   create_table "organisations", force: :cascade do |t|


### PR DESCRIPTION
# Contexte

Maintenant que nous nous connectons à l'espace opérateur de la suite territoriale, nous souhaitons pouvoir associer les espaces à leur opérateur.
Initialement, la suite devait fournir un ID, mais un changement a été fait la semaine dernière pour que cela soit le SIRET de l’organisation.

# Solution

On ajoute le SIRET et on permet de l’éditer via le SuperAdmin.
