### PR TITLE
Revert "Redémarrer les apps de prod une fois toutes les 2 heures"

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,7 +1,7 @@
 {
   "jobs": [
     {
-      "command": "0 */2 * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart"
+      "command": "0 6 * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart"
     }
   ]
 }


### PR DESCRIPTION
Reverts betagouv/rdv-service-public#6215

Depuis la mise en ligne du nouveau calculateur de créneau, il semble que les soucis de RAM se soient arrêtés.
On peut donc passer à un redémarrage quotidien.

#6235 