### PR TITLE
Fix : amplitude horaire élargie sur la vue calendier plage d’ouverture

### DIFF
--- a/app/javascript/components/agenda_plage_ouverture.js
+++ b/app/javascript/components/agenda_plage_ouverture.js
@@ -6,6 +6,7 @@ import {
   defaultFullCalendarConfig,
   preferencesModalToggle,
   hiddenDays,
+  calendarTimeRange,
 } from './calendar/utils'
 
 export class AgendaPlageOuverture {
@@ -23,6 +24,7 @@ export class AgendaPlageOuverture {
   initFullCalendar = () => {
     const options = {
       plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
+      ...calendarTimeRange(this.data),
       eventSources: JSON.parse(this.data.eventSourcesJson),
       hiddenDays: hiddenDays(this.data),
       select: this.selectEvent,

--- a/app/views/admin/planning/plage_ouvertures/calendar.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/calendar.html.slim
@@ -16,6 +16,7 @@
   data-organisation-id="#{@current_organisation.id}"
   data-display-saturdays="#{current_agent.display_saturdays}"
   data-display-sundays="#{current_territory.work_on_sunday? && current_agent.display_saturdays}"
+  data-display-extended-hours="#{current_agent.display_extended_hours}"
   data-event-sources-json="#{[admin_api_agenda_plage_ouvertures_path(agent_id: @agent, organisation_id: current_organisation.id), OffDays.to_full_calendar_array].to_json}"
 ]
 


### PR DESCRIPTION
# Contexte

En mettant en production le système d’amplitude horaire élargie, j’ai omis d’appliquer la logique sur la Vue Calendrier des plages d’ouverture.

Voir #6252 

# Solution

J’ajoute donc la logique sur la Vue Calendrier des plages d’ouverture.
