### PR TITLE
Bugfix: colonne email vide dans le CSV des participants quand il utilise notification_email

### DIFF
--- a/app/services/participants_csv.rb
+++ b/app/services/participants_csv.rb
@@ -9,7 +9,7 @@ class ParticipantsCsv
       @rdv.participations.includes(:user).order(created_at: :asc).each do |participation|
         csv << [
           participation.user.full_name,
-          participation.user.email,
+          participation.user.preferred_email,
           Rdv.human_attribute_value(:status, participation.temporal_status, disable_cast: true),
         ]
       end

--- a/spec/services/participants_csv_spec.rb
+++ b/spec/services/participants_csv_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe ParticipantsCsv, type: :service do
       expect(described_class.new(rdv).generate_csv).to eq(expected_csv)
     end
 
+    it "uses notification_email when email is blank" do
+      user1.update!(email: nil, notification_email: "alice-notif@example.com")
+
+      csv = CSV.parse(described_class.new(rdv).generate_csv, headers: true)
+      expect(csv[0]["adresse e-mail"]).to eq("alice-notif@example.com")
+    end
+
     it "uses the participation's temporal status, not the RDV's" do
       rdv.participations.find_by!(user: user1).update!(status: "seen")
 


### PR DESCRIPTION
Fixup de #6263