### PR TITLE
Clarifier le message de l’état des motifs de l’orga

### DIFF
--- a/app/views/admin/motifs/_creation_needed_callout.html.slim
+++ b/app/views/admin/motifs/_creation_needed_callout.html.slim
@@ -1,4 +1,4 @@
-/# locals: (motivation_text:)
+/# locals: (motivation_text:, non_admin_text: "Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un.")
 .fr-callout
   p.fr-callout__text.fr-icon-info-line
     - if Agent::MotifPolicy.new(current_agent, current_organisation.motifs.new).new?
@@ -8,4 +8,4 @@
       = link_to("Configuration > Motifs de rendez-vous", admin_organisation_motifs_path(organisation_id: current_organisation.id))
       = "."
     - else
-      = "Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un."
+      = non_admin_text

--- a/app/views/admin/planning/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_form.html.slim
@@ -76,4 +76,9 @@
 - else
   .card
     .card-body
-      = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."
+      - if plage_ouverture.organisation.motifs.active.none?
+        = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."
+      - elsif plage_ouverture.organisation.motifs.active.individuel.none?
+        = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous individuel. Cette organisation ne contient que des motifs collectifs.", non_admin_text: "Aucun motif de rendez-vous individuel n'est disponible dans cette organisation. Vous devez demander à un administrateur de votre organisation d'en créer un."
+      - else
+        = render "admin/motifs/creation_needed_callout", motivation_text: "Aucun motif individuel n'est accessible à cet agent. Les motifs existants sont liés à des services auxquels il n'appartient pas.", non_admin_text: "Vous n'avez accès à aucun motif individuel pour cette organisation. Les motifs existants sont liés à des services auxquels vous n'appartenez pas. Vous devez demander à un administrateur de votre organisation d'en créer un accessible à votre service."

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -1,4 +1,5 @@
 - content_for(:menu_item) { "menu-plages-ouvertures" }
+- available_motifs_for_agent = Motif.available_motifs_for_organisation_and_agent(current_organisation, @agent).individuel
 
 - content_for :title do
   - if current_agent == @agent
@@ -10,7 +11,8 @@
   - if current_organisation.motifs.active.any?
     .fr-btns-group.fr-btns-group--inline.fr-btns-group--icon-left
       = link_to t(".calendar_view"), calendar_admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: @agent.id), class: "fr-btn fr-btn--secondary fr-icon-calendar-fill mb-0"
-      = link_to t(".create_plage_ouverture"),  new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: @agent.id), class: "fr-btn fr-btn--secondary fr-btn fr-btn--icon-left fr-icon-add-line mb-0"
+      - if available_motifs_for_agent.any?
+        = link_to t(".create_plage_ouverture"),  new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: @agent.id), class: "fr-btn fr-btn--secondary fr-btn fr-btn--icon-left fr-icon-add-line mb-0"
 
 - if flash[:onboarding] == "online_booking_ready"
   - content_for :onboarding_banner do
@@ -63,17 +65,22 @@
             h2= t(".other_agent.not_yet_created_plage_ouverture", full_name: @agent.full_name_or_email)
             p = t(".other_agent.explanation_plage_ouverture")
 
-          - if current_organisation.motifs.active.any?
+          - if available_motifs_for_agent.any?
             .mt-3
               = link_to  new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: @agent.id), class: "fr-btn" do
                 - if current_agent == @agent
                   = t(".self.create_first_plage_cta")
                 - else
                   = t(".other_agent.create_first_plage_cta", full_name: @agent.full_name_or_email)
-    - if current_organisation.motifs.active.none?
+    - if available_motifs_for_agent.none?
       .fr-grid-row
         .fr-col-12.fr-px-2w
-          = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."
+          - if current_organisation.motifs.active.none?
+            = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."
+          - elsif current_organisation.motifs.active.individuel.none?
+            = render "admin/motifs/creation_needed_callout", motivation_text: "Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous individuel. Cette organisation ne contient que des motifs collectifs.", non_admin_text: "Aucun motif de rendez-vous individuel n'est disponible dans cette organisation. Vous devez demander à un administrateur de votre organisation d'en créer un."
+          - else
+            = render "admin/motifs/creation_needed_callout", motivation_text: "Aucun motif individuel n'est accessible à cet agent. Les motifs existants sont liés à des services auxquels il n'appartient pas.", non_admin_text: "Vous n'avez accès à aucun motif individuel pour cette organisation. Les motifs existants sont liés à des services auxquels vous n'appartenez pas. Vous devez demander à un administrateur de votre organisation d'en créer un accessible à votre service."
 
   - if params[:current_tab] == "expired"
     .rdv-text-align-center.text-muted = t(".hint_delete_old")

--- a/app/views/admin/planning/plage_ouvertures/index.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/index.html.slim
@@ -11,8 +11,7 @@
   - if current_organisation.motifs.active.any?
     .fr-btns-group.fr-btns-group--inline.fr-btns-group--icon-left
       = link_to t(".calendar_view"), calendar_admin_organisation_planning_plage_ouvertures_path(current_organisation, agent_id: @agent.id), class: "fr-btn fr-btn--secondary fr-icon-calendar-fill mb-0"
-      - if available_motifs_for_agent.any?
-        = link_to t(".create_plage_ouverture"),  new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: @agent.id), class: "fr-btn fr-btn--secondary fr-btn fr-btn--icon-left fr-icon-add-line mb-0"
+      = link_to t(".create_plage_ouverture"),  new_admin_organisation_planning_plage_ouverture_path(current_organisation, agent_id: @agent.id), class: "fr-btn fr-btn--secondary fr-btn fr-btn--icon-left fr-icon-add-line mb-0"
 
 - if flash[:onboarding] == "online_booking_ready"
   - content_for :onboarding_banner do

--- a/spec/features/agents/planning/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/planning/agent_can_crud_plage_ouvertures_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
 
     it "cannot create plage_ouverture" do
       click_link "Créer une plage d'ouverture", match: :first
-      expect(page).to have_content("Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un")
+      expect(page).to have_content("services auxquels vous n'appartenez pas")
     end
 
     context "with motif for_secretariat" do


### PR DESCRIPTION
Closes #6258

# Contexte

Lorsqu'un agent tente de créer une plage d'ouverture sans motif individuel accessible, le message affiché était toujours le même : _"Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."_ — même quand des motifs existent déjà dans l'organisation.

Il y a en réalité 3 cas distincts :
1. Aucun motif actif dans l'organisation
2. Des motifs actifs existent mais tous sont collectifs (les plages d'ouverture ne fonctionnent qu'avec des motifs individuels)
3. Des motifs individuels existent mais sont liés à des services auxquels l'agent n'appartient pas

# Solution

- Le callout `admin/motifs/_creation_needed_callout` accepte désormais un paramètre optionnel `non_admin_text:` pour permettre de personnaliser le message affiché aux agents non-admin.
- Le formulaire de création de plage (`_form.html.slim`) distingue les 3 cas et affiche un message adapté à chacun.
- La page de liste (`index.html.slim`) calcule les motifs accessibles à l'agent (`available_motifs_for_agent`) et :
  - ~~masque le bouton "Créer une plage d'ouverture" quand aucun motif individuel n'est accessible~~ : finalement ce n’est pas une très bonne idée si l’agent a des plages d’ouvertures dans sa liste, mais qu’entre temps, il n’y a plus de motifs actifs il risque de ne pas comprendre pourquoi il ne voit pas le bouton. En gardant le bouton, il peut quand même cliquer dessus et voir pourquoi il ne peut pas créer de plage
  - affiche le callout avec le message approprié au cas détecté


| # | Situation | Rôle | Message affiché |
|---|-----------|------|-----------------|
| 1 | Aucun motif actif dans l'orga | Admin | _"Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous."_ + lien vers Configuration > Motifs |
| 2 | Aucun motif actif dans l'orga | Agent basique | _"Aucun motif de rendez-vous ne vous est accessible. Vous devez demander à un administrateur de votre organisation d'en ajouter un."_ |
| 3 | Uniquement des motifs collectifs | Admin | _"Pour créer une plage d'ouverture, vous devez d'abord créer un motif de rendez-vous individuel. Cette organisation ne contient que des motifs collectifs."_ + lien vers Configuration > Motifs |
| 4 | Uniquement des motifs collectifs | Agent basique | _"Aucun motif de rendez-vous individuel n'est disponible dans cette organisation. Vous devez demander à un administrateur de votre organisation d'en créer un."_ |
| 5 | Motifs individuels liés à un service inaccessible à l'agent | Admin | _"Aucun motif individuel n'est accessible à cet agent. Les motifs existants sont liés à des services auxquels il n'appartient pas."_ + lien vers Configuration > Motifs |
| 6 | Motifs individuels liés à un service inaccessible à l'agent | Agent basique | _"Vous n'avez accès à aucun motif individuel pour cette organisation. Les motifs existants sont liés à des services auxquels vous n'appartenez pas. Vous devez demander à un administrateur de votre organisation d'en créer un accessible à votre service."_ |

