### PR TITLE
Ajout d'un message de confirmation lors de la synchronisation d'un agenda CalDAV

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -15,6 +15,7 @@ class Agents::CaldavSyncController < AgentAuthController
 
     error = caldav_config_error
     if error.nil?
+      flash[:success] = "La synchronisation avec votre agenda CalDAV #{current_agent.caldav_username} est activée."
       current_agent.save!
       Caldav::MassExportEventToCaldavJob.perform_later(current_agent)
     else

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -34,7 +34,7 @@ p
     .card-body
       .fr-mb-2w
         .fr-badge.fr-badge--success Synchronisation active
-        span.fr-ml-2w Votre agenda est synchronisé avec l'agenda CalDAV #{current_agent.caldav_username}.
+        p.fr-my-2w Votre agenda est synchronisé avec l'agenda CalDAV #{current_agent.caldav_username}.
       .fr-btns-group.fr-btns-group--inline
         - if current_agent.organisations.any?
           = link_to("Voir mon agenda", admin_organisation_planning_agenda_path(current_agent.organisations.first), class: "fr-btn fr-btn--secondary")

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -30,9 +30,16 @@ p
       |> Les événements qui avaient été importés dans votre agenda sont en cours de suppression. Cela peut prendre quelques minutes.
       | Vous pouvez revenir sur cette page plus tard pour reconfigurer vos identifiants CalDAV.
 - elsif current_agent.caldav_configured?
-  p Vos identifiants CalDAV sont déjà configurés.
-  = form_tag agents_calendar_sync_caldav_sync_path, method: :delete do
-    = submit_tag "Supprimer la configuration CalDAV", class: "fr-btn fr-btn--secondary", data: { confirm: "Êtes-vous sûr de vouloir supprimer vos identifiants CalDAV ?" }
+  .card
+    .card-body
+      .fr-mb-2w
+        .fr-badge.fr-badge--success Synchronisation active
+        span.fr-ml-2w Votre agenda est synchronisé avec l'agenda CalDAV #{current_agent.caldav_username}.
+      .fr-btns-group.fr-btns-group--inline
+        - if current_agent.organisations.any?
+          = link_to("Voir mon agenda", admin_organisation_planning_agenda_path(current_agent.organisations.first), class: "fr-btn fr-btn--secondary")
+        = form_tag agents_calendar_sync_caldav_sync_path, method: :delete do
+          = submit_tag "Supprimer la configuration CalDAV", class: "fr-btn fr-btn--tertiary", data: { confirm: "Êtes-vous sûr de vouloir supprimer vos identifiants CalDAV ?" }
 - else
   = form_tag agents_calendar_sync_caldav_sync_path, method: :put do
     .fr-input-group

--- a/spec/controllers/agents/caldav_sync_controller_spec.rb
+++ b/spec/controllers/agents/caldav_sync_controller_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Agents::CaldavSyncController, type: :controller do
         expect(response).to redirect_to(agents_calendar_sync_caldav_sync_path)
         expect(agent.reload.caldav_username).to eq("user@example.fr")
         expect(agent.reload.caldav_agenda_url).to eq("https://caldav.example.fr/dav/calendars/user/default")
+        expect(flash[:success]).to eq("La synchronisation avec votre agenda CalDAV user@example.fr est activée.")
       end
 
       it "ne met pas de message d’erreur en flash" do


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1402" height="567" alt="Screenshot 2026-03-20 at 10 36 17" src="https://github.com/user-attachments/assets/0ebe3eb6-00f3-403f-9ab7-e1cf71bc433b" />|<img width="1398" height="757" alt="Screenshot 2026-03-20 at 10 34 06" src="https://github.com/user-attachments/assets/8b0d3941-bb25-4b26-abba-ff2307fe3cb4" />

Suite au retour de Florian pendant son onboarding, on ajoute un message de confirmation quand la synchro caldav réussit.

J'ai aussi ajouté un lien vers le calendrier pour permettre de voir que tout fonctionne (ce qui est probablement la prochaine chose que veut faire l'agent après avoir activé cette synchronisation)


