### PR TITLE
Correction de la récupération des stats Metabase

### DIFF
--- a/app/jobs/cron_job/refresh_cached_stats.rb
+++ b/app/jobs/cron_job/refresh_cached_stats.rb
@@ -62,7 +62,7 @@ class CronJob::RefreshCachedStats
       return rows unless single_count_row?
 
       # Metabase can split thousands with spaces or commas depending on its configurations, which can be changed in its web ui
-      rows[0]["c"].gsub(/[, ]/, "").to_i
+      rows[0]["c"].to_s.gsub(/[, ]/, "").to_i
     end
 
     def single_count_row? = rows.count == 1 && rows[0]["c"].present?

--- a/app/lib/metabase_api.rb
+++ b/app/lib/metabase_api.rb
@@ -7,7 +7,7 @@ class MetabaseApi
   def self.sql_query(query, raw_json: false, timeout: DEFAULT_TYPHOEUS_TIMEOUT)
     res = Typhoeus.post(
       "#{HOST_URL}/api/dataset/json",
-      params: { query: { database: DATABASE_ID, native: { query: }, type: "native" }.to_json },
+      body: { query: { database: DATABASE_ID, native: { query: }, type: "native" } }.to_json,
       headers: {
         "x-api-key" => ENV["METABASE_API_KEY"],
         "Content-Type" => "application/json",

--- a/spec/lib/carto_anct_spec.rb
+++ b/spec/lib/carto_anct_spec.rb
@@ -2,17 +2,17 @@ RSpec.describe CartoANCT do
   describe ".fetch_and_merge_metrics" do
     it "merges siret and insee" do
       stub_request(:post, /#{MetabaseApi::HOST_URL}/)
-        .with { _1.uri.to_s.include?("code_insee") && _1.uri.to_s.include?("rdvs%") }
+        .with { _1.body.include?("code_insee") && _1.body.exclude?("rdvsp") }
         .to_return(body: [{ insee: "01001", tu: 200 }, { insee: "01006", tu: 100 }].to_json)
       stub_request(:post, /#{MetabaseApi::HOST_URL}/)
-        .with { _1.uri.to_s.include?("code_insee") && _1.uri.to_s.include?("rdvsp%") }
+        .with { _1.body.include?("code_insee") && _1.body.include?("rdvsp") }
         .to_return(body: [{ insee: "01001", tu: 44 }, { insee: "01006", tu: 33 }].to_json)
 
       stub_request(:post, /#{MetabaseApi::HOST_URL}/)
-        .with { _1.uri.to_s.include?("siret") && _1.uri.to_s.include?("rdvs%") }
+        .with { _1.body.include?("siret") && _1.body.exclude?("rdvsp") }
         .to_return(body: [{ siret: "13002526500013", tu: 2 }].to_json)
       stub_request(:post, /#{MetabaseApi::HOST_URL}/)
-        .with { _1.uri.to_s.include?("siret") && _1.uri.to_s.include?("rdvsp%") }
+        .with { _1.body.include?("siret") && _1.body.include?("rdvsp") }
         .to_return(body: [{ siret: "13002526500013", tu: 30 }, { siret: "12345678901234", tu: 10 }].to_json)
 
       expected_merged_results = [


### PR DESCRIPTION
# Contexte

Depuis, la mise à jour du Metabase, nous avons le job de récupération des stats qui plante car il n’est plus possible de passer la query en `params`.

# Solution

On passe la query dans le JSON body.
