### PR TITLE
Permettre de saisir des adresses de lieu à l’étranger

### DIFF
--- a/app/controllers/admin/lieux_controller.rb
+++ b/app/controllers/admin/lieux_controller.rb
@@ -90,6 +90,6 @@ class Admin::LieuxController < AgentAuthController
   end
 
   def lieu_params
-    params.require(:lieu).permit(:name, :address, :phone_number, :enabled, :latitude, :longitude)
+    params.require(:lieu).permit(:name, :address, :phone_number, :enabled, :latitude, :longitude, :address_without_geocoding)
   end
 end

--- a/app/controllers/api/v1/lieux_controller.rb
+++ b/app/controllers/api/v1/lieux_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::LieuxController < Api::V1::AgentAuthBaseController
   end
 
   def create
-    lieu = Lieu.new(params.permit(:organisation_id, :name, :address, :latitude, :longitude, :phone_number, :availability))
+    lieu = Lieu.new(params.permit(:organisation_id, :name, :address, :latitude, :longitude, :phone_number, :availability, :address_without_geocoding))
 
     authorize(lieu, policy_class: Agent::LieuPolicy)
 

--- a/app/dashboards/lieu_dashboard.rb
+++ b/app/dashboards/lieu_dashboard.rb
@@ -24,6 +24,7 @@ class LieuDashboard < Administrate::BaseDashboard
     phone_number_formatted: Field::String,
     availability: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     address: PlacesField.with_options(searchable: true),
+    address_without_geocoding: Field::Boolean,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -60,6 +61,7 @@ class LieuDashboard < Administrate::BaseDashboard
     latitude
     longitude
     address
+    address_without_geocoding
     organisation
   ].freeze
 

--- a/app/javascript/components/places-inputs.js
+++ b/app/javascript/components/places-inputs.js
@@ -13,6 +13,11 @@ class PlacesInput {
         map(name => ({ name, elt: form.querySelector(`input[name*=${name}]`)})).
         filter(i => !!i.elt) // filter only present inputs
 
+    const noGeocodingCheckboxName = container.dataset.addressNoGeocodingCheckbox;
+    this.noGeocodingCheckbox = noGeocodingCheckboxName
+      ? form.querySelector(`input[type="checkbox"][name="${noGeocodingCheckboxName}"]`)
+      : null;
+
     $(container).autocomplete(
       { hint: false },
       [{
@@ -25,10 +30,21 @@ class PlacesInput {
     );
 
     // clear dependent fields upon input event (before selecting suggestion)
-    container.addEventListener("input", () => this.setDependentInputs({}))
+    container.addEventListener("input", () => {
+      if (!this.noGeocodingCheckbox?.checked) this.setDependentInputs({})
+    })
+
+    // when checking "no geocoding": clear lat/lng; when unchecking: clear address to force re-selection
+    if (this.noGeocodingCheckbox) {
+      this.noGeocodingCheckbox.addEventListener("change", () => {
+        this.setDependentInputs({})
+      })
+    }
   }
 
   getSuggestions = (query, callback) => {
+    if (this.noGeocodingCheckbox?.checked) return callback([])
+
     const url = "https://data.geopf.fr/geocodage/search/"
     const searchParams = new URLSearchParams()
     searchParams.append("q", query)

--- a/app/javascript/components/places-inputs.js
+++ b/app/javascript/components/places-inputs.js
@@ -13,10 +13,7 @@ class PlacesInput {
         map(name => ({ name, elt: form.querySelector(`input[name*=${name}]`)})).
         filter(i => !!i.elt) // filter only present inputs
 
-    const noGeocodingCheckboxName = container.dataset.addressNoGeocodingCheckbox;
-    this.noGeocodingCheckbox = noGeocodingCheckboxName
-      ? form.querySelector(`input[type="checkbox"][name="${noGeocodingCheckboxName}"]`)
-      : null;
+    this.addressWithoutGeocodingInput = form.querySelector('input[type="hidden"][name*="address_without_geocoding"]');
 
     $(container).autocomplete(
       { hint: false },
@@ -25,33 +22,35 @@ class PlacesInput {
         debounce: 800,
         templates: { suggestion: this.suggestionTemplate }
       }]
-    ).on('autocomplete:selected', (_event, suggestion, _dataset, _context) =>
-      this.setDependentInputs(suggestion)
-    );
+    ).on('autocomplete:selected', (_event, suggestion, _dataset, _context) => {
+      if (suggestion.type === 'no_address') {
+        this.setDependentInputs({})
+        if (this.addressWithoutGeocodingInput) this.addressWithoutGeocodingInput.value = "1"
+      } else {
+        this.setDependentInputs(suggestion)
+        if (this.addressWithoutGeocodingInput) this.addressWithoutGeocodingInput.value = "0"
+      }
+    });
 
     // clear dependent fields upon input event (before selecting suggestion)
     container.addEventListener("input", () => {
-      if (!this.noGeocodingCheckbox?.checked) this.setDependentInputs({})
+      this.setDependentInputs({})
+      if (this.addressWithoutGeocodingInput) this.addressWithoutGeocodingInput.value = "0"
     })
-
-    // when checking "no geocoding": clear lat/lng; when unchecking: clear address to force re-selection
-    if (this.noGeocodingCheckbox) {
-      this.noGeocodingCheckbox.addEventListener("change", () => {
-        this.setDependentInputs({})
-      })
-    }
   }
 
   getSuggestions = (query, callback) => {
-    if (this.noGeocodingCheckbox?.checked) return callback([])
-
     const url = "https://data.geopf.fr/geocodage/search/"
     const searchParams = new URLSearchParams()
     searchParams.append("q", query)
     if (this.addressType) searchParams.append("type", this.addressType)
     fetch(`${url}?${searchParams}`).
       then(res => res.json()).
-      then(this.remapBanFeatures).
+      then(data => {
+        const suggestions = this.remapBanFeatures(data)
+        if (this.addressWithoutGeocodingInput) suggestions.push({ type: 'no_address', value: query })
+        return suggestions
+      }).
       then(callback)
   }
 
@@ -91,6 +90,15 @@ class PlacesInput {
     })
 
   suggestionTemplate = suggestion => {
+    if (suggestion.type === 'no_address') {
+      return `
+        <div class='d-flex'>
+          <div class='fr-ml-1w'><i class="fr-icon-question-fill"></i></div>
+          <div class='fr-ml-1w text-muted'><em>Adresse introuvable ou à l'étranger ?</em></div>
+        </div>
+      `
+    }
+
     const { type, name } = suggestion
     const icon = {
       housenumber: "home-4-fill",

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -80,6 +80,13 @@ class Domain
     ),
   ].freeze
 
+  # Dans le cadre de l’instance RDV Service Public, nous ne proposons pas de sélection d’adresse à l’usager, et nous avons des adresses de lieux
+  # à l’étranger qui ne peuvent pas être géocodées par la BAN.
+  # On souhaite donc proposer aux agents de pouvoir ajouter des lieux en bypassant le géocodage.
+  def accept_lieu_address_without_geocoding?
+    !provides_address_selection?
+  end
+
   def provides_address_selection?
     address_selection_template_name.present?
   end

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -108,6 +108,7 @@ class Lieu < ApplicationRecord
   private
 
   def longitude_and_latitude_must_be_present
+    return if address_without_geocoding?
     return if latitude.present? && longitude.present?
 
     errors.add(:address, :must_be_valid)

--- a/app/views/admin/lieux/_lieu_fields.html.slim
+++ b/app/views/admin/lieux/_lieu_fields.html.slim
@@ -7,7 +7,9 @@
 / All forms
 = f.dsfr_text_field :name, label: Lieu.human_attribute_name(:name), required: true, hint: "Le nom apparaît dans les notifications par email et SMS aux usagers."
 
-= f.dsfr_text_field :address, label: Lieu.human_attribute_name(:address), data: { "address-autocomplete": "on" }, required: true, hint: "L'adresse apparaît dans les notifications par email et SMS aux usagers."
+= f.dsfr_text_field :address, label: Lieu.human_attribute_name(:address), data: { "address-autocomplete": "on", "address-no-geocoding-checkbox": "lieu[address_without_geocoding]" }, required: true, hint: "L'adresse apparaît dans les notifications par email et SMS aux usagers."
+- if current_domain == Domain::RDV_SERVICE_PUBLIC
+  = f.dsfr_check_box :address_without_geocoding, label: "Le lieu est à l'étranger"
 = f.hidden_field :latitude
 = f.hidden_field :longitude
 

--- a/app/views/admin/lieux/_lieu_fields.html.slim
+++ b/app/views/admin/lieux/_lieu_fields.html.slim
@@ -10,7 +10,7 @@
 = f.dsfr_text_field :address, label: Lieu.human_attribute_name(:address), data: { "address-autocomplete": "on" }, required: true, hint: "L'adresse apparaît dans les notifications par email et SMS aux usagers."
 = f.hidden_field :latitude
 = f.hidden_field :longitude
-- if current_domain == Domain::RDV_SERVICE_PUBLIC
+- if current_domain.accept_lieu_address_without_geocoding?
   = f.hidden_field :address_without_geocoding
 
 - unless is_nested_form

--- a/app/views/admin/lieux/_lieu_fields.html.slim
+++ b/app/views/admin/lieux/_lieu_fields.html.slim
@@ -7,11 +7,11 @@
 / All forms
 = f.dsfr_text_field :name, label: Lieu.human_attribute_name(:name), required: true, hint: "Le nom apparaît dans les notifications par email et SMS aux usagers."
 
-= f.dsfr_text_field :address, label: Lieu.human_attribute_name(:address), data: { "address-autocomplete": "on", "address-no-geocoding-checkbox": "lieu[address_without_geocoding]" }, required: true, hint: "L'adresse apparaît dans les notifications par email et SMS aux usagers."
-- if current_domain == Domain::RDV_SERVICE_PUBLIC
-  = f.dsfr_check_box :address_without_geocoding, label: "Le lieu est à l'étranger"
+= f.dsfr_text_field :address, label: Lieu.human_attribute_name(:address), data: { "address-autocomplete": "on" }, required: true, hint: "L'adresse apparaît dans les notifications par email et SMS aux usagers."
 = f.hidden_field :latitude
 = f.hidden_field :longitude
+- if current_domain == Domain::RDV_SERVICE_PUBLIC
+  = f.hidden_field :address_without_geocoding
 
 - unless is_nested_form
   = f.dsfr_text_field :phone_number, label: Lieu.human_attribute_name(:phone_number), hint: "Facultatif. Ce numéro permet aux usagers de vous contacter. Faites en sorte que les personnes qui répondent au téléphone puissent avoir accès à #{current_domain.name}."

--- a/app/views/fields/places_field/_form.html.slim
+++ b/app/views/fields/places_field/_form.html.slim
@@ -1,4 +1,4 @@
 .field-unit__label
   = f.label field.attribute
 .field-unit__field
-  = f.text_field field.attribute, data: { "address-autocomplete": "on", "address-no-geocoding-checkbox": "lieu[address_without_geocoding]" }, dir: "ltr"
+  = f.text_field field.attribute, data: { "address-autocomplete": "on" }, dir: "ltr"

--- a/app/views/fields/places_field/_form.html.slim
+++ b/app/views/fields/places_field/_form.html.slim
@@ -1,4 +1,4 @@
 .field-unit__label
   = f.label field.attribute
 .field-unit__field
-  = f.text_field field.attribute, data: { "address-autocomplete": "on" }, dir: "ltr"
+  = f.text_field field.attribute, data: { "address-autocomplete": "on", "address-no-geocoding-checkbox": "lieu[address_without_geocoding]" }, dir: "ltr"

--- a/app/views/super_admins/lieux/_form.html.slim
+++ b/app/views/super_admins/lieux/_form.html.slim
@@ -8,11 +8,15 @@
         - page.resource.errors.full_messages.each do |message|
           li.flash-error= message
   - page.attributes.each do |attribute|
+    - next if current_domain != Domain::RDV_SERVICE_PUBLIC && attribute.name == "address_without_geocoding"
     div class=("field-unit field-unit--#{attribute.html_class} field-unit--#{requireness(attribute)}")
       = render_field attribute, f: f
   .form-actions
     p
-      | La latitude et la longitude sont requises. Vous pouvez les retrouver en cherchant l'adresse du lieu dans #{link_to("Open Street Map", "https://www.openstreetmap.org/")}
+      | La latitude et la longitude sont requises
+      - if current_domain == Domain::RDV_SERVICE_PUBLIC
+        |< (sauf si vous cochez la case « Adresse à l’étranger ou introuvable »)
+      | . Vous pouvez les retrouver en cherchant l'adresse du lieu dans #{link_to("Open Street Map", "https://www.openstreetmap.org/")}
     p
       | La latitude est le nombre plus élevé, proche de 48, et la longitude est le nombre plus faible, proche de 2.
     = f.submit

--- a/app/views/super_admins/lieux/_form.html.slim
+++ b/app/views/super_admins/lieux/_form.html.slim
@@ -8,13 +8,13 @@
         - page.resource.errors.full_messages.each do |message|
           li.flash-error= message
   - page.attributes.each do |attribute|
-    - next if current_domain != Domain::RDV_SERVICE_PUBLIC && attribute.name == "address_without_geocoding"
+    - next if !current_domain.accept_lieu_address_without_geocoding? && attribute.name == "address_without_geocoding"
     div class=("field-unit field-unit--#{attribute.html_class} field-unit--#{requireness(attribute)}")
       = render_field attribute, f: f
   .form-actions
     p
       | La latitude et la longitude sont requises
-      - if current_domain == Domain::RDV_SERVICE_PUBLIC
+      - if current_domain.accept_lieu_address_without_geocoding?
         |< (sauf si vous cochez la case « Adresse à l’étranger ou introuvable »)
       | . Vous pouvez les retrouver en cherchant l'adresse du lieu dans #{link_to("Open Street Map", "https://www.openstreetmap.org/")}
     p

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -245,6 +245,7 @@ tables:
       - longitude
       - availability
       - code_postal
+      - address_without_geocoding
 
   - table_name: participations
     anonymized_column_names:

--- a/config/locales/models/lieu.fr.yml
+++ b/config/locales/models/lieu.fr.yml
@@ -4,6 +4,7 @@ fr:
       lieu: Lieu
     attributes:
       lieu:
+        address_without_geocoding: Adresse à l'étranger ou introuvable
         availability: Ouverture
         enabled: Ouvert
         latitude: Latitude

--- a/db/migrate/20260320000001_add_address_without_geocoding_to_lieux.rb
+++ b/db/migrate/20260320000001_add_address_without_geocoding_to_lieux.rb
@@ -1,0 +1,5 @@
+class AddAddressWithoutGeocodingToLieux < ActiveRecord::Migration[8.0]
+  def change
+    add_column :lieux, :address_without_geocoding, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_19_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_20_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -383,6 +383,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_19_000001) do
     t.enum "availability", default: "enabled", null: false, comment: "Permet de savoir si le lieu est un lieu normal (enabled), un lieu ponctuel qui sera utilisé pour un seul rdv (single_use), ou un lieu supprimé par soft-delete (disabled). Dans la plupart des cas on s'intéresse uniquement aux lieux enabled\n", enum_type: "lieu_availability"
     t.string "address", null: false
     t.string "code_postal"
+    t.boolean "address_without_geocoding", default: false, null: false
     t.index ["availability"], name: "index_lieux_on_availability"
     t.index ["name"], name: "index_lieux_on_name"
     t.index ["organisation_id"], name: "index_lieux_on_organisation_id"

--- a/spec/controllers/admin/lieux_controller_spec.rb
+++ b/spec/controllers/admin/lieux_controller_spec.rb
@@ -48,6 +48,23 @@ RSpec.describe Admin::LieuxController, type: :controller do
       end
     end
 
+    context "with address_without_geocoding and no coordinates" do
+      let(:valid_attributes) do
+        build(:lieu, latitude: nil, longitude: nil, address_without_geocoding: true).attributes
+      end
+
+      it "creates a new Lieu" do
+        expect do
+          post :create, params: { organisation_id: organisation.id, lieu: valid_attributes }
+        end.to change(Lieu, :count).by(1)
+      end
+
+      it "persiste address_without_geocoding à true" do
+        post :create, params: { organisation_id: organisation.id, lieu: valid_attributes }
+        expect(Lieu.last.address_without_geocoding).to be true
+      end
+    end
+
     context "with invalid params" do
       let(:invalid_attributes) do
         {

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe Lieu, type: :model do
       expect(lieu.errors.full_messages).to eq(["Adresse doit être valide"])
     end
 
+    describe "address_without_geocoding" do
+      it "est valide sans coordonnées si address_without_geocoding est vrai" do
+        lieu = build(:lieu, latitude: nil, longitude: nil, address_without_geocoding: true)
+        expect(lieu).to be_valid
+      end
+
+      it "reste invalide sans coordonnées si address_without_geocoding est faux" do
+        lieu = build(:lieu, latitude: nil, longitude: nil, address_without_geocoding: false)
+        expect(lieu).to be_invalid
+      end
+    end
+
     describe "availability changes" do
       let(:lieu) { create :lieu, availability: initial_value }
 

--- a/spec/requests/api/v1/lieux_spec.rb
+++ b/spec/requests/api/v1/lieux_spec.rb
@@ -106,6 +106,25 @@ RSpec.describe "Lieux API" do
       end
     end
 
+    context "with address_without_geocoding and no coordinates" do
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          name: "Ambassade de France à Berlin",
+          address: "Pariser Platz 5, 10117 Berlin, Allemagne",
+          address_without_geocoding: true,
+        }
+      end
+
+      it "crée le lieu sans coordonnées" do
+        expect { post "/api/v1/lieux", headers:, params:, as: :json }.to change(Lieu, :count).by(1)
+        expect(response.status).to eq 200
+        expect(Lieu.last.address_without_geocoding).to be true
+        expect(Lieu.last.latitude).to be_nil
+        expect(Lieu.last.longitude).to be_nil
+      end
+    end
+
     context "when a lieux already exists for the given external reference" do
       let(:params) do
         {


### PR DESCRIPTION
# Contexte

Certains lieux se situent à l'étranger ou ne sont pas trouvés par l'autocomplétion d'adresse (basée sur la Base Adresse Nationale française). Dans ces cas, les agents ne pouvaient pas créer ou modifier ces lieux, car la validation exigeait une latitude et longitude, uniquement fournies par l'autocomplete. Jusqu’ici on créait les lieux en SuperAdmin, mais nous avons de plus en plus de demande. On souhaite donc ajouter cette possibilitié.

# Solution

Ajout d'une colonne `address_without_geocoding` (boolean, default: false) sur `lieux`. Quand ce flag est activé :
- La validation `longitude_and_latitude_must_be_present` est skippée
- L'autocomplétion JS est désactivée et les champs lat/lng sont vidés

Le formulaire agent expose une checkbox "Le lieu est à l'étranger" (uniquement sur RDV Service Public). Le param est également autorisé sur l'API v1.

Les lieux sans coordonnées remontent avec une distance de 0 dans le tri par proximité côté usager — comportement marginal et acceptable pour ces cas exceptionnels, d’autant plus que la distance n’est utilisée que sur RDV Solidarités à ce jour.

À terme, nous pourrons re-géocoder ces adresses au besoin avec OpenStreetMap par exemple.

Vu avec Victor : on préfère matérialiser le boolean en base pour faciliter l’édition notamment.

## Captures d'écran

<img width="1186" height="630" alt="image" src="https://github.com/user-attachments/assets/71b1123e-2be8-4e4f-817b-1f002f32ee12" />
