### PR TITLE
Repasser en attente demande d’ouverture de compte refusée

### DIFF
--- a/app/controllers/super_admins/territory_creation_requests_controller.rb
+++ b/app/controllers/super_admins/territory_creation_requests_controller.rb
@@ -22,7 +22,10 @@ module SuperAdmins
       @territory_creation_request = TerritoryCreationRequest.find(params[:id])
       authorize_resource(@territory_creation_request)
 
-      if @territory_creation_request.update(params.require(:territory_creation_request).permit(:response))
+      permitted = params.require(:territory_creation_request).permit(:response)
+      permitted[:response] = nil if permitted[:response].blank?
+
+      if @territory_creation_request.update(permitted)
         redirect_to super_admins_territory_creation_requests_path, flash: { success: "Demande traitée" }
       else
         flash.now[:error] = @territory_creation_request.errors.full_messages.join(" ")

--- a/app/models/territory_creation_request.rb
+++ b/app/models/territory_creation_request.rb
@@ -10,7 +10,7 @@ class TerritoryCreationRequest < ApplicationRecord
   private
 
   def can_only_have_one_response
-    if response_changed? && !response_was.nil?
+    if response_changed? && !response_was.nil? && response.present?
       errors.add(:response, "Un autre super admin a déjà traité cette demande")
     end
   end

--- a/app/views/super_admins/territory_creation_requests/edit.html.slim
+++ b/app/views/super_admins/territory_creation_requests/edit.html.slim
@@ -73,3 +73,10 @@ section.main-content__body
           = f.submit "Refuser"
 
         = link_to("Accepter", new_super_admins_compte_path(request_id: @territory_creation_request.id), class: "button")
+
+    - elsif @territory_creation_request.response == "refused"
+      hr
+      p Cette demande a été refusée.
+      = simple_form_for([namespace, @territory_creation_request], html: { class: "form" }) do |f|
+        = f.hidden_field :response, value: ""
+        = f.submit "Repasser en attente"


### PR DESCRIPTION
# Contexte

Nous avons de temps et en temps des personnes qui écrivent au support pour justifier une demande d’ouverture de compte que nous avons refusé.

# Solution

On permet donc de repasser en attente une demande d’ouverture de compte qui a été refusée.
