### PR TITLE
Envoyer un email en cas de refus de demande d’ouverture de compte

### DIFF
--- a/app/controllers/super_admins/territory_creation_requests_controller.rb
+++ b/app/controllers/super_admins/territory_creation_requests_controller.rb
@@ -26,6 +26,12 @@ module SuperAdmins
       permitted[:response] = nil if permitted[:response].blank?
 
       if @territory_creation_request.update(permitted)
+        if @territory_creation_request.response == "refused"
+          Agents::TerritoryCreationRequestMailer.refused(
+            agent: @territory_creation_request.agent,
+            domain_id: current_domain.id
+          ).deliver_later
+        end
         redirect_to super_admins_territory_creation_requests_path, flash: { success: "Demande traitée" }
       else
         flash.now[:error] = @territory_creation_request.errors.full_messages.join(" ")

--- a/app/mailers/agents/territory_creation_request_mailer.rb
+++ b/app/mailers/agents/territory_creation_request_mailer.rb
@@ -6,6 +6,12 @@ class Agents::TerritoryCreationRequestMailer < ApplicationMailer
     mail(to: agent.email, subject: t(".title", domain_name: domain))
   end
 
+  def refused(agent:, domain_id:)
+    @agent = agent
+    @domain = Domain.find(domain_id)
+    mail(to: agent.email, subject: t(".title", domain_name: domain))
+  end
+
   private
 
   attr_reader :domain

--- a/app/views/mailers/agents/territory_creation_request_mailer/refused.html.slim
+++ b/app/views/mailers/agents/territory_creation_request_mailer/refused.html.slim
@@ -1,0 +1,25 @@
+p = t("mailers.common.hello")
+
+p
+  | Nous avons bien reçu votre demande d'ouverture d'un espace
+  b = " #{@agent.territory_creation_request.organisation_name}"
+  |> . Après examen, nous ne sommes pas en mesure de donner suite à cette demande.
+  | En effet, seules les organisations suivantes peuvent prétendre à l’ouverture d’un espace sur #{domain.name} :
+  ul
+    li Les administrations de l’État
+    li Les opérateurs publics
+    li Les collectivités territoriales (communes, départements, régions)
+    li Les associations mandatées dans le cadre d’une mission de service public
+
+  |> Il est aussi possible que votre demande ait été refusée, car votre organisation possède déjà un espace sur #{domain.name}.
+  |> Dans ce cas, notre équipe est rentrée en contact avec vous et/ou votre administrateur d’espace pour vous accompagner
+  | dans la gestion de votre espace existant.
+
+br
+br
+
+p
+  |> Si vous pensez qu'il s'agit d'une erreur ou si vous souhaitez plus d'informations, n'hésitez pas à nous le faire savoir par retour de mail.
+  b> Si vous êtes une association ou une entreprise, merci de nous indiquer dans votre réponse, la mission de service public que votre organisation remplit.
+
+= t("mailers.common.farewell_html", domain_name: domain.name)

--- a/app/views/super_admins/territory_creation_requests/edit.html.slim
+++ b/app/views/super_admins/territory_creation_requests/edit.html.slim
@@ -65,7 +65,7 @@ section.main-content__body
 
       p Pour éviter de créer des doublons, vérifiez qu'il n'y a pas d'espace déjà existant avec un nom similaire
 
-      p Si vous refusez la demande, merci de contacter l'agent pour lui expliquer votre décision.
+      p En cas de refus, un email sera automatiquement envoyé à l'agent pour l'informer de votre décision.
 
       div[style="display: flex; padding-top: 12px"]
         = simple_form_for([namespace, @territory_creation_request], html: { class: "form", style: "padding-right: 20px" }) do |f|

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -51,6 +51,8 @@ fr:
     territory_creation_request_mailer:
       accepted:
         title: "Votre espace %{domain_name} est ouvert 🚀"
+      refused:
+        title: "Votre demande d’ouverture d’espace %{domain_name} a été refusée"
   users:
     file_attente_mailer:
       new_creneau_available:

--- a/spec/mailers/previews/agents/territory_creation_request_mailer_preview.rb
+++ b/spec/mailers/previews/agents/territory_creation_request_mailer_preview.rb
@@ -3,4 +3,9 @@ class Agents::TerritoryCreationRequestMailerPreview < ActionMailer::Preview
     agent = Agent.joins(:organisations).last
     Agents::TerritoryCreationRequestMailer.accepted(agent: agent, domain_id: Domain::RDV_SERVICE_PUBLIC.id, organisation: agent.organisations.last)
   end
+
+  def refused
+    agent = Agent.joins(:territory_creation_request).last
+    Agents::TerritoryCreationRequestMailer.refused(agent: agent, domain_id: Domain::RDV_SERVICE_PUBLIC.id)
+  end
 end


### PR DESCRIPTION
# Contexte

Vu avec Léa. On envoie un mail automatiquement, si on refuse une ouverture de compte. Si la personne considère qu’on a eu tort, elle peut toujours nous écrire en répondant au mail et ça ouvrira un ticket dans Zammad.


