### PR TITLE
Correction du nom affiché sur l’écran de demande d’ouverture d’espace

### DIFF
--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -25,7 +25,7 @@
   .fr-grid-row.fr-grid-row--gutters.fr-pb-8w
     .fr-col-12.fr-pb-8w
       h1.fr-h3.fr-pb-2w Ouverture d'espace en attente
-      p.fr-py-1w Nous avons bien reçu votre demande d'ouverture d'espace pour #{current_agent.territory_creation_request.territory_name}.
+      p.fr-py-1w Nous avons bien reçu votre demande d'ouverture d'espace pour #{current_agent.territory_creation_request.organisation_name}.
       p Vous recevrez un email dès que votre espace sera ouvert.
       p En attendant, si vous avez des questions vous pouvez consulter notre documentation ou nous contacter directement.
       = link_to "Consulter la documentation", current_domain.documentation_url, class: "fr-btn fr-btn--secondary fr-mr-2w", target: :_blank


### PR DESCRIPTION
# Contexte

Lors de la demande de création d’espace, nous enregistrons le nom de l’organisation et non le nom de l’espace. Par conséquence, sur l’écran de demande en attente, nous affichons ceci : 

<img width="1011" height="543" alt="image" src="https://github.com/user-attachments/assets/f2ab3dcf-dcc0-46ce-8075-d6511d2f9c0c" />


# Solution

On utilise le nom de l’organisation à la place.