### PR TITLE
Permettre d’afficher facilement les usagers avec le même email en SuperAdmin

### DIFF
--- a/app/views/super_admins/users/show.html.slim
+++ b/app/views/super_admins/users/show.html.slim
@@ -1,9 +1,14 @@
-- content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) }
+ruby:
+  content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) }
+  email_to_search = page.resource.email.presence || page.resource.notification_email
+  same_email_count = email_to_search.present? ? User.where.not(id: page.resource.id).where(email: email_to_search).or(User.where.not(id: page.resource.id).where(notification_email: email_to_search)).count : 0
 header.main-content__header role="banner"
   h1.main-content__page-title
     = content_for(:title)
   div
     => link_to(t("administrate.actions.edit_resource", name: page.page_title),[:edit, namespace, page.resource], class: "button") if accessible_action?(page.resource, :edit)
+    - if same_email_count > 0
+      => link_to "Voir les fiches avec le même email (#{same_email_count})", super_admins_users_path(search: email_to_search), class: "button"
 section.main-content__body
   dl
     - page.attributes.each do |attribute|


### PR DESCRIPTION
# Contexte

Avec le travail en cours de retrait de l’unicité des emails sur les fiches usagers (et la présence historique du notification_email), on se retrouve à avoir parfois 2 fiches ou plus avec le même email.

# Solution

On rajoute un bouton pour savoir que les fiches existent et pour les voir rapidement.

## Captures d'écran

<img width="885" height="210" alt="image" src="https://github.com/user-attachments/assets/9c9a5378-825f-4f60-bb8c-c6acca41a50f" />