### PR TITLE
Clarifier le SMS d’annulation de participation à un RDV

### DIFF
--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -36,17 +36,24 @@ class Users::RdvSms < Users::BaseSms
 
   def rdv_cancelled(rdv, _user, token)
     base_message = "RDV #{rdv_title(rdv)} #{I18n.l(rdv.starts_at, format: :short)} a été annulé."
-    url = prendre_rdv_short_url(host: domain_host, tkn: token)
 
-    footer = if rdv.phone_number.present?
-               "Appelez le #{rdv.phone_number} ou allez sur #{url} pour reprendre RDV."
-             else
-               "Allez sur #{url} pour reprendre RDV."
-             end
-    @content = "#{base_message}\n#{footer}"
+    @content = "#{base_message}\n#{cancellation_footer(rdv, token)}"
   end
 
-  alias participation_cancelled rdv_cancelled
+  def participation_cancelled(rdv, _user, token)
+    base_message = "Votre participation au RDV #{rdv_title(rdv)} #{I18n.l(rdv.starts_at, format: :short)} a été annulée."
+
+    @content = "#{base_message}\n#{cancellation_footer(rdv, token)}"
+  end
+
+  def cancellation_footer(rdv, token)
+    url = prendre_rdv_short_url(host: domain_host, tkn: token)
+    if rdv.phone_number.present?
+      "Appelez le #{rdv.phone_number} ou allez sur #{url} pour reprendre RDV."
+    else
+      "Allez sur #{url} pour reprendre RDV."
+    end
+  end
 
   MAX_RDV_NAME_LENGTH = 50
 


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6283.osc-secnum-fr1.scalingo.io/)

# Contexte

On a eu un retour ici : https://zammad10.ethibox.fr/#ticket/zoom/36377
Cela concerne les notifications d’annulation des RDV collectifs

On a communiqué en disant : « L'usager concerné reçoit automatiquement un e-mail ou un SMS adapté. Il comprend immédiatement que c'est uniquement sa participation qui est annulée, et non l'événement dans sa globalité. »

Néanmoins, le SMS pour l’usager semble être : « RDV Atelier numérique collectif, mercredi 25/03 à 09h00 a été annulé. »

# Solution

Vu avec Mehdi ce matin : 

- Pour la participation on envoie « Votre participation au RDV NOM DU RDV a été annulée » à la place sans préciser la raison pour une question de taille de SMS
- Dans le mail, il est déjà écrit « Votre participation a été annulée pour raisons administrative » ou « Votre participation a été annulée à votre demande »

 Le SMS informe et le mail donne détail le motif de l’annulation

