### PR TITLE
Ajouter un lien de support pour les opérateurs

### DIFF
--- a/app/dashboards/operator_dashboard.rb
+++ b/app/dashboards/operator_dashboard.rb
@@ -5,6 +5,7 @@ class OperatorDashboard < Administrate::BaseDashboard
     id: Field::Number,
     name: Field::String,
     siret: Field::String,
+    support_link: Field::String,
     territories: Field::HasMany,
     operator_managers: Field::HasMany,
   }.freeze
@@ -19,6 +20,7 @@ class OperatorDashboard < Administrate::BaseDashboard
     id
     name
     siret
+    support_link
     territories
     operator_managers
   ].freeze
@@ -26,6 +28,7 @@ class OperatorDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     name
     siret
+    support_link
   ].freeze
 
   def display_resource(operator)

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -1,6 +1,10 @@
 module AgentsHelper
   def may_need_onboarding_help?
     if defined?(current_territory)
+      # Si un opérateur est rattaché au territoire et qu’il assure le support, c’est lui qui se charge de l’accompagnement
+      # de ses adhérents.
+      return false if current_territory.operator&.support_link
+
       Rdv.joins(:organisation).where(organisation: { territory_id: current_territory.id }).limit(5).count < 5
     end
   end

--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -1,21 +1,35 @@
-- @hide_meet_the_team_banner = true
-- content_for(:title) { "Aide et support" }
-- content_for(:menu_item) { "menu-support" }
+ruby:
+  @hide_meet_the_team_banner = true
+  content_for(:title) { "Aide et support" }
+  content_for(:menu_item) { "menu-support" }
+  operator = current_territory.operator
+  operator_support_link = operator&.support_link.presence
 
 .fr-card.fr-card--horizontal.fr-card--sm
   .fr-card__body
-    .fr-card__content
-      h3.fr-card__title
-        | Contactez le support
-      p.fr-card__desc
-        | Vous avez des questions, vous rencontrez une difficulté, ou vous avez une suggestion à nous partager ? Contactez nous via notre formulaire.
-    .fr-card__footer
-      ul.fr-btns-group.fr-btns-group--inline-reverse.fr-btns-group--inline-lg
-        - if may_need_onboarding_help?
+    - if operator_support_link
+      .fr-card__content
+        h3.fr-card__title
+          | Contactez #{operator.name}
+        p.fr-card__desc
+          | Vous avez des questions, vous rencontrez une difficulté, ou vous avez une suggestion à partager ? Votre opérateur est là pour vous aider, n’hésitez pas à le contacter via son formulaire de contact.
+      .fr-card__footer
+        ul.fr-btns-group.fr-btns-group--inline-reverse.fr-btns-group--inline-lg
           li
-            = external_link_to "Contacter l’équipe", "https://rdv.anct.gouv.fr/motif/d17ekoDa/rendez-vous-d-accompagnement", class: "fr-btn"
-        li
-          = link_to "Formulaire de contact", new_aide_demande_support_path(role: "agent", sujet: "Question"), class: "fr-btn fr-btn--secondary"
+            = external_link_to "Formulaire de contact", operator_support_link, class: "fr-btn fr-btn--secondary"
+    - else
+      .fr-card__content
+        h3.fr-card__title
+          | Contactez le support
+        p.fr-card__desc
+          | Vous avez des questions, vous rencontrez une difficulté, ou vous avez une suggestion à nous partager ? Contactez nous via notre formulaire.
+      .fr-card__footer
+        ul.fr-btns-group.fr-btns-group--inline-reverse.fr-btns-group--inline-lg
+          - if may_need_onboarding_help?
+            li
+              = external_link_to "Contacter l’équipe", "https://rdv.anct.gouv.fr/motif/d17ekoDa/rendez-vous-d-accompagnement", class: "fr-btn"
+          li
+            = link_to "Formulaire de contact", new_aide_demande_support_path(role: "agent", sujet: "Question"), class: "fr-btn fr-btn--secondary"
   .fr-card__header.fr-background-alt--blue-france.rdv-max-width-400px
     .fr-card__img
       = dsfr_svg "artwork/pictograms/leisure/community", class: "fr-responsive-img"

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -537,6 +537,7 @@ tables:
     non_anonymized_column_names:
       - name
       - siret
+      - support_link
       - created_at
       - updated_at
   - table_name: operator_managers

--- a/config/locales/models/operator.fr.yml
+++ b/config/locales/models/operator.fr.yml
@@ -2,3 +2,6 @@ fr:
   activerecord:
     models:
       operator: Opérateur
+    attributes:
+      operator:
+        support_link: Lien de support

--- a/db/migrate/20260325000001_add_support_link_to_operators.rb
+++ b/db/migrate/20260325000001_add_support_link_to_operators.rb
@@ -1,0 +1,5 @@
+class AddSupportLinkToOperators < ActiveRecord::Migration[8.0]
+  def change
+    add_column :operators, :support_link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_20_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_25_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -522,6 +522,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_20_000001) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "siret"
+    t.string "support_link"
   end
 
   create_table "organisations", force: :cascade do |t|


### PR DESCRIPTION
# Contexte

Certains opérateurs (OPSN notamment) vont prendre en charge le support de niveau 1 ainsi que l’accompagnement à la mise en place de la solution.

# Solution

On retire donc le lien de contact de l’équipe dans Aide et Support au profit de celui de l’opérateur ainsi que le bandeau bleu d’accompagnement à condition que l’opérateur associé à l’espace ait un lien de support.

Pour le moment ce lien n’est modifiable qu'en SuperAdmin.

<img width="1488" height="561" alt="image" src="https://github.com/user-attachments/assets/ec74c7b5-9258-419f-9bf4-dab3dbe890db" />

