### PR TITLE
Correction de l’affichage des usagers avec le même email

### DIFF
--- a/app/views/super_admins/users/show.html.slim
+++ b/app/views/super_admins/users/show.html.slim
@@ -1,14 +1,13 @@
 ruby:
   content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) }
-  email_to_search = page.resource.email.presence || page.resource.notification_email
-  same_email_count = email_to_search.present? ? User.where.not(id: page.resource.id).where(email: email_to_search).or(User.where.not(id: page.resource.id).where(notification_email: email_to_search)).count : 0
+  same_email_count = page.resource.email.present? ? User.where.not(id: page.resource.id).where(email: page.resource.email).count : 0
 header.main-content__header role="banner"
   h1.main-content__page-title
     = content_for(:title)
   div
     => link_to(t("administrate.actions.edit_resource", name: page.page_title),[:edit, namespace, page.resource], class: "button") if accessible_action?(page.resource, :edit)
     - if same_email_count > 0
-      => link_to "Voir les fiches avec le même email (#{same_email_count})", super_admins_users_path(search: email_to_search), class: "button"
+      => link_to "Voir les fiches avec le même email (#{same_email_count})", super_admins_users_path(search: page.resource.email), class: "button"
 section.main-content__body
   dl
     - page.attributes.each do |attribute|


### PR DESCRIPTION
# Contexte

Depuis que nous déprécions `notification_email` nous avons des erreurs dans le SuperAdmin.

# Solution

Je corrige le code du bouton pour voir les autres fiches avec le même email.


