### PR TITLE
Se désinscrire de la liste d’attente un 1 clique

### DIFF
--- a/app/controllers/users/file_attentes_controller.rb
+++ b/app/controllers/users/file_attentes_controller.rb
@@ -1,5 +1,18 @@
 class Users::FileAttentesController < UserAuthController
+  skip_before_action :authenticate_user!, only: :unsubscribe
+  skip_before_action :set_paper_trail_whodunnit, only: :unsubscribe
+  skip_after_action :verify_authorized, only: :unsubscribe
+
   respond_to :js
+
+  # Permet à un utilisateur de se désinscrire de la file d'attente via le lien dans les mails de notification
+  # en un seul clique sans avoir à se connecter
+  def unsubscribe
+    participation = Participation.find_by!(restricted_auth_token: params[:token])
+    @file_attente = FileAttente.find_by(rdv: participation.rdv, user: participation.user)
+    @file_attente&.destroy!
+    render layout: "application_narrow"
+  end
 
   def create_or_delete
     skip_authorization

--- a/app/views/mailers/users/file_attente_mailer/new_creneau_available.html.slim
+++ b/app/views/mailers/users/file_attente_mailer/new_creneau_available.html.slim
@@ -6,4 +6,8 @@ div
   .btn-wrapper
     = link_to "Vérifier la disponibilité", creneaux_users_rdv_url(@rdv, invitation_token: @token), class:"btn btn-primary"
 
+  p
+    |> Si vous ne souhaitez pas recevoir ce type de notification, vous pouvez vous désinscrire en cliquant sur ce lien :
+    = link_to "ne plus me notifier des créneaux disponibles", users_unsubscribe_file_attente_url(token: @token)
+
   = t("mailers.common.farewell_html", domain_name: domain.name)

--- a/app/views/users/file_attentes/unsubscribe.html.slim
+++ b/app/views/users/file_attentes/unsubscribe.html.slim
@@ -1,0 +1,6 @@
+- content_for :title, "Liste d'attente"
+
+- if @file_attente
+  p Vous avez bien été retiré·e de la liste d'attente pour ce RDV.
+- else
+  p Vous n'étiez plus sur la liste d'attente pour ce RDV.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
     get :user_name_initials_verification, to: redirect(path: "/users/user_name_initials_verification/new")
 
     post "file_attente", to: "file_attentes#create_or_delete"
+    get "file_attente/unsubscribe/:token", to: "file_attentes#unsubscribe", as: "unsubscribe_file_attente"
 
     resource :sessions_by_code, only: %i[new create], controller: "sessions_by_code" do
       collection do

--- a/spec/controllers/users/file_attentes_controller_spec.rb
+++ b/spec/controllers/users/file_attentes_controller_spec.rb
@@ -2,11 +2,49 @@ RSpec.describe Users::FileAttentesController, type: :controller do
   let(:user) { create(:user) }
   let!(:rdv) { create(:rdv, users: [user]) }
 
-  before do
-    sign_in user
+  describe "GET #unsubscribe" do
+    subject { get :unsubscribe, params: { token: token } }
+
+    let(:token) { rdv.participations.first.restricted_auth_token }
+
+    context "when a file attente exists" do
+      let!(:file_attente) { create(:file_attente, rdv: rdv, user: user) }
+
+      it "destroys the file attente" do
+        expect { subject }.to change(FileAttente, :count).from(1).to(0)
+      end
+
+      it "returns a success response" do
+        subject
+        expect(response).to be_successful
+      end
+    end
+
+    context "when no file attente exists" do
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "returns a success response" do
+        subject
+        expect(response).to be_successful
+      end
+    end
+
+    context "when the token is invalid" do
+      let(:token) { "INVALID" }
+
+      it "returns a 404" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 
   describe "POST #create_or_delete" do
+    before do
+      sign_in user
+    end
+
     context "when rdv and user is given" do
       subject { post :create_or_delete, params: { file_attente: { rdv_id: rdv.id, user_id: user.id } } }
 

--- a/spec/mailers/previews/users/file_attente_mailer_preview.rb
+++ b/spec/mailers/previews/users/file_attente_mailer_preview.rb
@@ -1,5 +1,8 @@
 class Users::FileAttenteMailerPreview < ActionMailer::Preview
   def new_creneau_available
-    Users::FileAttenteMailer.with(rdv: Rdv.last, user: User.last).new_creneau_available
+    rdv = Rdv.last
+    user = User.last
+    token = rdv.participations.find_by(user: user)&.restricted_auth_token
+    Users::FileAttenteMailer.with(rdv: rdv, user: user, token: token).new_creneau_available
   end
 end

--- a/spec/mailers/users/file_attente_mailer_spec.rb
+++ b/spec/mailers/users/file_attente_mailer_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe Users::FileAttenteMailer, type: :mailer do
   describe "#new_creneau_available" do
     let(:rdv) { create(:rdv) }
     let(:user) { rdv.users.first }
-    let(:mail) { described_class.with(rdv:, user:).new_creneau_available }
+    let(:token) { rdv.participations.first.restricted_auth_token }
+    let(:mail) { described_class.with(rdv:, user:, token:).new_creneau_available }
 
     specify do
       expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites-test\.localhost>/)
@@ -10,6 +11,7 @@ RSpec.describe Users::FileAttenteMailer, type: :mailer do
       expect(mail.reply_to).to be_nil
       expect(mail.subject).to eq("Un créneau vient de se liberer !")
       expect(mail.body.raw_source).to match(/Des créneaux pour votre RDV/) # for some reason, mail.html_part is nil
+      expect(mail.body.raw_source).to include("/users/file_attente/unsubscribe/#{token}")
     end
   end
 end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6288.osc-secnum-fr1.scalingo.io/)

⚠️ Emails activés sur cette review app

# Contexte

Nous avons parfois des usagers qui ont coché la case pour recevoir les emails de notifications pour obtenir un RDV plutôt et qui finalement ne souhaitent plus recevoir ce type de message.
On ajoute donc la possibilité de se désinscrire en 1 clique via un lien dans l’email.

Cela pourra nous permettre à terme, d’activer la fonctionnalité de « File d’attente » côté agent lors de la prise de RDV.

# Solution

<img width="623" height="460" alt="image" src="https://github.com/user-attachments/assets/e8ca0ffc-4ae2-4d6b-b103-76b77f98732e" />


