### PR TITLE
Correctif de l'affichage de la carte sur la page de stats

### DIFF
--- a/app/javascript/lieux_map.js
+++ b/app/javascript/lieux_map.js
@@ -25,7 +25,7 @@ const initMap = (mapElt, lieux) => {
           "properties": lieu,
           "geometry": {
             "type": "Point",
-            "coordinates": [lieu.longitude.replace(",", "."), lieu.latitude.replace(",", ".")]
+            "coordinates": [lieu.longitude, lieu.latitude]
             // selon la config de Metabase, les latitudes longitudes peuvent arriver avec des virgules
           }
         }))


### PR DESCRIPTION
Ça semble effectivement être lié à la montée de version, le format de lat/long a changé.