### PR TITLE
Nettoyage du code des connexions supplémentaires à la db

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -42,7 +42,7 @@ default: &default
   #
   # cf docs/4-notes-techniques.md pour une vue d’ensemble du nombre de threads et de connexions à
   # la base de données
-  pool: <%= $PROGRAM_NAME.include?("good_job") ? GoodJob.configuration.max_threads + 2 + 1 : (ENV.fetch("RAILS_MAX_THREADS", 4).to_i + ENV.fetch("RAILS_EXTRA_DB_CONNECTIONS", 0).to_i) %>
+  pool: <%= $PROGRAM_NAME.include?("good_job") ? GoodJob.configuration.max_threads + 2 + 1 : (ENV.fetch("RAILS_MAX_THREADS", 4).to_i) %>
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,13 +27,9 @@ default: &default
   # And also GoodJob doc: https://github.com/bensheldon/good_job#database-connections
   #
   # Pour les containers web, on ouvre une connexion par thread puma.
-  # On utilise `load_async` à certains endroits, ce qui veut dire qu'un thread peut utiliser plusieurs connexions à la fois (voir global_executor_concurrency).
-  # Dans le scénario du pire, il est possible que tous les thread soient en train d'accéder à la base de données, et que certains d'entre eux soient en plus en train d'exécuter du code qui utilise `load_async`. Cependant, ce cas ne se produit jamais ou quasiment jamais. S'il a lieu, les thread attendront d'avoir une connexion disponible, ce qui peut causer un ralentissement de l'application, mais probablement pas assez pour générer un timeout.
   # Les connexions ont un cout au niveau du server de base de données : chaque connexion utilise de la RAM, donc on essaye de ne pas trop en ouvrir.
   # Pour savoir combien de connexions on utilise, on peut vérifier sur Scalingo via la page "Running queries" du dashboard postgres
   # par exemple https://dashboard.scalingo.com/apps/osc-secnum-fr1/production-rdv-solidarites/db/postgresql/running-queries
-  #
-  # Sur l'instance RDV Service Public, on ajoute quelques connexions supplémentaire parce qu'on a de la marge côté DB.
   #
   # For GoodJob container, we need connections for :
   # - the max number of threads (5 by default, cf https://github.com/bensheldon/good_job/blob/main/lib/good_job/configuration.rb#L126-L134)

--- a/docs/4-notes-techniques.md
+++ b/docs/4-notes-techniques.md
@@ -195,11 +195,10 @@ Il s’agit des chiffres pour l’instance historique RDV Solidarités.
 
 |                                      | web | jobs | variables d’env | où trouver la config ? |
 |------------------------------------- | --- | ---- | --------------- | ---------------------- |
-| scalingo_workers_count               | 8   | 2    | -               | `scalingo scale`       |
-| processes_per_worker                 | 3   | 1    | WEB_CONCURRENCY | config/puma.rb         |
+| scalingo_workers_count               | 6   | 2    | -               | `scalingo scale`       |
+| processes_per_worker                 | 4   | 1    | WEB_CONCURRENCY | config/puma.rb         |
 | connection_pools_sizes_per_worker    | 4   | 8    | GOOD_JOB_MAX_THREADS et RAILS_MAX_THREADS | config/database.yml |
-| extra_connections_per_process        | 0   | 3    | -               | doc de GoodJob         |
-| total_max_connections                | 96  | 22   | -               | -                      |
+| total_max_connections                | 96  | 16   | -               | -                      |
 
 Soit un total de 118 connexions à la base PostgreSQL ouvertes simultanées possibles.
 


### PR DESCRIPTION
Autre suite de https://github.com/betagouv/rdv-service-public/pull/6235, on peut maintenant supprimer le code qui ouvrait des connexions supplémentaires à la db puisqu'on n'utilise plus de parallélisme (ça va nous libérer un peu de ram sur pg).