### PR TITLE
Pas besoin de définir une timezone système en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,9 +140,6 @@ jobs:
         ports: ["6379:6379"]
     steps:
       - uses: actions/checkout@v4
-      - uses: WitherZuo/set-timezone@v1.0.0
-        with:
-          timezoneLinux: "Europe/Paris"
       - name: Prevent https://github.com/rails/rails/issues/53661
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
@@ -225,9 +222,6 @@ jobs:
         ports: ["6379:6379"]
     steps:
       - uses: actions/checkout@v4
-      - uses: WitherZuo/set-timezone@v1.0.0
-        with:
-          timezoneLinux: "Europe/Paris"
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
L'action `WitherZuo/set-timezone` avait été ajoutée dans #3373, je pense pour contrôler la timezone de Selenium.

Désormais, la timezone système n'a pas d'influence sur la suite de test, puisqu'on définit `Europe/Paris` explicitement à notre driver Playwright depuis #6227 ! :tada: 

Je propose donc de virer la dépendance à cette action, qui exécutait d'ailleurs [beaucoup de JS chelou](https://github.com/hoang-rio/set-timezone/blob/a1f090d69b796d093c1080817dc821792ea33cc7/dist/index.js#L341) juste pour lancer `sudo timedatectl set-timezone Europe/Paris` !