### PR TITLE
Correction LAPINS-6SF

### DIFF
--- a/app/models/file_attente.rb
+++ b/app/models/file_attente.rb
@@ -62,7 +62,7 @@ class FileAttente < ApplicationRecord
   end
 
   def invitation_token_for(rdv, user)
-    participation = Participation.find_by(rdv: rdv, user: user)
+    participation = user.participation_for(rdv)
     return nil unless participation
 
     # TODO: Supprimer ce if une fois que toutes les participations ont des restricted_auth_token

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe FileAttente, type: :model do
           expect { send_notifications }.to change(file_attente, :last_creneau_sent_at).from(nil).to(now)
         end
       end
+
+      context "when the rdv participant is a proche of the user to notify" do
+        let!(:responsible) { create(:user) }
+        let!(:user) { create(:user, :relative, responsible: responsible) }
+
+        it "sends the notification to the responsible with a valid invitation token" do
+          allow(Users::FileAttenteMailer).to receive(:with).and_call_original
+          expect(Users::FileAttenteMailer).to receive(:with).with(hash_including(user: responsible, token: be_present))
+          subject
+        end
+      end
     end
 
     context "without availabilities before rdv" do


### PR DESCRIPTION
# Contexte

Lors de l'envoi des notifications de file d'attente (`FileAttente#send_notification`), on récupérait le token d'invitation en cherchant la participation par `rdv` et `user_to_notify`. Cependant, quand le participant du RDV est un proche de l'utilisateur à notifier, la participation appartient au proche et non au responsable — `Participation.find_by` retournait donc `nil` et le token était absent des notifications.

# Solution

Remplacement de `Participation.find_by(rdv: rdv, user: user)` par `user.participation_for(rdv)`, qui existe déjà sur le modèle `User` et cherche la participation parmi `self_and_relatives_and_responsible`. Cela permet de retrouver la participation du proche quand on notifie le responsable.


