### PR TITLE
Ajout du SIRET sur l’espace

### DIFF
--- a/app/dashboards/territory_dashboard.rb
+++ b/app/dashboards/territory_dashboard.rb
@@ -21,6 +21,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     work_on_sunday: Field::Boolean,
+    siret: Field::String,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -48,6 +49,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     category
     territory_tags
     operator
+    siret
     created_at
     updated_at
   ].freeze
@@ -63,6 +65,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     operator
     departement_number
     work_on_sunday
+    siret
   ].freeze
 
   def display_resource(territory)

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -48,6 +48,7 @@ class Territory < ApplicationRecord
 
   # Validations
   validates :departement_number, length: { maximum: 3 }, if: -> { departement_number.present? }
+  validates :siret, format: { with: /\A\d{14}\z/, message: "doit contenir exactement 14 chiffres" }, allow_blank: true
 
   validate do
     if name_changed? && name_was.in?(SPECIAL_NAMES)

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -322,6 +322,7 @@ tables:
       - work_on_sunday
       - operator_id
       - public_stats
+      - siret
 
   # Tables sans données personnelles
   - table_name: agent_territorial_roles

--- a/db/migrate/20260401000001_add_siret_to_territories.rb
+++ b/db/migrate/20260401000001_add_siret_to_territories.rb
@@ -1,0 +1,5 @@
+class AddSiretToTerritories < ActiveRecord::Migration[8.0]
+  def change
+    add_column :territories, :siret, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_25_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_01_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -780,6 +780,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_25_000001) do
     t.boolean "work_on_sunday", default: false
     t.bigint "operator_id"
     t.boolean "public_stats", default: true, null: false
+    t.string "siret"
     t.index ["departement_number"], name: "index_territories_on_departement_number", where: "((departement_number)::text <> ''::text)"
     t.index ["operator_id"], name: "index_territories_on_operator_id"
   end


### PR DESCRIPTION
# Contexte

Dans le contexte de notre branchement à l’espace opérateur de La Suite Territoriale, nous allons avoir besoin d’avoir les SIRET des espaces (notamment ceux des communes).

# Solution

Dans un premier temps, on ajoute ce nouveau champ et on permet de l’éditer en SuperAdmin.