### PR TITLE
Création automatique d’espace quand RDV-SP est activé par un OPSN

### DIFF
--- a/app/controllers/agents/inscription_via_operateur_controller.rb
+++ b/app/controllers/agents/inscription_via_operateur_controller.rb
@@ -1,0 +1,20 @@
+class Agents::InscriptionViaOperateurController < AgentAuthController
+  layout "application"
+
+  def show
+    skip_authorization
+
+    if params[:operator_name].present? && params[:signup_url].present?
+      render locals: { operator_name: params[:operator_name], signup_url: params[:signup_url] }
+    else
+      flash[:error] = "Une erreur est survenue lors de la récupération des informations de votre opérateur. Nous vous invitons à contacter leur support."
+      redirect_to root_path
+    end
+  end
+
+  private
+
+  def pundit_user
+    current_agent
+  end
+end

--- a/app/controllers/agents/inscription_via_operateur_controller.rb
+++ b/app/controllers/agents/inscription_via_operateur_controller.rb
@@ -5,6 +5,11 @@ class Agents::InscriptionViaOperateurController < AgentAuthController
     skip_authorization
 
     if params[:operator_name].present? && params[:signup_url].present?
+      Sentry.capture_message(
+        "ProConnectOnboardingRouter: agent invité à s'inscrire via son opérateur",
+        level: "info",
+        extra: { agent_id: current_agent.id, operator_name: params[:operator_name] }
+      )
       render locals: { operator_name: params[:operator_name], signup_url: params[:signup_url] }
     else
       flash[:error] = "Une erreur est survenue lors de la récupération des informations de votre opérateur. Nous vous invitons à contacter leur support."

--- a/app/controllers/agents/territory_creation_requests_controller.rb
+++ b/app/controllers/agents/territory_creation_requests_controller.rb
@@ -1,5 +1,7 @@
 class Agents::TerritoryCreationRequestsController < AgentAuthController
   layout "application"
+  before_action :redirect_if_opsn_restricted
+
   def new
     authorize(TerritoryCreationRequest.new, policy_class: Agent::TerritoryCreationRequestPolicy)
     @territory_creation_request = TerritoryCreationRequest.new
@@ -18,6 +20,21 @@ class Agents::TerritoryCreationRequestsController < AgentAuthController
   end
 
   private
+
+  def redirect_if_opsn_restricted
+    return unless current_domain.allow_self_onboarding
+    return unless current_agent.agent_territorial_access_rights.none?
+
+    result = ProConnectFirstLoginHandler.new(current_agent, current_domain).call
+
+    case result.action
+    when :contact_admin
+      flash[:info] = "Votre organisation est rattachée à un opérateur RDV Service Public, mais vous n'avez pas les droits d'administrateur. Rapprochez-vous de votre administrateur pour qu'il vous accorde les accès sur votre espace."
+      redirect_to authenticated_agent_root_path
+    when :signup_via_operator
+      redirect_to agents_inscription_via_operateur_path(signup_url: result.signup_url, operator_name: result.operator_name)
+    end
+  end
 
   def permitted_params
     params.require(:territory_creation_request).permit(:territory_name, :organisation_name, :service_name)

--- a/app/controllers/agents/territory_creation_requests_controller.rb
+++ b/app/controllers/agents/territory_creation_requests_controller.rb
@@ -29,7 +29,8 @@ class Agents::TerritoryCreationRequestsController < AgentAuthController
 
     case result.action
     when :contact_admin
-      flash[:info] = "Votre organisation est rattachée à un opérateur RDV Service Public, mais vous n'avez pas les droits d'administrateur. Rapprochez-vous de votre administrateur pour qu'il vous accorde les accès sur votre espace."
+      flash[:info] = "Votre organisation est rattachée à un espace RDV Service Public, mais vous n'avez pas les droits " \
+                     "d'administrateur. Rapprochez-vous de votre administrateur pour qu'il vous accorde les accès sur votre espace."
       redirect_to authenticated_agent_root_path
     when :signup_via_operator
       redirect_to agents_inscription_via_operateur_path(signup_url: result.signup_url, operator_name: result.operator_name)

--- a/app/controllers/agents/territory_creation_requests_controller.rb
+++ b/app/controllers/agents/territory_creation_requests_controller.rb
@@ -25,7 +25,7 @@ class Agents::TerritoryCreationRequestsController < AgentAuthController
     return unless current_domain.allow_self_onboarding
     return unless current_agent.agent_territorial_access_rights.none?
 
-    result = ProConnectFirstLoginHandler.new(current_agent, current_domain).call
+    result = ProConnectOnboardingRouter.new(current_agent, current_domain).call
 
     case result.action
     when :contact_admin

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -213,7 +213,7 @@ class ProConnectController < ApplicationController
   # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 
   def redirect_after_first_proconnect_login(agent)
-    result = ProConnectFirstLoginHandler.new(agent, current_domain).call
+    result = ProConnectOnboardingRouter.new(agent, current_domain).call
 
     case result.action
     when :attached_as_admin

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -219,7 +219,8 @@ class ProConnectController < ApplicationController
     when :attached_as_admin
       redirect_to after_sign_in_path_for(agent)
     when :contact_admin
-      flash[:info] = "Votre organisation est rattachée à un opérateur RDV Service Public, mais vous n'avez pas les droits d'administrateur. Rapprochez-vous de votre administrateur pour qu'il vous accorde les accès sur votre espace."
+      flash[:info] = "Votre organisation est rattachée à un espace RDV Service Public, mais vous n'avez pas les droits " \
+                     "d'administrateur. Rapprochez-vous de votre administrateur pour qu'il vous accorde les accès sur votre espace."
       redirect_to after_sign_in_path_for(agent)
     when :signup_via_operator
       redirect_to agents_inscription_via_operateur_path(operator_name: result.operator_name, signup_url: result.signup_url)

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -165,6 +165,7 @@ class ProConnectController < ApplicationController
     end
 
     agent = agent_by_sub || agent_by_email
+    was_new_agent = agent.nil?
 
     if agent.nil?
       if current_domain.allow_self_onboarding
@@ -202,9 +203,30 @@ class ProConnectController < ApplicationController
 
     bypass_sign_in agent, scope: :agent
     session[:pro_connect_id_token] = callback_client.id_token_for_logout
-    redirect_to after_sign_in_path_for(agent)
+
+    if was_new_agent && current_domain.allow_self_onboarding
+      redirect_after_first_proconnect_login(agent)
+    else
+      redirect_to after_sign_in_path_for(agent)
+    end
   end
   # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+
+  def redirect_after_first_proconnect_login(agent)
+    result = ProConnectFirstLoginHandler.new(agent, current_domain).call
+
+    case result.action
+    when :attached_as_admin
+      redirect_to after_sign_in_path_for(agent)
+    when :contact_admin
+      flash[:info] = "Votre organisation est rattachée à un opérateur RDV Service Public, mais vous n'avez pas les droits d'administrateur. Rapprochez-vous de votre administrateur pour qu'il vous accorde les accès sur votre espace."
+      redirect_to after_sign_in_path_for(agent)
+    when :signup_via_operator
+      redirect_to agents_inscription_via_operateur_path(operator_name: result.operator_name, signup_url: result.signup_url)
+    else # :classic
+      redirect_to new_agents_territory_creation_request_path
+    end
+  end
 
   def generic_error_message
     support_link = new_aide_demande_support_path(role: "agent", sujet: "Connexion ProConnect")

--- a/app/services/espace_operateur_anct.rb
+++ b/app/services/espace_operateur_anct.rb
@@ -17,6 +17,10 @@ class EspaceOperateurANCT
     parsed_response&.fetch("operator", nil)
   end
 
+  def potential_operators
+    parsed_response&.fetch("potentialOperators", nil)
+  end
+
   def can_access?
     return false unless entitlements
 

--- a/app/services/espace_operateur_anct.rb
+++ b/app/services/espace_operateur_anct.rb
@@ -47,6 +47,8 @@ class EspaceOperateurANCT
 
   def client
     @client ||= Faraday.new(url: "https://operateurs.suite.anct.gouv.fr/api/v1.0/") do |faraday|
+      faraday.options.timeout = 3
+      faraday.options.open_timeout = 3
       faraday.headers = {
         "X-Service-Auth": ENV.fetch("ESPACE_OPERATEUR_ANCT_AUTH_TOKEN", nil),
       }

--- a/app/services/pro_connect_first_login_handler.rb
+++ b/app/services/pro_connect_first_login_handler.rb
@@ -1,0 +1,83 @@
+# TODO: Pas du tout convaincu du nom de ce handler. À renommer
+# TODO: Clarifier la logique métier
+
+class ProConnectFirstLoginHandler
+  Result = Struct.new(:action, :signup_url, :operator_name, keyword_init: true)
+
+  def initialize(agent, domain)
+    @agent = agent
+    @domain = domain
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def call
+    return Result.new(action: :classic) unless @agent.proconnect_siret.present?
+
+    # TODO: Rennomer cette variable
+    anct = build_anct_client
+    return Result.new(action: :classic) if anct.nil?
+
+    begin
+      operator_data = anct.operator
+      potential_operators_data = anct.potential_operators
+    rescue => e
+      Sentry.capture_exception(e)
+      return Result.new(action: :classic)
+    end
+
+    if operator_data.present?
+      operator = Operator.find_by(siret: operator_data["siret"])
+      return handle_operator_case(anct, operator) if operator
+    end
+
+    if potential_operators_data.present?
+      matching = potential_operators_data.find { |po| Operator.exists?(siret: po["siret"]) }
+      if matching
+        return Result.new(action: :signup_via_operator, signup_url: matching["signupUrl"], operator_name: matching["name"])
+      end
+
+      # TODO: Si plusieurs opérateurs potentiels, dans un premier temps envoyer un Sentry.
+    end
+
+    Result.new(action: :classic)
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  private
+
+  def build_anct_client
+    EspaceOperateurANCT.new(@agent.proconnect_siret, @agent.email)
+  rescue => e
+    Sentry.capture_exception(e)
+    nil
+  end
+
+  def handle_operator_case(anct, operator)
+    if anct.admin?
+      attach_or_create_territory(operator, anct)
+      Result.new(action: :attached_as_admin)
+    elsif anct.can_access?
+      Result.new(action: :contact_admin)
+    else
+      Result.new(action: :classic)
+    end
+  end
+
+  def attach_or_create_territory(operator, anct)
+    ActiveRecord::Base.transaction do
+      territory = operator.territories.first || Territory.create!(operator: operator)
+      organisation = territory.organisations.first || Organisation.create!(
+        name: anct.organization&.fetch("name", nil) || operator.name,
+        territory: territory,
+        verticale: @domain.verticale
+      )
+      AgentRole.create!(agent: @agent, organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN)
+      AgentTerritorialRole.create!(agent: @agent, territory: territory)
+      AgentTerritorialAccessRight.create!(
+        agent: @agent, territory: territory,
+        allow_to_manage_access_rights: true,
+        allow_to_invite_agents: true
+      )
+    end
+  end
+end

--- a/app/services/pro_connect_first_login_handler.rb
+++ b/app/services/pro_connect_first_login_handler.rb
@@ -9,9 +9,9 @@ class ProConnectFirstLoginHandler
     @domain = domain
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def call
-    return Result.new(action: :classic) unless @agent.proconnect_siret.present?
+    return Result.new(action: :classic) if @agent.proconnect_siret.blank?
 
     # TODO: Rennomer cette variable
     anct = build_anct_client
@@ -20,7 +20,7 @@ class ProConnectFirstLoginHandler
     begin
       operator_data = anct.operator
       potential_operators_data = anct.potential_operators
-    rescue => e
+    rescue StandardError => e
       Sentry.capture_exception(e)
       return Result.new(action: :classic)
     end
@@ -41,13 +41,13 @@ class ProConnectFirstLoginHandler
 
     Result.new(action: :classic)
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   private
 
   def build_anct_client
     EspaceOperateurANCT.new(@agent.proconnect_siret, @agent.email)
-  rescue => e
+  rescue StandardError => e
     Sentry.capture_exception(e)
     nil
   end

--- a/app/services/pro_connect_onboarding_router.rb
+++ b/app/services/pro_connect_onboarding_router.rb
@@ -72,15 +72,21 @@ class ProConnectOnboardingRouter
 
   def attach_or_create_territory(operator, anct_client)
     ActiveRecord::Base.transaction do
-      territory = operator.territories.first || Territory.create!(
+      existing_territory = operator.territories.first
+      territory = existing_territory || Territory.create!(
         operator: operator,
         category: ANCT_TYPE_TO_CATEGORY.fetch(anct_client.organization&.fetch("type", nil), "Inconnu")
       )
-      organisation = territory.organisations.first || Organisation.create!(
+
+      existing_organisation = territory.organisations.first
+      organisation = existing_organisation || Organisation.create!(
         name: anct_client.organization&.fetch("name", nil) || operator.name,
         territory: territory,
         verticale: @domain.verticale
       )
+
+      capture_attach_sentry_message(operator, territory, organisation, new_account: existing_territory.nil? || existing_organisation.nil?)
+
       AgentRole.create!(agent: @agent, organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN)
       AgentTerritorialRole.create!(agent: @agent, territory: territory)
       AgentTerritorialAccessRight.create!(
@@ -89,5 +95,14 @@ class ProConnectOnboardingRouter
         allow_to_invite_agents: true
       )
     end
+  end
+
+  def capture_attach_sentry_message(operator, territory, organisation, new_account:)
+    message = if new_account
+                "ProConnectOnboardingRouter: création d'un compte (territory/organisation) via ANCT"
+              else
+                "ProConnectOnboardingRouter: ajout d'un administrateur sur un compte existant via ANCT"
+              end
+    Sentry.capture_message(message, level: "info", extra: { agent_id: @agent.id, operator_id: operator.id, territory_id: territory.id, organisation_id: organisation.id })
   end
 end

--- a/app/services/pro_connect_onboarding_router.rb
+++ b/app/services/pro_connect_onboarding_router.rb
@@ -1,4 +1,11 @@
 class ProConnectOnboardingRouter
+  ANCT_TYPE_TO_CATEGORY = {
+    "commune" => "Commune",
+    "epci" => "Intercommunalité",
+    "departement" => "Département",
+    "region" => "Région",
+  }.freeze
+
   Result = Struct.new(:action, :signup_url, :operator_name, keyword_init: true)
 
   def initialize(agent, domain)
@@ -65,7 +72,10 @@ class ProConnectOnboardingRouter
 
   def attach_or_create_territory(operator, anct_client)
     ActiveRecord::Base.transaction do
-      territory = operator.territories.first || Territory.create!(operator: operator)
+      territory = operator.territories.first || Territory.create!(
+        operator: operator,
+        category: ANCT_TYPE_TO_CATEGORY.fetch(anct_client.organization&.fetch("type", nil), "Inconnu")
+      )
       organisation = territory.organisations.first || Organisation.create!(
         name: anct_client.organization&.fetch("name", nil) || operator.name,
         territory: territory,

--- a/app/services/pro_connect_onboarding_router.rb
+++ b/app/services/pro_connect_onboarding_router.rb
@@ -1,7 +1,4 @@
-# TODO: Pas du tout convaincu du nom de ce handler. À renommer
-# TODO: Clarifier la logique métier
-
-class ProConnectFirstLoginHandler
+class ProConnectOnboardingRouter
   Result = Struct.new(:action, :signup_url, :operator_name, keyword_init: true)
 
   def initialize(agent, domain)
@@ -13,13 +10,12 @@ class ProConnectFirstLoginHandler
   def call
     return Result.new(action: :classic) if @agent.proconnect_siret.blank?
 
-    # TODO: Rennomer cette variable
-    anct = build_anct_client
-    return Result.new(action: :classic) if anct.nil?
+    anct_client = build_anct_client
+    return Result.new(action: :classic) if anct_client.nil?
 
     begin
-      operator_data = anct.operator
-      potential_operators_data = anct.potential_operators
+      operator_data = anct_client.operator
+      potential_operators_data = anct_client.potential_operators
     rescue StandardError => e
       Sentry.capture_exception(e)
       return Result.new(action: :classic)
@@ -27,16 +23,20 @@ class ProConnectFirstLoginHandler
 
     if operator_data.present?
       operator = Operator.find_by(siret: operator_data["siret"])
-      return handle_operator_case(anct, operator) if operator
+      return handle_operator_case(anct_client, operator) if operator
     end
 
     if potential_operators_data.present?
-      matching = potential_operators_data.find { |po| Operator.exists?(siret: po["siret"]) }
-      if matching
-        return Result.new(action: :signup_via_operator, signup_url: matching["signupUrl"], operator_name: matching["name"])
+      matches = potential_operators_data.select { |po| Operator.exists?(siret: po["siret"]) }
+      if matches.any?
+        if matches.size > 1
+          Sentry.capture_message(
+            "ProConnectOnboardingRouter: plusieurs potentialOperators matchent notre DB",
+            extra: { agent_id: @agent.id, sirets: matches.pluck("siret") }
+          )
+        end
+        return Result.new(action: :signup_via_operator, signup_url: matches.first["signupUrl"], operator_name: matches.first["name"])
       end
-
-      # TODO: Si plusieurs opérateurs potentiels, dans un premier temps envoyer un Sentry.
     end
 
     Result.new(action: :classic)
@@ -52,22 +52,22 @@ class ProConnectFirstLoginHandler
     nil
   end
 
-  def handle_operator_case(anct, operator)
-    if anct.admin?
-      attach_or_create_territory(operator, anct)
+  def handle_operator_case(anct_client, operator)
+    if anct_client.admin?
+      attach_or_create_territory(operator, anct_client)
       Result.new(action: :attached_as_admin)
-    elsif anct.can_access?
+    elsif anct_client.can_access?
       Result.new(action: :contact_admin)
     else
       Result.new(action: :classic)
     end
   end
 
-  def attach_or_create_territory(operator, anct)
+  def attach_or_create_territory(operator, anct_client)
     ActiveRecord::Base.transaction do
       territory = operator.territories.first || Territory.create!(operator: operator)
       organisation = territory.organisations.first || Organisation.create!(
-        name: anct.organization&.fetch("name", nil) || operator.name,
+        name: anct_client.organization&.fetch("name", nil) || operator.name,
         territory: territory,
         verticale: @domain.verticale
       )

--- a/app/views/agents/inscription_via_operateur/show.html.slim
+++ b/app/views/agents/inscription_via_operateur/show.html.slim
@@ -1,0 +1,16 @@
+/# locals: (operator_name:, signup_url:)
+
+.fr-grid-row.fr-mb-8w
+  .fr-col-12.fr-col-md-8.fr-col-offset-md-2
+    .card
+      .card-body
+        h1.fr-h2 Inscription via votre opérateur
+
+        p
+          | Votre organisation est rattachée à l'opérateur
+          strong  #{operator_name}
+          | , qui gère votre accès à RDV Service Public.
+
+        p Pour créer votre espace, vous devez faire une demande d'accès directement auprès de cet opérateur.
+
+        = external_link_to "Faire une demande d'accès auprès de #{operator_name}", signup_url, class: "fr-btn"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,7 @@ Rails.application.routes.draw do
 
       resources :territories, only: %i[new create]
       resources :territory_creation_requests, only: %i[new create]
+      get "inscription_via_operateur", to: "inscription_via_operateur#show", as: :inscription_via_operateur
       resources :instance_exports, only: %i[index]
       resources :exports, only: %i[index] do
         get :download

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -146,13 +146,91 @@ RSpec.describe ProConnectController do
           expect(current_agent_id).to be_nil
         end
 
-        it "creates the agent if the domain allows it" do
+        it "creates the agent if the domain allows it, et redirige vers la demande d'ouverture classique quand l'ANCT ne retourne rien" do
           allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
+          # Sans token ANCT configuré, le handler renvoie :classic
           expect do
             get :callback, params: { state:, code: }
           end.to change(Agent, :count).by(1)
           agent = Agent.last
-          expect_agent_to_be_updated_and_logged_in(agent)
+          expected_attrs = {
+            pro_connect_openid_sub: user_info["sub"],
+            email: user_info["email"],
+            first_name: "Francis",
+            last_name: "Factice",
+            pro_connect_idp_id: user_info["idp_id"],
+            pro_connect_2fa_active: false,
+          }
+          expect(agent).to have_attributes(expected_attrs)
+          expect(current_agent_id).to eq(agent.id)
+          expect(session["pro_connect_id_token"]).to be_present
+          expect(response).to redirect_to(new_agents_territory_creation_request_path)
+        end
+
+        context "avec le token ANCT configuré" do
+          stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: "Bearer fake-token")
+
+          context "quand l'API retourne un opérateur qui matche un Operator de notre DB et l'agent est admin" do
+            let!(:operator) { create(:operator, siret: user_info["siret"]) }
+
+            around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_admin") { ex.run } }
+
+            let(:user_info) do
+              super().merge("email" => "test-admin@example.com", "siret" => "21550050500015")
+            end
+
+            before { ProConnectStubs.stub_callback_requests(code, user_info) }
+
+            it "crée l'agent, le rattache au territoire de l'opérateur et redirige normalement" do
+              allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
+              expect do
+                get :callback, params: { state:, code: }
+              end.to change(Agent, :count).by(1)
+                .and change(Territory, :count).by(1)
+                .and change(Organisation, :count).by(1)
+                .and change(AgentRole, :count).by(1)
+
+              expect(current_agent_id).to be_present
+              expect(response).to redirect_to("/agents/edit") # stored location
+            end
+          end
+
+          context "quand l'API retourne un opérateur mais l'agent n'est pas admin" do
+            # La cassette entitlements_success est enregistrée avec email=contact@mairie-nantes.fr et siret=21550050500015
+            let(:user_info) { super().merge("email" => "contact@mairie-nantes.fr", "siret" => "21550050500015") }
+            let!(:operator) { create(:operator, siret: "21550050500015") }
+
+            before { ProConnectStubs.stub_callback_requests(code, user_info) }
+
+            around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_success") { ex.run } }
+
+            it "crée l'agent avec un flash info et redirige normalement" do
+              allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
+              get :callback, params: { state:, code: }
+              expect(flash[:info]).to include("Rapprochez-vous de votre administrateur")
+              expect(response).to redirect_to("/agents/edit") # stored location via after_sign_in_path_for
+            end
+          end
+
+          context "quand l'API retourne des potentialOperators dont un matche notre DB" do
+            # La cassette entitlements_with_potential_operators est enregistrée avec email=contact@mairie-nantes.fr et siret=20005671100019
+            let(:user_info) { super().merge("email" => "contact@mairie-nantes.fr", "siret" => "20005671100019") }
+            let!(:operator) { create(:operator, siret: "13002603200016") } # premier potentialOperator de la cassette
+
+            before { ProConnectStubs.stub_callback_requests(code, user_info) }
+
+            around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { ex.run } }
+
+            it "crée l'agent et redirige vers la page inscription_via_operateur" do
+              allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
+              get :callback, params: { state:, code: }
+              expect(response).to redirect_to(agents_inscription_via_operateur_path)
+              expect(session[:inscription_via_operateur]).to include(
+                "signup_url" => "https://suiteterritoriale.anct.gouv.fr/deep-link-signup/",
+                "operator_name" => "ANCT"
+              )
+            end
+          end
         end
       end
 
@@ -163,6 +241,25 @@ RSpec.describe ProConnectController do
             get :callback, params: { state:, code: }
           end.to change { agent.reload.pro_connect_openid_sub }.to(user_info["sub"])
           expect_agent_to_be_updated_and_logged_in(agent)
+        end
+
+        context "quand l'agent n'a pas d'organisation (reconnexion sans espace)" do
+          stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: "Bearer fake-token")
+
+          context "quand l'API retourne des potentialOperators dont un matche notre DB" do
+            let(:user_info) { super().merge("email" => "contact@mairie-nantes.fr", "siret" => "20005671100019") }
+            let!(:operator) { create(:operator, siret: "13002603200016") }
+
+            before { ProConnectStubs.stub_callback_requests(code, user_info) }
+
+            around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { ex.run } }
+
+            it "redirige vers inscription_via_operateur même sur reconnexion" do
+              create(:agent, email: user_info["email"])
+              get :callback, params: { state:, code: }
+              expect(response).to redirect_to(agents_inscription_via_operateur_path)
+            end
+          end
         end
       end
 

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -167,65 +167,62 @@ RSpec.describe ProConnectController do
           expect(response).to redirect_to(new_agents_territory_creation_request_path)
         end
 
-        context "avec le token ANCT configuré" do
+        context "avec token ANCT : opérateur admin qui matche notre DB" do
           stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: "Bearer fake-token")
 
-          context "quand l'API retourne un opérateur qui matche un Operator de notre DB et l'agent est admin" do
-            let!(:operator) { create(:operator, siret: user_info["siret"]) }
+          # La cassette entitlements_admin est enregistrée avec email=test-admin@example.com et siret=21550050500015
+          let(:user_info) { super().merge("email" => "test-admin@example.com", "siret" => "21550050500015") }
+          let!(:operator) { create(:operator, siret: user_info["siret"]) }
 
-            around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_admin") { ex.run } }
+          before { ProConnectStubs.stub_callback_requests(code, user_info) }
+          around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_admin") { ex.run } }
 
-            let(:user_info) do
-              super().merge("email" => "test-admin@example.com", "siret" => "21550050500015")
-            end
-
-            before { ProConnectStubs.stub_callback_requests(code, user_info) }
-
-            it "crée l'agent, le rattache au territoire de l'opérateur et redirige normalement" do
-              allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
-              expect do
-                get :callback, params: { state:, code: }
-              end.to change(Agent, :count).by(1)
-                .and change(Territory, :count).by(1)
-                .and change(Organisation, :count).by(1)
-                .and change(AgentRole, :count).by(1)
-
-              expect(current_agent_id).to be_present
-              expect(response).to redirect_to("/agents/edit") # stored location
-            end
-          end
-
-          context "quand l'API retourne un opérateur mais l'agent n'est pas admin" do
-            # La cassette entitlements_success est enregistrée avec email=contact@mairie-nantes.fr et siret=21550050500015
-            let(:user_info) { super().merge("email" => "contact@mairie-nantes.fr", "siret" => "21550050500015") }
-            let!(:operator) { create(:operator, siret: "21550050500015") }
-
-            before { ProConnectStubs.stub_callback_requests(code, user_info) }
-
-            around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_success") { ex.run } }
-
-            it "crée l'agent avec un flash info et redirige normalement" do
-              allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
+          it "crée l'agent, le rattache au territoire de l'opérateur et redirige normalement" do
+            allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
+            expect do
               get :callback, params: { state:, code: }
-              expect(flash[:info]).to include("Rapprochez-vous de votre administrateur")
-              expect(response).to redirect_to("/agents/edit") # stored location via after_sign_in_path_for
-            end
+            end.to change(Agent, :count).by(1)
+              .and change(Territory, :count).by(1)
+              .and change(Organisation, :count).by(1)
+              .and change(AgentRole, :count).by(1)
+
+            expect(current_agent_id).to be_present
+            expect(response).to redirect_to("/agents/edit") # stored location
           end
+        end
 
-          context "quand l'API retourne des potentialOperators dont un matche notre DB" do
-            # La cassette entitlements_with_potential_operators est enregistrée avec email=contact@mairie-nantes.fr et siret=20005671100019
-            let(:user_info) { super().merge("email" => "contact@mairie-nantes.fr", "siret" => "20005671100019") }
-            let!(:operator) { create(:operator, siret: "13002603200016") } # premier potentialOperator de la cassette
+        context "avec token ANCT : opérateur non-admin qui matche notre DB" do
+          stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: "Bearer fake-token")
 
-            before { ProConnectStubs.stub_callback_requests(code, user_info) }
+          # La cassette entitlements_success est enregistrée avec email=contact@mairie-nantes.fr et siret=21550050500015
+          let(:user_info) { super().merge("email" => "contact@mairie-nantes.fr", "siret" => "21550050500015") }
+          let!(:operator) { create(:operator, siret: "21550050500015") }
 
-            around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { ex.run } }
+          before { ProConnectStubs.stub_callback_requests(code, user_info) }
+          around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_success") { ex.run } }
 
-            it "crée l'agent et redirige vers la page inscription_via_operateur" do
-              allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
-              get :callback, params: { state:, code: }
-              expect(response).to redirect_to(agents_inscription_via_operateur_path("signup_url": "https://suiteterritoriale.anct.gouv.fr/deep-link-signup/", "operator_name": "ANCT"))
-            end
+          it "crée l'agent avec un flash info et redirige normalement" do
+            allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
+            get :callback, params: { state:, code: }
+            expect(flash[:info]).to include("Rapprochez-vous de votre administrateur")
+            expect(response).to redirect_to("/agents/edit") # stored location via after_sign_in_path_for
+          end
+        end
+
+        context "avec token ANCT : potentialOperators dont un matche notre DB" do
+          stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: "Bearer fake-token")
+
+          # La cassette entitlements_with_potential_operators est enregistrée avec email=contact@mairie-nantes.fr et siret=20005671100019
+          let(:user_info) { super().merge("email" => "contact@mairie-nantes.fr", "siret" => "20005671100019") }
+          let!(:operator) { create(:operator, siret: "13002603200016") } # premier potentialOperator de la cassette
+
+          before { ProConnectStubs.stub_callback_requests(code, user_info) }
+          around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { ex.run } }
+
+          it "crée l'agent et redirige vers la page inscription_via_operateur" do
+            allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
+            get :callback, params: { state:, code: }
+            expect(response).to redirect_to(agents_inscription_via_operateur_path(signup_url: "https://suiteterritoriale.anct.gouv.fr/deep-link-signup/", operator_name: "ANCT"))
           end
         end
       end

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe ProConnectController do
           before { ProConnectStubs.stub_callback_requests(code, user_info) }
           around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_admin") { ex.run } }
 
-          it "crée l'agent, le rattache au territoire de l'opérateur et redirige normalement" do
+          it "crée l'agent, son espace et son orga puis le redirige normalement" do
             allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
             expect do
               get :callback, params: { state:, code: }

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -224,11 +224,7 @@ RSpec.describe ProConnectController do
             it "crée l'agent et redirige vers la page inscription_via_operateur" do
               allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
               get :callback, params: { state:, code: }
-              expect(response).to redirect_to(agents_inscription_via_operateur_path)
-              expect(session[:inscription_via_operateur]).to include(
-                "signup_url" => "https://suiteterritoriale.anct.gouv.fr/deep-link-signup/",
-                "operator_name" => "ANCT"
-              )
+              expect(response).to redirect_to(agents_inscription_via_operateur_path("signup_url": "https://suiteterritoriale.anct.gouv.fr/deep-link-signup/", "operator_name": "ANCT"))
             end
           end
         end
@@ -241,25 +237,6 @@ RSpec.describe ProConnectController do
             get :callback, params: { state:, code: }
           end.to change { agent.reload.pro_connect_openid_sub }.to(user_info["sub"])
           expect_agent_to_be_updated_and_logged_in(agent)
-        end
-
-        context "quand l'agent n'a pas d'organisation (reconnexion sans espace)" do
-          stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: "Bearer fake-token")
-
-          context "quand l'API retourne des potentialOperators dont un matche notre DB" do
-            let(:user_info) { super().merge("email" => "contact@mairie-nantes.fr", "siret" => "20005671100019") }
-            let!(:operator) { create(:operator, siret: "13002603200016") }
-
-            before { ProConnectStubs.stub_callback_requests(code, user_info) }
-
-            around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { ex.run } }
-
-            it "redirige vers inscription_via_operateur même sur reconnexion" do
-              create(:agent, email: user_info["email"])
-              get :callback, params: { state:, code: }
-              expect(response).to redirect_to(agents_inscription_via_operateur_path)
-            end
-          end
         end
       end
 

--- a/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_admin.yml
+++ b/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_admin.yml
@@ -50,6 +50,6 @@ http_interactions:
       Set-Cookie: "[Filtered in vcr.rb -> before_record]"
     body:
       encoding: UTF-8
-      string: '{"organization":{"type":"other","name":"Bezonvaux","oidc_valid":null},"operator":{"id":"f33e9b4b-213f-4db9-8b39-ab17558f2931","name":"TEST","url":null,"config":{}},"entitlements":{"can_access":true,"is_admin":true,"is_admin_resolve_level":"service"}}'
+      string: '{"organization":{"type":"other","name":"Bezonvaux","oidc_valid":null},"operator":{"id":"f33e9b4b-213f-4db9-8b39-ab17558f2931","name":"TEST","siret":"21550050500015","url":null,"config":{}},"entitlements":{"can_access":true,"is_admin":true,"is_admin_resolve_level":"service"}}'
   recorded_at: Mon, 09 Mar 2026 17:05:01 GMT
 recorded_with: VCR 6.4.0

--- a/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_with_potential_operators.yml
+++ b/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_with_potential_operators.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://operateurs.suite.anct.gouv.fr/api/v1.0/entitlements/?account_email=contact@mairie-nantes.fr&account_type=user&service_id=49&siret=21550050500015
+    uri: https://operateurs.suite.anct.gouv.fr/api/v1.0/entitlements/?account_email=contact@mairie-nantes.fr&account_type=user&service_id=49&siret=20005671100019
     body:
       encoding: US-ASCII
       string: ''
@@ -21,17 +21,18 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Apr 2026 09:59:46 GMT
+      - Wed, 01 Apr 2026 09:51:20 GMT
       Content-Type:
       - application/json
-      Content-Length:
-      - '197'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       X-Request-Id:
-      - ff70c1ec-53d5-439a-8660-cb4cd33e34e6
+      - b7efebcc-e70e-49ad-8145-14ca39769ef4
       Vary:
       - Accept, origin, Accept-Language, Cookie
+      - Accept-Encoding
       Allow:
       - GET, HEAD, OPTIONS
       X-Frame-Options:
@@ -53,20 +54,31 @@ http_interactions:
       string: |-
         {
           "organization": {
-            "type": "other",
-            "name": "Bezonvaux",
+            "type": "commune",
+            "name": "Jugon-les-Lacs",
             "oidc_valid": null
           },
-          "operator": {
-            "name": "TEST",
-            "siret": "21550050500015",
-            "url": null,
-            "config": {}
-          },
+          "operator": null,
           "entitlements": {
-            "can_access": true,
-            "is_admin": false
-          }
+            "can_access": false,
+            "can_access_reason": "not_activated"
+          },
+          "potentialOperators": [
+            {
+              "name": "ANCT",
+              "siret": "13002603200016",
+              "url": "https://anct.gouv.fr/",
+              "config": {},
+              "signupUrl": "https://suiteterritoriale.anct.gouv.fr/deep-link-signup/"
+            },
+            {
+              "name": "Nom OPSN",
+              "siret": "12345678901234",
+              "url": "https://site.opsn/offre-lst/",
+              "config": {},
+              "signupUrl": "https://suiteterritoriale.anct.gouv.fr/deep-link-signup/"
+            }
+          ]
         }
-  recorded_at: Wed, 01 Apr 2026 09:59:46 GMT
+  recorded_at: Wed, 01 Apr 2026 09:51:20 GMT
 recorded_with: VCR 6.4.0

--- a/spec/services/espace_operateur_anct_spec.rb
+++ b/spec/services/espace_operateur_anct_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe EspaceOperateurANCT do
       expect(service.operator).to be_present
     end
 
+    it "n’a pas d’opérateurs potentiels" do
+      expect(service.potential_operators).to be_nil
+    end
+
     it "retourne les entitlements" do
       expect(service.entitlements).to be_present
     end
@@ -28,6 +32,22 @@ RSpec.describe EspaceOperateurANCT do
       service.operator
       service.entitlements
       expect(WebMock).to have_requested(:get, /entitlements/).once
+    end
+
+    context "quand l’organisation a des opérateurs potentiels" do
+      let(:siret) { "20005671100019" }
+
+      around do |example|
+        VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { example.run }
+      end
+
+      it "a un opérateur null" do
+        expect(service.operator).to be_nil
+      end
+
+      it "retourne les opérateurs potentiels" do
+        expect(service.potential_operators).to be_present
+      end
     end
   end
 

--- a/spec/services/pro_connect_first_login_handler_spec.rb
+++ b/spec/services/pro_connect_first_login_handler_spec.rb
@@ -1,0 +1,143 @@
+RSpec.describe ProConnectFirstLoginHandler do
+  subject(:handler) { described_class.new(agent, domain) }
+
+  let(:domain) { Domain::RDV_SERVICE_PUBLIC }
+  let(:siret) { "21550050500015" }
+  let(:agent) { create(:agent, email: "test-admin@example.com", proconnect_siret: siret) }
+
+  stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: "Bearer fake-token")
+
+  describe "#call" do
+    context "quand l'agent n'a pas de SIRET ProConnect" do
+      let(:agent) { create(:agent, proconnect_siret: nil) }
+
+      it "retourne :classic sans appeler l'API" do
+        expect(EspaceOperateurANCT).not_to receive(:new)
+        expect(handler.call.action).to eq(:classic)
+      end
+    end
+
+    context "quand l'API ANCT échoue (token absent)" do
+      stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: nil)
+
+      it "retourne :classic et capture l'exception dans Sentry" do
+        expect(Sentry).to receive(:capture_exception)
+        expect(handler.call.action).to eq(:classic)
+      end
+    end
+
+    context "Cas A : l'API retourne un opérateur qui matche un Operator de notre DB" do
+      let!(:operator) { create(:operator, siret:) }
+
+      context "et l'agent est admin" do
+        let(:agent) { create(:agent, email: "test-admin@example.com", proconnect_siret: siret) }
+
+        around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_admin") { ex.run } }
+
+        it "retourne :attached_as_admin" do
+          expect(handler.call.action).to eq(:attached_as_admin)
+        end
+
+        context "quand l'opérateur a déjà un territoire avec une organisation" do
+          let!(:territory) { create(:territory, operator: operator) }
+          let!(:organisation) { create(:organisation, territory: territory) }
+
+          it "rattache l'agent à l'organisation et au territoire existants sans créer de nouveaux records" do
+            expect { handler.call }
+              .to change(AgentRole, :count).by(1)
+              .and change(AgentTerritorialRole, :count).by(1)
+              .and change(AgentTerritorialAccessRight, :count).by(1)
+
+            expect(Territory.count).to eq(1)
+            expect(Organisation.count).to eq(1)
+            expect(AgentRole.last).to have_attributes(agent: agent, organisation: organisation, access_level: "admin")
+            expect(AgentTerritorialRole.last).to have_attributes(agent: agent, territory: territory)
+            expect(AgentTerritorialAccessRight.last).to have_attributes(
+              agent: agent, territory: territory,
+              allow_to_manage_access_rights: true,
+              allow_to_invite_agents: true
+            )
+          end
+        end
+
+        context "quand l'opérateur a un territoire sans organisation" do
+          let!(:territory) { create(:territory, operator: operator) }
+
+          it "crée une organisation et rattache l'agent sans créer de nouveau territoire" do
+            expect { handler.call }.to change(Organisation, :count).by(1)
+
+            expect(Territory.count).to eq(1)
+            organisation = Organisation.last
+            expect(organisation.name).to eq("Bezonvaux") # nom retourné par la cassette VCR
+            expect(organisation.territory).to eq(territory)
+          end
+        end
+
+        context "quand l'opérateur n'a pas encore de territoire" do
+          it "crée un territoire vide et une organisation" do
+            expect { handler.call }
+              .to change(Territory, :count).by(1)
+              .and change(Organisation, :count).by(1)
+
+            territory = Territory.last
+            expect(territory.operator).to eq(operator)
+            expect(territory.name).to be_nil
+
+            organisation = Organisation.last
+            expect(organisation.name).to eq("Bezonvaux")
+          end
+        end
+      end
+
+      context "et l'agent a accès mais n'est pas admin" do
+        let(:agent) { create(:agent, email: "contact@mairie-nantes.fr", proconnect_siret: siret) }
+
+        around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_success") { ex.run } }
+
+        it "retourne :contact_admin sans créer de territoire" do
+          result = handler.call
+          expect(result.action).to eq(:contact_admin)
+          expect(Territory.count).to eq(0)
+          expect(Organisation.count).to eq(0)
+        end
+      end
+    end
+
+    context "Cas B : l'API retourne des potentialOperators dont un matche un Operator de notre DB" do
+      let(:agent) { create(:agent, email: "contact@mairie-nantes.fr", proconnect_siret: "20005671100019") }
+      let!(:operator) { create(:operator, siret: "13002603200016") } # SIRET du premier potentialOperator dans la cassette
+
+      around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { ex.run } }
+
+      it "retourne :signup_via_operator avec le signupUrl et le nom de l'opérateur" do
+        result = handler.call
+        expect(result.action).to eq(:signup_via_operator)
+        expect(result.signup_url).to eq("https://suiteterritoriale.anct.gouv.fr/deep-link-signup/")
+        expect(result.operator_name).to eq("ANCT")
+      end
+
+      it "ne crée pas de territoire" do
+        handler.call
+        expect(Territory.count).to eq(0)
+      end
+    end
+
+    context "Cas C : l'API retourne des potentialOperators mais aucun ne matche notre DB" do
+      let(:agent) { create(:agent, email: "contact@mairie-nantes.fr", proconnect_siret: "20005671100019") }
+
+      around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { ex.run } }
+
+      it "retourne :classic" do
+        expect(handler.call.action).to eq(:classic)
+      end
+    end
+
+    context "Cas D : l'API retourne un opérateur mais le SIRET ne matche pas notre DB" do
+      around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_success") { ex.run } }
+
+      it "retourne :classic" do
+        expect(handler.call.action).to eq(:classic)
+      end
+    end
+  end
+end

--- a/spec/services/pro_connect_onboarding_router_spec.rb
+++ b/spec/services/pro_connect_onboarding_router_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ProConnectFirstLoginHandler do
+RSpec.describe ProConnectOnboardingRouter do
   subject(:handler) { described_class.new(agent, domain) }
 
   let(:domain) { Domain::RDV_SERVICE_PUBLIC }
@@ -119,6 +119,29 @@ RSpec.describe ProConnectFirstLoginHandler do
       it "ne crée pas de territoire" do
         handler.call
         expect(Territory.count).to eq(0)
+      end
+    end
+
+    context "Cas B bis : plusieurs potentialOperators matchent notre DB" do
+      let(:agent) { create(:agent, email: "contact@mairie-nantes.fr", proconnect_siret: "20005671100019") }
+      let!(:operator_1) { create(:operator, siret: "13002603200016") }
+      let!(:operator_2) { create(:operator, siret: "12345678901234") }
+
+      around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { ex.run } }
+
+      it "envoie un message Sentry" do
+        expect(Sentry).to receive(:capture_message).with(
+          "ProConnectOnboardingRouter: plusieurs potentialOperators matchent notre DB",
+          extra: { agent_id: agent.id, sirets: %w[13002603200016 12345678901234] }
+        )
+        handler.call
+      end
+
+      it "retourne quand même :signup_via_operator avec le premier match" do
+        allow(Sentry).to receive(:capture_message)
+        result = handler.call
+        expect(result.action).to eq(:signup_via_operator)
+        expect(result.operator_name).to eq("ANCT")
       end
     end
 

--- a/spec/services/pro_connect_onboarding_router_spec.rb
+++ b/spec/services/pro_connect_onboarding_router_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe ProConnectOnboardingRouter do
       stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: nil)
 
       it "retourne :classic et capture l'exception dans Sentry" do
-        expect(Sentry).to receive(:capture_exception)
+        expect { handler.call }.to change(sentry_events, :size).by(1)
+        expect(sentry_events.last.exception.values.first.value).to eq("Ce service n’est pas utilisable dans cet environnement. (RuntimeError)")
         expect(handler.call.action).to eq(:classic)
       end
     end

--- a/spec/services/pro_connect_onboarding_router_spec.rb
+++ b/spec/services/pro_connect_onboarding_router_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe ProConnectOnboardingRouter do
             territory = Territory.last
             expect(territory.operator).to eq(operator)
             expect(territory.name).to be_nil
+            expect(territory.category).to eq("Inconnu") # la cassette VCR retourne type "other"
 
             organisation = Organisation.last
             expect(organisation.name).to eq("Bezonvaux")

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -11,6 +11,19 @@ VCR.configure do |config|
   config.before_record do |interaction|
     interaction.request.headers["Authorization"] = "[Filtered in vcr.rb -> before_record]"
     interaction.response.headers["Set-Cookie"] = "[Filtered in vcr.rb -> before_record]"
+    interaction.request.headers["X-Service-Auth"] = "[Filtered in vcr.rb -> before_record]"
+    interaction.response.headers["X-Service-Auth"] = "[Filtered in vcr.rb -> before_record]"
+  end
+
+  # Ce block formate les réponses JSON afin d'améliorer la lisibilité de la cassette
+  config.before_record do |interaction|
+    content_type = interaction.response.headers["Content-Type"]&.first
+    next unless content_type&.include?("json")
+
+    body = interaction.response.body.dup.force_encoding("UTF-8")
+    interaction.response.body = JSON.pretty_generate(JSON.parse(body))
+  rescue JSON::ParserError
+    # If JSON is malformed, leave it untouched
   end
 
   # Ce block formate les réponses XML afin d'améliorer la lisibilité de la cassette


### PR DESCRIPTION
# Contexte

Lors du premier login ProConnect d'un nouvel agent sur RDV Service Public (domaine avec `allow_self_onboarding`), l'agent était systématiquement redirigé vers le formulaire de demande de création de territoire, sans tenir compte de son éventuelle adhésion à un opérateur déjà connu.

L'API Espace Opérateur ANCT permet de savoir si l'organisation de l’agent est rattaché à un opérateur (`operator`) ou pressenti pour l'être (`potentialOperators`), et si c'est le cas, quel est son niveau d'accès.

# Solution

Ajout d'un service `ProConnectOnboardingRouter` qui est appelé après le premier login ProConnect d'un agent. Il interroge l'API ANCT (timeout 3s, fallback silencieux vers le flux classique) et adapte la redirection selon quatre cas :

- **Opérateur connu + admin** : l'agent est automatiquement rattaché à l’espace existant ou s'il n’existe pas, celui-ci est crée.
- **Opérateur connu + accès sans droits admin** : flash d'information invitant l'agent à contacter son administrateur. On laisse la responsabilité aux agents admin de terrain de donner les bons droits dans leur orga.
- **PotentialOperator connu** : redirection vers une page dédiée avec un lien vers le formulaire d'inscription de l'opérateur.
- **Aucun match / erreur API** : flux classique (demande de création de territoire).

Le même routeur est aussi appelé en `before_action` sur `TerritoryCreationRequestsController` pour empêcher le contournement via une connexion ultérieure ou un accès direct à l'URL.

Un message Sentry est envoyé si plusieurs `potentialOperators` matchent simultanément notre base (cas normalement improbable tant que l’équipe ANCT ne fait pas de déploiement de son côté).
