### PR TITLE
Renommer "Exceptionnelle" en "Ponctuelle" (plages et indispos)

### DIFF
--- a/app/helpers/recurrence_helper.rb
+++ b/app/helpers/recurrence_helper.rb
@@ -78,8 +78,8 @@ module RecurrenceHelper
     weekdays[weekday]
   end
 
-  def exceptionnelle_tag(recurrent_record)
-    tag.span("Exceptionnelle", class: "fr-badge fr-badge--sm fr-badge--green-archipel") if recurrent_record.exceptionnelle?
+  def ponctuelle_tag(recurrent_record)
+    tag.span("Ponctuelle", class: "fr-badge fr-badge--sm fr-badge--green-archipel") if recurrent_record.ponctuelle?
   end
 
   def filter_plage_ouvertures_in_departement_scope(plage_ouvertures)

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -133,9 +133,9 @@ class CronJob < ApplicationJob
 
   class DestroyOldPlageOuvertureJob < CronJob
     def perform
-      po_exceptionnelle_closed_since_1_year = PlageOuverture.where(recurrence: nil).where(first_day: ..1.year.ago)
+      po_ponctuelle_closed_since_1_year = PlageOuverture.where(recurrence: nil).where(first_day: ..1.year.ago)
       po_recurrent_closed_since_1_year = PlageOuverture.where(recurrence_ends_at: ..1.year.ago)
-      po_exceptionnelle_closed_since_1_year.or(po_recurrent_closed_since_1_year).each do |po|
+      po_ponctuelle_closed_since_1_year.or(po_recurrent_closed_since_1_year).each do |po|
         po.webhook_reason = "rgpd"
         po.destroy
       end

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -12,7 +12,7 @@ module RecurrenceConcern
     validate :recurrence_starts_matches_first_day, if: :recurring?
     validate :recurrence_ends_after_first_day, if: :recurring?
 
-    scope :exceptionnelles, -> { where(recurrence: nil) }
+    scope :ponctuelles, -> { where(recurrence: nil) }
     scope :regulieres, -> { where.not(recurrence: nil) }
     scope :overlapping_range, lambda { |range|
       in_range(range).select { _1.occurrences_for(range).any? { |occurrence| occurrence.overlaps?(range) } }
@@ -84,7 +84,7 @@ module RecurrenceConcern
     (first_occurrence_ends_at - starts_at).to_i
   end
 
-  def exceptionnelle?
+  def ponctuelle?
     !recurring?
   end
 
@@ -117,7 +117,7 @@ module RecurrenceConcern
     if recurring?
       occurrences_for_recurring(inclusive_datetime_range, inclusive_datetime_range)
     else
-      occurrences_for_exceptionnelle(inclusive_datetime_range)
+      occurrences_for_ponctuelle(inclusive_datetime_range)
     end
   end
 
@@ -144,7 +144,7 @@ module RecurrenceConcern
     occurrences.sort
   end
 
-  def occurrences_for_exceptionnelle(inclusive_datetime_range)
+  def occurrences_for_ponctuelle(inclusive_datetime_range)
     occurrences = []
     occurrences << occurrence_in_range(starts_at, ends_at, inclusive_datetime_range)
     occurrences << occurrence_in_range(secondary_starts_at, secondary_end_time.on(first_day), inclusive_datetime_range) if secondary_times_present?

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -140,12 +140,12 @@ class PlageOuverture < ApplicationRecord
       .not_expired
       .where.not(id: id)
 
-    if exceptionnelle?
+    if ponctuelle?
       candidate_pos.regulieres.where(first_day: ..first_day)
-        .or(candidate_pos.exceptionnelles.where(first_day: first_day))
+        .or(candidate_pos.ponctuelles.where(first_day: first_day))
     else
       candidate_pos.regulieres
-        .or(candidate_pos.exceptionnelles.where(first_day: first_day..))
+        .or(candidate_pos.ponctuelles.where(first_day: first_day..))
     end
   end
 

--- a/app/services/plage_ouverture_overlap.rb
+++ b/app/services/plage_ouverture_overlap.rb
@@ -9,8 +9,8 @@ class PlageOuvertureOverlap
   def exists? # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     return false if po1.agent != po2.agent
 
-    if po1.exceptionnelle? && po2.exceptionnelle?
-      both_exceptionnelles_overlap?
+    if po1.ponctuelle? && po2.ponctuelle?
+      both_ponctuelles_overlap?
     else
       !po1_ends_before_po2? &&
         !po2_ends_before_po1? &&
@@ -23,7 +23,7 @@ class PlageOuvertureOverlap
 
   private
 
-  def both_exceptionnelles_overlap?
+  def both_ponctuelles_overlap?
     po1.starts_at < po2.ends_at && po1.ends_at > po2.starts_at
   end
 
@@ -83,9 +83,9 @@ class PlageOuvertureOverlap
   end
 
   def occurrences_date_range
-    @occurrences_date_range ||= if po1.exceptionnelle?
+    @occurrences_date_range ||= if po1.ponctuelle?
                                   po1.first_day.past? ? nil : (po1.first_day..po1.first_day)
-                                elsif po2.exceptionnelle?
+                                elsif po2.ponctuelle?
                                   po2.first_day.past? ? nil : (po2.first_day..po2.first_day)
                                 else
                                   min = [[po1.first_day, po2.first_day].min, Time.zone.today].max

--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -5,7 +5,8 @@ tr
     span.badge.badge-pill style="background: #{plage_ouverture.hex_color};" &nbsp;
   td
     = link_to plage_ouverture.title_with_default, admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture), class: "fr-link"
-    = exceptionnelle_tag(plage_ouverture)
+    span.ml-1
+      = ponctuelle_tag(plage_ouverture)
   td
     ul.pl-2
       - plage_ouverture.motifs.each do |motif|

--- a/app/views/admin/planning/plage_ouvertures/show.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/show.html.slim
@@ -31,7 +31,7 @@
             span= @plage_ouverture.title
         div.mt-2.d-flex
           .flex-shrink-0.mr-1.font-weight-bold Répétition&nbsp;:
-          span= @plage_ouverture.recurring? ? "Récurrente" : exceptionnelle_tag(@plage_ouverture)
+          span= @plage_ouverture.recurring? ? "Récurrente" : ponctuelle_tag(@plage_ouverture)
         div.mt-2.d-flex
           .flex-shrink-0.mr-1.font-weight-bold Dates&nbsp;:
           - if @plage_ouverture.recurring?

--- a/app/views/mailers/agents/absence_mailer/_absence_overview.html.slim
+++ b/app/views/mailers/agents/absence_mailer/_absence_overview.html.slim
@@ -10,7 +10,7 @@
     .clear
   div.row-result
     span.title Répétition :
-    span.float-right= @absence.recurring? ? "Récurrente" : exceptionnelle_tag(@absence)
+    span.float-right= @absence.recurring? ? "Récurrente" : ponctuelle_tag(@absence)
     .clear
   div.row-result.no-border
     span.title Dates :

--- a/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
@@ -21,7 +21,7 @@
     .clear
   div.row-result
     span.title Répétition :
-    span.float-right= plage_ouverture.recurring? ? "Récurrente" : exceptionnelle_tag(plage_ouverture)
+    span.float-right= plage_ouverture.recurring? ? "Récurrente" : ponctuelle_tag(plage_ouverture)
     .clear
   div.row-result.no-border
     span.title Dates :

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -650,7 +650,7 @@ _plage_ouverture_org_paris_nord_martine_mercredi = PlageOuverture.create!(
   end_time: Tod::TimeOfDay.new(12),
   recurrence: Montrose.every(:week, on: [:wednesday], interval: 1, starts: Date.tomorrow)
 )
-_plage_ouverture_org_paris_nord_martine_exceptionnelle = PlageOuverture.create!(
+_plage_ouverture_org_paris_nord_martine_ponctuelle = PlageOuverture.create!(
   title: "Aprem PMI exptn",
   organisation_id: org_paris_nord.id,
   agent_id: agent_org_paris_nord_pmi_martine.id,

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     expect(absence_representing_rdv.external_references.last.external_url).to eq "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/rdvs/#{future_rdv.id}"
 
     # On crée aussi des copies des absences futures
-    expect(agent_rdv_sp.absences.exceptionnelles.first.starts_at).to eq absence.starts_at
+    expect(agent_rdv_sp.absences.ponctuelles.first.starts_at).to eq absence.starts_at
 
     new_absence_without_end_date = agent_rdv_sp.absences.regulieres.where(recurrence_ends_at: nil).first
     expect(Montrose::Recurrence.dump(new_absence_without_end_date.recurrence)).to eq Montrose::Recurrence.dump(recurrent_absence.recurrence)

--- a/spec/helpers/recurrence_helper_spec.rb
+++ b/spec/helpers/recurrence_helper_spec.rb
@@ -44,15 +44,15 @@ RSpec.describe RecurrenceHelper do
     end
   end
 
-  describe "#exceptionnelle_tag" do
-    it "return exceptionnelle badge without recurrence" do
+  describe "#ponctuelle_tag" do
+    it "return ponctuelle badge without recurrence" do
       plage_ouverture = build(:plage_ouverture)
-      expect(exceptionnelle_tag(plage_ouverture)).to eq(%(<span class="fr-badge fr-badge--sm fr-badge--green-archipel">Exceptionnelle</span>))
+      expect(ponctuelle_tag(plage_ouverture)).to eq(%(<span class="fr-badge fr-badge--sm fr-badge--green-archipel">Ponctuelle</span>))
     end
 
     it "return nil with recurrence" do
       plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week))
-      expect(exceptionnelle_tag(plage_ouverture)).to be_nil
+      expect(ponctuelle_tag(plage_ouverture)).to be_nil
     end
   end
 end

--- a/spec/jobs/cron_job/update_expirations_job_spec.rb
+++ b/spec/jobs/cron_job/update_expirations_job_spec.rb
@@ -7,15 +7,15 @@ RSpec.describe CronJob::UpdateExpirationsJob, type: :job do
 
   context "PO without recurrence" do
     it "expired past first_day" do
-      plage_ouverture_exceptionnelle = create(:plage_ouverture, :no_recurrence, first_day: now.to_date - 1.week)
+      plage_ouverture_ponctuelle = create(:plage_ouverture, :no_recurrence, first_day: now.to_date - 1.week)
       described_class.perform_now
-      expect(plage_ouverture_exceptionnelle.reload.expired_cached).to be true
+      expect(plage_ouverture_ponctuelle.reload.expired_cached).to be true
     end
 
     it "not expired futur first_day" do
-      plage_ouverture_exceptionnelle = create(:plage_ouverture, :no_recurrence, first_day: now.to_date + 1.week)
+      plage_ouverture_ponctuelle = create(:plage_ouverture, :no_recurrence, first_day: now.to_date + 1.week)
       described_class.perform_now
-      expect(plage_ouverture_exceptionnelle.reload.expired_cached).to be false
+      expect(plage_ouverture_ponctuelle.reload.expired_cached).to be false
     end
   end
 
@@ -35,15 +35,15 @@ RSpec.describe CronJob::UpdateExpirationsJob, type: :job do
 
   context "Absence without recurrence" do
     it "expired past first_day" do
-      absence_exceptionnelle = create(:absence, :no_recurrence, first_day: now.to_date - 1.week)
+      absence_ponctuelle = create(:absence, :no_recurrence, first_day: now.to_date - 1.week)
       described_class.perform_now
-      expect(absence_exceptionnelle.reload.expired_cached).to be true
+      expect(absence_ponctuelle.reload.expired_cached).to be true
     end
 
     it "not expired futur first_day" do
-      absence_exceptionnelle = create(:absence, :no_recurrence, first_day: now.to_date + 1.week)
+      absence_ponctuelle = create(:absence, :no_recurrence, first_day: now.to_date + 1.week)
       described_class.perform_now
-      expect(absence_exceptionnelle.reload.expired_cached).to be false
+      expect(absence_ponctuelle.reload.expired_cached).to be false
     end
   end
 

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe RecurrenceConcern do
   end
 
   describe "plage avec horaires d'après-midi" do
-    context "quand elle est exceptionnelle" do
+    context "quand elle est ponctuelle" do
       it "works" do
         plage = build(:plage_ouverture, :no_recurrence,
                       first_day: Date.new(2025, 2, 10),

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe PlageOuverture, type: :model do
   describe "#expired?" do
     subject { plage_ouverture.expired? }
 
-    context "with exceptionnelles plages" do
+    context "with ponctuelles plages" do
       describe "when first_day is in past" do
         let(:plage_ouverture) { create(:plage_ouverture, :no_recurrence, first_day: Date.parse("2020-07-30"), organisation: organisation) }
 
@@ -216,7 +216,7 @@ RSpec.describe PlageOuverture, type: :model do
       end
     end
 
-    describe "exceptionnelle" do
+    describe "ponctuelle" do
       let(:plage_ouverture) do
         build(
           :plage_ouverture,

--- a/spec/services/plage_ouverture_overlap_spec.rb
+++ b/spec/services/plage_ouverture_overlap_spec.rb
@@ -33,130 +33,130 @@ RSpec.describe PlageOuvertureOverlap do
     end
   end
 
-  # both exceptionnelles
+  # both ponctuelles
 
-  context "po1 and po2 exceptionnelles, exactly overlapping" do
+  context "po1 and po2 ponctuelles, exactly overlapping" do
     let(:po1) { build_po(monday, 14, 18) }
     let(:po2) { build_po(monday, 14, 18) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
-  context "po1 and po2 exceptionnelles, included in other" do
+  context "po1 and po2 ponctuelles, included in other" do
     let(:po1) { build_po(monday, 14, 18) }
     let(:po2) { build_po(monday, 15, 16) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
-  context "po1 and po2 exceptionnelles, includes other" do
+  context "po1 and po2 ponctuelles, includes other" do
     let(:po1) { build_po(monday, 14, 18) }
     let(:po2) { build_po(monday, 8, 20) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
-  context "po1 and po2 exceptionnelles, partially overlapping start" do
+  context "po1 and po2 ponctuelles, partially overlapping start" do
     let(:po1) { build_po(monday, 14, 18) }
     let(:po2) { build_po(monday, 8, 16) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
-  context "po1 and po2 exceptionnelles, partially overlapping end" do
+  context "po1 and po2 ponctuelles, partially overlapping end" do
     let(:po1) { build_po(monday, 14, 18) }
     let(:po2) { build_po(monday, 16, 20) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
-  context "po1 and po2 exceptionnelles, non overlapping same day" do
+  context "po1 and po2 ponctuelles, non overlapping same day" do
     let(:po1) { build_po(monday, 14, 18) }
     let(:po2) { build_po(monday, 8, 12) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
-  context "po1 and po2 exceptionnelles, non overlapping other day" do
+  context "po1 and po2 ponctuelles, non overlapping other day" do
     let(:po1) { build_po(monday, 14, 18) }
     let(:po2) { build_po(monday + 1.day, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
-  # po1 recurring, po2 exceptionnelle
+  # po1 recurring, po2 ponctuelle
 
-  context "po1 recurring without end date, po2 exceptionnelle before recurring" do
+  context "po1 recurring without end date, po2 ponctuelle before recurring" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday - 7.days, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
-  context "po1 recurring without end date, po2 exceptionnelle on other day same week" do
+  context "po1 recurring without end date, po2 ponctuelle on other day same week" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday + 3.days, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
-  context "po1 recurring without end date, po2 exceptionnelle on other day next week" do
+  context "po1 recurring without end date, po2 ponctuelle on other day next week" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday + 1.week + 3.days, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
-  context "po1 recurring without end date, po2 exceptionnelle on same day but times don't overlap" do
+  context "po1 recurring without end date, po2 ponctuelle on same day but times don't overlap" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday + 8.days, 8, 10) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
-  context "po1 recurring without end date, po2 exceptionnelle on same day and times overlap" do
+  context "po1 recurring without end date, po2 ponctuelle on same day and times overlap" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday + 8.days, 15, 20) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
-  context "po1 recurring every 3 weeks without end date, po2 exceptionnelle on same week day 6 weeks after" do
+  context "po1 recurring every 3 weeks without end date, po2 ponctuelle on same week day 6 weeks after" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks, starts: monday, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday + 6.weeks, 14, 18) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
-  context "po1 recurring every 3 weeks without end date, po2 exceptionnelle on same week day 4 weeks after" do
+  context "po1 recurring every 3 weeks without end date, po2 ponctuelle on same week day 4 weeks after" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks, on: %i[monday tuesday], starts: monday, interval: 1)) }
     let(:po2) { build_po(monday + 4.weeks, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
-  context "po1 recurring with end date, po2 exceptionnelle before recurring" do
+  context "po1 recurring with end date, po2 ponctuelle before recurring" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
     let(:po2) { build_po(monday - 7.days, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
-  context "po1 recurring with end date, po2 exceptionnelle same weekday before po1 end date" do
+  context "po1 recurring with end date, po2 ponctuelle same weekday before po1 end date" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
     let(:po2) { build_po(monday + 7.days, 14, 18) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
-  context "po1 recurring with end date, po2 exceptionnelle other weekday before po1 end date" do
+  context "po1 recurring with end date, po2 ponctuelle other weekday before po1 end date" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
     let(:po2) { build_po(monday - 10.days, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
-  context "po1 recurring with end date, po2 exceptionnelle same weekday after po1 end date" do
+  context "po1 recurring with end date, po2 ponctuelle same weekday after po1 end date" do
     let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
     let(:po2) { build_po(monday + 4.weeks, 14, 18) }
 

--- a/spec/support/recurrence_concern.rb
+++ b/spec/support/recurrence_concern.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples_for "recurrence" do
   describe "#starts_at" do
     subject { model_instance.starts_at }
 
-    context "exceptionnelle" do
+    context "ponctuelle" do
       let(:model_instance) { create(model_symbol, first_day: Date.new(2019, 7, 22), start_time: Tod::TimeOfDay.new(9)) }
 
       it { is_expected.to eq(Time.zone.local(2019, 7, 22, 9)) }
@@ -15,7 +15,7 @@ RSpec.shared_examples_for "recurrence" do
   describe "#ends_at" do
     subject { model_instance.ends_at }
 
-    context "exceptionnelle" do
+    context "ponctuelle" do
       let(:model_instance) { create(model_symbol, first_day: Date.new(2019, 7, 22), end_time: Tod::TimeOfDay.new(12)) }
 
       it { is_expected.to eq(Time.zone.local(2019, 7, 22, 12)) }


### PR DESCRIPTION
# Contexte

Actuellement, une plage ou une indispo qui n'est pas récurrente est qualifiée de "Exceptionnelle". Après concertation avec l'équipe, nous sommes une majorité à préférer "Ponctuelle" à "Exceptionnelle", et donc nous décidons d'adopter "Ponctuelle".

Cela permet aussi d'être cohérent dans avec le radio button introduit dans #6292.

# Solution

Je renomme à la fois dans le produit et dans le code.

Finalement, dans le produit, seul le tag affiché sur l'index, le show et les mails de notif affiche ce terme.

## Captures d'écran

Avant | Après
:- | -:
<img width="1029" height="292" alt="image" src="https://github.com/user-attachments/assets/5b46948d-6f54-4602-b24e-1f5f08a06bd3" /> | <img width="1029" height="292" alt="image" src="https://github.com/user-attachments/assets/bc6c2323-3820-46f4-8031-5b178feffca5" />
 <img width="1220" height="717" alt="image" src="https://github.com/user-attachments/assets/d4331835-8080-4e39-adfa-a94139a2a397" /> |<img width="1220" height="717" alt="image" src="https://github.com/user-attachments/assets/951caebd-63d3-4531-a2ec-d0f15d39216c" />
