### PR TITLE
Fix flaky test suite à la maj Phonelib

### DIFF
--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -8,7 +8,11 @@ FactoryBot.define do
 
     trait :with_contact do
       email { generate(:orga_email) }
-      phone_number { Faker::PhoneNumber.cell_phone }
+      phone_number do
+        num = ""
+        num = Faker::PhoneNumber.cell_phone until Phonelib.parse(num, "FR").valid?
+        num
+      end
       website { Faker::Internet.url }
     end
   end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
 
     trait :with_contact do
       email { generate(:orga_email) }
-      phone_number { Faker::PhoneNumber.phone_number_with_country_code }
+      phone_number { Faker::PhoneNumber.cell_phone }
       website { Faker::Internet.url }
     end
   end


### PR DESCRIPTION
Suit à la maj de `phonelib` on a des flaky test. Logiquement c'est fix en changeant la façon dont Faker génére le numéro de tel.