### PR TITLE
Passage des formulaires de création/édition agent au DSFR

### DIFF
--- a/app/views/admin/agent_intervenants/_name_form.html.slim
+++ b/app/views/admin/agent_intervenants/_name_form.html.slim
@@ -2,7 +2,6 @@
   .col-md-12.col-lg-8
     .card
       .card-body
-        = simple_form_for [:admin, current_organisation,  agent_intervenant], url: admin_organisation_agent_intervenant_path(current_organisation, agent_intervenant), html: { method: :put, class: "form-inline full-width-inline-form" }, wrapper: :inline_form do |f|
-          .d-flex.w-100
-            = f.input :last_name, label: "Nom", placeholder: "Avocat #1", input_html: { autocomplete: "off", class: "full-width-input" }
-            = f.button :submit, "Modifier le nom"
+        = form_for [:admin, current_organisation, agent_intervenant], url: admin_organisation_agent_intervenant_path(current_organisation, agent_intervenant), html: { method: :put }, builder: Dsfr::FormBuilder do |f|
+          = f.dsfr_text_field :last_name, label: "Nom", placeholder: "Avocat #1", autocomplete: "off"
+          = f.submit "Modifier le nom", class: "fr-btn"

--- a/app/views/admin/agents/edit.html.slim
+++ b/app/views/admin/agents/edit.html.slim
@@ -7,11 +7,11 @@
 - if @agent.is_an_intervenant?
   = render "admin/agent_intervenants/name_form", agent_intervenant: @agent
 
-.row.justify-content-center
-  .col-md-12.col-lg-8
+.fr-grid-row.fr-grid-row--gutters
+  .fr-col-md-12.fr-col-lg-8
     .card
       .card-body.js_agent_role_form
-        = simple_form_for [:admin, current_organisation, @agent] do |f|
+        = form_for [:admin, current_organisation, @agent], builder: Dsfr::FormBuilder do |f|
           = render "model_errors", model: @agent
 
           - if current_territory.services.any? || @agent.agent_services.any?
@@ -31,44 +31,49 @@
               = link_to "Ajouter ou retirer des services", edit_admin_territory_agent_path(territory_id: current_territory.id, agent_id: @agent.id), class: "fr-link fr-icon-pencil-line fr-link--icon-left"
             - else
               .fr-mb-0.fr-text--sm.text-muted
-                | Le changement ou l’ajout de service est réservé aux admins d'espace avec ce droit d’accès
+                | Le changement ou l'ajout de service est réservé aux admins d'espace avec ce droit d'accès
 
             hr
 
-          = f.simple_fields_for @agent_role do |ff|
-            = ff.input :access_level,
-              collection: @roles,
-              label_method: -> { render("admin/agents/role_labels/#{_1}", { services: @agent.services }) },
+          = f.fields_for @agent_role do |ff|
+            ruby:
+              role_choices = @roles.map do |role|
+                {
+                  value: role,
+                  label: render("admin/agents/role_labels/#{role}"),
+                  hint: render("admin/agents/role_hints/#{role}", services: @agent.services),
+                  checked: ff.object.access_level == role,
+                }
+              end
+            = ff.dsfr_radio_buttons :access_level, role_choices,
+              legend: "Niveau de permissions",
               hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations_count > 1),
-              as: :radio_buttons
+              rich: true
 
           / allow turning an intervenant into an agent with an account
           - if AgentRole.find(@agent_role.id).access_level == "intervenant"
             .js_agent_role_form__agent_with_account_fields[style="display:none;"]
-              = f.input :email, label: "Email d'invitation de l'agent", required: true, disabled: true
-              .row
-                .col-md-6
-                  = f.input :first_name, required: true, disabled: true
-                .col-md-6
-                  = f.input :last_name, required: true, input_html: { value: "" }, disabled: true
+              = f.dsfr_email_field :email, label: "Email d'invitation de l'agent", required: true, disabled: true
+              .fr-grid-row.fr-grid-row--gutters
+                .fr-col-md-6
+                  = f.dsfr_text_field :first_name, label: Agent.human_attribute_name(:first_name), required: true, disabled: true
+                .fr-col-md-6
+                  = f.dsfr_text_field :last_name, label: Agent.human_attribute_name(:last_name), required: true, value: "", disabled: true
 
-          .row
+          .fr-btns-group
             - if policy(@agent, policy_class: Agent::AgentPolicy).destroy?
-              .col.text-left
-                = link_to @agent_removal_presenter.button_value, \
-                  admin_organisation_agent_path(current_organisation, @agent), \
-                  data: { confirm: @agent_removal_presenter.confirm_message }, \
-                  method: :delete, \
-                  class: "btn btn-outline-danger"
-            .col.text-right
-              - if AgentRole.find(@agent_role.id).access_level == "intervenant"
-                = f.button :submit
-              - else
-                .js_agent_role_form__agent_with_account_fields
-                  = f.button :submit
-                .js_agent_role_form__intervenant_fields[style="display:none;"]
-                  = f.button :submit, data: { confirm: "Cet agent ne pourra plus se connecter à son compter. Êtes vous sûr de vouloir continuer ?" }
+              = link_to @agent_removal_presenter.button_value, \
+                admin_organisation_agent_path(current_organisation, @agent), \
+                data: { confirm: @agent_removal_presenter.confirm_message }, \
+                method: :delete, \
+                class: "fr-btn fr-btn--tertiary"
+            - if AgentRole.find(@agent_role.id).access_level == "intervenant"
+              = f.submit class: "fr-btn"
+            - else
+              .js_agent_role_form__agent_with_account_fields
+                = f.submit class: "fr-btn"
+              .js_agent_role_form__intervenant_fields[style="display:none;"]
+                = f.submit data: { confirm: "Cet agent ne pourra plus se connecter à son compter. Êtes vous sûr de vouloir continuer ?" }, class: "fr-btn"
 
-.row.justify-content-center
-  .col-md-12.col-lg-8
+  .fr-col-md-12.fr-col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: policy(@agent, policy_class: Agent::AgentPolicy), resource: @agent

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -4,42 +4,50 @@
 = render "admin/agents/fil_ariane", current_page_title: content_for(:title)
 - content_for(:menu_item) { "menu-settings" }
 
-.row.justify-content-center
-  .col-md-12.col-lg-8
+.fr-grid-row.fr-grid-row--gutters
+  .fr-col-md-12.fr-col-lg-8
     .card
       .card-body.js_agent_role_form
-        = simple_form_for [:admin, @agent], url: admin_organisation_agents_path(current_organisation), html: { method: :post } do |f|
+        = form_for [:admin, @agent], url: admin_organisation_agents_path(current_organisation), html: { method: :post }, builder: Dsfr::FormBuilder do |f|
           = render "devise/shared/error_messages", resource: @agent
-          = f.simple_fields_for @agent_role do |ff|
+          = f.fields_for @agent_role do |ff|
+            ruby:
+              role_choices = @roles.map do |role|
+                {
+                  value: role,
+                  label: render("admin/agents/role_labels/#{role}"),
+                  hint: render("admin/agents/role_hints/#{role}", services: @services),
+                  checked: ff.object.access_level == role,
+                }
+              end
+            ruby:
+              access_level_hint = "Quel type d’agent souhaitez-vous ajouter ?"
+              access_level_hint += " Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations_count > 1
+            = ff.dsfr_radio_buttons :access_level, role_choices,
+              legend: "Niveau de permissions",
+              hint: access_level_hint,
+              rich: true
 
-            label.big-label Niveau de permissions
-            .text-muted.form-text
-              | Quel type d'agent souhaitez-vous ajouter ?
-            = ff.input :access_level,
-              collection: @roles,
-              label_method: -> { render("admin/agents/role_labels/#{_1}", { services: @services }) },
-              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if current_agent.organisations_count > 1),
-              as: :radio_buttons,
-              label: "",
-              html: { class: "mt-4" }
+          = f.dsfr_email_field :email, label: "Email", placeholder: "a.dupond@departement.fr", autocomplete: "off", hint: "Une invitation sera envoyée automatiquement à cette adresse", class: "js_agent_role_form__agent_with_account_fields"
 
-          .js_agent_role_form__agent_with_account_fields
-            = f.input :email, placeholder: "a.dupond@departement.fr", input_html: { autocomplete: "off"}, label_html: { class: "big-label mt-3" }, hint: "Une invitation sera envoyée automatiquement à cette adresse"
-
-          .js_agent_role_form__intervenant_fields
-            = f.input :last_name, input_html: { autocomplete: "off"}, label: "Nom", label_html: { class: "big-label mt-3" }
+          = f.dsfr_text_field :last_name, label: "Nom", autocomplete: "off", class: "js_agent_role_form__intervenant_fields"
 
           - if @services.any?
-            label.big-label.mt-3 Services
-            .text-muted.form-text
-              | Dans quel domaine d'activité est-ce que cet agent effectue des rendez-vous ?
-            = f.association :services, collection: @services, include_blank: false, as: :check_boxes, label: ""
-            - if Agent::TerritoryPolicy.new(current_agent, current_territory).edit?
-              small.form-text.text-muted.mb-4
-                |> Si le service dont vous avez besoin n'apparaît pas dans cette liste, vous pouvez
-                = link_to("activer des services supplémentaires", edit_admin_territory_services_path(current_territory, redirect_to_organisation_id: current_organisation.id))
-            - else
-              | Si le service dont vous avez besoin n'apparaît pas dans cette liste, vous pouvez demander à un admin de votre espace d'activer des services supplémentaires.
+            fieldset.fr-fieldset
+              legend.fr-fieldset__legend--regular.fr-fieldset__legend
+                | Services
+                span.fr-hint-text Dans quel domaine d'activité est-ce que cet agent effectue des rendez-vous ?
+              = f.collection_check_boxes :service_ids, @services, :id, :name do |cb|
+                .fr-fieldset__element
+                  .fr-checkbox-group
+                    = cb.check_box
+                    = cb.label
+              - if Agent::TerritoryPolicy.new(current_agent, current_territory).edit?
+                p.fr-hint-text
+                  |> Si le service dont vous avez besoin n'apparaît pas dans cette liste, vous pouvez
+                  = link_to("activer des services supplémentaires", edit_admin_territory_services_path(current_territory, redirect_to_organisation_id: current_organisation.id))
+              - else
+                p.fr-hint-text Si le service dont vous avez besoin n'apparaît pas dans cette liste, vous pouvez demander à un admin de votre espace d'activer des services supplémentaires.
 
           .text-right
-            = f.button :submit, "Enregistrer"
+            = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/agents/role_hints/_admin.html.slim
+++ b/app/views/admin/agents/role_hints/_admin.html.slim
@@ -1,0 +1,3 @@
+ul.fr-mb-0
+  li Peut consulter et modifier l'agenda de tous les agents de l'organisation
+  li Peut gérer la configuration

--- a/app/views/admin/agents/role_hints/_basic.html.slim
+++ b/app/views/admin/agents/role_hints/_basic.html.slim
@@ -1,0 +1,8 @@
+/# locals: (services:)
+ul.fr-mb-0
+  - if services.any?
+    li Peut consulter et modifier son agenda et celui des agents de son service
+  - else
+    li Peut consulter et modifier son agenda et celui de ses collègues
+  - if services.any?(&:secretariat?)
+    li Service secrétariat : peut consulter et modifier les agendas de tous les agents de l'organisation

--- a/app/views/admin/agents/role_hints/_intervenant.html.slim
+++ b/app/views/admin/agents/role_hints/_intervenant.html.slim
@@ -1,0 +1,4 @@
+ul.fr-mb-0
+  li Ne nécessite pas d'email et ne peut donc pas se connecter
+  li Ne peut pas modifier son agenda
+  li Ne reçoit aucune notification

--- a/app/views/admin/agents/role_labels/_admin.html.slim
+++ b/app/views/admin/agents/role_labels/_admin.html.slim
@@ -1,6 +1,3 @@
-= icon("fr-icon-user-setting-fill", class: "fr-mr-1w")
-| Administrateur
-br
-ul
-  li Peut consulter et modifier l'agenda de tous les agents de l'organisation
-  li Peut gérer la configuration
+span
+  span.fr-icon-user-setting-fill.fr-mr-1w
+  | Administrateur

--- a/app/views/admin/agents/role_labels/_basic.html.slim
+++ b/app/views/admin/agents/role_labels/_basic.html.slim
@@ -1,11 +1,3 @@
-/# locals: (services:)
-= icon("fr-icon-user-fill", class: "fr-mr-1w")
-| Basique
-br
-ul
-  - if services.any?
-    li Peut consulter et modifier son agenda et celui des agents de son service
-  - else
-    li Peut consulter et modifier son agenda et celui de ses collègues
-  - if services.any?(&:secretariat?)
-    li Service secrétariat: peut consulter et modifier les agendas de tous les agents de l'organisation
+span
+  span.fr-icon-user-fill.fr-mr-1w
+  | Basique

--- a/app/views/admin/agents/role_labels/_intervenant.html.slim
+++ b/app/views/admin/agents/role_labels/_intervenant.html.slim
@@ -1,7 +1,3 @@
-= icon("fr-icon-admin-fill", class: "fr-mr-1w")
-| Intervenant
-br
-ul
-  li Ne nécessite pas d'email et ne peut donc pas se connecter
-  li Ne peut pas modifier son agenda
-  li Ne reçoit aucune notification
+span
+  span.fr-icon-admin-fill.fr-mr-1w
+  | Intervenant

--- a/spec/features/agents/agents/agent_can_crud_intervenants_spec.rb
+++ b/spec/features/agents/agents/agent_can_crud_intervenants_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Agent can CRUD intervenants" do
     # Create an intervenant
     click_link "Ajouter un agent", match: :first
     expect_page_title("Ajouter un agent")
-    check(service.name)
+    find("label", text: service.name).click
     find("label", text: "Intervenant").click
     fill_in "Nom", with: "Avocat 1"
     click_button("Enregistrer")


### PR DESCRIPTION
# Contexte

Dans le cadre du travail que je suis en train de faire ici #6285 je me suis rendu compte qu’on pouvait faire un petit passage au DSFR des formulaires.

# Solution

J’en profite pour ré-aligné à droite les card. Nous avions commencé à faire ça avec Téo sur certains écrans donc c’est cool si on uniformise.

## Captures d'écran

Avant | Après
:- | -:
<img width="973" height="698" alt="image" src="https://github.com/user-attachments/assets/a6cdc262-2b1c-499c-a17e-42ffef5f18ff" /> | <img width="969" height="700" alt="image" src="https://github.com/user-attachments/assets/36cec850-bb56-44f9-b942-dca4ba5c195b" />
<img width="973" height="840" alt="image" src="https://github.com/user-attachments/assets/dc1c810e-37a6-496f-833a-c9297939d858" /> |  <img width="733" height="903" alt="image" src="https://github.com/user-attachments/assets/77f5e1f8-3ddf-47f0-a637-64d601733834" />

