### PR TITLE
Forcer le 2FA pour certains IDP ProConnect

### DIFF
--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -69,7 +69,11 @@ class ProConnectController < ApplicationController
           redirect_to operators_root_path
         end
       when "agent"
-        connect_agent(callback_client)
+        if IDP_PRO_CONNECT_FORCE_2FA_ENABLED.include?(callback_client.user_idp_id) && !callback_client.went_through_2fa?
+          require_2fa_for_sensitive_agent(callback_client)
+        else
+          connect_agent(callback_client)
+        end
       else
         Sentry.capture_message("Unknown connection_for: #{pro_connect_session[:connection_for].inspect}", extra: { session: session.to_h, pro_connect_session: })
         flash[:error] = generic_error_message
@@ -215,6 +219,20 @@ class ProConnectController < ApplicationController
     end
   end
   # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+
+  def require_2fa_for_sensitive_agent(callback_client)
+    auth_client = ProConnectOpenIdClient::Auth.new(
+      login_hint: callback_client.user_email,
+      client_id: current_domain.pro_connect_client_id,
+      client_secret: current_domain.pro_connect_client_secret
+    )
+    session[:pro_connect] = {
+      state: auth_client.state,
+      nonce: auth_client.nonce,
+      connection_for: "agent",
+    }
+    redirect_to auth_client.redirect_url(pro_connect_callback_url, force_2fa: true), allow_other_host: true
+  end
 
   def redirect_after_first_proconnect_login(agent)
     result = ProConnectOnboardingRouter.new(agent, current_domain).call

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -307,6 +307,77 @@ RSpec.describe ProConnectController do
           expect_agent_to_be_updated_and_logged_in(agent.reload, with_2fa: true)
         end
       end
+
+      context "when the agent's IDP is in the sensitive list" do
+        before do
+          stub_const("ProConnectController::IDP_PRO_CONNECT_FORCE_2FA_ENABLED", [user_info["idp_id"]])
+        end
+
+        context "without 2FA" do
+          it "redirects to ProConnect with force_2fa rather than logging in the agent" do
+            create(:agent, email: user_info["email"])
+            get :callback, params: { state:, code: }
+
+            expect(current_agent_id).to be_nil
+            expect(response).to redirect_to(start_with("https://fca.integ01.dev-agentconnect.fr/api/v2/authorize?"))
+
+            redirect_url_query_params = Rack::Utils.parse_query(URI.parse(response.headers["Location"]).query)
+            expect(redirect_url_query_params.symbolize_keys).to include(
+              login_hint: user_info["email"],
+              claims: {
+                id_token: {
+                  acr: {
+                    essential: true,
+                    values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
+                  },
+                },
+              }.to_json
+            )
+          end
+
+          it "does not update the agent record" do
+            agent = create(:agent, email: user_info["email"])
+            expect do
+              get :callback, params: { state:, code: }
+            end.not_to change { agent.reload.pro_connect_openid_sub }
+          end
+
+          it "sets up a new ProConnect session for the 2FA re-authentication" do
+            create(:agent, email: user_info["email"])
+            get :callback, params: { state:, code: }
+
+            expect(session["pro_connect"]).to include(
+              connection_for: "agent",
+              state: be_a(String),
+              nonce: be_a(String)
+            )
+          end
+        end
+
+        context "with 2FA" do
+          before do
+            ProConnectStubs.stub_callback_requests(code, user_info, with_2fa: true)
+          end
+
+          it "logs in the agent normally" do
+            agent = create(:agent, email: user_info["email"])
+            get :callback, params: { state:, code: }
+            expect_agent_to_be_updated_and_logged_in(agent.reload, with_2fa: true)
+          end
+        end
+      end
+
+      context "when the agent's IDP is not in the sensitive list" do
+        before do
+          stub_const("ProConnectController::IDP_PRO_CONNECT_FORCE_2FA_ENABLED", ["autre-idp"])
+        end
+
+        it "logs in the agent normally without requiring 2FA" do
+          agent = create(:agent, email: user_info["email"])
+          get :callback, params: { state:, code: }
+          expect_agent_to_be_updated_and_logged_in(agent.reload)
+        end
+      end
     end
 
     context "when logging in a user" do

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -346,11 +346,10 @@ RSpec.describe ProConnectController do
             create(:agent, email: user_info["email"])
             get :callback, params: { state:, code: }
 
-            expect(session["pro_connect"]).to include(
-              connection_for: "agent",
-              state: be_a(String),
-              nonce: be_a(String)
-            )
+            new_redirect_url = Rack::Utils.parse_query(URI.parse(response.headers["Location"]).query)
+            expect(session["pro_connect"]).to include(connection_for: "agent",
+                                                      state: new_redirect_url["state"],
+                                                      nonce: new_redirect_url["nonce"])
           end
         end
 


### PR DESCRIPTION
> [!NOTE]
> Fusionner cette PR le 15 avril.

# Contexte

Pour les comptes d’agents que nous avons jugés sensibles, nous activons l’authentification à deux facteurs pour les fournisseurs d’identités compatibles.

# Solution

Si après la ProConnection, on voit que l’agent à un compte sensible, qu’il n’a pas utilisé de moyen de double authentification et qu’il est sur un fournisseur d’identité compatible, on relance une deuxième requête à ProConnect avec les claims pour forcer le 2FA.