### PR TITLE
Corrige une flaky spec à l'aide du "travel_to" de Playwright

### DIFF
--- a/spec/features/agents/planning/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/planning/agent_has_a_calendar_spec.rb
@@ -203,16 +203,11 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
     end
 
     it "fonctionne depuis la vue jour", js: true do
-      # On navigue vers la prochaine journée non-fériée pour éviter que l'événement
-      # "Jour férié" ne bloque le clic sur le créneau horaire
-      target_date = (Time.zone.today + 1.day..).lazy.find { |d| OffDays::JOURS_FERIES.exclude?(d) }
-      days_forward = (target_date - Time.zone.today).to_i
-
+      page.driver.with_playwright_page { _1.clock.pause_at(Time.zone.parse("2026-04-02 08:00")) }
       visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
       click_button "Journée"
-      days_forward.times { find(".fc-next-button").click }
       find('.fc-timegrid-slot-lane[data-time="08:30:00"]').click
-      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(target_date, format: '%-d/%m/%Y')} à 08:30")
+      expect(page).to have_content("Nouveau RDV pour le 2/04/2026 à 08:30")
     end
   end
 


### PR DESCRIPTION
Le fix initial apporté dans #6290 s'est mis à échouer parce le décompte de jours à skipper devait prendre en compte le weekend, ce qui dépend aussi de si le weekend est affiché sur l'agenda ou non.

Pour simplifier les choses, j'utilise `page.driver.with_playwright_page { _1.clock.pause_at(...) }`.