### PR TITLE
Ne pas faire d’appel à l’API de l’ANCT pour un email d’un agent de l’État

### DIFF
--- a/app/services/pro_connect_onboarding_router.rb
+++ b/app/services/pro_connect_onboarding_router.rb
@@ -15,6 +15,7 @@ class ProConnectOnboardingRouter
 
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def call
+    return Result.new(action: :classic) if VerifiedServicePublicDomainNames.verified?(@agent.email)
     return Result.new(action: :classic) if @agent.proconnect_siret.blank?
 
     anct_client = build_anct_client

--- a/spec/services/pro_connect_onboarding_router_spec.rb
+++ b/spec/services/pro_connect_onboarding_router_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe ProConnectOnboardingRouter do
   stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: "Bearer fake-token")
 
   describe "#call" do
+    context "quand l'agent a un email d'un domaine de l'État" do
+      let(:agent) { create(:agent, email: "agent@etat.gouv.fr", proconnect_siret: siret) }
+
+      it "retourne :classic sans appeler l'API" do
+        expect(EspaceOperateurANCT).not_to receive(:new)
+        expect(handler.call.action).to eq(:classic)
+      end
+    end
+
     context "quand l'agent n'a pas de SIRET ProConnect" do
       let(:agent) { create(:agent, proconnect_siret: nil) }
 


### PR DESCRIPTION
# Contexte

Suite à #6304 

Pour les agents de l’État dont nous reconnaissons les domaines, nous acceptons automatiquement les ouvertures de comptes.
On peut donc ajouter une garde pour ne pas faire appel à l’API de l’ANCT pour ces mêmes cas.

