### PR TITLE
Informer les agents de la mise en place de la double authentification

### DIFF
--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -1,6 +1,10 @@
 # Le guide pour configurer ProConnect en local : docs/interconnexions/proconnect.md
 
 class ProConnectController < ApplicationController
+  # IDP ProConnect nécessitant une double authentification pour les agents qui ont des comptes sensibles.
+  # Configurable via la variable d'environnement IDP_PRO_CONNECT_FORCE_2FA_ENABLED (liste séparée par des virgules).
+  IDP_PRO_CONNECT_FORCE_2FA_ENABLED = ENV.fetch("IDP_PRO_CONNECT_FORCE_2FA_ENABLED", "").split(",").map(&:strip).freeze
+
   def auth
     auth_client = ProConnectOpenIdClient::Auth.new(
       login_hint: params[:login_hint],

--- a/app/jobs/cron_job/refresh_agents_sensitive_account_job.rb
+++ b/app/jobs/cron_job/refresh_agents_sensitive_account_job.rb
@@ -1,5 +1,5 @@
 class CronJob::RefreshAgentsSensitiveAccountJob < CronJob
-  SENSITIVE_TERRITORY_RDV_THRESHOLD = 10_000
+  SENSITIVE_TERRITORY_RDV_THRESHOLD = 5_000
 
   def perform
     sensitive_territory_ids = Territory.joins(:organisations)

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -1,6 +1,7 @@
 header.header.bg-white
   = render "layouts/rdv_solidarites_instance_name"
   = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
+  = render "layouts/force_2fa_notice"
   nav.navbar.navbar-expand-lg.bg-transparent.navbar-dsfr[role="navigation" aria-label="navigation"]
     = link_to root_path, class: "header-brand ml-4" do
       = image_tag current_domain.dark_logo_path, alt: current_domain.name, class: "logo-dsfr logo-dsfr--compactable"

--- a/app/views/layouts/_force_2fa_notice.html.slim
+++ b/app/views/layouts/_force_2fa_notice.html.slim
@@ -1,0 +1,6 @@
+- if current_agent&.sensitive_account && ProConnectController::IDP_PRO_CONNECT_FORCE_2FA_ENABLED.include?(current_agent.pro_connect_idp_id) && !current_agent.pro_connect_2fa_active
+  = dsfr_notice title: "Information",
+          description: "À partir du 15 avril, la connexion à votre compte #{current_domain.name} nécessitera une double authentification (2FA).",
+          link_label: "En savoir plus",
+          link_href: "https://aide.rdv-service-public.fr/toutes-les-notions/activation-de-la-double-authentification",
+          link_title: "En savoir plus - Nouvel onglet"


### PR DESCRIPTION
# Contexte

Nous continuons la mise en place de l’authentification à 2 facteurs. Je propose que nous commencions par activer l’authentification via ProConnect pour tous les agents qui ont un compte sensible et qui se connectent en utilisant ProConnect Identité (seul fournisseur d’identité pour lequel nous pouvons forcer le 2FA pour le moment).

# Solution

Afin de préparer les agents à ce changement, je propose un petit bandeau et une page de documentation.

On fera le changement dans une PR suivante.

J’en ai profité pour redescendre la limite de RDV de 10k à 5k parce que ça me parait vraiment beaucoup 10k mais c’est totalement arbitraire.

<img width="1224" height="693" alt="image" src="https://github.com/user-attachments/assets/e0d13b6e-7f6b-4b9f-aecf-756fc6781906" />

La page de documentation : https://aide.rdv-service-public.fr/toutes-les-notions/activation-de-la-double-authentification

Dans un temps futur, je vais certainement proposer de modifier la colonne de compte sensible pour passer d’un booléen à une date, ce qui nous permettra d’étendre peu à peu le dispositif.
