### PR TITLE
Retrait du feature flag new planning et des bandeaux de nouveautés

### DIFF
--- a/app/controllers/admin/planning/absences_controller.rb
+++ b/app/controllers/admin/planning/absences_controller.rb
@@ -8,11 +8,6 @@ class Admin::Planning::AbsencesController < AgentAuthController
   before_action { @planning_layout = true }
 
   def index
-    # TODO: retirer ce code 2 semaines après la mise en prod, il affiche une pastille sur les nouveaux onglets.
-    unless current_agent.feature_enabled?(Agent::FeatureFlags::NEW_PLANNING)
-      current_agent.update_columns(feature_flags: current_agent.feature_flags.merge("new_planning" => true)) # rubocop:disable Rails/SkipsModelValidations
-    end
-
     @multiple_agents_makes_sense = true
     render :multi_agents_index and return if @agents.size > 1
 

--- a/app/controllers/admin/planning/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/planning/plage_ouvertures_controller.rb
@@ -12,11 +12,6 @@ class Admin::Planning::PlageOuverturesController < AgentAuthController
   end
 
   def index
-    # TODO: retirer ce code 2 semaines après la mise en prod, il affiche une pastille sur les nouveaux onglets.
-    unless current_agent.feature_enabled?(Agent::FeatureFlags::NEW_PLANNING)
-      current_agent.update_columns(feature_flags: current_agent.feature_flags.merge("new_planning" => true)) # rubocop:disable Rails/SkipsModelValidations
-    end
-
     @multiple_agents_makes_sense = true
     render :multi_agents_index and return if @agents.size > 1
 

--- a/app/models/concerns/agent/feature_flags.rb
+++ b/app/models/concerns/agent/feature_flags.rb
@@ -1,9 +1,7 @@
 module Agent::FeatureFlags
   extend ActiveSupport::Concern
 
-  NEW_PLANNING = "new_planning".freeze
-
-  AVAILABLE_FEATURES = [NEW_PLANNING].freeze
+  AVAILABLE_FEATURES = [].freeze
 
   def feature_enabled?(feature)
     feature_flags[feature] == true

--- a/app/views/admin/planning/_planning_tabs.html.slim
+++ b/app/views/admin/planning/_planning_tabs.html.slim
@@ -9,8 +9,3 @@ nav#planning_tabs.fr-nav[role="navigation" aria-label="Menu du planning"]
     li.fr-nav__item
       = active_link_to(admin_organisation_planning_absences_path(current_organisation, { agent_id: params[:agent_id] }.compact_blank), class: "fr-nav__link") do
         | Indisponibilités
-    - unless current_agent.feature_enabled?(Agent::FeatureFlags::NEW_PLANNING)
-      li.rdv-callout
-        = icon("fr-icon-arrow-left-line")
-        strong.ml-1> Nouveauté
-        | : Retrouvez vos rubriques dans cette nouvelle navigation

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -37,8 +37,6 @@ nav.left-side-menu-wrapper
           = active_link_to(admin_organisation_planning_agenda_path(current_organisation, **query_params), active: menu_top_level_item == "planning", class: "side-menu__item")
             span.fr-icon-calendar-event-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
             | Planning
-            - unless current_agent.feature_enabled?(Agent::FeatureFlags::NEW_PLANNING)
-              .fr-ml-1w.rdv-pastille
 
         li.fr-pb-0
           = active_link_to(admin_organisation_users_path(current_organisation), class: "side-menu__item")


### PR DESCRIPTION
# Contexte

Cela fait suffisamment de temps que le code du nouveau planning a été mis en production.
Je pense qu’on peut donc retirer tous les indicateurs de nouveauté.

À terme on pourra faire un système qui nettoie la colonne JSONb dans laquelle on stock les features flags.
