### PR TITLE
Demande un code de vérification pour l’accès aux comptes sensibles

### DIFF
--- a/app/controllers/agents/sessions_by_code_controller.rb
+++ b/app/controllers/agents/sessions_by_code_controller.rb
@@ -1,0 +1,48 @@
+class Agents::SessionsByCodeController < ApplicationController
+  before_action :require_pending_agent_login
+
+  def new
+    @email = pending_agent.email
+    @existing_login_code = LoginCode.most_recent_usable_for(email: @email)
+
+    unless @existing_login_code&.very_recent?
+      @existing_login_code = LoginCode.create!(email: @email, domain_id: current_domain.id)
+      Agents::LoginCodeMailer.with(login_code: @existing_login_code).login_code.deliver_later
+    end
+  end
+
+  def create
+    agent = pending_agent
+    code = params.require(:login_code).expect(:code)
+    validator = Users::LoginCodeValidator.new(email: agent.email, code:)
+
+    if validator.valid?
+      validator.valid_login_code.update!(used_at: Time.zone.now)
+      session.delete(:pending_agent_login_id)
+      if session[:pending_pro_connect_id_token]
+        session[:pro_connect_id_token] = session.delete(:pending_pro_connect_id_token)
+      end
+      bypass_sign_in(agent, scope: :agent)
+      redirect_to after_sign_in_path_for(agent), flash: { success: "Connexion réussie" }
+    else
+      @email = agent.email
+      @existing_login_code = LoginCode.most_recent_usable_for(email: @email)
+      @existing_login_code&.errors&.add(:base, validator.error)
+      render :new
+    end
+  end
+
+  private
+
+  def require_pending_agent_login
+    redirect_to new_agent_session_path unless session[:pending_agent_login_id]
+  end
+
+  def pending_agent
+    @pending_agent ||= Agent.find(session[:pending_agent_login_id])
+  end
+
+  def storable_location?
+    false
+  end
+end

--- a/app/controllers/agents/sessions_by_code_controller.rb
+++ b/app/controllers/agents/sessions_by_code_controller.rb
@@ -10,9 +10,7 @@ class Agents::SessionsByCodeController < ApplicationController
   end
 
   def resend
-    email = pending_agent.email
-    login_code = LoginCode.create!(email:, domain_id: current_domain.id)
-    Agents::LoginCodeMailer.with(login_code:).login_code.deliver_later
+    Agents::LoginCodeSender.perform(email: pending_agent.email, domain_id: current_domain.id)
     redirect_to new_agents_sessions_by_code_path
   end
 

--- a/app/controllers/agents/sessions_by_code_controller.rb
+++ b/app/controllers/agents/sessions_by_code_controller.rb
@@ -1,4 +1,7 @@
 class Agents::SessionsByCodeController < ApplicationController
+  SESSION_AGENT_ID_KEY = :pending_agent_login_id
+  SESSION_PRO_CONNECT_ID_TOKEN_KEY = :pending_pro_connect_id_token
+
   before_action :require_pending_agent_login
 
   def new
@@ -18,9 +21,9 @@ class Agents::SessionsByCodeController < ApplicationController
 
     if validator.valid?
       validator.valid_login_code.update!(used_at: Time.zone.now)
-      session.delete(:pending_agent_login_id)
-      if session[:pending_pro_connect_id_token]
-        session[:pro_connect_id_token] = session.delete(:pending_pro_connect_id_token)
+      session.delete(SESSION_AGENT_ID_KEY)
+      if session[SESSION_PRO_CONNECT_ID_TOKEN_KEY]
+        session[:pro_connect_id_token] = session.delete(SESSION_PRO_CONNECT_ID_TOKEN_KEY)
       end
       bypass_sign_in(agent, scope: :agent)
       redirect_to after_sign_in_path_for(agent), flash: { success: "Connexion réussie" }
@@ -35,11 +38,11 @@ class Agents::SessionsByCodeController < ApplicationController
   private
 
   def require_pending_agent_login
-    redirect_to new_agent_session_path unless session[:pending_agent_login_id]
+    redirect_to new_agent_session_path unless session[SESSION_AGENT_ID_KEY]
   end
 
   def pending_agent
-    @pending_agent ||= Agent.find(session[:pending_agent_login_id])
+    @pending_agent ||= Agent.find(session[SESSION_AGENT_ID_KEY])
   end
 
   def storable_location?

--- a/app/controllers/agents/sessions_by_code_controller.rb
+++ b/app/controllers/agents/sessions_by_code_controller.rb
@@ -45,6 +45,7 @@ class Agents::SessionsByCodeController < ApplicationController
     @pending_agent ||= Agent.find(session[SESSION_AGENT_ID_KEY])
   end
 
+  # Hook Devise — empêche que cette page intermédiaire soit mémorisée comme destination après connexion
   def storable_location?
     false
   end

--- a/app/controllers/agents/sessions_by_code_controller.rb
+++ b/app/controllers/agents/sessions_by_code_controller.rb
@@ -17,7 +17,7 @@ class Agents::SessionsByCodeController < ApplicationController
   def create
     agent = pending_agent
     code = params.require(:login_code).expect(:code)
-    validator = Users::LoginCodeValidator.new(email: agent.email, code:)
+    validator = LoginCodeValidator.new(email: agent.email, code:)
 
     if validator.valid?
       validator.valid_login_code.update!(used_at: Time.zone.now)

--- a/app/controllers/agents/sessions_by_code_controller.rb
+++ b/app/controllers/agents/sessions_by_code_controller.rb
@@ -25,7 +25,7 @@ class Agents::SessionsByCodeController < ApplicationController
       if session[SESSION_PRO_CONNECT_ID_TOKEN_KEY]
         session[:pro_connect_id_token] = session.delete(SESSION_PRO_CONNECT_ID_TOKEN_KEY)
       end
-      bypass_sign_in(agent, scope: :agent)
+      sign_in(agent, scope: :agent)
       redirect_to after_sign_in_path_for(agent), flash: { success: "Connexion réussie" }
     else
       @email = agent.email

--- a/app/controllers/agents/sessions_by_code_controller.rb
+++ b/app/controllers/agents/sessions_by_code_controller.rb
@@ -7,11 +7,13 @@ class Agents::SessionsByCodeController < ApplicationController
   def new
     @email = pending_agent.email
     @existing_login_code = LoginCode.most_recent_usable_for(email: @email)
+  end
 
-    unless @existing_login_code&.very_recent?
-      @existing_login_code = LoginCode.create!(email: @email, domain_id: current_domain.id)
-      Agents::LoginCodeMailer.with(login_code: @existing_login_code).login_code.deliver_later
-    end
+  def resend
+    email = pending_agent.email
+    login_code = LoginCode.create!(email:, domain_id: current_domain.id)
+    Agents::LoginCodeMailer.with(login_code:).login_code.deliver_later
+    redirect_to new_agents_sessions_by_code_path
   end
 
   def create

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -36,6 +36,13 @@ class Agents::SessionsController < Devise::SessionsController
 
     return if reset_current_agent_password_if_weak!(params[:agent][:password])
 
+    if resource.sensitive_account?
+      sign_out(resource)
+      session[:pending_agent_login_id] = resource.id
+      redirect_to new_agents_sessions_by_code_path
+      return
+    end
+
     super
     # super will repeat warden.authenticate! which will not repeat everything but fetch from the session
     # cf https://github.com/wardencommunity/warden/blob/master/lib/warden/proxy.rb#L332-L334

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -38,7 +38,7 @@ class Agents::SessionsController < Devise::SessionsController
 
     if resource.sensitive_account?
       sign_out(resource)
-      session[:pending_agent_login_id] = resource.id
+      session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = resource.id
       redirect_to new_agents_sessions_by_code_path
       return
     end

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -39,6 +39,8 @@ class Agents::SessionsController < Devise::SessionsController
     if resource.sensitive_account?
       sign_out(resource)
       session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = resource.id
+      login_code = LoginCode.create!(email: resource.email, domain_id: current_domain.id)
+      Agents::LoginCodeMailer.with(login_code:).login_code.deliver_later
       redirect_to new_agents_sessions_by_code_path
       return
     end

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -39,8 +39,7 @@ class Agents::SessionsController < Devise::SessionsController
     if resource.sensitive_account?
       sign_out(resource)
       session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = resource.id
-      login_code = LoginCode.create!(email: resource.email, domain_id: current_domain.id)
-      Agents::LoginCodeMailer.with(login_code:).login_code.deliver_later
+      Agents::LoginCodeSender.perform(email: resource.email, domain_id: current_domain.id)
       redirect_to new_agents_sessions_by_code_path
       return
     end

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -206,6 +206,12 @@ class ProConnectController < ApplicationController
     agent.skip_reconfirmation!
     agent.save!
 
+    if agent.sensitive_account? && IDP_PRO_CONNECT_FORCE_2FA_ENABLED.exclude?(callback_client.user_idp_id)
+      session[:pending_agent_login_id] = agent.id
+      session[:pending_pro_connect_id_token] = callback_client.id_token_for_logout
+      redirect_to new_agents_sessions_by_code_path and return
+    end
+
     bypass_sign_in agent, scope: :agent
     session[:pro_connect_id_token] = callback_client.id_token_for_logout
 

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -182,8 +182,15 @@ class ProConnectController < ApplicationController
         ERROR
         redirect_to new_agent_session_path and return
       end
-    elsif agent.sensitive_account? && !callback_client.went_through_2fa? && IDP_PRO_CONNECT_FORCE_2FA_ENABLED.include?(callback_client.user_idp_id)
-      require_2fa_for_sensitive_agent(callback_client) and return
+    elsif agent.sensitive_account? && !callback_client.went_through_2fa?
+      if IDP_PRO_CONNECT_FORCE_2FA_ENABLED.include?(callback_client.user_idp_id)
+        require_2fa_for_sensitive_agent(callback_client) and return
+      else
+        session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = agent.id
+        session[Agents::SessionsByCodeController::SESSION_PRO_CONNECT_ID_TOKEN_KEY] = callback_client.id_token_for_logout
+        Agents::LoginCodeSender.perform(email: agent.email, domain_id: current_domain.id)
+        redirect_to new_agents_sessions_by_code_path and return
+      end
     end
 
     if agent.email != callback_client.user_email
@@ -205,13 +212,6 @@ class ProConnectController < ApplicationController
     )
     agent.skip_reconfirmation!
     agent.save!
-
-    if agent.sensitive_account? && IDP_PRO_CONNECT_FORCE_2FA_ENABLED.exclude?(callback_client.user_idp_id)
-      session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = agent.id
-      session[Agents::SessionsByCodeController::SESSION_PRO_CONNECT_ID_TOKEN_KEY] = callback_client.id_token_for_logout
-      Agents::LoginCodeSender.perform(email: agent.email, domain_id: current_domain.id)
-      redirect_to new_agents_sessions_by_code_path and return
-    end
 
     bypass_sign_in agent, scope: :agent
     session[:pro_connect_id_token] = callback_client.id_token_for_logout

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -209,6 +209,8 @@ class ProConnectController < ApplicationController
     if agent.sensitive_account? && IDP_PRO_CONNECT_FORCE_2FA_ENABLED.exclude?(callback_client.user_idp_id)
       session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = agent.id
       session[Agents::SessionsByCodeController::SESSION_PRO_CONNECT_ID_TOKEN_KEY] = callback_client.id_token_for_logout
+      login_code = LoginCode.create!(email: agent.email, domain_id: current_domain.id)
+      Agents::LoginCodeMailer.with(login_code:).login_code.deliver_later
       redirect_to new_agents_sessions_by_code_path and return
     end
 

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -209,8 +209,7 @@ class ProConnectController < ApplicationController
     if agent.sensitive_account? && IDP_PRO_CONNECT_FORCE_2FA_ENABLED.exclude?(callback_client.user_idp_id)
       session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = agent.id
       session[Agents::SessionsByCodeController::SESSION_PRO_CONNECT_ID_TOKEN_KEY] = callback_client.id_token_for_logout
-      login_code = LoginCode.create!(email: agent.email, domain_id: current_domain.id)
-      Agents::LoginCodeMailer.with(login_code:).login_code.deliver_later
+      Agents::LoginCodeSender.perform(email: agent.email, domain_id: current_domain.id)
       redirect_to new_agents_sessions_by_code_path and return
     end
 

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -207,8 +207,8 @@ class ProConnectController < ApplicationController
     agent.save!
 
     if agent.sensitive_account? && IDP_PRO_CONNECT_FORCE_2FA_ENABLED.exclude?(callback_client.user_idp_id)
-      session[:pending_agent_login_id] = agent.id
-      session[:pending_pro_connect_id_token] = callback_client.id_token_for_logout
+      session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = agent.id
+      session[Agents::SessionsByCodeController::SESSION_PRO_CONNECT_ID_TOKEN_KEY] = callback_client.id_token_for_logout
       redirect_to new_agents_sessions_by_code_path and return
     end
 

--- a/app/controllers/users/sessions_by_code_controller.rb
+++ b/app/controllers/users/sessions_by_code_controller.rb
@@ -12,7 +12,7 @@ class Users::SessionsByCodeController < ApplicationController
 
   def create
     email, code = params.require(:login_code).expect(:email, :code)
-    validator = Users::LoginCodeValidator.new(email:, code:)
+    validator = LoginCodeValidator.new(email:, code:)
 
     if validator.valid?
       valid_login_code = validator.valid_login_code

--- a/app/mailers/agents/login_code_mailer.rb
+++ b/app/mailers/agents/login_code_mailer.rb
@@ -1,0 +1,13 @@
+class Agents::LoginCodeMailer < ApplicationMailer
+  attr_reader :domain
+
+  def login_code
+    @login_code = params[:login_code]
+    @domain = Domain.find(@login_code.domain_id)
+
+    mail(
+      subject: "Votre code de connexion est #{@login_code.code}",
+      to: @login_code.email
+    )
+  end
+end

--- a/app/services/agents/login_code_sender.rb
+++ b/app/services/agents/login_code_sender.rb
@@ -1,0 +1,8 @@
+class Agents::LoginCodeSender
+  def self.perform(email:, domain_id:)
+    return if LoginCode.most_recent_usable_for(email:)&.very_recent?
+
+    login_code = LoginCode.create!(email:, domain_id:)
+    Agents::LoginCodeMailer.with(login_code:).login_code.deliver_later
+  end
+end

--- a/app/services/login_code_validator.rb
+++ b/app/services/login_code_validator.rb
@@ -1,4 +1,4 @@
-class Users::LoginCodeValidator
+class LoginCodeValidator
   # dans ce service on distingue 2 LoginCodes :
   # - `usable` : moins de 30 minutes et pas utilisé, peut servir à se connecter
   # - `matching` : celui qui correspond au code saisi par l’usager et a moins de 24h

--- a/app/views/agents/sessions_by_code/new.html.slim
+++ b/app/views/agents/sessions_by_code/new.html.slim
@@ -38,4 +38,4 @@
         => external_link_to "documentation", "https://aide.rdv-service-public.fr/toutes-les-notions/authentification-a-deux-facteurs-par-code", class: "fr-link"
       div
         |> Si vous n'avez pas reçu le code, vous pouvez
-        = button_to "en demander un nouveau", resend_agents_sessions_by_code_path, class: "fr-link", form: { style: "display: inline" }
+        = button_to "en demander un nouveau", resend_agents_sessions_by_code_path, class: "fr-link", form: { class: "d-inline" }

--- a/app/views/agents/sessions_by_code/new.html.slim
+++ b/app/views/agents/sessions_by_code/new.html.slim
@@ -36,6 +36,6 @@
         |> Votre compte est considéré comme sensible. Pour des raisons de sécurité, la saisie d'un code de vérification envoyé par email est requise à chaque connexion.
         |> Pour en savoir plus sur la vérification par code, consultez notre
         => external_link_to "documentation", "https://aide.rdv-service-public.fr/toutes-les-notions/authentification-a-deux-facteurs-par-code", class: "fr-link"
-      p
+      div
         |> Si vous n'avez pas reçu le code, vous pouvez
-        => link_to "en demander un nouveau", new_agents_sessions_by_code_path, class: "fr-link"
+        = button_to "en demander un nouveau", resend_agents_sessions_by_code_path, class: "fr-link", form: { style: "display: inline" }

--- a/app/views/agents/sessions_by_code/new.html.slim
+++ b/app/views/agents/sessions_by_code/new.html.slim
@@ -1,0 +1,41 @@
+- content_for :title, "Vérification de votre identité"
+
+- if @existing_login_code&.errors&.any?
+  .fr-mb-2w= render "model_errors", model: @existing_login_code
+
+.card
+  .card-body.fr-pt-4w
+    - if @existing_login_code
+      p
+        |> ✅ Un code à 6 chiffres a été envoyé à
+        b> #{@existing_login_code.email}
+        | à #{l(@existing_login_code.created_at, format: :time_only)}
+
+      - if Rails.env.development?
+        .fr-mb-4w
+          = button_tag class: "fr-btn fr-btn--tertiary fr-btn--sm fr-mr-1w js-copy-to-clipboard", data: { "clipboard-content": @existing_login_code.code }
+            = icon("fr-icon-survey-line fr-icon--sm", class: "fr-mr-1w")
+            | copier le code #{@existing_login_code.code}
+          span.fr-text--sm
+            | (visible uniquement en env de dev)
+
+    .rdv-legible-code-form
+      = form_for LoginCode.new(email: @email), url: agents_sessions_by_code_path, method: :post, builder: Dsfr::FormBuilder do |form|
+        = form.hidden_field :email
+        = form.dsfr_text_field :code,
+          label: "Code à 6 chiffres",
+          type: "text",
+          inputmode: "numeric",
+          maxlength: 6,
+          required: true,
+          autocomplete: "off"
+        = form.submit "Valider", class: "fr-btn"
+
+    .fr-mt-8w.fr-mb-4w
+      p
+        |> Votre compte est considéré comme sensible. Pour des raisons de sécurité, la saisie d'un code de vérification envoyé par email est requise à chaque connexion.
+        |> Pour en savoir plus sur la vérification par code, consultez notre
+        => external_link_to "documentation", "https://aide.rdv-service-public.fr/toutes-les-notions/authentification-a-deux-facteurs-par-code", class: "fr-link"
+      p
+        |> Si vous n'avez pas reçu le code, vous pouvez
+        => link_to "en demander un nouveau", new_agents_sessions_by_code_path, class: "fr-link"

--- a/app/views/mailers/agents/login_code_mailer/login_code.html.slim
+++ b/app/views/mailers/agents/login_code_mailer/login_code.html.slim
@@ -1,0 +1,10 @@
+p Votre code de connexion à #{@domain.name} est :
+
+p{style="font-family: monospace; letter-spacing: .5rem; font-size: 1.4rem; max-height: 4rem; height: 4rem;"}
+  = @login_code.code
+
+p Ce code est valable 30 minutes (jusqu'à #{I18n.l(@login_code.created_at + 30.minutes, format: :time_only)})
+
+hr{style="margin: 1rem 0;"}
+p
+  | Si vous n'avez pas demandé de code de connexion, nous vous invitons à changer votre mot de passe immédiatement.

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -13,6 +13,12 @@ class Rack::Attack
     end
   end
 
+  throttle("saisie de code de connexion agent - throttling par email", limit: Rails.env.test? ? 2 : 60, period: 10.minutes) do |request|
+    if request.path.match(%r{agents/sessions_by_code}) && request.post? && request.params.dig("login_code", "email").present?
+      request.params.dig("login_code", "email")
+    end
+  end
+
   Rack::Attack.throttled_responder = lambda do |request|
     exception = ThrottleError.new(request.env["rack.attack.matched"])
     Sentry.set_context("rack_attack_match_data", request.env["rack.attack.match_data"])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,6 +136,7 @@ Rails.application.routes.draw do
     put "agents/mot_de_passe" => "agents/mot_de_passes#update", as: "agent_mot_de_passes"
 
     namespace :agents do
+      resource :sessions_by_code, only: %i[new create], controller: "sessions_by_code"
       resource :preferences, only: %i[show update]
       resource :calendar_sync, only: %i[show], controller: :calendar_sync do
         resource :caldav_sync, only: %i[show update destroy], controller: :caldav_sync

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,7 +136,9 @@ Rails.application.routes.draw do
     put "agents/mot_de_passe" => "agents/mot_de_passes#update", as: "agent_mot_de_passes"
 
     namespace :agents do
-      resource :sessions_by_code, only: %i[new create], controller: "sessions_by_code"
+      resource :sessions_by_code, only: %i[new create], controller: "sessions_by_code" do
+        post :resend, on: :collection
+      end
       resource :preferences, only: %i[show update]
       resource :calendar_sync, only: %i[show], controller: :calendar_sync do
         resource :caldav_sync, only: %i[show update destroy], controller: :caldav_sync

--- a/spec/controllers/agents/sessions_by_code_controller_spec.rb
+++ b/spec/controllers/agents/sessions_by_code_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Agents::SessionsByCodeController, type: :controller do
     end
 
     context "quand il y a une connexion en attente dans la session" do
-      before { session[:pending_agent_login_id] = agent.id }
+      before { session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = agent.id }
 
       it "affiche le formulaire de saisie du code" do
         get :new
@@ -49,7 +49,7 @@ RSpec.describe Agents::SessionsByCodeController, type: :controller do
     end
 
     context "quand il y a une connexion en attente dans la session" do
-      before { session[:pending_agent_login_id] = agent.id }
+      before { session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = agent.id }
 
       context "avec un code valide" do
         it "connecte l'agent" do
@@ -59,7 +59,7 @@ RSpec.describe Agents::SessionsByCodeController, type: :controller do
 
         it "supprime la connexion en attente de la session" do
           post :create, params: { login_code: { code: login_code.code } }
-          expect(session[:pending_agent_login_id]).to be_nil
+          expect(session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY]).to be_nil
         end
 
         it "redirige après la connexion" do
@@ -73,12 +73,12 @@ RSpec.describe Agents::SessionsByCodeController, type: :controller do
         end
 
         context "quand un token ProConnect en attente est présent dans la session" do
-          before { session[:pending_pro_connect_id_token] = "fake_pro_connect_token" }
+          before { session[Agents::SessionsByCodeController::SESSION_PRO_CONNECT_ID_TOKEN_KEY] = "fake_pro_connect_token" }
 
           it "transfère le token vers pro_connect_id_token et supprime le pending" do
             post :create, params: { login_code: { code: login_code.code } }
             expect(session[:pro_connect_id_token]).to eq("fake_pro_connect_token")
-            expect(session[:pending_pro_connect_id_token]).to be_nil
+            expect(session[Agents::SessionsByCodeController::SESSION_PRO_CONNECT_ID_TOKEN_KEY]).to be_nil
           end
         end
       end

--- a/spec/controllers/agents/sessions_by_code_controller_spec.rb
+++ b/spec/controllers/agents/sessions_by_code_controller_spec.rb
@@ -17,23 +17,33 @@ RSpec.describe Agents::SessionsByCodeController, type: :controller do
         expect(response).to have_http_status(:ok)
       end
 
-      it "crée et envoie un code de connexion par email" do
-        expect { get :new }
+      it "ne crée pas de code" do
+        expect { get :new }.not_to change(LoginCode, :count)
+      end
+    end
+  end
+
+  describe "#resend" do
+    context "quand il n'y a pas de connexion en attente dans la session" do
+      it "redirige vers la page de connexion" do
+        post :resend
+        expect(response).to redirect_to(new_agent_session_path)
+      end
+    end
+
+    context "quand il y a une connexion en attente dans la session" do
+      before { session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY] = agent.id }
+
+      it "crée et envoie un nouveau code par email" do
+        expect { post :resend }
           .to change(LoginCode, :count).by(1)
           .and have_enqueued_mail(Agents::LoginCodeMailer, :login_code)
         expect(LoginCode.last.email).to eq(agent.email)
       end
 
-      context "quand un code utilisable récent existe déjà" do
-        before { create(:login_code, email: agent.email, created_at: 1.minute.ago) }
-
-        it "ne crée pas de nouveau code" do
-          expect { get :new }.not_to change(LoginCode, :count)
-        end
-
-        it "n'envoie pas de nouvel email" do
-          expect { get :new }.not_to have_enqueued_mail(Agents::LoginCodeMailer, :login_code)
-        end
+      it "redirige vers le formulaire de saisie du code" do
+        post :resend
+        expect(response).to redirect_to(new_agents_sessions_by_code_path)
       end
     end
   end

--- a/spec/controllers/agents/sessions_by_code_controller_spec.rb
+++ b/spec/controllers/agents/sessions_by_code_controller_spec.rb
@@ -1,0 +1,108 @@
+RSpec.describe Agents::SessionsByCodeController, type: :controller do
+  let(:agent) { create(:agent, sensitive_account: true) }
+
+  describe "#new" do
+    context "quand il n'y a pas de connexion en attente dans la session" do
+      it "redirige vers la page de connexion" do
+        get :new
+        expect(response).to redirect_to(new_agent_session_path)
+      end
+    end
+
+    context "quand il y a une connexion en attente dans la session" do
+      before { session[:pending_agent_login_id] = agent.id }
+
+      it "affiche le formulaire de saisie du code" do
+        get :new
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "crée et envoie un code de connexion par email" do
+        expect { get :new }
+          .to change(LoginCode, :count).by(1)
+          .and have_enqueued_mail(Agents::LoginCodeMailer, :login_code)
+        expect(LoginCode.last.email).to eq(agent.email)
+      end
+
+      context "quand un code utilisable récent existe déjà" do
+        before { create(:login_code, email: agent.email, created_at: 1.minute.ago) }
+
+        it "ne crée pas de nouveau code" do
+          expect { get :new }.not_to change(LoginCode, :count)
+        end
+
+        it "n'envoie pas de nouvel email" do
+          expect { get :new }.not_to have_enqueued_mail(Agents::LoginCodeMailer, :login_code)
+        end
+      end
+    end
+  end
+
+  describe "#create" do
+    let!(:login_code) { create(:login_code, email: agent.email) }
+
+    context "quand il n'y a pas de connexion en attente dans la session" do
+      it "redirige vers la page de connexion" do
+        post :create, params: { login_code: { code: login_code.code } }
+        expect(response).to redirect_to(new_agent_session_path)
+      end
+    end
+
+    context "quand il y a une connexion en attente dans la session" do
+      before { session[:pending_agent_login_id] = agent.id }
+
+      context "avec un code valide" do
+        it "connecte l'agent" do
+          post :create, params: { login_code: { code: login_code.code } }
+          expect(current_agent_id).to eq(agent.id)
+        end
+
+        it "supprime la connexion en attente de la session" do
+          post :create, params: { login_code: { code: login_code.code } }
+          expect(session[:pending_agent_login_id]).to be_nil
+        end
+
+        it "redirige après la connexion" do
+          post :create, params: { login_code: { code: login_code.code } }
+          expect(response).to be_redirect
+        end
+
+        it "marque le code comme utilisé" do
+          post :create, params: { login_code: { code: login_code.code } }
+          expect(login_code.reload.used_at).to be_present
+        end
+
+        context "quand un token ProConnect en attente est présent dans la session" do
+          before { session[:pending_pro_connect_id_token] = "fake_pro_connect_token" }
+
+          it "transfère le token vers pro_connect_id_token et supprime le pending" do
+            post :create, params: { login_code: { code: login_code.code } }
+            expect(session[:pro_connect_id_token]).to eq("fake_pro_connect_token")
+            expect(session[:pending_pro_connect_id_token]).to be_nil
+          end
+        end
+      end
+
+      context "avec un code invalide" do
+        it "ne connecte pas l'agent" do
+          post :create, params: { login_code: { code: "000000" } }
+          expect(current_agent_id).to be_nil
+        end
+
+        it "réaffiche le formulaire" do
+          post :create, params: { login_code: { code: "000000" } }
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context "avec un code déjà utilisé" do
+        before { login_code.update!(used_at: Time.zone.now) }
+
+        it "ne connecte pas l'agent" do
+          post :create, params: { login_code: { code: login_code.code } }
+          expect(current_agent_id).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -26,6 +26,25 @@ RSpec.describe Agents::SessionsController do
         expect(controller.current_agent).to eq(agent)
       end
     end
+
+    context "quand l'agent a un compte sensible" do
+      let(:agent) { create(:agent, password: "c0rrecThorse!", sensitive_account: true) }
+
+      it "ne connecte pas l'agent" do
+        post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
+        expect(session["warden.agent.key"]).to be_nil
+      end
+
+      it "stocke l'id de l'agent dans la session comme connexion en attente" do
+        post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
+        expect(session[:pending_agent_login_id]).to eq(agent.id)
+      end
+
+      it "redirige vers le formulaire de vérification par code" do
+        post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
+        expect(response).to redirect_to(new_agents_sessions_by_code_path)
+      end
+    end
   end
 
   describe "#destroy" do

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe Agents::SessionsController do
         post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
         expect(response).to redirect_to(new_agents_sessions_by_code_path)
       end
+
+      it "crée et envoie un code de connexion par email" do
+        expect { post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } } }
+          .to change(LoginCode, :count).by(1)
+          .and have_enqueued_mail(Agents::LoginCodeMailer, :login_code)
+        expect(LoginCode.last.email).to eq(agent.email)
+      end
     end
   end
 

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Agents::SessionsController do
 
       it "stocke l'id de l'agent dans la session comme connexion en attente" do
         post :create, params: { agent: { email: agent.email, password: "c0rrecThorse!" } }
-        expect(session[:pending_agent_login_id]).to eq(agent.id)
+        expect(session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY]).to eq(agent.id)
       end
 
       it "redirige vers le formulaire de vérification par code" do

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -312,15 +312,51 @@ RSpec.describe ProConnectController do
         end
       end
 
-      context "quand l’agent utilise un fournisseur d’identité non compatible avec le 2FA" do
+      context "quand l’id du founrisseur d’identité de l’agent n’est pas dans la liste des id double authentifiable" do
         before do
           stub_const("ProConnectController::IDP_PRO_CONNECT_FORCE_2FA_ENABLED", ["autre-idp"])
         end
 
-        it "connecte l’agent normalement" do
+        it "connecte l’agent normalement sans exiger le 2FA" do
           agent = create(:agent, email: user_info["email"])
           get :callback, params: { state:, code: }
           expect_agent_to_be_updated_and_logged_in(agent.reload)
+        end
+
+        context "quand l’agent a un compte sensible" do
+          it "ne connecte pas l'agent" do
+            create(:agent, email: user_info["email"], sensitive_account: true)
+            get :callback, params: { state:, code: }
+            expect(current_agent_id).to be_nil
+          end
+
+          it "stocke l’id de l’agent dans la session comme connexion en attente" do
+            agent = create(:agent, email: user_info["email"], sensitive_account: true)
+            get :callback, params: { state:, code: }
+            expect(session[:pending_agent_login_id]).to eq(agent.id)
+          end
+
+          it "stocke le token ProConnect comme pending et non comme token actif" do
+            create(:agent, email: user_info["email"], sensitive_account: true)
+            get :callback, params: { state:, code: }
+            expect(session[:pending_pro_connect_id_token]).to be_present
+            expect(session[:pro_connect_id_token]).to be_nil
+          end
+
+          it "redirige vers le formulaire de vérification par code" do
+            create(:agent, email: user_info["email"], sensitive_account: true)
+            get :callback, params: { state:, code: }
+            expect(response).to redirect_to(new_agents_sessions_by_code_path)
+          end
+
+          it "met à jour les attributs ProConnect de l'agent" do
+            agent = create(:agent, email: user_info["email"], sensitive_account: true)
+            get :callback, params: { state:, code: }
+            expect(agent.reload).to have_attributes(
+              pro_connect_openid_sub: user_info["sub"],
+              pro_connect_idp_id: user_info["idp_id"]
+            )
+          end
         end
       end
     end

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -333,13 +333,13 @@ RSpec.describe ProConnectController do
           it "stocke l’id de l’agent dans la session comme connexion en attente" do
             agent = create(:agent, email: user_info["email"], sensitive_account: true)
             get :callback, params: { state:, code: }
-            expect(session[:pending_agent_login_id]).to eq(agent.id)
+            expect(session[Agents::SessionsByCodeController::SESSION_AGENT_ID_KEY]).to eq(agent.id)
           end
 
           it "stocke le token ProConnect comme pending et non comme token actif" do
             create(:agent, email: user_info["email"], sensitive_account: true)
             get :callback, params: { state:, code: }
-            expect(session[:pending_pro_connect_id_token]).to be_present
+            expect(session[Agents::SessionsByCodeController::SESSION_PRO_CONNECT_ID_TOKEN_KEY]).to be_present
             expect(session[:pro_connect_id_token]).to be_nil
           end
 

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -356,15 +356,6 @@ RSpec.describe ProConnectController do
               .and have_enqueued_mail(Agents::LoginCodeMailer, :login_code)
             expect(LoginCode.last.email).to eq(agent.email)
           end
-
-          it "met à jour les attributs ProConnect de l'agent" do
-            agent = create(:agent, email: user_info["email"], sensitive_account: true)
-            get :callback, params: { state:, code: }
-            expect(agent.reload).to have_attributes(
-              pro_connect_openid_sub: user_info["sub"],
-              pro_connect_idp_id: user_info["idp_id"]
-            )
-          end
         end
       end
     end

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -349,6 +349,14 @@ RSpec.describe ProConnectController do
             expect(response).to redirect_to(new_agents_sessions_by_code_path)
           end
 
+          it "crée et envoie un code de connexion par email" do
+            agent = create(:agent, email: user_info["email"], sensitive_account: true)
+            expect { get :callback, params: { state:, code: } }
+              .to change(LoginCode, :count).by(1)
+              .and have_enqueued_mail(Agents::LoginCodeMailer, :login_code)
+            expect(LoginCode.last.email).to eq(agent.email)
+          end
+
           it "met à jour les attributs ProConnect de l'agent" do
             agent = create(:agent, email: user_info["email"], sensitive_account: true)
             get :callback, params: { state:, code: }

--- a/spec/services/login_code_validator_spec.rb
+++ b/spec/services/login_code_validator_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Users::LoginCodeValidator, type: :service do
+RSpec.describe LoginCodeValidator, type: :service do
   context "code valide et utilisable" do
     let!(:login_code) { create(:login_code, email: "test@example.com", code: "123456") }
     let(:service) { described_class.new(email: "test@example.com", code: "123456") }


### PR DESCRIPTION
# Contexte

Nous mettons en place petit à petit l’authentification à deux facteurs. Celle-ci passe par ProConnect pour les fournisseurs d’identité qui le permettent. Pour agents qui utilisent des fournisseurs d’identités qui ne le permettent pas encore ou pour les agents qui n’utilisent pas ProConnect, on envoie un code à 6 chiffres pour vérifier leur identité.

# Solution

- Je réutilise le modèle existant des logins codes
- J’ai ajouté une petite documentation sur la page de saisie du code qui permet à l’agent d’avoir davantage d’information : https://aide.rdv-service-public.fr/toutes-les-notions/authentification-a-deux-facteurs-par-code