### PR TITLE
Ajouter le nombre d’habitants commune dans la demande d’ouverture compte

### DIFF
--- a/app/services/annuaire_service_public.rb
+++ b/app/services/annuaire_service_public.rb
@@ -18,6 +18,15 @@ class AnnuaireServicePublic
     first_result&.fetch("nom", nil)
   end
 
+  def code_insee
+    return nil unless first_result&.fetch("pivot", nil)
+
+    JSON.parse(first_result["pivot"]).first&.dig("code_insee_commune")&.first
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+    nil
+  end
+
   private
 
   def first_result

--- a/app/services/geo_api_gouv.rb
+++ b/app/services/geo_api_gouv.rb
@@ -1,0 +1,25 @@
+class GeoApiGouv
+  def initialize(code_insee)
+    @code_insee = code_insee
+  end
+
+  def population
+    parsed_response&.fetch("population", nil)
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+    nil
+  end
+
+  private
+
+  def parsed_response
+    @parsed_response ||= JSON.parse(response.body)
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+    nil
+  end
+
+  def response
+    @response ||= Faraday.get("https://geo.api.gouv.fr/communes/#{@code_insee}?fields=population")
+  end
+end

--- a/app/views/mailers/agents/territory_creation_request_mailer/refused.html.slim
+++ b/app/views/mailers/agents/territory_creation_request_mailer/refused.html.slim
@@ -8,7 +8,7 @@ p
   ul
     li Les administrations de l’État
     li Les opérateurs publics
-    li Les collectivités territoriales (communes, départements, régions)
+    li Les collectivités territoriales (communes de moins de 3500 habitants, intercommunalité de moins de 15 000 habitants, départements, régions)
     li Les associations mandatées dans le cadre d’une mission de service public
 
   |> Il est aussi possible que votre demande ait été refusée, car votre organisation possède déjà un espace sur #{domain.name}.

--- a/app/views/super_admins/territory_creation_requests/edit.html.slim
+++ b/app/views/super_admins/territory_creation_requests/edit.html.slim
@@ -31,6 +31,9 @@ section.main-content__body
         p= link_title = annuaire_client.nom
         - if annuaire_client.mairie?
           p ✅ Cette structure est une mairie
+          - population = GeoApiGouv.new(annuaire_client.code_insee).population
+          - if population
+            p Population : #{number_with_delimiter(population)} habitants
 
     - if @territory_creation_request.service_name.present?
       dt.attribute-label.attribute-label--normal-case Service

--- a/spec/services/annuaire_service_public_spec.rb
+++ b/spec/services/annuaire_service_public_spec.rb
@@ -41,6 +41,26 @@ RSpec.describe AnnuaireServicePublic do
     end
   end
 
+  describe "#code_insee" do
+    subject { described_class.new(siret).code_insee }
+
+    context "pour une mairie" do
+      let(:siret) { "21600660100019" }
+
+      before { AnnuaireServicePublicStubs.stub_siret_as_mairie(siret, self) }
+
+      it { is_expected.to eq "60669" }
+    end
+
+    context "pour une autre structure" do
+      let(:siret) { "13002603200016" }
+
+      before { AnnuaireServicePublicStubs.stub_siret_as_anct(siret, self) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   context "si l'api ne répond pas" do
     before do
       allow(Faraday).to receive(:get).and_raise(Faraday::TimeoutError)


### PR DESCRIPTION
# Contexte

Pour les besoins du déploiement, on ajoute le nombre d’habitants dans l’écran de demande d’ouverture d’espace.

# Solution

J’ai ajouté un appel à geo.api.data.gouv.fr pour récupérer ce chiffre via le code INSEE que je récupère sur l’annuaire des entreprises.
On en profite pour modifier le mail de refus.

Pour les EPCI, on traite les cas à la main, car il n’est pas simple de récupérer le chiffre directement par API.