### PR TITLE
Rend plus robuste FileAttenteJob

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -24,9 +24,14 @@ class CronJob < ApplicationJob
   end
 
   class FileAttenteJob < CronJob
+    include GoodJob::ActiveJobExtensions::Concurrency
+    include MonitorConcern
+
     queue_as :latency_30s
 
-    include MonitorConcern
+    good_job_control_concurrency_with(
+      perform_limit: 1
+    )
 
     def perform
       FileAttente.send_notifications

--- a/app/models/file_attente.rb
+++ b/app/models/file_attente.rb
@@ -40,24 +40,26 @@ class FileAttente < ApplicationRecord
 
       invitation_token = invitation_token_for(rdv, user)
 
-      if user.notifiable_by_sms?
-        Users::FileAttenteSms.new_creneau_available(rdv, user, invitation_token).deliver_later
+      ActiveRecord::Base.transaction do
+        if user.notifiable_by_sms?
+          Users::FileAttenteSms.new_creneau_available(rdv, user, invitation_token).deliver_later
+        end
+
+        if user.notifiable_by_email?
+          Users::FileAttenteMailer.with(rdv: rdv, user: user, token: invitation_token).new_creneau_available.deliver_later
+
+          Receipt.create!(
+            rdv: rdv,
+            user: user,
+            event: :new_creneau_available,
+            channel: :mail,
+            result: :processed,
+            email_address: user.email
+          )
+        end
+
+        update!(notifications_sent: notifications_sent + 1, last_creneau_sent_at: Time.zone.now)
       end
-
-      if user.notifiable_by_email?
-        Users::FileAttenteMailer.with(rdv: rdv, user: user, token: invitation_token).new_creneau_available.deliver_later
-
-        Receipt.create!(
-          rdv: rdv,
-          user: user,
-          event: :new_creneau_available,
-          channel: :mail,
-          result: :processed,
-          email_address: user.email
-        )
-      end
-
-      update!(notifications_sent: notifications_sent + 1, last_creneau_sent_at: Time.zone.now)
     end
   end
 


### PR DESCRIPTION
# Contexte

Ce matin notre worker de jobs a swappé à fond, et nous avons eu plusieurs `FileAttenteJob` accumulés qui s'exécutaient en parallèle.

Cela pose problème car on, peut avoir des race condition qui causent des doubles envois de notifs.

Note : ce job appelle le calculateur de créneau pour chaque RDV traité, ce qui peut être assez lourd.

# Solution

- empêcher d'exécuter plusieurs `FileAttenteJob` en même temps
- mettre dans la même transaction les `deliver_later`, la création du receipt et la mise à jour de `last_creneau_sent_at`.