### PR TITLE
Correction redirect lors de l’onboarding

### DIFF
--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -220,16 +220,14 @@ class ProConnectController < ApplicationController
     result = ProConnectOnboardingRouter.new(agent, current_domain).call
 
     case result.action
-    when :attached_as_admin
-      redirect_to after_sign_in_path_for(agent)
     when :contact_admin
       flash[:info] = "Votre organisation est rattachée à un espace RDV Service Public, mais vous n'avez pas les droits " \
                      "d'administrateur. Rapprochez-vous de votre administrateur pour qu'il vous accorde les accès sur votre espace."
       redirect_to after_sign_in_path_for(agent)
     when :signup_via_operator
       redirect_to agents_inscription_via_operateur_path(operator_name: result.operator_name, signup_url: result.signup_url)
-    else # :classic
-      redirect_to new_agents_territory_creation_request_path
+    else # :attached_as_admin, :classic
+      redirect_to after_sign_in_path_for(agent)
     end
   end
 

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe ProConnectController do
           expect(current_agent_id).to be_nil
         end
 
-        it "creates the agent if the domain allows it, et redirige vers la demande d'ouverture classique quand l'ANCT ne retourne rien" do
+        it "crée l'agent si le domaine le permet, et redirige vers la page de retour quand l'ANCT ne retourne rien" do
           allow(Domain::RDV_SERVICE_PUBLIC).to receive(:allow_self_onboarding).and_return(true)
           # Sans token ANCT configuré, le handler renvoie :classic
           expect do
@@ -164,7 +164,7 @@ RSpec.describe ProConnectController do
           expect(agent).to have_attributes(expected_attrs)
           expect(current_agent_id).to eq(agent.id)
           expect(session["pro_connect_id_token"]).to be_present
-          expect(response).to redirect_to(new_agents_territory_creation_request_path)
+          expect(response).to redirect_to("/agents/edit") # stored location via after_sign_in_path_for
         end
 
         context "avec token ANCT : opérateur admin qui matche notre DB" do


### PR DESCRIPTION
# Contexte

Il y a une petite coquille dans le code proposé dans #6304 

Quand un agent arrive pour la première fois, il est redirigé vers le formulaire de demande d’ouverture de compte même si à le droit d’ouvrir un compte directement.

# Solution

On aurait pu mettre une garde également sur le formulaire de demande d’ouverture de compte, mais ça ne me semble pas nécessaire et un peu lourd à partir du moment où on n’a plus de lien vers ce formulaire.
