### PR TITLE
Correctif de l'affichage des jours fériés pour l'agenda multi-agent

### DIFF
--- a/app/services/off_days.rb
+++ b/app/services/off_days.rb
@@ -58,7 +58,7 @@ class OffDays
     JOURS_FERIES.intersection(date_range)
   end
 
-  def self.to_full_calendar_array
+  def self.to_full_calendar_array(agent_ids = nil)
     JOURS_FERIES.map do |jour_ferie|
       {
         title: "Jour férié",
@@ -66,7 +66,8 @@ class OffDays
         end: jour_ferie.end_of_day.as_json,
         backgroundColor: AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
         textColor: "white",
-      }
+        resourceIds: agent_ids,
+      }.compact
     end
   end
 end

--- a/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
+++ b/app/views/admin/planning/agendas/multi_agents_agenda.html.slim
@@ -10,7 +10,7 @@ ruby:
   ]
 
   event_sources.push({ id: "ExternalCalendarEvent", url: admin_api_agenda_external_calendar_events_path(agent_id: @agents.map(&:id), format: :json) }) if @agents.any?(&:caldav_configured?)
-  event_sources.push(OffDays.to_full_calendar_array) unless current_territory.work_on_sunday?
+  event_sources.push(OffDays.to_full_calendar_array(@agents.map(&:id))) unless current_territory.work_on_sunday?
 
   resources = @agents.map { { id: _1.id, title: _1.full_name_or_email } }
 

--- a/spec/services/off_days_spec.rb
+++ b/spec/services/off_days_spec.rb
@@ -44,5 +44,12 @@ RSpec.describe OffDays, type: :service do
       expect(array[0].keys).to match_array(%i[title start end backgroundColor textColor])
       expect(array[0][:backgroundColor]).to eq "rgba(52, 57, 58, 0.7)"
     end
+
+    context "when passing agent_ids" do
+      it "sets resourceIds so that we can use it with the multi-agent calendar" do
+        array = described_class.to_full_calendar_array([1, 2, 3])
+        expect(array[0][:resourceIds]).to eq [1, 2, 3]
+      end
+    end
   end
 end


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1420" height="773" alt="Screenshot 2026-04-13 at 14 23 15" src="https://github.com/user-attachments/assets/16b55455-4dff-46ff-82da-ba00d3e37396" />| <img width="1414" height="762" alt="Screenshot 2026-04-13 at 14 23 02" src="https://github.com/user-attachments/assets/06fc9a78-a86c-41b9-88e0-9e5b00350c07" />

# Contexte

Remonté par ce ticket zammad : https://zammad10.ethibox.fr/#ticket/zoom/37245

Les jours fériés ne s'affichent pas sur le calendrier multi-agent.

# Solution

Il manquait juste les `resourceIds` pour les jours fériés


