### PR TITLE
Autoriser la recherche d'usager dans une nouvelle organisation pour un territoire ayant déjà des usagers

### DIFF
--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -44,7 +44,7 @@ ruby:
       /On met un margin-left négatif pour que l'icône du bouton soit alignée avec celle de l'usager au-dessus
       = link_to t("helpers.add"), ".collapse-add-user-selection", style: "margin-left: -12px", class: "fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-add-circle-fill", data: { toggle: "collapse" }
     .collapse.collapse-add-user-selection.no-transition class=(show_add_user ? "show" : "")
-      - if current_organisation.users.any?
+      - if current_territory.users.any?  # La recherche d'usager se fait sur les autres organisations du territoire, donc on propose une recherche dès que possible
         = label_tag :user_search, "Rechercher un usager", {class: "form-control-label string optional"}
         div.form-row.grid-align-center
           .flex-grow-1.pr-4.ml-1


### PR DESCRIPTION
# Contexte

Un agent de France Service nous a remonté un soucis via un ticket zammad : 
- ils ont un espace avec trois organisations.
- dans une de leur organisation ils peuvent faire une recherche d'usagers lors de la prise de rendez-vous, mais pas dans une autre
- ça leur donne l'impression qu'il n'est pas possible de partager les données, alors que notre recherche d'usager le permet

# Solution

Vu que notre recherche d'usagers se fait à travers tout l'espace, on propose la recherche dès que l'espace (et non pas l'orga) a des usagers

