### PR TITLE
Fixup #6296 (Passer à Node24 dans nos jobs GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
           --health-retries 5
         ports: ["6379:6379"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prevent https://github.com/rails/rails/issues/53661
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
@@ -223,7 +223,7 @@ jobs:
           --health-retries 5
         ports: ["6379:6379"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -9,7 +9,7 @@ jobs:
    runs-on: ubuntu-latest
    steps:
    - name: 'Checkout Repository'
-     uses: actions/checkout@v4
+     uses: actions/checkout@v6
    - name: Dependency Review
      uses: actions/dependency-review-action@v3
      with:


### PR DESCRIPTION
J'avais oublié des `actions/checkout@v4` : 

<img width="1346" height="580" alt="image" src="https://github.com/user-attachments/assets/ef5aa70d-4e22-4841-bc48-2ff7029d241e" />
