### PR TITLE
Automatiquement sélectionner la barre de recherche usager

### DIFF
--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -15,7 +15,7 @@
         .col-md-8
           .form-group.string.optional._search
             = label_tag :search, "Recherche", {class: "form-control-label string optional"}
-            = text_field_tag :search, {}, {placeholder: "Prénom, Nom, Email, Téléphone", autofocus: true, autocomplete: "off", class: "form-control string optional search-form-control", value: params[:search] }
+            = text_field_tag :search, {}, {placeholder: "Prénom, Nom, Email, Téléphone", autofocus: params[:search].blank?, autocomplete: "off", class: "form-control string optional search-form-control", value: params[:search] }
         .col-md-4
           .form-group.string.optional._search
             = f.label :agent_id, "Agent référent", {class: "form-control-label select optional"}

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -15,7 +15,7 @@
         .col-md-8
           .form-group.string.optional._search
             = label_tag :search, "Recherche", {class: "form-control-label string optional"}
-            = text_field_tag :search, {}, {placeholder: "Prénom, Nom, Email, Téléphone", autocomplete: "off", class: "form-control string optional search-form-control", value: params[:search] }
+            = text_field_tag :search, {}, {placeholder: "Prénom, Nom, Email, Téléphone", autofocus: true, autocomplete: "off", class: "form-control string optional search-form-control", value: params[:search] }
         .col-md-4
           .form-group.string.optional._search
             = f.label :agent_id, "Agent référent", {class: "form-control-label select optional"}


### PR DESCRIPTION
# Contexte

Je suis en train de faire des tests sur la recherche usager, et j'ai constaté que le champ de recherche textuelle n'est pas automatiquement sélectionné lorsqu'on arrive sur la page de recherche usager ("Usagers" dans le menu de gauche).

# Solution

https://developer.mozilla.org/fr/docs/Web/HTML/Reference/Global_attributes/autofocus