### PR TITLE
Ne mettre en place le 2FA ProConnect que pour les comptes sensibles

### DIFF
--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -69,12 +69,7 @@ class ProConnectController < ApplicationController
           redirect_to operators_root_path
         end
       when "agent"
-        sensitive_agent = Agent.active.where(pro_connect_openid_sub: callback_client.openid_sub).or(Agent.where(email: callback_client.user_email)).exists?(sensitive_account: true)
-        if IDP_PRO_CONNECT_FORCE_2FA_ENABLED.include?(callback_client.user_idp_id) && !callback_client.went_through_2fa? && sensitive_agent
-          require_2fa_for_sensitive_agent(callback_client)
-        else
-          connect_agent(callback_client)
-        end
+        connect_agent(callback_client)
       else
         Sentry.capture_message("Unknown connection_for: #{pro_connect_session[:connection_for].inspect}", extra: { session: session.to_h, pro_connect_session: })
         flash[:error] = generic_error_message
@@ -188,6 +183,8 @@ class ProConnectController < ApplicationController
         ERROR
         redirect_to new_agent_session_path and return
       end
+    elsif agent.sensitive_account? && !callback_client.went_through_2fa? && IDP_PRO_CONNECT_FORCE_2FA_ENABLED.include?(callback_client.user_idp_id)
+      require_2fa_for_sensitive_agent(callback_client) and return
     end
 
     if agent.email != callback_client.user_email

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -69,7 +69,8 @@ class ProConnectController < ApplicationController
           redirect_to operators_root_path
         end
       when "agent"
-        if IDP_PRO_CONNECT_FORCE_2FA_ENABLED.include?(callback_client.user_idp_id) && !callback_client.went_through_2fa?
+        sensitive_agent = Agent.active.where(pro_connect_openid_sub: callback_client.openid_sub).or(Agent.where(email: callback_client.user_email)).exists?(sensitive_account: true)
+        if IDP_PRO_CONNECT_FORCE_2FA_ENABLED.include?(callback_client.user_idp_id) && !callback_client.went_through_2fa? && sensitive_agent
           require_2fa_for_sensitive_agent(callback_client)
         else
           connect_agent(callback_client)

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -308,42 +308,48 @@ RSpec.describe ProConnectController do
         end
       end
 
-      context "when the agent's IDP is in the sensitive list" do
+      context "quand l’agent utilise un fournisseur d’identité compatible avec le 2FA" do
         before do
           stub_const("ProConnectController::IDP_PRO_CONNECT_FORCE_2FA_ENABLED", [user_info["idp_id"]])
         end
 
-        context "without 2FA" do
+        context "quand l’agent n’a pas de compte sensible" do
+          let!(:agent) { create(:agent, email: user_info["email"], sensitive_account: false) }
+
+          it "connecte l’agent normalement sans demander la double authentification" do
+            get :callback, params: { state:, code: }
+            expect_agent_to_be_updated_and_logged_in(agent.reload)
+          end
+        end
+
+        context "quand l’agent a un compte sensible et n’a pas utiliser son deuxième facteur d’authentification" do
+          let!(:agent) { create(:agent, email: user_info["email"], sensitive_account: true) }
+
           it "redirects to ProConnect with force_2fa rather than logging in the agent" do
-            create(:agent, email: user_info["email"])
             get :callback, params: { state:, code: }
 
             expect(current_agent_id).to be_nil
             expect(response).to redirect_to(start_with("https://fca.integ01.dev-agentconnect.fr/api/v2/authorize?"))
 
             redirect_url_query_params = Rack::Utils.parse_query(URI.parse(response.headers["Location"]).query)
-            expect(redirect_url_query_params.symbolize_keys).to include(
-              login_hint: user_info["email"],
-              claims: {
-                id_token: {
-                  acr: {
-                    essential: true,
-                    values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
-                  },
-                },
-              }.to_json
-            )
+            expect(redirect_url_query_params.symbolize_keys).to include(login_hint: user_info["email"],
+                                                                        claims: {
+                                                                          id_token: {
+                                                                            acr: {
+                                                                              essential: true,
+                                                                              values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
+                                                                            },
+                                                                          },
+                                                                        }.to_json)
           end
 
-          it "does not update the agent record" do
-            agent = create(:agent, email: user_info["email"])
+          it "ne met pas à jour l’agent" do
             expect do
               get :callback, params: { state:, code: }
             end.not_to change { agent.reload.pro_connect_openid_sub }
           end
 
-          it "sets up a new ProConnect session for the 2FA re-authentication" do
-            create(:agent, email: user_info["email"])
+          it "met en place une nouvelle variable de session pour la ré-authentification avec ProConnect" do
             get :callback, params: { state:, code: }
 
             new_redirect_url = Rack::Utils.parse_query(URI.parse(response.headers["Location"]).query)
@@ -353,12 +359,12 @@ RSpec.describe ProConnectController do
           end
         end
 
-        context "with 2FA" do
+        context "quand l’agent a déjà utiliser son deuxième facteur d’authentification" do
           before do
             ProConnectStubs.stub_callback_requests(code, user_info, with_2fa: true)
           end
 
-          it "logs in the agent normally" do
+          it "connecte l’agent normalement" do
             agent = create(:agent, email: user_info["email"])
             get :callback, params: { state:, code: }
             expect_agent_to_be_updated_and_logged_in(agent.reload, with_2fa: true)
@@ -366,12 +372,12 @@ RSpec.describe ProConnectController do
         end
       end
 
-      context "when the agent's IDP is not in the sensitive list" do
+      context "quand l’agent utilise un fournisseur d’identité non compatible avec le 2FA" do
         before do
           stub_const("ProConnectController::IDP_PRO_CONNECT_FORCE_2FA_ENABLED", ["autre-idp"])
         end
 
-        it "logs in the agent normally without requiring 2FA" do
+        it "connecte l’agent normalement" do
           agent = create(:agent, email: user_info["email"])
           get :callback, params: { state:, code: }
           expect_agent_to_be_updated_and_logged_in(agent.reload)


### PR DESCRIPTION
# Contexte

Lorsque que j’ai fais la dev pour exiger ProConnect pour le FI ProConnect identité, j’ai oublié de vérifier que le compte de l’agent est sensible

# Solution

Rajouter un élément dans la condition
