### PR TITLE
Correction de la création d’espace via les OPSN

### DIFF
--- a/app/services/pro_connect_onboarding_router.rb
+++ b/app/services/pro_connect_onboarding_router.rb
@@ -73,15 +73,23 @@ class ProConnectOnboardingRouter
 
   def attach_or_create_territory(operator, anct_client)
     ActiveRecord::Base.transaction do
-      existing_territory = operator.territories.first
+      existing_territories = Territory.where(operator: operator, siret: @agent.proconnect_siret)
+
+      if existing_territories.many?
+        raise "ProConnectOnboardingRouter: plusieurs territoires avec le même SIRET et opérateur (#{existing_territories.pluck(:id).join(', ')})"
+      end
+
+      existing_territory = existing_territories.first
+
       territory = existing_territory || Territory.create!(
         operator: operator,
-        category: ANCT_TYPE_TO_CATEGORY.fetch(anct_client.organization&.fetch("type", nil), "Inconnu")
+        category: ANCT_TYPE_TO_CATEGORY.fetch(anct_client.organization&.fetch("type", nil), "Inconnu"),
+        siret: @agent.proconnect_siret
       )
 
       existing_organisation = territory.organisations.first
       organisation = existing_organisation || Organisation.create!(
-        name: anct_client.organization&.fetch("name", nil) || operator.name,
+        name: anct_client.organization&.fetch("name", nil),
         territory: territory,
         verticale: @domain.verticale
       )

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe ProConnectController do
 
           # La cassette entitlements_admin est enregistrée avec email=test-admin@example.com et siret=21550050500015
           let(:user_info) { super().merge("email" => "test-admin@example.com", "siret" => "21550050500015") }
-          let!(:operator) { create(:operator, siret: user_info["siret"]) }
+          let!(:operator) { create(:operator, siret: "13002603200016") }
 
           before { ProConnectStubs.stub_callback_requests(code, user_info) }
           around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_admin") { ex.run } }
@@ -196,7 +196,7 @@ RSpec.describe ProConnectController do
 
           # La cassette entitlements_success est enregistrée avec email=contact@mairie-nantes.fr et siret=21550050500015
           let(:user_info) { super().merge("email" => "contact@mairie-nantes.fr", "siret" => "21550050500015") }
-          let!(:operator) { create(:operator, siret: "21550050500015") }
+          let!(:operator) { create(:operator, siret: "13002603200016") }
 
           before { ProConnectStubs.stub_callback_requests(code, user_info) }
           around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_success") { ex.run } }

--- a/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_admin.yml
+++ b/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_admin.yml
@@ -50,6 +50,6 @@ http_interactions:
       Set-Cookie: "[Filtered in vcr.rb -> before_record]"
     body:
       encoding: UTF-8
-      string: '{"organization":{"type":"other","name":"Bezonvaux","oidc_valid":null},"operator":{"id":"f33e9b4b-213f-4db9-8b39-ab17558f2931","name":"TEST","siret":"21550050500015","url":null,"config":{}},"entitlements":{"can_access":true,"is_admin":true,"is_admin_resolve_level":"service"}}'
+      string: '{"organization":{"type":"other","name":"Bezonvaux","oidc_valid":null},"operator":{"id":"f33e9b4b-213f-4db9-8b39-ab17558f2931","name":"TEST","siret":"13002603200016","url":null,"config":{}},"entitlements":{"can_access":true,"is_admin":true,"is_admin_resolve_level":"service"}}'
   recorded_at: Mon, 09 Mar 2026 17:05:01 GMT
 recorded_with: VCR 6.4.0

--- a/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_success.yml
+++ b/spec/fixtures/vcr_cassettes/espace_operateur_anct/entitlements_success.yml
@@ -59,7 +59,7 @@ http_interactions:
           },
           "operator": {
             "name": "TEST",
-            "siret": "21550050500015",
+            "siret": "13002603200016",
             "url": null,
             "config": {}
           },

--- a/spec/services/pro_connect_onboarding_router_spec.rb
+++ b/spec/services/pro_connect_onboarding_router_spec.rb
@@ -2,14 +2,15 @@ RSpec.describe ProConnectOnboardingRouter do
   subject(:handler) { described_class.new(agent, domain) }
 
   let(:domain) { Domain::RDV_SERVICE_PUBLIC }
-  let(:siret) { "21550050500015" }
-  let(:agent) { create(:agent, email: "test-admin@example.com", proconnect_siret: siret) }
+  let(:operator_siret) { "13002603200016" }
+  let(:proconnect_siret) { "21550050500015" }
+  let(:agent) { create(:agent, email: "test-admin@example.com", proconnect_siret:) }
 
   stub_env_with(ESPACE_OPERATEUR_ANCT_AUTH_TOKEN: "Bearer fake-token")
 
   describe "#call" do
     context "quand l'agent a un email d'un domaine de l'État" do
-      let(:agent) { create(:agent, email: "agent@etat.gouv.fr", proconnect_siret: siret) }
+      let(:agent) { create(:agent, email: "agent@etat.gouv.fr") }
 
       it "retourne :classic sans appeler l'API" do
         expect(EspaceOperateurANCT).not_to receive(:new)
@@ -36,11 +37,11 @@ RSpec.describe ProConnectOnboardingRouter do
       end
     end
 
-    context "Cas A : l'API retourne un opérateur qui matche un Operator de notre DB" do
-      let!(:operator) { create(:operator, siret:) }
+    context "l'API retourne un opérateur qui matche un Operator de notre DB" do
+      let!(:operator) { create(:operator, siret: operator_siret) }
 
       context "et l'agent est admin" do
-        let(:agent) { create(:agent, email: "test-admin@example.com", proconnect_siret: siret) }
+        let(:agent) { create(:agent, email: "test-admin@example.com", proconnect_siret:) }
 
         around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_admin") { ex.run } }
 
@@ -48,8 +49,8 @@ RSpec.describe ProConnectOnboardingRouter do
           expect(handler.call.action).to eq(:attached_as_admin)
         end
 
-        context "quand l'opérateur a déjà un territoire avec une organisation" do
-          let!(:territory) { create(:territory, operator: operator) }
+        context "quand l'organisation a déjà un territoire avec une organisation" do
+          let!(:territory) { create(:territory, operator: operator, siret: proconnect_siret) }
           let!(:organisation) { create(:organisation, territory: territory) }
 
           it "rattache l'agent à l'organisation et au territoire existants sans créer de nouveaux records" do
@@ -70,20 +71,19 @@ RSpec.describe ProConnectOnboardingRouter do
           end
         end
 
-        context "quand l'opérateur a un territoire sans organisation" do
-          let!(:territory) { create(:territory, operator: operator) }
+        context "quand l'organisation a un territoire sans organisation" do
+          let!(:territory) { create(:territory, operator: operator, siret: proconnect_siret) }
 
           it "crée une organisation et rattache l'agent sans créer de nouveau territoire" do
             expect { handler.call }.to change(Organisation, :count).by(1)
 
-            expect(Territory.count).to eq(1)
             organisation = Organisation.last
             expect(organisation.name).to eq("Bezonvaux") # nom retourné par la cassette VCR
             expect(organisation.territory).to eq(territory)
           end
         end
 
-        context "quand l'opérateur n'a pas encore de territoire" do
+        context "quand l'organisation n'a pas encore de territoire" do
           it "crée un territoire vide et une organisation" do
             expect { handler.call }
               .to change(Territory, :count).by(1)
@@ -93,6 +93,7 @@ RSpec.describe ProConnectOnboardingRouter do
             expect(territory.operator).to eq(operator)
             expect(territory.name).to be_nil
             expect(territory.category).to eq("Inconnu") # la cassette VCR retourne type "other"
+            expect(territory.siret).to eq(proconnect_siret)
 
             organisation = Organisation.last
             expect(organisation.name).to eq("Bezonvaux")
@@ -101,7 +102,7 @@ RSpec.describe ProConnectOnboardingRouter do
       end
 
       context "et l'agent a accès mais n'est pas admin" do
-        let(:agent) { create(:agent, email: "contact@mairie-nantes.fr", proconnect_siret: siret) }
+        let(:agent) { create(:agent, email: "contact@mairie-nantes.fr", proconnect_siret:) }
 
         around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_success") { ex.run } }
 
@@ -114,7 +115,7 @@ RSpec.describe ProConnectOnboardingRouter do
       end
     end
 
-    context "Cas B : l'API retourne des potentialOperators dont un matche un Operator de notre DB" do
+    context "l'API retourne des potentialOperators dont un matche un Operator de notre DB" do
       let(:agent) { create(:agent, email: "contact@mairie-nantes.fr", proconnect_siret: "20005671100019") }
       let!(:operator) { create(:operator, siret: "13002603200016") } # SIRET du premier potentialOperator dans la cassette
 
@@ -133,7 +134,7 @@ RSpec.describe ProConnectOnboardingRouter do
       end
     end
 
-    context "Cas B bis : plusieurs potentialOperators matchent notre DB" do
+    context "plusieurs potentialOperators matchent notre DB" do
       let(:agent) { create(:agent, email: "contact@mairie-nantes.fr", proconnect_siret: "20005671100019") }
       let!(:operator_1) { create(:operator, siret: "13002603200016") }
       let!(:operator_2) { create(:operator, siret: "12345678901234") }
@@ -156,7 +157,7 @@ RSpec.describe ProConnectOnboardingRouter do
       end
     end
 
-    context "Cas C : l'API retourne des potentialOperators mais aucun ne matche notre DB" do
+    context "l'API retourne des potentialOperators mais aucun ne matche notre DB" do
       let(:agent) { create(:agent, email: "contact@mairie-nantes.fr", proconnect_siret: "20005671100019") }
 
       around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { ex.run } }
@@ -166,7 +167,7 @@ RSpec.describe ProConnectOnboardingRouter do
       end
     end
 
-    context "Cas D : l'API retourne un opérateur mais le SIRET ne matche pas notre DB" do
+    context "l'API retourne un opérateur mais le SIRET ne matche pas notre DB" do
       around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_success") { ex.run } }
 
       it "retourne :classic" do


### PR DESCRIPTION
# Contexte

Lors de l’implémentation de #6304 il y a eu pas mal de confusion dans les SIRET. Le SIRET de l’opérateur et le SIRET de l’organisation qui nous est renvoyé par ProConnect.
La conséquence de cela, c’est qu’au lieu un nouvel espace pour les nouveaux administrateurs adhérents des OPSNs, on rattachait ceux-ci directement à l’espace de l’opérateur.

# Solution

J’ai écrit des tests qui décrivent le bon comportement puis j’ai corrigé le problème.

En faisant cette PR, je me rappelle que nous n’avons pas encore géré le rattachement de communes existantes, mais on pourra faire cela dans un second temps avec la mise en place des SIRET sur les espaces.

À ce jour, si un OPSN ouvre un compte à une collectivité qui est déjà équipé, l’agent pourra se connecter sans problème et cela sera transparent pour lui.