### PR TITLE
Api(usagers): ajout des champs de geocoding dans le blueprint users pour l'api V1

### DIFF
--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -2,7 +2,8 @@ class UserBlueprint < Blueprinter::Base
   identifier :id
 
   fields  :first_name, :birth_name, :last_name, :email, :address, :phone_number, :phone_number_formatted, :birth_date,
-          :responsible_id, :affiliation_number, :notify_by_sms, :notify_by_email, :created_at, :address_details
+          :responsible_id, :affiliation_number, :notify_by_sms, :notify_by_email, :created_at, :address_details,
+          :city_code, :post_code, :city_name
 
   association :responsible, blueprint: UserBlueprint
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -62,6 +62,7 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
       first_name birth_name last_name email address phone_number
       birth_date responsible_id caisse_affiliation affiliation_number
       family_situation number_of_children notify_by_sms notify_by_email
+      city_code post_code city_name
     ]
 
     attrs -= User::FranceconnectFrozenFieldsConcern::FROZEN_FIELDS if @user&.logged_once_with_franceconnect?

--- a/spec/requests/api/v1/swagger_doc/users_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/users_request_spec.rb
@@ -79,6 +79,9 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
       parameter name: "email", in: :query, type: :string, description: "Email", example: "johnny@77.com", required: false
       parameter name: "phone_number", in: :query, type: :string, description: "Numéro de téléphone", example: "33600008012", required: false
       parameter name: "address", in: :query, type: :string, description: "Adresse", example: "10 rue du Havre, Paris, 75016", required: false
+      parameter name: "city_code", in: :query, type: :string, description: "Code INSEE de la commune", example: "75116", required: false
+      parameter name: "post_code", in: :query, type: :string, description: "Code postal", example: "75016", required: false
+      parameter name: "city_name", in: :query, type: :string, description: "Nom de la commune", example: "Paris", required: false
       parameter name: "caisse_affiliation", in: :query, type: :string, description: "Caisse d'affiliation", example: "caf", required: false
       parameter name: "affiliation_number", in: :query, type: :string, description: "Numéro d'affiliation", example: "101010", required: false
       parameter name: "family_situation", in: :query, type: :string, description: "Situation familiale", example: "single", required: false
@@ -104,6 +107,9 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         let(:email) { "jean@jacques.fr" }
         let(:phone_number) { "33600008012" }
         let(:address) { "10 rue du Havre, Paris, 75016" }
+        let(:city_code) { "75116" }
+        let(:post_code) { "75016" }
+        let(:city_name) { "Paris" }
         let(:caisse_affiliation) { "caf" }
         let(:affiliation_number) { "101010" }
         let(:family_situation) { "single" }
@@ -127,6 +133,9 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
             email: email,
             phone_number: phone_number,
             address: address,
+            city_code: city_code,
+            post_code: post_code,
+            city_name: city_name,
             caisse_affiliation: caisse_affiliation,
             affiliation_number: affiliation_number,
             family_situation: family_situation,
@@ -369,6 +378,9 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
       parameter name: "email", in: :query, type: :string, description: "Email", example: "johnny@77.com", required: false
       parameter name: "phone_number", in: :query, type: :string, description: "Numéro de téléphone", example: "33600008012", required: false
       parameter name: "address", in: :query, type: :string, description: "Adresse", example: "10 rue du Havre, Paris, 75016", required: false
+      parameter name: "city_code", in: :query, type: :string, description: "Code INSEE de la commune", example: "75116", required: false
+      parameter name: "post_code", in: :query, type: :string, description: "Code postal", example: "75016", required: false
+      parameter name: "city_name", in: :query, type: :string, description: "Nom de la commune", example: "Paris", required: false
       parameter name: "caisse_affiliation", in: :query, type: :string, description: "Caisse d'affiliation", example: "caf", required: false
       parameter name: "affiliation_number", in: :query, type: :string, description: "Numéro d'affiliation", example: "101010", required: false
       parameter name: "family_situation", in: :query, type: :string, description: "Situation familiale", example: "single", required: false
@@ -393,6 +405,9 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         let(:email) { "jean@jacques.fr" }
         let(:phone_number) { "33600008012" }
         let(:address) { "10 rue du Havre, Paris, 75016" }
+        let(:city_code) { "75116" }
+        let(:post_code) { "75016" }
+        let(:city_name) { "Paris" }
         let(:caisse_affiliation) { "caf" }
         let(:affiliation_number) { "101010" }
         let(:family_situation) { "single" }
@@ -421,6 +436,9 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
             email:,
             phone_number:,
             address:,
+            city_code:,
+            post_code:,
+            city_name:,
             caisse_affiliation:,
             affiliation_number:,
             family_situation:,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -183,6 +183,8 @@ RSpec.configure do |config|
               birth_date: { type: "string", format: "date", nullable: true },
               birth_name: { type: "string", nullable: true },
               caisse_affiliation: { type: "string", enum: %w[aucun caf msa], nullable: true },
+              city_code: { type: "string", nullable: true },
+              city_name: { type: "string", nullable: true },
               created_at: { type: "string" },
               email: { type: "string", nullable: true },
               first_name: { type: "string" },
@@ -191,6 +193,7 @@ RSpec.configure do |config|
               notify_by_sms: { type: "boolean" },
               phone_number: { type: "string", nullable: true },
               phone_number_formatted: { type: "string", nullable: true },
+              post_code: { type: "string", nullable: true },
               responsible: { type: "object", nullable: true },
               responsible_id: { type: "integer", nullable: true },
               user_profiles: {
@@ -199,8 +202,8 @@ RSpec.configure do |config|
                 items: { "$ref" => "#/components/schemas/user_profile" },
               },
             },
-            required: %w[id address address_details affiliation_number birth_date birth_name created_at first_name
-                         last_name notify_by_email notify_by_sms phone_number phone_number_formatted responsible responsible_id user_profiles],
+            required: %w[id address address_details affiliation_number birth_date birth_name city_code city_name created_at first_name
+                         last_name notify_by_email notify_by_sms phone_number phone_number_formatted post_code responsible responsible_id user_profiles],
           },
           user_profile_with_root: {
             type: "object",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -278,6 +278,14 @@
             ],
             "nullable": true
           },
+          "city_code": {
+            "type": "string",
+            "nullable": true
+          },
+          "city_name": {
+            "type": "string",
+            "nullable": true
+          },
           "created_at": {
             "type": "string"
           },
@@ -305,6 +313,10 @@
             "type": "string",
             "nullable": true
           },
+          "post_code": {
+            "type": "string",
+            "nullable": true
+          },
           "responsible": {
             "type": "object",
             "nullable": true
@@ -328,6 +340,8 @@
           "affiliation_number",
           "birth_date",
           "birth_name",
+          "city_code",
+          "city_name",
           "created_at",
           "first_name",
           "last_name",
@@ -335,6 +349,7 @@
           "notify_by_sms",
           "phone_number",
           "phone_number_formatted",
+          "post_code",
           "responsible",
           "responsible_id",
           "user_profiles"
@@ -4717,6 +4732,36 @@
             }
           },
           {
+            "name": "city_code",
+            "in": "query",
+            "description": "Code INSEE de la commune",
+            "example": "75116",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "post_code",
+            "in": "query",
+            "description": "Code postal",
+            "example": "75016",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "city_name",
+            "in": "query",
+            "description": "Nom de la commune",
+            "example": "Paris",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "caisse_affiliation",
             "in": "query",
             "description": "Caisse d'affiliation",
@@ -5276,6 +5321,36 @@
             "in": "query",
             "description": "Adresse",
             "example": "10 rue du Havre, Paris, 75016",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "city_code",
+            "in": "query",
+            "description": "Code INSEE de la commune",
+            "example": "75116",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "post_code",
+            "in": "query",
+            "description": "Code postal",
+            "example": "75016",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "city_name",
+            "in": "query",
+            "description": "Nom de la commune",
+            "example": "Paris",
             "required": false,
             "schema": {
               "type": "string"


### PR DESCRIPTION
Fait suite et remplace (en partie) cette PR : https://github.com/betagouv/rdv-service-public/pull/6306

Permet à RDVI (ou tout autre consommateur de l'API) d'envoyer directement les champs de geocoding (`city_code`, `post_code`, `city_name`) lors de la création/modification d'un usager  via l'API v1, et expose ces champs en réponse.