### PR TITLE
Add time_zone to Organisation blueprint

### DIFF
--- a/app/blueprints/organisation_blueprint.rb
+++ b/app/blueprints/organisation_blueprint.rb
@@ -1,5 +1,5 @@
 class OrganisationBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :phone_number, :email, :website, :verticale
+  fields :name, :phone_number, :email, :website, :verticale, :time_zone
 end


### PR DESCRIPTION
# Contexte

Depuis #6207 on a un problèmes assez gênant sur les rdvs qui ne sont pas dans la time zone de Paris côté rdv-i.
En effet, on récupère et enregistre la date du rdv via le webhook qui nous est envoyé, seulement Rails fait automatiquement la conversion de la date de début dans la time zone de nos serveurs. 
Ainsi, pour des rdvs qui ne sont pas dans la time zone "Europe/Paris", lorsqu'on envoie des messages aux usagers avec l'heure du rdv, celle-ci est erronée puisqu'on ne l'affiche pas dans la time zone de l'usager.

# Solution

La solution la plus complète et à priori pas trop complexe est d'exposer les `time_zone` des orgas côté RDV-S pour qu'on puisse les récupérer via webhook et la stocker dans rdv-i. Ainsi on sera en mesure d'afficher l'heure des rdvs dans la bonne time zone tout en gardant l'heure exacte du rdv en DB. C'est ce que je propose ici en ajoutant l'attribut `time_zone` dans le blueprint des organisations.

Une solution alternative mais moins complète serait de parser l'heure du rdv que l'on reçoit du webhook pour enlever la timezone et juste stocker l'heure initiale (qui serait marquée dans notre timezone du coup et donc pas vraiment exacte).