### PR TITLE
Ajoute le champ `time_zone` dans l'API `rdvs`

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -3,7 +3,7 @@ class RdvBlueprint < Blueprinter::Base
 
   fields :uuid, :status, :duration_in_min, :address, :context, :cancelled_at,
          :max_participants_count, :users_count, :name, :collectif, :created_by_type, :created_by_id, :created_at,
-         :visio_url
+         :visio_url, :time_zone
 
   # Retrocompatibilité avec l'ancien format de l'API pour created_by
   field :created_by do |rdv, _options|

--- a/app/models/concerns/rdv/timezone_concern.rb
+++ b/app/models/concerns/rdv/timezone_concern.rb
@@ -8,6 +8,8 @@
 module Rdv::TimezoneConcern
   extend ActiveSupport::Concern
 
+  delegate :time_zone, to: :organisation
+
   def starts_at_in_time_zone
     if organisation.time_zone == "Europe/Paris"
       starts_at

--- a/spec/requests/api/v1/rdvs_spec.rb
+++ b/spec/requests/api/v1/rdvs_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe "RDV API" do
           get "/api/v1/rdvs", headers: headers, params: { user_id: user.id, agent_id: agent.id }, as: :json
           expect(parsed_response_body["rdvs"].first["starts_at"]).to eq rdv_with_user_and_agent.starts_at.to_s
           expect(parsed_response_body["rdvs"].first["ends_at"]).to eq rdv_with_user_and_agent.ends_at.to_s
+          expect(parsed_response_body["rdvs"].first["time_zone"]).to eq "Europe/Paris"
         end
       end
 
@@ -125,6 +126,7 @@ RSpec.describe "RDV API" do
           get "/api/v1/rdvs", headers: headers, params: { user_id: user.id, agent_id: agent.id }, as: :json
           expect(parsed_response_body["rdvs"].first["starts_at"]).to eq "2025-01-15 10:00:00 -0400"
           expect(parsed_response_body["rdvs"].first["ends_at"]).to eq "2025-01-15 10:45:00 -0400"
+          expect(parsed_response_body["rdvs"].first["time_zone"]).to eq "America/Guadeloupe"
         end
       end
     end


### PR DESCRIPTION
# Contexte

Dans #6339, @aminedhobb décrit pourquoi il est utile pour un système externe de connaître la timezone d'un RDV afin d'afficher son heure de début dans l'heure locale. 

En effet, actuellement l'API renvoie par exemple `"starts_at": "2025-01-15 10:00:00 -0400"` pour un RDV dans une organisation de `America/Guadeloupe`. Bien que ce timestamp porte l'offset et l'heure locale, son rôle est avant tout un timestamp. De ce fait, le système externe (ici RDV Insertion) est amené à le stocker comme un [timestamp sans information de zone](https://github.com/gip-inclusion/rdv-insertion/blob/97c746bfdd9c4a4b1036f3442c39fa94d6917719/db/schema.rb#L466).

En fournissant explicitement la timezone, on permet donc plusieurs choses : 
- le système peut interpréter `starts_at` comme un simple timestamp (pour le moment il exprime l'heure locale mais il pourrait très bien exprimer l'heure en UTC ou via un timestamp integer)
- le système possède explicitement le nom de la timezone, qui est une information plus complète que l'offset 

# Solution

Initialement dans #6339, Amine proposait d'ajouter la time zone dans l'API des organisations, mais je suis convaincu que la vision cible est d'avoir une time zone explicite par RDV (comme expliqué dans [ce commentaire](https://github.com/betagouv/rdv-service-public/pull/6339#pullrequestreview-4139516106)). 
