### PR TITLE
Distinguer les erreurs Caldav sur Sentry par statut HTTP

### DIFF
--- a/app/jobs/caldav/base_job.rb
+++ b/app/jobs/caldav/base_job.rb
@@ -1,0 +1,9 @@
+class Caldav::BaseJob < ApplicationJob
+  rescue_from Calendav::RequestError do |exception|
+    http_status = exception.response.status.code
+    # Cela permet d'identifier singulièrement l'erreur selon le code HTTP de la réponse
+    Sentry.get_current_scope.set_fingerprint(["{{default}}", "Calendav::RequestError", http_status.to_s])
+    Sentry.capture_exception(exception)
+    retry_job queue: :latency_whenever
+  end
+end

--- a/app/jobs/caldav/export_rdv_to_caldav_job.rb
+++ b/app/jobs/caldav/export_rdv_to_caldav_job.rb
@@ -1,5 +1,5 @@
 module Caldav
-  class ExportRdvToCaldavJob < ApplicationJob
+  class ExportRdvToCaldavJob < Caldav::BaseJob
     include GoodJob::ActiveJobExtensions::Concurrency
 
     good_job_control_concurrency_with(

--- a/app/jobs/caldav/import_absences_from_caldav_job.rb
+++ b/app/jobs/caldav/import_absences_from_caldav_job.rb
@@ -1,5 +1,5 @@
 module Caldav
-  class ImportAbsencesFromCaldavJob < ApplicationJob
+  class ImportAbsencesFromCaldavJob < Caldav::BaseJob
     include GoodJob::ActiveJobExtensions::Concurrency
 
     good_job_control_concurrency_with(

--- a/app/jobs/caldav/mass_destroy_events_and_absences_job.rb
+++ b/app/jobs/caldav/mass_destroy_events_and_absences_job.rb
@@ -1,5 +1,5 @@
 module Caldav
-  class MassDestroyEventsAndAbsencesJob < ApplicationJob
+  class MassDestroyEventsAndAbsencesJob < Caldav::BaseJob
     queue_as :latency_5m
     include ExtendedRetryStrategyConcern
 

--- a/app/jobs/caldav/mass_export_event_to_caldav_job.rb
+++ b/app/jobs/caldav/mass_export_event_to_caldav_job.rb
@@ -1,5 +1,5 @@
 module Caldav
-  class MassExportEventToCaldavJob < ApplicationJob
+  class MassExportEventToCaldavJob < Caldav::BaseJob
     include ExtendedRetryStrategyConcern
 
     def perform(agent)

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -119,25 +119,39 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
     end
   end
 
-  it "enregistre la réponse dans Sentry si la récupération du token retourne un body inattendu" do
-    cal_url = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id"
-    stub_request(:propfind, cal_url)
-      .and_return({ status: 500, body: "ceci est mon corps", headers: { "Set-Cookie" => "secret" } })
+  describe "gestion des réponses en erreur" do
+    it "enregistre requête et réponse dans Sentry si la récupération du token retourne une erreur" do
+      cal_url = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id"
+      stub_request(:propfind, cal_url)
+        .and_return({ status: 500, body: "ceci est mon corps", headers: { "Set-Cookie" => "secret" } })
 
-    described_class.perform_now(agent.id)
+      described_class.perform_now(agent.id)
 
-    expect(sentry_events.last.exception.values.last.value).to eq("500 Internal Server Error (Calendav::RequestError)")
+      expect(sentry_events.last.exception.values.last.value).to eq("500 Internal Server Error (Calendav::RequestError)")
 
-    request_breadcrumb = sentry_events.last.breadcrumbs.compact[0]
-    expect(request_breadcrumb.data[:method]).to eq(:propfind)
-    expect(request_breadcrumb.data[:url]).to eq(cal_url)
-    expect(request_breadcrumb.data[:headers]["Authorization"]).to eq("[FILTERED]")
+      request_breadcrumb = sentry_events.last.breadcrumbs.compact[0]
+      expect(request_breadcrumb.data[:method]).to eq(:propfind)
+      expect(request_breadcrumb.data[:url]).to eq(cal_url)
+      expect(request_breadcrumb.data[:headers]["Authorization"]).to eq("[FILTERED]")
 
-    response_breadcrumb = sentry_events.last.breadcrumbs.compact[1]
-    expect(response_breadcrumb.data[:status_code]).to eq(500)
-    expect(response_breadcrumb.data[:body]).to eq("ceci est mon corps")
-    expect(response_breadcrumb.data[:duration_ms]).to be_between(0, 100)
-    expect(response_breadcrumb.data[:headers]["Set-Cookie"]).to eq("[FILTERED]")
+      response_breadcrumb = sentry_events.last.breadcrumbs.compact[1]
+      expect(response_breadcrumb.data[:status_code]).to eq(500)
+      expect(response_breadcrumb.data[:body]).to eq("ceci est mon corps")
+      expect(response_breadcrumb.data[:duration_ms]).to be_between(0, 100)
+      expect(response_breadcrumb.data[:headers]["Set-Cookie"]).to eq("[FILTERED]")
+    end
+
+    it "utilise un fingerprint différent pour chaque statut HTTP de réponse d'erreur" do
+      cal_url = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id"
+
+      stub_request(:propfind, cal_url).and_return({ status: 403 })
+      described_class.perform_now(agent.id)
+      expect(sentry_events.last.fingerprint).to eq(["{{default}}", "Calendav::RequestError", "403"])
+
+      stub_request(:propfind, cal_url).and_return({ status: 500 })
+      described_class.perform_now(agent.id)
+      expect(sentry_events.last.fingerprint).to eq(["{{default}}", "Calendav::RequestError", "500"])
+    end
   end
 
   describe "debounce du job" do


### PR DESCRIPTION
:information_source:  Review plus facile avec "Hide whitespace" (j'ai indenté des specs)

# Contexte

Sur Sentry, toutes les erreurs Caldav nous remontent groupées dans la [même issue](https://sentry.incubateur.net/organizations/betagouv/issues/268836/events) :

<img width="1484" height="810" alt="image" src="https://github.com/user-attachments/assets/d2fcf9cc-0012-4836-9a1d-10f59e019828" />


# Solution

Moduler le fingerprint pour que chaque statut d'erreur soit groupé dans une issue Sentry différente.

J'utilise `"{{default}}"` afin de conserver le groupement par défaut opéré par Sentry, sans qui par exemple on grouperait dans la même issue :
- les réponses 404 obtenues lorsqu'on veut lister les événements (ce qui peut être causé par une mauvaise URL, et signifie que la synchro est pétée et qu'on doit alerter l'agent)
- les réponses 404 obtenues lorsqu'on veut supprimer un événement (ce qui peut être causé par le fait que l'événement a déjà été supprimé côté agenda externe, et donc que tout va bien, pas la peine de retry