### PR TITLE
Gérer le cas où un Caldav événement externe est déjà supprimé

### DIFF
--- a/app/jobs/caldav/export_rdv_to_caldav_job.rb
+++ b/app/jobs/caldav/export_rdv_to_caldav_job.rb
@@ -44,6 +44,13 @@ module Caldav
 
     def delete_event(caldav_event_url)
       agent.caldav_client.events.delete(caldav_event_url)
+    rescue Calendav::RequestError => e
+      if e.response.status.code == 404
+        # L'événement externe à supprimer est introuvable, pas la peine de retry
+        Rails.logger.info("Got a 404 calling DELETE on #{caldav_event_url}")
+      else
+        raise
+      end
     end
 
     def agent

--- a/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
+++ b/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
@@ -81,7 +81,6 @@ RSpec.describe Caldav::ExportRdvToCaldavJob do
         let(:response_status) { 500 }
 
         it "raises the exception" do
-          expect(Rails.logger).not_to receive(:info).with("Got a 404 calling DELETE on https://caldav.example.com/event.ics")
           expect { described_class.new.perform(-1, agent.id, caldav_event_url:) }.to raise_error(Calendav::RequestError, "500 Internal Server Error")
         end
       end

--- a/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
+++ b/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
@@ -62,6 +62,30 @@ RSpec.describe Caldav::ExportRdvToCaldavJob do
       expect(caldav_events).to receive(:delete).with(caldav_event_url)
       described_class.new.perform(-1, agent.id, caldav_event_url:)
     end
+
+    context "et que le serveur répond à la suppression par une erreur" do
+      before do
+        allow(caldav_events).to receive(:delete).with(caldav_event_url).and_raise(Calendav::RequestError.new(instance_double(HTTP::Response, status: HTTP::Response::Status.new(response_status))))
+      end
+
+      context "404" do
+        let(:response_status) { 404 }
+
+        it "loggue l'info et ne retry pas" do
+          expect(Rails.logger).to receive(:info).with("Got a 404 calling DELETE on https://caldav.example.com/event.ics")
+          described_class.new.perform(-1, agent.id, caldav_event_url:)
+        end
+      end
+
+      context "500" do
+        let(:response_status) { 500 }
+
+        it "raises the exception" do
+          expect(Rails.logger).not_to receive(:info).with("Got a 404 calling DELETE on https://caldav.example.com/event.ics")
+          expect { described_class.new.perform(-1, agent.id, caldav_event_url:) }.to raise_error(Calendav::RequestError, "500 Internal Server Error")
+        end
+      end
+    end
   end
 
   context "quand l'agents_rdv n'existe plus et qu'aucun caldav_event_url n'est fourni" do


### PR DESCRIPTION
# Contexte

Nous avons des remontées Sentry pour un `Caldav::ExportRdvToCaldavJob` qui retry en boucle car il tente de supprimer un événement distant et que l'événement est vraisemblablement déjà supprimé manuellement par l'agent.

Issue Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/273582

<img width="1642" height="1322" alt="image" src="https://github.com/user-attachments/assets/12258d65-caea-422c-8b63-d7c604604cd3" />

# Solution

Je propose de ne pas remonter ce cas dans Sentry, mais plutôt de le logger un petit message. En effet, nous avons beaucoup de remontées Sentry de véritables problèmes (synchro pétées), et ajouter une remontée Sentry juste pour nous informer qu'un événement à supprimer est déjà supprimé, c'est de la paranoia. :shrug: 