### PR TITLE
Revert "Distinguer les erreurs Caldav sur Sentry par statut HTTP"

### DIFF
--- a/app/jobs/caldav/base_job.rb
+++ b/app/jobs/caldav/base_job.rb
@@ -1,9 +1,0 @@
-class Caldav::BaseJob < ApplicationJob
-  rescue_from Calendav::RequestError do |exception|
-    http_status = exception.response.status.code
-    # Cela permet d'identifier singulièrement l'erreur selon le code HTTP de la réponse
-    Sentry.get_current_scope.set_fingerprint(["{{default}}", "Calendav::RequestError", http_status.to_s])
-    Sentry.capture_exception(exception)
-    retry_job queue: :latency_whenever
-  end
-end

--- a/app/jobs/caldav/export_rdv_to_caldav_job.rb
+++ b/app/jobs/caldav/export_rdv_to_caldav_job.rb
@@ -1,5 +1,5 @@
 module Caldav
-  class ExportRdvToCaldavJob < Caldav::BaseJob
+  class ExportRdvToCaldavJob < ApplicationJob
     include GoodJob::ActiveJobExtensions::Concurrency
 
     good_job_control_concurrency_with(

--- a/app/jobs/caldav/import_absences_from_caldav_job.rb
+++ b/app/jobs/caldav/import_absences_from_caldav_job.rb
@@ -1,5 +1,5 @@
 module Caldav
-  class ImportAbsencesFromCaldavJob < Caldav::BaseJob
+  class ImportAbsencesFromCaldavJob < ApplicationJob
     include GoodJob::ActiveJobExtensions::Concurrency
 
     good_job_control_concurrency_with(

--- a/app/jobs/caldav/mass_destroy_events_and_absences_job.rb
+++ b/app/jobs/caldav/mass_destroy_events_and_absences_job.rb
@@ -1,5 +1,5 @@
 module Caldav
-  class MassDestroyEventsAndAbsencesJob < Caldav::BaseJob
+  class MassDestroyEventsAndAbsencesJob < ApplicationJob
     queue_as :latency_5m
     include ExtendedRetryStrategyConcern
 

--- a/app/jobs/caldav/mass_export_event_to_caldav_job.rb
+++ b/app/jobs/caldav/mass_export_event_to_caldav_job.rb
@@ -1,5 +1,5 @@
 module Caldav
-  class MassExportEventToCaldavJob < Caldav::BaseJob
+  class MassExportEventToCaldavJob < ApplicationJob
     include ExtendedRetryStrategyConcern
 
     def perform(agent)

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -119,39 +119,25 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
     end
   end
 
-  describe "gestion des réponses en erreur" do
-    it "enregistre requête et réponse dans Sentry si la récupération du token retourne une erreur" do
-      cal_url = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id"
-      stub_request(:propfind, cal_url)
-        .and_return({ status: 500, body: "ceci est mon corps", headers: { "Set-Cookie" => "secret" } })
+  it "enregistre la réponse dans Sentry si la récupération du token retourne un body inattendu" do
+    cal_url = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id"
+    stub_request(:propfind, cal_url)
+      .and_return({ status: 500, body: "ceci est mon corps", headers: { "Set-Cookie" => "secret" } })
 
-      described_class.perform_now(agent.id)
+    described_class.perform_now(agent.id)
 
-      expect(sentry_events.last.exception.values.last.value).to eq("500 Internal Server Error (Calendav::RequestError)")
+    expect(sentry_events.last.exception.values.last.value).to eq("500 Internal Server Error (Calendav::RequestError)")
 
-      request_breadcrumb = sentry_events.last.breadcrumbs.compact[0]
-      expect(request_breadcrumb.data[:method]).to eq(:propfind)
-      expect(request_breadcrumb.data[:url]).to eq(cal_url)
-      expect(request_breadcrumb.data[:headers]["Authorization"]).to eq("[FILTERED]")
+    request_breadcrumb = sentry_events.last.breadcrumbs.compact[0]
+    expect(request_breadcrumb.data[:method]).to eq(:propfind)
+    expect(request_breadcrumb.data[:url]).to eq(cal_url)
+    expect(request_breadcrumb.data[:headers]["Authorization"]).to eq("[FILTERED]")
 
-      response_breadcrumb = sentry_events.last.breadcrumbs.compact[1]
-      expect(response_breadcrumb.data[:status_code]).to eq(500)
-      expect(response_breadcrumb.data[:body]).to eq("ceci est mon corps")
-      expect(response_breadcrumb.data[:duration_ms]).to be_between(0, 100)
-      expect(response_breadcrumb.data[:headers]["Set-Cookie"]).to eq("[FILTERED]")
-    end
-
-    it "utilise un fingerprint différent pour chaque statut HTTP de réponse d'erreur" do
-      cal_url = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id"
-
-      stub_request(:propfind, cal_url).and_return({ status: 403 })
-      described_class.perform_now(agent.id)
-      expect(sentry_events.last.fingerprint).to eq(["{{default}}", "Calendav::RequestError", "403"])
-
-      stub_request(:propfind, cal_url).and_return({ status: 500 })
-      described_class.perform_now(agent.id)
-      expect(sentry_events.last.fingerprint).to eq(["{{default}}", "Calendav::RequestError", "500"])
-    end
+    response_breadcrumb = sentry_events.last.breadcrumbs.compact[1]
+    expect(response_breadcrumb.data[:status_code]).to eq(500)
+    expect(response_breadcrumb.data[:body]).to eq("ceci est mon corps")
+    expect(response_breadcrumb.data[:duration_ms]).to be_between(0, 100)
+    expect(response_breadcrumb.data[:headers]["Set-Cookie"]).to eq("[FILTERED]")
   end
 
   describe "debounce du job" do


### PR DESCRIPTION
Reverts betagouv/rdv-service-public#6347

Effet très indésirable : le retry semble se faire sans suivre les règles de nombre de retry ! :fearful: 

<img width="2162" height="694" alt="image" src="https://github.com/user-attachments/assets/5034aca8-74ae-45e8-8b84-f6db827ae94d" />

Donc en gros on DDoS La Suite actuellement.