### PR TITLE
Afficher les informations de l’usager dans la synchro Caldav

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -7,11 +7,7 @@ class Agents::CaldavSyncController < AgentAuthController
 
   def update
     skip_authorization
-    current_agent.assign_attributes(
-      caldav_agenda_url: params[:caldav_agenda_url],
-      caldav_username: params[:caldav_username],
-      caldav_password: params[:caldav_password]
-    )
+    current_agent.assign_attributes(permitted_params)
 
     error = caldav_config_error
     if error.nil?
@@ -33,6 +29,10 @@ class Agents::CaldavSyncController < AgentAuthController
   end
 
   private
+
+  def permitted_params
+    params.permit(:caldav_agenda_url, :caldav_username, :caldav_password, :caldav_include_sensitive_data)
+  end
 
   # Vérifie la configuration CalDAV en 3 étapes : authentification, lecture, écriture.
   # Retourne nil si tout est OK, ou un message d’erreur décrivant l’étape qui a échoué.

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -9,6 +9,7 @@ class Users::RdvsController < UserAuthController
   layout "application_base", only: %i[index]
 
   include TokenInvitable
+
   prepend_before_action :store_invitation_in_session_and_redirect, only: %i[show creneaux]
 
   def index
@@ -91,7 +92,7 @@ class Users::RdvsController < UserAuthController
   end
 
   def ics
-    payload = @rdv.payload(nil, current_user)
+    payload = @rdv.payload(recipient: current_user)
     cal = IcalFormatters::Ics.from_payload(payload)
     send_data cal.to_ical,
               filename: payload[:attachement_filename],

--- a/app/jobs/caldav/export_rdv_to_caldav_job.rb
+++ b/app/jobs/caldav/export_rdv_to_caldav_job.rb
@@ -28,7 +28,7 @@ module Caldav
     private
 
     def create_event
-      ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(:create, agents_rdv.agent)).to_ical
+      ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(action: :create, recipient: agents_rdv.agent)).to_ical
       identifier = "agents_rdv-#{agents_rdv.id}.ics"
       event = agent.caldav_client.events.create(agent.caldav_agenda_url, identifier, ics)
       # Le provider Caldav n’utilise pas forcément l’identifiant qu’on lui donne pour créer l’event
@@ -38,7 +38,7 @@ module Caldav
     end
 
     def update_event
-      ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(:update, agents_rdv.agent)).to_ical
+      ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(action: :update, recipient: agents_rdv.agent)).to_ical
       agent.caldav_client.events.update(agents_rdv.caldav_url, ics)
     end
 

--- a/app/jobs/caldav/export_rdv_to_caldav_job.rb
+++ b/app/jobs/caldav/export_rdv_to_caldav_job.rb
@@ -28,7 +28,8 @@ module Caldav
     private
 
     def create_event
-      ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(action: :create, recipient: agents_rdv.agent)).to_ical
+      payload = agents_rdv.rdv.payload(action: :create, recipient: agents_rdv.agent, sensitive_data: agent.caldav_include_sensitive_data)
+      ics = IcalFormatters::Ics.from_payload(payload).to_ical
       identifier = "agents_rdv-#{agents_rdv.id}.ics"
       event = agent.caldav_client.events.create(agent.caldav_agenda_url, identifier, ics)
       # Le provider Caldav n’utilise pas forcément l’identifiant qu’on lui donne pour créer l’event
@@ -38,7 +39,8 @@ module Caldav
     end
 
     def update_event
-      ics = IcalFormatters::Ics.from_payload(agents_rdv.rdv.payload(action: :update, recipient: agents_rdv.agent)).to_ical
+      payload = agents_rdv.rdv.payload(action: :update, recipient: agents_rdv.agent, sensitive_data: agent.caldav_include_sensitive_data)
+      ics = IcalFormatters::Ics.from_payload(payload).to_ical
       agent.caldav_client.events.update(agents_rdv.caldav_url, ics)
     end
 

--- a/app/jobs/caldav/mass_destroy_events_and_absences_job.rb
+++ b/app/jobs/caldav/mass_destroy_events_and_absences_job.rb
@@ -12,7 +12,7 @@ module Caldav
 
       ExternalCalendarEvent.where(agent:).delete_all
 
-      agent.update!(caldav_username: nil, caldav_password: nil, caldav_agenda_url: nil, caldav_disconnect_started_at: nil, caldav_sync_token: nil)
+      agent.update!(caldav_username: nil, caldav_password: nil, caldav_agenda_url: nil, caldav_disconnect_started_at: nil, caldav_sync_token: nil, caldav_include_sensitive_data: false)
     end
 
     private

--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -1,5 +1,6 @@
 class Agents::RdvMailer < ApplicationMailer
   include DateHelper
+
   helper DateHelper
 
   before_action do
@@ -12,7 +13,7 @@ class Agents::RdvMailer < ApplicationMailer
   default to: -> { @agent.email }
 
   def rdv_created
-    self.ics_payload = @rdv.payload(:create, @agent)
+    self.ics_payload = @rdv.payload(action: :create, recipient: @agent)
     subject = "Nouveau RDV ajouté pour #{relative_date(@rdv.starts_at)} sur votre agenda #{domain.name}"
     mail(subject: subject)
   end
@@ -21,14 +22,14 @@ class Agents::RdvMailer < ApplicationMailer
     @participation = params[:participation]
     @user = @participation.user
     @rdv = @participation.rdv
-    self.ics_payload = @rdv.payload(:create, @agent)
+    self.ics_payload = @rdv.payload(action: :create, recipient: @agent)
     subject = "Nouvelle participation au RDV collectif #{relative_date_with_preposition(@rdv.starts_at)} sur votre agenda #{domain.name}"
     mail(subject: subject)
   end
 
   def rdv_cancelled(old_starts_at: nil)
     date = old_starts_at || @rdv.starts_at
-    self.ics_payload = @rdv.payload(:destroy, @agent)
+    self.ics_payload = @rdv.payload(action: :destroy, recipient: @agent)
     subject = "RDV #{relative_date_with_preposition(date)} annulé"
     mail(subject: subject)
   end
@@ -37,7 +38,7 @@ class Agents::RdvMailer < ApplicationMailer
     @participation = params[:participation]
     @user = @participation.user
     @rdv = @participation.rdv
-    self.ics_payload = @rdv.payload(:create, @agent)
+    self.ics_payload = @rdv.payload(action: :create, recipient: @agent)
     subject = "Participation au RDV collectif #{relative_date_with_preposition(@rdv.starts_at)} annulée sur votre agenda #{domain.name}"
     mail(subject: subject)
   end
@@ -45,7 +46,7 @@ class Agents::RdvMailer < ApplicationMailer
   def rdv_updated(old_starts_at:, lieu_id:)
     @old_starts_at = old_starts_at
     @address_name = Lieu.find(lieu_id).full_name if lieu_id
-    self.ics_payload = @rdv.payload(:update, @agent)
+    self.ics_payload = @rdv.payload(action: :update, recipient: @agent)
     subject = "RDV #{relative_date_with_preposition(@old_starts_at)} modifié"
     mail(subject: subject)
   end

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -1,5 +1,6 @@
 class Users::RdvMailer < ApplicationMailer
   include DateHelper
+
   helper UsersHelper
   helper RdvsHelper
   helper DateHelper
@@ -14,7 +15,7 @@ class Users::RdvMailer < ApplicationMailer
   default to: -> { @user.email }
 
   def rdv_created
-    self.ics_payload = @rdv.payload(:create, @user)
+    self.ics_payload = @rdv.payload(action: :create, recipient: @user)
     subject = t("users.rdv_mailer.rdv_created.title", date: l(@rdv.starts_at, format: :human))
     mail(subject: subject)
     save_receipt(subject)
@@ -24,21 +25,21 @@ class Users::RdvMailer < ApplicationMailer
     @old_starts_at = old_starts_at
     @address_name = Lieu.find(lieu_id).full_name if lieu_id
 
-    self.ics_payload = @rdv.payload(:update, @user)
+    self.ics_payload = @rdv.payload(action: :update, recipient: @user)
     subject = t("users.rdv_mailer.rdv_updated.title", date: l(@old_starts_at, format: :human))
     mail(subject: subject)
     save_receipt(subject)
   end
 
   def rdv_upcoming_reminder
-    self.ics_payload = @rdv.payload(nil, @user)
+    self.ics_payload = @rdv.payload(recipient: @user)
     subject = t("users.rdv_mailer.rdv_upcoming_reminder.title", date: l(@rdv.starts_at, format: :human))
     mail(subject: subject)
     save_receipt(subject)
   end
 
   def rdv_cancelled
-    self.ics_payload = @rdv.payload(:destroy, @user)
+    self.ics_payload = @rdv.payload(action: :destroy, recipient: @user)
     subject = t("users.rdv_mailer.rdv_cancelled.title", date: l(@rdv.starts_at, format: :human), organisation: @rdv.organisation.name)
     mail(subject: subject)
     save_receipt(subject)

--- a/app/models/concerns/ics_payloads/rdv.rb
+++ b/app/models/concerns/ics_payloads/rdv.rb
@@ -1,6 +1,6 @@
 module IcsPayloads
   module Rdv
-    def payload(action = nil, recipient = users.first, sensitive_data = false)
+    def payload(action: nil, recipient: users.first, sensitive_data: false) # rubocop:disable Lint/UnusedMethodArgument
       payload = {
         attachement_filename: "rdv-#{motif&.name&.parameterize}-#{starts_at.strftime('%Y-%m-%d-%Hh%M')}.ics",
         starts_at: starts_at,
@@ -25,7 +25,7 @@ module IcsPayloads
       payload
     end
 
-    def ics_location(sensitive_data = false)
+    def ics_location(sensitive_data: false) # rubocop:disable Lint/UnusedMethodArgument
       if motif.phone?
         # TODO: numéro de téléphone si RDV tel + données sensibles activés
         nil

--- a/app/models/concerns/ics_payloads/rdv.rb
+++ b/app/models/concerns/ics_payloads/rdv.rb
@@ -1,6 +1,6 @@
 module IcsPayloads
   module Rdv
-    def payload(action = nil, recipient = users.first)
+    def payload(action = nil, recipient = users.first, sensitive_data = false)
       payload = {
         attachement_filename: "rdv-#{motif&.name&.parameterize}-#{starts_at.strftime('%Y-%m-%d-%Hh%M')}.ics",
         starts_at: starts_at,
@@ -25,8 +25,9 @@ module IcsPayloads
       payload
     end
 
-    def ics_location
+    def ics_location(sensitive_data = false)
       if motif.phone?
+        # TODO: numéro de téléphone si RDV tel + données sensibles activés
         nil
       elsif motif.visio?
         visio_url

--- a/app/models/concerns/ics_payloads/rdv.rb
+++ b/app/models/concerns/ics_payloads/rdv.rb
@@ -1,19 +1,19 @@
 module IcsPayloads
   module Rdv
-    def payload(action: nil, recipient: users.first, sensitive_data: false) # rubocop:disable Lint/UnusedMethodArgument
+    def payload(action: nil, recipient: users.first, sensitive_data: false)
       payload = {
         attachement_filename: "rdv-#{motif&.name&.parameterize}-#{starts_at.strftime('%Y-%m-%d-%Hh%M')}.ics",
         starts_at: starts_at,
         ends_at: ends_at,
         ical_uid: uuid,
-        summary: "RDV #{motif&.name}",
-        location: ics_location,
+        summary: ics_summary(recipient: recipient, sensitive_data: sensitive_data),
+        location: ics_location(sensitive_data: sensitive_data),
         domain: domain,
         status: ics_status,
         tzid: organisation&.time_zone,
       }
 
-      payload[:description] = ics_description(recipient)
+      payload[:description] = ics_description(recipient, sensitive_data: sensitive_data)
 
       # NOTE: for agents, we include all agents as the attendees. This also changes the method from PUBLISH to REQUEST.
       if recipient.is_a? Agent
@@ -25,36 +25,64 @@ module IcsPayloads
       payload
     end
 
-    def ics_location(sensitive_data: false) # rubocop:disable Lint/UnusedMethodArgument
-      if motif.phone?
-        # TODO: numéro de téléphone si RDV tel + données sensibles activés
-        nil
-      elsif motif.visio?
-        visio_url
-      else
-        address
+    def ics_location(sensitive_data: false)
+      case motif.location_type.to_sym
+      when :phone then users.first&.phone_number_formatted if sensitive_data
+      when :visio then visio_url
+      when :home then users.first&.address if sensitive_data
+      else address
       end
     end
 
-    def ics_description(recipient) # rubocop:disable Metrics/CyclomaticComplexity
-      description = ""
-      description += "RDV Téléphonique " if motif.phone?
-      description += "RDV par visioconférence " if motif.visio?
-      description += case recipient
-                     when User
-                       "Infos et annulation: #{Rails.application.routes.url_helpers.rdvs_short_url(host: domain.host_name)}"
-                     when Agent
-                       "Voir sur #{domain.name}: #{Rails.application.routes.url_helpers.admin_organisation_rdv_url(organisation_id, self, host: domain.host_name)}"
-                     end
-
-      if recipient.is_a?(Agent) && rdv_plan&.dossier_url
-        description += "\nVoir sur #{rdv_plan.oauth_application&.name}: #{rdv_plan.dossier_url}"
-      end
-
+    def ics_description(recipient, sensitive_data: false)
+      description = ics_description_prefix
+      description += ics_description_link(recipient)
+      description += ics_description_dossier_link(recipient)
+      description += ics_description_context(recipient, sensitive_data)
       description
     end
 
     private
+
+    def ics_description_prefix
+      description = ""
+      description += "RDV Téléphonique " if motif.phone?
+      description += "RDV par visioconférence " if motif.visio?
+      description
+    end
+
+    def ics_description_link(recipient)
+      case recipient
+      when User
+        "Infos et annulation: #{Rails.application.routes.url_helpers.rdvs_short_url(host: domain.host_name)}"
+      when Agent
+        "Voir sur #{domain.name}: #{Rails.application.routes.url_helpers.admin_organisation_rdv_url(organisation_id, self, host: domain.host_name)}"
+      else
+        ""
+      end
+    end
+
+    def ics_description_dossier_link(recipient)
+      return "" unless recipient.is_a?(Agent) && rdv_plan&.dossier_url
+
+      "\nVoir sur #{rdv_plan.oauth_application&.name}: #{rdv_plan.dossier_url}"
+    end
+
+    def ics_description_context(recipient, sensitive_data)
+      return "" unless sensitive_data && recipient.is_a?(Agent) && context.present?
+
+      "\nContexte : #{context}"
+    end
+
+    def ics_summary(recipient:, sensitive_data:)
+      if motif.collectif?
+        "RDV collectif - #{motif&.name}"
+      elsif sensitive_data
+        "RDV avec #{recipient.full_name} - #{motif&.name}"
+      else
+        "RDV #{motif&.name}"
+      end
+    end
 
     def ics_status
       if cancelled?

--- a/app/models/concerns/ics_payloads/rdv.rb
+++ b/app/models/concerns/ics_payloads/rdv.rb
@@ -6,7 +6,7 @@ module IcsPayloads
         starts_at: starts_at,
         ends_at: ends_at,
         ical_uid: uuid,
-        summary: ics_summary(recipient: recipient, sensitive_data: sensitive_data),
+        summary: ics_summary(sensitive_data: sensitive_data),
         location: ics_location(sensitive_data: sensitive_data),
         domain: domain,
         status: ics_status,
@@ -74,11 +74,11 @@ module IcsPayloads
       "\nContexte : #{context}"
     end
 
-    def ics_summary(recipient:, sensitive_data:)
+    def ics_summary(sensitive_data:)
       if motif.collectif?
         "RDV collectif - #{motif&.name}"
       elsif sensitive_data
-        "RDV avec #{recipient.full_name} - #{motif&.name}"
+        "RDV avec #{users.first.full_name} - #{motif&.name}"
       else
         "RDV #{motif&.name}"
       end

--- a/app/models/concerns/ics_payloads/rdv.rb
+++ b/app/models/concerns/ics_payloads/rdv.rb
@@ -76,9 +76,9 @@ module IcsPayloads
 
     def ics_summary(sensitive_data:)
       if motif.collectif?
-        "RDV collectif - #{motif&.name}"
+        motif&.name
       elsif sensitive_data
-        "RDV avec #{users.first.full_name} - #{motif&.name}"
+        "#{users.first.full_name} - #{motif&.name}"
       else
         "RDV #{motif&.name}"
       end

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -57,4 +57,10 @@ p
     .fr-input-group
       label.fr-label for="caldav_agenda_url" URL de l’agenda CalDAV
       input#caldav_agenda_url.fr-input type="text" name="caldav_agenda_url"
+    .fr-checkbox-group.mb-3
+      input#caldav_include_sensitive_data.fr-checkbox.fr-input type="checkbox" name="caldav_include_sensitive_data"
+      label.fr-label for="caldav_include_sensitive_data"
+        | Inclure les données sensibles (nom, adresse, contexte du RDV)
+        span.fr-hint-text
+          | En cochant cette case, vous prenez la responsabilité de copier des données personnelles en dehors de cette plateforme
     = submit_tag "Enregistrer", class: "fr-btn"

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -57,10 +57,21 @@ p
     .fr-input-group
       label.fr-label for="caldav_agenda_url" URL de l’agenda CalDAV
       input#caldav_agenda_url.fr-input type="text" name="caldav_agenda_url"
-    .fr-checkbox-group.mb-3
-      input#caldav_include_sensitive_data.fr-checkbox.fr-input type="checkbox" name="caldav_include_sensitive_data"
-      label.fr-label for="caldav_include_sensitive_data"
-        | Inclure les données sensibles (nom, adresse, contexte du RDV)
-        span.fr-hint-text
-          | En cochant cette case, vous prenez la responsabilité de copier des données personnelles en dehors de cette plateforme
+    fieldset.fr-fieldset
+      legend.fr-fieldset__legend--regular.fr-fieldset__legend
+        | Données personnelles dans l'agenda externe
+      .fr-fieldset__element
+        .fr-radio-group
+          input#caldav_include_sensitive_data_false type="radio" name="caldav_include_sensitive_data" value="false" checked="checked"
+          label.fr-label for="caldav_include_sensitive_data_false"
+            | Anonymiser les informations du rendez-vous
+            span.fr-hint-text
+              | Cette option vous permet de ne pas transmettre de données personnelles liées aux rendez-vous à votre agenda externe.
+      .fr-fieldset__element
+        .fr-radio-group
+          input#caldav_include_sensitive_data_true type="radio" name="caldav_include_sensitive_data" value="true"
+          label.fr-label for="caldav_include_sensitive_data_true"
+            | Inclure les données personnelles liées au rendez-vous dans mon agenda externe
+            span.fr-hint-text
+              | Cette option est plus pratique, mais les autres personnes qui ont accès à votre agenda externe auront accès aux données personnelles liées au rendez-vous.
     = submit_tag "Enregistrer", class: "fr-btn"

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -106,6 +106,7 @@ tables:
       - caldav_agenda_url
       - caldav_username
       - caldav_password
+      - caldav_include_sensitive_data
       - caldav_sync_token
       - sensitive_account
     non_anonymized_column_names:

--- a/db/migrate/20260505142243_add_caldav_include_sensitive_data_to_agents.rb
+++ b/db/migrate/20260505142243_add_caldav_include_sensitive_data_to_agents.rb
@@ -1,0 +1,5 @@
+class AddCaldavIncludeSensitiveDataToAgents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :agents, :caldav_include_sensitive_data, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_01_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_05_142243) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -157,6 +157,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_01_000001) do
     t.boolean "sensitive_account", default: false, null: false
     t.datetime "caldav_disconnect_started_at"
     t.boolean "display_extended_hours", default: false, null: false
+    t.boolean "caldav_include_sensitive_data", default: false, null: false
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true

--- a/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
+++ b/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe Caldav::ExportRdvToCaldavJob do
       described_class.new.perform(agents_rdv.id, agent.id)
       expect(agents_rdv.reload.caldav_url).to eq("https://caldav.example.com/event.ics")
     end
+
+    it "envoie un ICS sans données personnelles" do
+
+    end
+
+    context "quand l’agent a activé l’option permettant d’envoyer les données personnelles" do
+
+    end
   end
 
   context "quand l'agents_rdv existe avec une caldav_url (mise à jour)" do

--- a/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
+++ b/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
@@ -40,14 +40,6 @@ RSpec.describe Caldav::ExportRdvToCaldavJob do
       described_class.new.perform(agents_rdv.id, agent.id)
       expect(agents_rdv.reload.caldav_url).to eq("https://caldav.example.com/event.ics")
     end
-
-    it "envoie un ICS sans données personnelles" do
-
-    end
-
-    context "quand l’agent a activé l’option permettant d’envoyer les données personnelles" do
-
-    end
   end
 
   context "quand l'agents_rdv existe avec une caldav_url (mise à jour)" do

--- a/spec/models/concerns/ics_payloads/rdv_spec.rb
+++ b/spec/models/concerns/ics_payloads/rdv_spec.rb
@@ -34,10 +34,21 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
     describe ":description" do
       let(:user) { build(:user) }
       let(:agent) { build(:agent) }
-      let(:rdv) { create(:rdv, users: [user], agents: [agent]) }
+      let(:rdv) { create(:rdv, users: [user], agents: [agent], context: "Ceci est un RDV pour faire un passeport") }
 
       it "provides a link to the RDV index for users" do
         expect(rdv.payload[:description]).to eq("Infos et annulation: http://www.rdv-solidarites-test.localhost/r")
+      end
+
+      it "does not display the context" do
+        expect(rdv.payload[:description]).not_to include("Ceci est un RDV pour faire un passeport")
+      end
+
+      context "when sensitive data is enabled" do
+        it "includes the context in the description for agent only" do
+          expect(rdv.payload(nil, agent, true)[:description]).to include("Contexte : Ceci est un RDV pour faire un passeport")
+          expect(rdv.payload(nil, user, true)[:description]).not_to include("Contexte : Ceci est un RDV pour faire un passeport")
+        end
       end
 
       context "with a visio motif" do
@@ -75,12 +86,30 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
         let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :by_phone)) }
 
         it { expect(rdv.payload[:location]).to be_nil }
+
+        context "with sensitive data enabled" do
+          it "includes the phone number in the location" do
+            expect(rdv.payload(nil, rdv.users.first, true)[:location]).to eq(user.phone_number_formatted)
+          end
+        end
       end
 
-      context "without a phone motif" do
+      context "with a public office motif" do
         let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :public_office), lieu: build(:lieu, address: "17 rue de l'adresse, Paris, 75016")) }
 
         it { expect(rdv.payload[:location]).to eq("17 rue de l'adresse, Paris, 75016") }
+      end
+
+      context "with a home motif" do
+        let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :home)) }
+
+        it { expect(rdv.payload[:location]).to eq(nil) }
+
+        context "with sensitive data enabled" do
+          it "includes the address in the location" do
+            expect(rdv.payload(nil, rdv.users.first, true)[:location]).to eq(user.address)
+          end
+        end
       end
 
       context "with a visio motif" do
@@ -103,7 +132,33 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
       let(:user) { build(:user, first_name: "Ethan", last_name: "DUVAL") }
       let(:rdv) { build(:rdv, users: [user], motif: build(:motif, name: "Consultation")) }
 
-      it { expect(rdv.payload[:summary]).to eq("RDV Consultation") }
+      context "with sensitive data enabled" do
+        it "includes the user's name in the summary" do
+          expect(rdv.payload(nil, rdv.users.first, true)[:summary]).to eq("RDV avec Ethan DUVAL - Consultation")
+        end
+
+        context "when RDV is collectif" do
+          let(:rdv) { build(:rdv, users: [user], motif: build(:motif, name: "Atelier", collectif: true)) }
+
+          it "display motif name" do
+            expect(rdv.payload(nil, rdv.users.first, true)[:summary]).to eq("RDV collectif - Atelier")
+          end
+        end
+      end
+
+      context "with sensitive data disabled" do
+        it "does not include the user's name in the summary" do
+          expect(rdv.payload[:summary]).to eq("RDV Consultation")
+        end
+
+        context "when RDV is collectif" do
+          let(:rdv) { build(:rdv, users: [user], motif: build(:motif, name: "Atelier", collectif: true)) }
+
+          it "display motif name" do
+            expect(rdv.payload(nil, rdv.users.first, true)[:summary]).to eq("RDV collectif - Atelier")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/concerns/ics_payloads/rdv_spec.rb
+++ b/spec/models/concerns/ics_payloads/rdv_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
 
       context "when sensitive data is enabled" do
         it "includes the context in the description for agent only" do
-          expect(rdv.payload(nil, agent, true)[:description]).to include("Contexte : Ceci est un RDV pour faire un passeport")
-          expect(rdv.payload(nil, user, true)[:description]).not_to include("Contexte : Ceci est un RDV pour faire un passeport")
+          expect(rdv.payload(recipient: agent, sensitive_data: true)[:description]).to include("Contexte : Ceci est un RDV pour faire un passeport")
+          expect(rdv.payload(recipient: user, sensitive_data: true)[:description]).not_to include("Contexte : Ceci est un RDV pour faire un passeport")
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
       context "when sending to an agent" do
         it "provides a link to the RDV in the agent interface" do
           description = "Voir sur RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{rdv.organisation_id}/rdvs/#{rdv.id}"
-          expect(rdv.payload(nil, agent)[:description]).to eq(description)
+          expect(rdv.payload(recipient: agent)[:description]).to eq(description)
         end
 
         context "when there is a link to a dossier in an external app" do
@@ -73,7 +73,7 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
           let(:oauth_application) { create(:oauth_application, name: "Démarches Simplifiées") }
 
           it "provides the link in the description" do
-            expect(rdv.payload(nil, agent)[:description]).to include("Voir sur Démarches Simplifiées: http://demarches-simplifies.test/exemple")
+            expect(rdv.payload(recipient: agent)[:description]).to include("Voir sur Démarches Simplifiées: http://demarches-simplifies.test/exemple")
           end
         end
       end
@@ -89,7 +89,7 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
 
         context "with sensitive data enabled" do
           it "includes the phone number in the location" do
-            expect(rdv.payload(nil, rdv.users.first, true)[:location]).to eq(user.phone_number_formatted)
+            expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:location]).to eq(user.phone_number_formatted)
           end
         end
       end
@@ -103,11 +103,11 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
       context "with a home motif" do
         let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :home)) }
 
-        it { expect(rdv.payload[:location]).to eq(nil) }
+        it { expect(rdv.payload[:location]).to be_nil }
 
         context "with sensitive data enabled" do
           it "includes the address in the location" do
-            expect(rdv.payload(nil, rdv.users.first, true)[:location]).to eq(user.address)
+            expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:location]).to eq(user.address)
           end
         end
       end
@@ -134,14 +134,14 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
 
       context "with sensitive data enabled" do
         it "includes the user's name in the summary" do
-          expect(rdv.payload(nil, rdv.users.first, true)[:summary]).to eq("RDV avec Ethan DUVAL - Consultation")
+          expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:summary]).to eq("RDV avec Ethan DUVAL - Consultation")
         end
 
         context "when RDV is collectif" do
           let(:rdv) { build(:rdv, users: [user], motif: build(:motif, name: "Atelier", collectif: true)) }
 
           it "display motif name" do
-            expect(rdv.payload(nil, rdv.users.first, true)[:summary]).to eq("RDV collectif - Atelier")
+            expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:summary]).to eq("RDV collectif - Atelier")
           end
         end
       end
@@ -155,7 +155,7 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
           let(:rdv) { build(:rdv, users: [user], motif: build(:motif, name: "Atelier", collectif: true)) }
 
           it "display motif name" do
-            expect(rdv.payload(nil, rdv.users.first, true)[:summary]).to eq("RDV collectif - Atelier")
+            expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:summary]).to eq("RDV collectif - Atelier")
           end
         end
       end

--- a/spec/models/concerns/ics_payloads/rdv_spec.rb
+++ b/spec/models/concerns/ics_payloads/rdv_spec.rb
@@ -134,14 +134,14 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
 
       context "with sensitive data enabled" do
         it "includes the user's name in the summary" do
-          expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:summary]).to eq("RDV avec Ethan DUVAL - Consultation")
+          expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:summary]).to eq("Ethan DUVAL - Consultation")
         end
 
         context "when RDV is collectif" do
           let(:rdv) { build(:rdv, users: [user], motif: build(:motif, name: "Atelier", collectif: true)) }
 
           it "display motif name" do
-            expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:summary]).to eq("RDV collectif - Atelier")
+            expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:summary]).to eq("Atelier")
           end
         end
       end
@@ -155,7 +155,7 @@ RSpec.describe IcsPayloads::Rdv, type: :service do
           let(:rdv) { build(:rdv, users: [user], motif: build(:motif, name: "Atelier", collectif: true)) }
 
           it "display motif name" do
-            expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:summary]).to eq("RDV collectif - Atelier")
+            expect(rdv.payload(recipient: rdv.users.first, sensitive_data: true)[:summary]).to eq("Atelier")
           end
         end
       end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6351.osc-secnum-fr1.scalingo.io/)

Closes #6346

# Contexte

Voir issue

Pour cette première PR, on a fait le choix de s’occuper uniquement de la synchronisation CalDav car il s’agit de la plus demandée et de la plus safe.

# Solution

On a refacto le payload pour utiliser des keywords args, et permettre de spécifier que nous voulons les données sensibles.

La génération de payload commence à être un peu lourde et un peu confuse notamment du fait qu’on utilise le même fichier pour la partie agent et la partie usager. On prévoit un split dans une prochaine PR, mais pour ce sujet de cooldown on reste là.

<img width="725" height="345" alt="image" src="https://github.com/user-attachments/assets/d2102098-9252-44ce-8398-f7fb5449914e" />

