### PR TITLE
Lien vers l’annuaire des entreprises pour les espaces dans le SuperAdmin

### DIFF
--- a/app/dashboards/territory_dashboard.rb
+++ b/app/dashboards/territory_dashboard.rb
@@ -21,7 +21,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     work_on_sunday: Field::Boolean,
-    siret: Field::String,
+    siret: SiretField,
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/fields/siret_field.rb
+++ b/app/fields/siret_field.rb
@@ -1,0 +1,5 @@
+require "administrate/field/base"
+
+class SiretField < Administrate::Field::Base
+  delegate :to_s, to: :data
+end

--- a/app/views/fields/siret_field/_form.html.slim
+++ b/app/views/fields/siret_field/_form.html.slim
@@ -1,0 +1,4 @@
+.field-unit__label
+  = f.label field.attribute
+.field-unit__field
+  = f.text_field field.attribute, class: "text-input"

--- a/app/views/fields/siret_field/_index.html.slim
+++ b/app/views/fields/siret_field/_index.html.slim
@@ -1,0 +1,2 @@
+- if field.data.present?
+  = field.data

--- a/app/views/fields/siret_field/_show.html.slim
+++ b/app/views/fields/siret_field/_show.html.slim
@@ -1,0 +1,5 @@
+- if field.data.present?
+  => field.data
+  = "("
+  = link_to "voir dans l'annuaire des entreprises", "https://annuaire-entreprises.data.gouv.fr/etablissement/#{field.data}", target: "_blank"
+  = ")"


### PR DESCRIPTION
# Contexte

Maintenant que nous avons les SIRETs au sein des espaces, on affiche un lien dans le SuperAdmin pour accéder facilement à la fiche de l’annuaire des entreprises pour ce SIRET.

# Solution

<img width="737" height="284" alt="image" src="https://github.com/user-attachments/assets/ee3a6dbc-6b72-4f10-8410-f4e5c6cb0075" />
