### PR TITLE
Indiquer le statut des synchros de calendrier

### DIFF
--- a/app/views/agents/calendar_sync/show.html.slim
+++ b/app/views/agents/calendar_sync/show.html.slim
@@ -6,20 +6,32 @@ p
 div.d-flex.justify-content-center.align-items-center.flex-wrap
   div.card.w-100
     div.card-body
-      h5.card-title CalDAV
+      h5.card-title
+        span CalDAV
+        - if current_agent.caldav_configured?
+          span.ml-2.fr-badge.fr-badge--success Synchronisation active
       p.fr-badge.fr-badge--pink-tuile Beta
       p
         |> Vos rendez-vous RDV Service Public s’ajoutent automatiquement à votre agenda externe.
         |> Les événements de votre agenda externe sont utilisés pour vérifier les conflits et éviter toute double réservation.
       div.rdv-text-align-center
-        = link_to "Synchronisation CalDAV", agents_calendar_sync_caldav_sync_path, class: "fr-btn"
+        - if current_agent.caldav_configured?
+          = link_to "Gérer la connexion avec mon agenda Caldav", agents_calendar_sync_caldav_sync_path, class: "fr-btn fr-btn--secondary"
+        - else
+          = link_to "Connecter mon agenda via Caldav", agents_calendar_sync_caldav_sync_path, class: "fr-btn fr-btn--primary"
 
   div.card.w-100
     div.card-body
-      h5.card-title Connexion Outlook (Microsoft 365)
+      h5.card-title
+        span Connexion Outlook (Microsoft 365)
+        - if current_agent.connected_to_outlook?
+          span.ml-2.fr-badge.fr-badge--success Synchronisation active
       p Vos rendez-vous seront synchronisés automatiquement dans votre agenda Outlook.
       div.rdv-text-align-center
-        = link_to "Connecter mon compte Outlook (Microsoft 365)", agents_calendar_sync_outlook_sync_path, class: "fr-btn"
+        - if current_agent.connected_to_outlook?
+          = link_to "Gérer la connexion avec mon compte Outlook", agents_calendar_sync_outlook_sync_path, class: "fr-btn fr-btn--secondary"
+        - else
+          = link_to "Connecter mon compte Outlook (Microsoft 365)", agents_calendar_sync_outlook_sync_path, class: "fr-btn fr-btn--primary"
 
   - if current_agent.calendar_uid.present?
     div.card.w-100
@@ -30,7 +42,10 @@ div.d-flex.justify-content-center.align-items-center.flex-wrap
         div.rdv-text-align-center
           = link_to "Synchronisation par lien Webcal", agents_calendar_sync_webcal_sync_path, class: "fr-btn fr-btn--secondary"
 
-  h2.fr-h6 Notifications par email
-  p.fr-col-12 Vous pouvez aussi recevoir un email avec une invitation ics pour chaque rendez-vous, absence et plage d'ouverture.
-  div.rdv-text-align-center
-    = link_to t("agents.preferences.show.title"), agents_preferences_path, class: "fr-btn fr-btn--secondary"
+  div.card.w-100
+    div.card-body
+      h5.card-title
+        span Notifications par email
+      p.fr-col-12 Vous pouvez aussi recevoir un email avec une invitation ics pour chaque rendez-vous, absence et plage d'ouverture.
+      div.rdv-text-align-center
+        = link_to t("agents.preferences.show.title"), agents_preferences_path, class: "fr-btn fr-btn--secondary"


### PR DESCRIPTION
# Contexte

Nous souhaitons que la page de configuration des synchros indique mieux l'état actuel des synchros.

Ceci est un petit premier pas pour améliorer l'existant sans atteindre la perfection.

# Solution

- Ajouter un badge `Synchronisation active` à côté du titre de la section
- Changer le wording du bouton de synchro si elle est active
- Changer la sémantique du bouton : bouton primaire pour activer une synchro, bouton secondaire pour géré une synchro déjà active
- Même look et même logique pour la synchro par e-mail via pièce jointe ICS (pourquoi pas ?)

# Captures d'écran

(synchro Caldav activée, Outlook non activée)

## Avant

<img width="1398" height="1236" alt="image" src="https://github.com/user-attachments/assets/91d8db7c-4b53-4325-922b-ad81572c394c" />

## Après

<img width="1398" height="1236" alt="image" src="https://github.com/user-attachments/assets/2fc484a4-2a0e-4cbd-9bbc-98a419d61cfa" />
