### PR TITLE
Liste des RDV : revenir à la page 1 quand on adapte la taille de page

### DIFF
--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -56,7 +56,7 @@
           span.mr-2.fr-pt-1v Nombre de RDV par page :
           .fr-pagination__list.rdv-per-page-list
             - Admin::RdvsController::PERMITTED_PER_PAGE.each do |per|
-              - path = admin_organisation_rdvs_path(@form.to_query.merge(per:, page: params[:page], organisation_id: current_organisation.id))
+              - path = admin_organisation_rdvs_path(@form.to_query.merge(per:, page: 1, organisation_id: current_organisation.id))
               - if per == params.fetch(:per, 10).to_i
                 = link_to per, path, class: "fr-pagination__link fr-pagination__link--current", "aria-current": "page"
               - else


### PR DESCRIPTION
# Contexte

Ce bug a été remonté au support le 28 avril 2026 : 

> [...] sur cet écran « Liste des RDV », l’affichage est en erreur (vide) lorsque je choisi « 25 RDV par page » ou « 50 RDV par page ».

https://zammad10.ethibox.fr/#ticket/zoom/38592

## Capture d'écran du bug

<img width="1129" height="381" alt="image" src="https://github.com/user-attachments/assets/d17a7d2e-8d98-48cd-bbc3-2859ef306462" />

## Comprendre le bug

Le problème est que nous conservons le numéro de page quand nous changeons la taille de page. 

Si nous avons par exemple 3200 RDV, affichés 10 par page, la dernière page est la 320. Mais si nous voulons en affichons 25 par page, alors la dernière page est la page 128 (3200 / 25). Et donc si l'on visite un numero de page supérieur à 128, il n'affichera aucun RDV, car cet interval est "hors limite".

## Pour reproduire

1. Visiter la dernière page de la liste des RDV
2. Cliquer sur "Nombre de RDV par page : 25"
3. La liste est vide

# Solution

Je propose de revenir à la page 1 lorsqu'on change de taille de page.

J'ai songé à faire des calculs pour garder le premier élément de la page, mais je pense que cette complexité n'est pas nécessaire.

Une solution future qui serait peut-être meilleure : utiliser une pagination par seuil, du genre `&startsAfter=#{page.last.starts_at}`. Ça a pour avantage d'éviter des sauts dans la navigation si l'on ajoute ou supprime un RDV.
