### PR TITLE
Fixup #6342 (Éviter `Notion::Api::Errors::TooManyRequests`)

### DIFF
--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -18,20 +18,33 @@ class CronJob::SynchronizeCrm < CronJob
       ],
     }
 
+    jobs = []
     client.database_query(database_id: NOTION_DATABASE_ID, filter:) do |page|
-      page.results.each.with_index do |notion_page, index|
-        # Notion rate-limiting is 3 API calls per second, so we'll execute jobs every 400ms
-        SynchronizeCrmPageJob.set(wait: (index * 0.4).seconds).perform_later(
-          notion_page_id: notion_page.id,
-          account_url: notion_page.properties["COMPTE PROD"].url,
-          notion_page_url: notion_page.url,
-          notion_page_title: notion_page.properties["Project name"]["title"][0]["plain_text"]
-        )
+      page.results.each do |notion_page|
+        jobs << sync_job_for(notion_page)
       end
     end
+
+    # Notion rate-limiting is 3 API calls per second, so we'll execute jobs every 400ms
+    delay = 0.seconds
+    jobs.each do |job|
+      job.set(wait: delay)
+      delay += 0.4.seconds
+    end
+
+    ActiveJob.perform_all_later(jobs)
   end
 
   private
+
+  def sync_job_for(notion_page)
+    SynchronizeCrmPageJob.new(
+      notion_page_id: notion_page.id,
+      account_url: notion_page.properties["COMPTE PROD"].url,
+      notion_page_url: notion_page.url,
+      notion_page_title: notion_page.properties["Project name"]["title"][0]["plain_text"]
+    )
+  end
 
   def instance_hostname
     ENV["HOST"]

--- a/spec/jobs/cron_job/synchronize_crm_spec.rb
+++ b/spec/jobs/cron_job/synchronize_crm_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
       }
     )
   end
-  let(:page_of_results) { Notion::Messages::Message.new(results: [notion_page, notion_page, notion_page, notion_page]) }
+  let(:page_of_4_results) { Notion::Messages::Message.new(results: [notion_page, notion_page, notion_page, notion_page]) }
   let(:notion_client) { instance_double(Notion::Client) }
 
   before do
     allow(Notion::Client).to receive(:new).and_return(notion_client)
     # On simule 2 pages de résultats
-    allow(notion_client).to receive(:database_query).and_yield(page_of_results).and_yield(page_of_results)
+    allow(notion_client).to receive(:database_query).and_yield(page_of_4_results).and_yield(page_of_4_results)
   end
 
   context "quand la clef NOTION_API_SECRET n'est pas définie" do
@@ -36,15 +36,6 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
       ENV["NOTION_API_SECRET"] = "secret"
     end
 
-    let(:notion_pages) do
-      [
-        notion_page,
-        notion_page,
-        notion_page,
-        notion_page,
-      ]
-    end
-
     it "enqueue un job SynchronizeCrmPageJob pour chaque page Notion" do
       expect { described_class.new.perform }.to have_enqueued_job(SynchronizeCrmPageJob).with(
         notion_page_id: "page_id",
@@ -58,7 +49,6 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
 
       # Les jobs sont scheduled pour s'exécuter à 400 ms d'intervalle
       0.upto(6) do |i|
-        puts i.inspect
         expect(Time.zone.parse(enqueued_jobs[i + 1]["scheduled_at"]) - Time.zone.parse(enqueued_jobs[i]["scheduled_at"])).to be >= 0.4.seconds
       end
     end

--- a/spec/jobs/cron_job/synchronize_crm_spec.rb
+++ b/spec/jobs/cron_job/synchronize_crm_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
       }
     )
   end
+  let(:page_of_results) { Notion::Messages::Message.new(results: [notion_page, notion_page, notion_page, notion_page]) }
   let(:notion_client) { instance_double(Notion::Client) }
 
   before do
     allow(Notion::Client).to receive(:new).and_return(notion_client)
-    allow(notion_client).to receive(:database_query).and_yield(Notion::Messages::Message.new(results: [notion_page]))
+    # On simule 2 pages de résultats
+    allow(notion_client).to receive(:database_query).and_yield(page_of_results).and_yield(page_of_results)
   end
 
   context "quand la clef NOTION_API_SECRET n'est pas définie" do
@@ -34,13 +36,31 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
       ENV["NOTION_API_SECRET"] = "secret"
     end
 
+    let(:notion_pages) do
+      [
+        notion_page,
+        notion_page,
+        notion_page,
+        notion_page,
+      ]
+    end
+
     it "enqueue un job SynchronizeCrmPageJob pour chaque page Notion" do
       expect { described_class.new.perform }.to have_enqueued_job(SynchronizeCrmPageJob).with(
         notion_page_id: "page_id",
         account_url: compte_prod_url,
         notion_page_url: "https://notion.so/page",
         notion_page_title: "Mon projet"
-      )
+      ).exactly(8).times
+
+      # On a stubbé 2 pages de 4 résultats
+      expect(enqueued_jobs.size).to eq(8)
+
+      # Les jobs sont scheduled pour s'exécuter à 400 ms d'intervalle
+      0.upto(6) do |i|
+        puts i.inspect
+        expect(Time.zone.parse(enqueued_jobs[i + 1]["scheduled_at"]) - Time.zone.parse(enqueued_jobs[i]["scheduled_at"])).to be >= 0.4.seconds
+      end
     end
   end
 end


### PR DESCRIPTION
Mon implémentation du fix dans #6342 ne prenait pas en compte la pagination des résultats lors de l'appel à la liste des "pages" Notion. 

J'ai donc fait ici en sorte de récupérer tous les résultats, puis de calculer les temps d'intervalle d'exécutions dans une boucle séparée qui itère sur les résultats en mémoire.

J'en profite pour utiliser `ActiveJob.perform_all_later`, qui évite de faire 3000 appels `INSERT` à Postgres, ça ne mange pas de pain.