### PR TITLE
Upgrade gem DSFR Form Builder pour les champs select, 2e tentative

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,7 +129,7 @@ gem "rails_autolink"
 gem "active_link_to"
 gem "dsfr-assets", "~> 1.14.2"
 gem "dsfr-view-components", "~> 5.0.0"
-gem "dsfr-form_builder", "= 0.0.7" # On fixe la version tant qu’on est pas en 1.0
+gem "dsfr-form_builder", "= 0.0.14" # On fixe la version tant qu’on est pas en 1.0
 
 # Easily create styled HTML emails in Rails.
 gem "premailer-rails" # Mail formatting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
       railties (>= 3.2)
     drb (2.2.3)
     dsfr-assets (1.14.3)
-    dsfr-form_builder (0.0.7)
+    dsfr-form_builder (0.0.14)
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
@@ -811,7 +811,7 @@ DEPENDENCIES
   doorkeeper-i18n
   dotenv-rails
   dsfr-assets (~> 1.14.2)
-  dsfr-form_builder (= 0.0.7)
+  dsfr-form_builder (= 0.0.14)
   dsfr-view-components (~> 5.0.0)
   factory_bot
   faker
@@ -951,7 +951,7 @@ CHECKSUMS
   dotenv-rails (2.8.1) sha256=b05b81b7f4e51d1359e218d92279db1d84b12440f7118c9df19b5dfffb620f6c
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   dsfr-assets (1.14.3) sha256=132dae8bbe8ddbcc2cf90f598c0112f3956453cd3c40bcd58442427b4215d9f1
-  dsfr-form_builder (0.0.7) sha256=16165ee281de4645617fdb79c4fc03384f9125cbbdf6a149daa1ef2bb367ffde
+  dsfr-form_builder (0.0.14) sha256=d0acd0ee8bca09643b6025ea624ae62c632b9e15be9fb9ef891df54dd3386cda
   dsfr-view-components (5.0.0) sha256=549c252625f1e4d117007dacfbe7dc8a8e83aa8ddf54f81f2f1d7ba71f80c399
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9

--- a/app/views/admin/motifs/form/_configuration_principale.html.slim
+++ b/app/views/admin/motifs/form/_configuration_principale.html.slim
@@ -3,7 +3,7 @@
 - if motif.duplicated_from_motif && motif.new_record? && organisations_i_can_manage.count > 1
   .card
     .card-body
-      = f.dsfr_select :organisation_id, organisations_i_can_manage.sort.collect { |organisation| [organisation.name, organisation.id] }, label: "Créer le motif dans cette organisation", required: true
+      = f.dsfr_select :organisation_id, organisations_i_can_manage.sort.collect { |organisation| [organisation.name, organisation.id] }, label: "Créer le motif dans cette organisation"
 
 .card
   .card-body
@@ -18,7 +18,7 @@
       - available_services = (current_territory.services.reject(&:secretariat?) + [motif.service].compact).sort.uniq
       - if available_services.any? || motif.service_id.present?
         .fr-col-md-12
-          = f.dsfr_select :service_id, available_services.collect { |service| [service.name, service.id] }, label: "Service associé", include_blank: "Aucun", hint: "Optionnel"
+          = f.dsfr_select :service_id, available_services.collect { |service| [service.name, service.id] }, { include_blank: "Aucun" }, label: "Service associé", hint: "Optionnel"
       .fr-col-md-6= f.dsfr_number_field :default_duration_in_min, label: "Durée du RDV (en minutes)"
       // Le DSFR ne propose pas d’input color, on utilise donc le champ classique avec le style DSFR pour lequel on fixe la hauteur.
       .fr-col-md-6= f.dsfr_input_field :color, :color_field, label: "Couleur associée", style: "height: 2.5rem"

--- a/app/views/admin/motifs/form/_resa_en_ligne.html.slim
+++ b/app/views/admin/motifs/form/_resa_en_ligne.html.slim
@@ -68,7 +68,7 @@
 - if current_territory.motif_categories.present?
   .card
     .card-body
-      = f.dsfr_select :motif_category_id, current_territory.motif_categories.collect { |motif_categorie| [motif_categorie.name, motif_categorie.id] }, label: MotifCategory.model_name.human, hint: MotifCategory.human_attribute_name("category_hint"), include_blank: "Aucune"
+      = f.dsfr_select :motif_category_id, current_territory.motif_categories.collect { |motif_categorie| [motif_categorie.name, motif_categorie.id] }, { include_blank: "Aucune" }, label: MotifCategory.model_name.human, hint: MotifCategory.human_attribute_name("category_hint")
 
 - unless current_domain.online_reservation_with_public_link
   .card.collapse [data-motif-form-target="sectoSection"]

--- a/app/views/users/users/_form_fields.html.slim
+++ b/app/views/users/users/_form_fields.html.slim
@@ -50,9 +50,9 @@ div= f.dsfr_check_box :notify_by_sms
   - if f.object.show_caisse_affiliation_field? || f.object.show_affiliation_number_field?
     .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
       - if f.object.show_caisse_affiliation_field?
-        .fr-col-12.fr-col-md-6= f.dsfr_select :caisse_affiliation, User.human_attribute_values(:caisse_affiliation), include_blank: true
+        .fr-col-12.fr-col-md-6= f.dsfr_select :caisse_affiliation, User.human_attribute_values(:caisse_affiliation), { include_blank: true }
       - if f.object.show_affiliation_number_field?
         .fr-col-12.fr-col-md-6= f.dsfr_text_field :affiliation_number
 
   - if f.object.show_logement_field?
-    = f.dsfr_select :logement, User.human_attribute_values(:logement), include_blank: true
+    = f.dsfr_select :logement, User.human_attribute_values(:logement), { include_blank: true }


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6356.osc-secnum-fr1.scalingo.io/)

Réapplication de #6137 suite au revert #6201 : 

> le champ adresse du formulaire d'édition des lieux, l'autocomplete n'apparait plus. Le kwarg ne semble pas être correctement passé par dsfr_text_field

Le correctif est ici https://github.com/betagouv/dsfr-form-builder/pull/73 , le problème était que le kwarg `data` n'était plus passé correctement à l’input. ça corrige l’autocomplétion du champ adresse des lieux : 

<img width="543" height="195" alt="image" src="https://github.com/user-attachments/assets/7286ea2b-bb5f-4912-8049-f6c2aa0d401d" />


# Contexte

Il y a eu beaucoup de changements dans le dsfr-form-builder suite à des rapatriements de fonctionnalités depuis les forks / origines : https://github.com/betagouv/dsfr-form-builder/compare/0.0.7...v0.0.13

Le breaking change principal est que la signature de `f.dsfr_select` est maintenant alignée avec la signature du helper `select` natif cf https://github.com/betagouv/dsfr-form-builder/pull/58

Un des correctifs principaux est le support de disabled sur les selects justement : à ma connaissance on ne l'utilise que dans `Admins::Rdvs#edit`

<img width="1416" height="298" alt="image" src="https://github.com/user-attachments/assets/ab8b3bac-3e55-4f84-96a5-c632c589dcdb" />

# Solution & tests

J'ai vérifié manuellement en local tous les endroits où j'ai du modifier un peu les appels .

Par exemple ce `{include_blank: "Aucune"}`

<img width="667" height="217" alt="image" src="https://github.com/user-attachments/assets/6ed7b693-9350-4c68-a031-931eba895bdf" />


J'ai aussi fait un tour à la recherche des astérisques qui existent actuellement. Par exemple celles-ci dans le formulaire creation usager, qui restent bien après cette PR 


<img width="666" height="207" alt="image" src="https://github.com/user-attachments/assets/85d9d5c6-f883-4703-82fc-57b86ecd1ed4" />

(je pense que c'est rajouté par simple_form 🤷 )

ici sur le formulaire de connexion ça disparait, et je pense que c'est une bonne chose

<img width="836" height="937" alt="image" src="https://github.com/user-attachments/assets/12a8ee38-599e-4e3f-96c7-da1ccdf7692c" />

ici aussi ça disparait 

<img width="800" height="393" alt="image" src="https://github.com/user-attachments/assets/40cd7776-b506-40c3-9af6-0400f2a15585" />


