### PR TITLE
Ajoute `kmeet.infomaniak.com` aux domaines autorisés en visio custom

### DIFF
--- a/app/models/concerns/rdv/visio_concern.rb
+++ b/app/models/concerns/rdv/visio_concern.rb
@@ -9,6 +9,7 @@ module Rdv::VisioConcern
     meet.google.com
     zoom.us
     meet.jit.si
+    kmeet.infomaniak.com
   ].freeze
 
   VISIO_URL_TYPES = %w[default custom].freeze


### PR DESCRIPTION
Un agent nous indique que l'université de Brest utilise kMeet comme outil de visio ([ticket Zammad](https://zammad10.ethibox.fr/#ticket/zoom/38906)).

kMeet est une alternative européenne aux géants de la visio (Zoom, MS Teams, Google Meet) proposée par Infomaniak. 

> Infomaniak Network est une entreprise informatique suisse voulant proposer des services Cloud durables et centrés sur la confidentialité.
>
> https://fr.wikipedia.org/wiki/Infomaniak

Je pense qu'il est raisonnable de l'ajouter aux outils autorisés car la balance bénéfice / risque est bonne. Full disclosure : je suis client d'Infomaniak en perso car j'apprécie leurs valeurs et leurs produits.

Je reste partagé sur ce genre de décision, si il y a des objections je les prends.