### PR TITLE
Débugger nos appels à l'espace opérateur et le doc de changelog

### DIFF
--- a/app/lib/docs_numerique_changelog.rb
+++ b/app/lib/docs_numerique_changelog.rb
@@ -29,6 +29,7 @@ module DocsNumeriqueChangelog
         f.request :json
         f.response :json
         f.response :raise_error
+        f.use :sentry_breadcrumbs
       end
     end
   end

--- a/app/services/espace_operateur_anct.rb
+++ b/app/services/espace_operateur_anct.rb
@@ -52,6 +52,7 @@ class EspaceOperateurANCT
       faraday.headers = {
         "X-Service-Auth": ENV.fetch("ESPACE_OPERATEUR_ANCT_AUTH_TOKEN", nil),
       }
+      faraday.use :sentry_breadcrumbs
     end
   end
 


### PR DESCRIPTION
# Contexte

Nous avons une nouvelle erreur dans le fetch du doc de changelog, et je remarque que nous n'avons pas le contenu des appels HTTP en breadcrumb : https://sentry.incubateur.net/organizations/betagouv/issues/275487

# Solution

Utiliser le middleware Sentry pour Faraday.

Note : pas besoin de tests car le middleware est déjà testé unitairement dans `spec/initializers/faraday_sentry_breadcrumbs_middleware_spec.rb`.