### PR TITLE
Mise à jour des règles de refus d’ouverture espace

### DIFF
--- a/app/views/mailers/agents/territory_creation_request_mailer/refused.html.slim
+++ b/app/views/mailers/agents/territory_creation_request_mailer/refused.html.slim
@@ -8,7 +8,13 @@ p
   ul
     li Les administrations de l’État
     li Les opérateurs publics
-    li Les collectivités territoriales (communes de moins de 3500 habitants, intercommunalité de moins de 15 000 habitants, départements, régions)
+    li
+      | Les collectivités territoriales :
+      ul
+        li communes de moins de 3500 habitants avec un dispositif de recueil
+        li CCAS utilisant MSS
+        li France Services
+        li Conseils départementaux
     li Les associations mandatées dans le cadre d’une mission de service public
 
   |> Il est aussi possible que votre demande ait été refusée, car votre organisation possède déjà un espace sur #{domain.name}.


### PR DESCRIPTION
# Contexte

On met à jour le mail de refus d’ouverture de compte avec les nouvelles restrictions

Vu avec Léa



