### PR TITLE
correction de la cohérence des listes de RDV avec plusieurs agents

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -21,7 +21,7 @@ class Admin::RdvsController < AgentAuthController
 
     # On fait cette requête en deux temps pour éviter de faire un `order` et un `include` sur le même scope,
     # parce que ça fait un sort et beaucoup de left outer joins
-    @rdvs_in_page = Rdv.where(id: @rdvs.pluck(:id)).order(order).includes(
+    @rdvs_in_page = Rdv.where(id: @rdvs.reselect("DISTINCT ON (#{distinct_on}) rdvs.id")).order(order).includes(
       [
         :agents_rdvs, :organisation, :lieu, :motif,
         {

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -795,6 +795,21 @@ Rdv.create!(
   )
 end
 
+# 11 RDVs binôme Martine+Marco il y a 1 mois : ils apparaissent en tête de liste (tri starts_at ASC)
+# s'il y a des bugs de dedoublonnage ils seront visibles dans la pagination en dev
+11.times do |i|
+  Rdv.create!(
+    starts_at: 1.month.ago.beginning_of_day + 8.hours + (i * 30.minutes),
+    duration_in_min: 30,
+    motif_id: motif_org_paris_nord_pmi_suivi.id,
+    lieu: lieu_org_paris_nord_bolivar,
+    organisation_id: org_paris_nord.id,
+    agent_ids: [agent_org_paris_nord_pmi_martine.id, agent_org_paris_nord_pmi_marco.id],
+    user_ids: [user_org_paris_nord_patricia.id],
+    created_by: agent_org_paris_nord_pmi_martine
+  )
+end
+
 # Insert a lot of rdvs in the past 2 years
 # rubocop:disable Rails/SkipsModelValidations
 rdv_attributes = 1000.times.flat_map do |i|

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -55,13 +55,14 @@ RSpec.describe Admin::RdvsController, type: :controller do
     end
 
     context "quand il y a plus de RDVs que la limite par page et que certains ont plusieurs agents" do
-      it "rdvs_in_page ne contient pas plus de RDVs que la limite par page" do
+      it "rdvs_in_page contient le bon nombre de RDVs uniques : 10" do
         # Agent::RdvPolicy::Scope fait un INNER JOIN sur agents_rdvs, ce qui produit plusieurs lignes
         # par RDV quand celui-ci a plusieurs agents. Ce test s'assure qu'on dédoublonne correctement
 
         create_list(:rdv, 11, agents: [agent, agent2], organisation:, motif:)
         get :index, params: { organisation_id: organisation.id, per: 10 }
         expect(assigns(:rdvs_in_page).size).to eq(10)
+        expect(assigns(:rdvs_in_page).map(&:id).uniq.size).to eq(10)
       end
     end
   end

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe Admin::RdvsController, type: :controller do
         expect(response).to be_successful
       end
     end
+
+    context "quand il y a plus de RDVs que la limite par page et que certains ont plusieurs agents" do
+      it "rdvs_in_page ne contient pas plus de RDVs que la limite par page" do
+        # Agent::RdvPolicy::Scope fait un INNER JOIN sur agents_rdvs, ce qui produit plusieurs lignes
+        # par RDV quand celui-ci a plusieurs agents. Ce test s'assure qu'on dédoublonne correctement
+
+        create_list(:rdv, 11, agents: [agent, agent2], organisation:, motif:)
+        get :index, params: { organisation_id: organisation.id, per: 10 }
+        expect(assigns(:rdvs_in_page).size).to eq(10)
+      end
+    end
   end
 
   describe "GET #edit" do


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6371.osc-secnum-fr1.scalingo.io/)

# Contexte

[Une agent nous a prévenu](https://zammad10.ethibox.fr/#ticket/zoom/38592) que des incohérences se produisent lorsqu'elle visionne la liste des RDV : 9 RDV affichés par pages au lieu de 10, la dernière page qui contient trop de RDV, des RDV qui apparaissent sur plusieurs pages…

J’ai identifié un problème : c'est le `pluck(:id)` fait ici https://github.com/betagouv/rdv-service-public/blob/d546640c04234783040e814437edbfbd65ff2899/app/controllers/admin/rdvs_controller.rb#L24 

Ce pluck fait sauter le `distinct` défini plus haut. Par conséquent le pluck renvoie des id doublons dans les cas de RDV avec plusieurs agents car on fait un `inner join` sur les agents_rdvs. On fait une seconde requête qui appelle `Rdv.where(@rdvs.pluck(:id))` et qui va donc renvoyer moins de RDV que prévu. 

cf #6369 qui propose de rajouter un monitor service pour éviter ce genre de pb à l’avenir.

# Solution

J’introduis d'abord une failing spec et des seeds qui mettent en exergue ce cas. Sur la review app on peut [voir le problème corrigé ici](https://rdv-service-public-review-app-pr6371.osc-secnum-fr1.scalingo.io/admin/organisations/4/rdvs?agent_id=3&end=__%2F__%2F____&lieu_ids%5B%5D=&motif_ids%5B%5D=&per=&start=__%2F__%2F____&status=&user_id=) une fois connecté en tant que martine. `document.querySelectorAll(".card.rdv-item").length` dans la console JS permet de verifier rapidement le nombre de RDV par page.

Puis le correctif :

## Avant

```rb
Rdv.where(id: @rdvs.pluck(:id))
```

```sql
SELECT "rdvs"."id" 
FROM "rdvs" INNER JOIN agents_rdvs ... 
ORDER BY starts_at ASC, id ASC LIMIT 10 OFFSET 0`
```

`pluck` s’exécutait dans une première requête indépendante. Le `DISTINCT ON` était supprimé par `pluck`, donc `LIMIT 10` s'appliquait sur des lignes dupliquées.

## Après

```rb
Rdv.where(id: @rdvs.reselect("DISTINCT ON (#{distinct_on}) rdvs.id"))
```

```sql
  WHERE "rdvs"."id" IN (
    SELECT DISTINCT ON (rdvs.starts_at, rdvs.id) rdvs.id 
    FROM "rdvs" INNER JOIN agents_rdvs ...
    ORDER BY starts_at ASC, id ASC LIMIT 10 OFFSET 0
  )
```

`DISTINCT ON` est préservé, donc `LIMIT 10` s'applique bien sur 10 RDVs uniques.

## Autres

Je pense que ce correctif résoudra au moins une partie des problèmes de cette agent, j'irai verifier son cas en prod