### PR TITLE
Ajout d'un texte pour inciter les agents à utiliser la fonctionnalité de rdv non notifiés au niveau des motifs

### DIFF
--- a/app/views/admin/motifs/form/_notifs_et_instructions.html.slim
+++ b/app/views/admin/motifs/form/_notifs_et_instructions.html.slim
@@ -9,7 +9,7 @@
           hint: Motif.human_attribute_value(:visibility_type, value, context: rdvi_mode ? :hint_rdv_insertion : :hint),
         }
       end
-    = f.dsfr_radio_buttons :visibility_type, visibility_types
+    = f.dsfr_radio_buttons :visibility_type, visibility_types, hint: "Si ce motif est sensible (par exemple s'il lié à des services médicaux ou sociaux), vous pouvez désactiver les notifications pour protéger la confidentialité de vos usagers."
 
 .card
   .card-body


### PR DESCRIPTION
## Captures d'écran

Avant | Après
:- | -:
<img width="797" height="372" alt="Screenshot 2026-05-12 at 14 31 25" src="https://github.com/user-attachments/assets/2e276eaf-ab1c-4ef1-a572-c3143bdb745a" />|<img width="808" height="435" alt="Screenshot 2026-05-12 at 14 31 10" src="https://github.com/user-attachments/assets/99a595db-628f-47eb-993a-94850d8ec177" />


# Contexte

Permet d'avancer sur le AR1 de la feuille de route de sécurité en vue de l'homologation.
En explicitant cette option, il est considéré qu'on limite les risques de problèmes de confidentialités.




