### PR TITLE
Carto ANCT: renvoyer uniquement les espaces avec un SIRET

### DIFF
--- a/app/lib/carto_anct.rb
+++ b/app/lib/carto_anct.rb
@@ -13,61 +13,31 @@ module CartoANCT
   end
 
   def self.fetch_and_merge_metrics
-    insee_hash = Hash.new(0)
     siret_hash = Hash.new(0)
 
-    nombre_agents_par_code_insee(db_name: "rdvs").each  { |row| insee_hash[row["insee"]] += row["tu"].to_i }
-    nombre_agents_par_code_insee(db_name: "rdvsp").each { |row| insee_hash[row["insee"]] += row["tu"].to_i }
-    nombre_agents_par_siret(db_name: "rdvs").each       { |row| siret_hash[row["siret"]] += row["tu"].to_i }
-    nombre_agents_par_siret(db_name: "rdvsp").each      { |row| siret_hash[row["siret"]] += row["tu"].to_i }
+    nombre_agents_par_siret_espace(db_name: "rdvs").each  { |row| siret_hash[row["siret"]] += row["tu"].to_i }
+    nombre_agents_par_siret_espace(db_name: "rdvsp").each { |row| siret_hash[row["siret"]] += row["tu"].to_i }
 
-    insee_metrics = insee_hash.sort.map { |insee, tu| { insee:, metrics: { tu: } } }
-    siret_metrics = siret_hash.sort.map { |siret, tu| { siret:, metrics: { tu: } } }
-
-    insee_metrics + siret_metrics
+    siret_hash.sort.map { |siret, tu| { siret:, metrics: { tu: } } }
   end
 
-  def self.nombre_agents_par_siret(db_name:)
+  def self.nombre_agents_par_siret_espace(db_name:)
     query = <<~SQL.squish.gsub("$db_name", db_name)
       SELECT
-        "$db_name"."agents"."proconnect_siret" AS "siret",
+        "$db_name"."territories"."siret" AS "siret",
         COUNT(DISTINCT "$db_name"."agents"."id") AS tu
       FROM
-        "$db_name"."agents"
+        "$db_name"."territories"
       JOIN
-        "$db_name"."agents_rdvs" ON "$db_name"."agents_rdvs"."agent_id" = "$db_name"."agents"."id"
+        "$db_name"."organisations" ON "$db_name"."organisations"."territory_id" = "$db_name"."territories"."id"
       JOIN
-        "$db_name"."rdvs" ON "$db_name"."rdvs"."id" = "$db_name"."agents_rdvs"."rdv_id"
+        "$db_name"."agent_roles" ON "$db_name"."agent_roles"."organisation_id" = "$db_name"."organisations"."id"
+      JOIN
+        "$db_name"."agents" ON "$db_name"."agents"."id" = "$db_name"."agent_roles"."agent_id"
       WHERE
-        "$db_name"."agents"."proconnect_siret" IS NOT NULL
+        "$db_name"."territories"."siret" IS NOT NULL
       GROUP BY
-        "$db_name"."agents"."proconnect_siret";
-    SQL
-    MetabaseApi.sql_query(query, timeout: 60)
-  end
-
-  def self.nombre_agents_par_code_insee(db_name:)
-    query = <<~SQL.squish.gsub("$db_name", db_name)
-      SELECT
-        "Correspondance Code Insee Code Postal - Code Postal"."code_insee" AS "insee",
-        COUNT(DISTINCT "$db_name"."agents"."id") AS "tu"
-      FROM
-        "$db_name"."agents"
-
-      JOIN "$db_name"."agents_rdvs" AS "Agents Rdvs" ON "$db_name"."agents"."id" = "Agents Rdvs"."agent_id"
-        JOIN "$db_name"."rdvs" AS "Rdvs" ON "Agents Rdvs"."rdv_id" = "Rdvs"."id"
-        JOIN "$db_name"."lieux" AS "Lieux - Lieu" ON "Rdvs"."lieu_id" = "Lieux - Lieu"."id"
-        JOIN (
-          SELECT
-            "csv_uploads"."correspondance_code_insee_code_postal_20251105084418"."code_insee" AS "code_insee",
-            "csv_uploads"."correspondance_code_insee_code_postal_20251105084418"."code_postal" AS "code_postal"
-          FROM
-            "csv_uploads"."correspondance_code_insee_code_postal_20251105084418"
-        ) AS "Correspondance Code Insee Code Postal - Code Postal" ON "Lieux - Lieu"."code_postal" = "Correspondance Code Insee Code Postal - Code Postal"."code_postal"
-      GROUP BY
-        "Correspondance Code Insee Code Postal - Code Postal"."code_insee"
-      ORDER BY
-        "insee" ASC
+        "$db_name"."territories"."siret";
     SQL
     MetabaseApi.sql_query(query, timeout: 60)
   end

--- a/docs/interconnexions/carto_anct.md
+++ b/docs/interconnexions/carto_anct.md
@@ -9,18 +9,17 @@ https://docs.numerique.gouv.fr/docs/6b33b32e-2f58-4179-8d1b-7c01414c44d3/
 
 ## Quelle données fournissons-nous ?
 
-La spec nous indique de fournir pour chaque code SIRET et INSEE présent dans la base le
-"Nombre total d'agents présents dans la base de donnée pour cette commune / collectivité".
+La spec nous indique de fournir pour chaque code SIRET présent dans la base le
+"Nombre total d'agents présents dans la base de donnée pour cette collectivité".
 
-Notre source de SIRET est le code SIRET fourni par ProConnect lors d'une connexion agent.
-Notre source de code INSEE est les lieux physiques où les agents organisent les rendez-vous. 
+Notre source de SIRET est le champ `siret` des espaces (territories).
+
+Suite à une demande de la suite territoriale, nous ne fournissons plus les codes INSEE.
 
 Nous avons besoin d'inclure ces données pour les instances RDV-Solidarités et RDV-SP.
-Nou faisons donc 4 requêtes à Metabse :
-- Nombre d'agents par code INSEE (RDV-Solidarités)
-- Nombre d'agents par code INSEE (RDV-SP)
-- Nombre d'agents par SIRET (RDV-Solidarités)
-- Nombre d'agents par SIRET (RDV-SP)
+Nous faisons donc 2 requêtes à Metabase :
+- Nombre d'agents par SIRET d'espace (RDV-Solidarités)
+- Nombre d'agents par SIRET d'espace (RDV-SP)
 
 Nous fusionnons ensuite les résultats pour qu'ils soient conformes à l'exemple de la spec :
 

--- a/spec/lib/carto_anct_spec.rb
+++ b/spec/lib/carto_anct_spec.rb
@@ -1,23 +1,14 @@
 RSpec.describe CartoANCT do
   describe ".fetch_and_merge_metrics" do
-    it "merges siret and insee" do
+    it "merges siret from both databases" do
       stub_request(:post, /#{MetabaseApi::HOST_URL}/)
-        .with { _1.body.include?("code_insee") && _1.body.exclude?("rdvsp") }
-        .to_return(body: [{ insee: "01001", tu: 200 }, { insee: "01006", tu: 100 }].to_json)
-      stub_request(:post, /#{MetabaseApi::HOST_URL}/)
-        .with { _1.body.include?("code_insee") && _1.body.include?("rdvsp") }
-        .to_return(body: [{ insee: "01001", tu: 44 }, { insee: "01006", tu: 33 }].to_json)
-
-      stub_request(:post, /#{MetabaseApi::HOST_URL}/)
-        .with { _1.body.include?("siret") && _1.body.exclude?("rdvsp") }
+        .with { _1.body.include?("territories") && _1.body.exclude?("rdvsp") }
         .to_return(body: [{ siret: "13002526500013", tu: 2 }].to_json)
       stub_request(:post, /#{MetabaseApi::HOST_URL}/)
-        .with { _1.body.include?("siret") && _1.body.include?("rdvsp") }
+        .with { _1.body.include?("territories") && _1.body.include?("rdvsp") }
         .to_return(body: [{ siret: "13002526500013", tu: 30 }, { siret: "12345678901234", tu: 10 }].to_json)
 
       expected_merged_results = [
-        { insee: "01001", metrics: { tu: 244 } },
-        { insee: "01006", metrics: { tu: 133 } },
         { metrics: { tu: 10 }, siret: "12345678901234" },
         { metrics: { tu: 32 }, siret: "13002526500013" },
       ]


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6373.osc-secnum-fr1.scalingo.io/)

# Contexte

Suite à la demande des équipes de la Suite Territoriale, nous ne renvoyons plus que les SIRETs des espaces et plus toutes les zones équipées comme initialement prévu.

L’objectif était initialement de voir tous les territoires couverts par RDV-SP, aujourd’hui on veut seulement voir les communes et EPCI équipé pour leur compte.

