### PR TITLE
Mise à jour de premailer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -475,9 +475,9 @@ GEM
       mime-types (>= 3.0)
     pp (0.6.3)
       prettyprint
-    premailer (1.18.0)
+    premailer (1.29.0)
       addressable
-      css_parser (>= 1.12.0)
+      css_parser (>= 1.19.0)
       htmlentities (>= 4.0.0)
     premailer-rails (1.12.0)
       actionmailer (>= 3)
@@ -1047,7 +1047,7 @@ CHECKSUMS
   phonelib (0.10.17) sha256=8c97b6abc1877a8313ef32f9438cd35e24a943f9a70666af85eb69ab81caf4e3
   playwright-ruby-client (1.56.0) sha256=f7a772fabda46f0d04a2b20d86a8e7d2897e6c9b05d1fe49555626d499e9b104
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
-  premailer (1.18.0) sha256=b930beb10a7d8b5e60dbff0d0b35b4ab3f0b10d8263ea6482aab7ecab9b3d335
+  premailer (1.29.0) sha256=015f30c520701f3d47fd898886a3eaf4e5171efcc5fd239b872efd1ba61d3da0
   premailer-rails (1.12.0) sha256=c13815d161b9bc7f7d3d81396b0bb0a61a90fa9bd89931548bf4e537c7710400
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6375.osc-secnum-fr1.scalingo.io/)

⚠️ E-mail activé sur cette review app

# Contexte

Depuis la mise à jour de nokogiri, on a un deprecation warning déclenché par premailer.
Ceci est corrigé en version 1.26 de premailer. Je propose donc de faire la montée de version.
Au vu du changelog ça ne semble pas risqué.

Testé en review app. RàS


