### PR TITLE
Geocoding : Nettoie l'adresse avant l'appel IGN et sécurise le cache d'erreurs

### DIFF
--- a/app/lib/geo_coding.rb
+++ b/app/lib/geo_coding.rb
@@ -1,6 +1,6 @@
 class GeoCoding
   def find_geo_coordinates(address)
-    address_api_response(address).dig("features", 0, "geometry", "coordinates")
+    address_api_response(address)&.dig("features", 0, "geometry", "coordinates")
   end
 
   def get_geolocation_results(address, departement_number)
@@ -32,9 +32,13 @@ class GeoCoding
     cleaned_address = clean_address(address)
     return nil if cleaned_address.blank?
 
-    Rails.cache.fetch("api-adresse:#{cleaned_address}", expires_in: 7.days, skip_nil: true) do
-      fetch_and_parse(cleaned_address)
-    end
+    cache_key = "api-adresse:#{cleaned_address}"
+    cached_response = Rails.cache.read(cache_key)
+    return cached_response if cached_response
+
+    response = fetch_and_parse(cleaned_address)
+    Rails.cache.write(cache_key, response, expires_in: 7.days) if response
+    response
   end
 
   def fetch_and_parse(address)

--- a/app/lib/geo_coding.rb
+++ b/app/lib/geo_coding.rb
@@ -29,10 +29,19 @@ class GeoCoding
   end
 
   def address_api_response(address)
-    address_api_response = Rails.cache.fetch("api-adresse:#{address}") do
-      Faraday.get("https://data.geopf.fr/geocodage/search/", q: address)
+    cleaned_address = clean_address(address)
+    return nil if cleaned_address.blank?
+
+    response = Rails.cache.fetch("api-adresse:#{cleaned_address}") do
+      Faraday.get("https://data.geopf.fr/geocodage/search/", q: cleaned_address)
     end
 
-    JSON.parse(address_api_response.body)
+    JSON.parse(response.body)
+  end
+
+  # L'API IGN refuse les requêtes qui ne commencent pas par un caractère alphanumérique.
+  # On retire donc tous les caractères non-alphanumériques en début d'adresse.
+  def clean_address(address)
+    address&.gsub(/\A[^\p{Alnum}]+/, "")&.strip
   end
 end

--- a/app/lib/geo_coding.rb
+++ b/app/lib/geo_coding.rb
@@ -32,11 +32,23 @@ class GeoCoding
     cleaned_address = clean_address(address)
     return nil if cleaned_address.blank?
 
-    response = Rails.cache.fetch("api-adresse:#{cleaned_address}") do
-      Faraday.get("https://data.geopf.fr/geocodage/search/", q: cleaned_address)
+    Rails.cache.fetch("api-adresse:#{cleaned_address}", expires_in: 7.days, skip_nil: true) do
+      fetch_and_parse(cleaned_address)
     end
+  end
 
-    JSON.parse(response.body)
+  def fetch_and_parse(address)
+    response = Faraday.get("https://data.geopf.fr/geocodage/search/", q: address)
+    return JSON.parse(response.body) if response.success?
+
+    Sentry.capture_message(
+      "GeoCoding: l'API IGN a retourné un status non-success (#{response.status})",
+      fingerprint: ["geo_coding_ign_non_success", response.status.to_s]
+    )
+    nil
+  rescue Faraday::Error, JSON::ParserError => e
+    Sentry.capture_exception(e)
+    nil
   end
 
   # L'API IGN refuse les requêtes qui ne commencent pas par un caractère alphanumérique.

--- a/spec/lib/geo_coding_spec.rb
+++ b/spec/lib/geo_coding_spec.rb
@@ -1,14 +1,30 @@
 RSpec.describe GeoCoding do
   describe "#find_geo_coordinates" do
-    before do
-      stub_request(
-        :get,
-        "https://data.geopf.fr/geocodage/search/?q=03%20Rue%20Lambert,%20Paris,%2075018"
-      ).to_return(status: 200, body: file_fixture("geocode_result.json").read, headers: {})
+    context "quand l'API IGN répond avec succès" do
+      before do
+        stub_request(
+          :get,
+          "https://data.geopf.fr/geocodage/search/?q=03%20Rue%20Lambert,%20Paris,%2075018"
+        ).to_return(status: 200, body: file_fixture("geocode_result.json").read, headers: {})
+      end
+
+      it "retourne les coordonnées" do
+        expect(described_class.new.find_geo_coordinates("03 Rue Lambert, Paris, 75018")).to eq([2.372095, 48.88393])
+      end
     end
 
-    it "returns the coordinates" do
-      expect(described_class.new.find_geo_coordinates("03 Rue Lambert, Paris, 75018")).to eq([2.372095, 48.88393])
+    context "quand l'API IGN retourne une erreur" do
+      before do
+        stub_request(
+          :get,
+          "https://data.geopf.fr/geocodage/search/?q=03%20Rue%20Lambert,%20Paris,%2075018"
+        ).to_return(status: 400, body: "")
+        allow(Sentry).to receive(:capture_message)
+      end
+
+      it "retourne nil" do
+        expect(described_class.new.find_geo_coordinates("03 Rue Lambert, Paris, 75018")).to be_nil
+      end
     end
   end
 

--- a/spec/lib/geo_coding_spec.rb
+++ b/spec/lib/geo_coding_spec.rb
@@ -112,12 +112,12 @@ RSpec.describe GeoCoding do
     context "quand l'adresse commence par des caractères non-alphanumériques" do
       let(:address) { ". LA BEGUDE 84750 SAINT-MARTIN-DE-CASTILLON" }
       let(:departement_number) { "84" }
+      let(:cleaned_request_url) do
+        "https://data.geopf.fr/geocodage/search/?q=LA%20BEGUDE%2084750%20SAINT-MARTIN-DE-CASTILLON"
+      end
 
       before do
-        stub_request(
-          :get,
-          "https://data.geopf.fr/geocodage/search/?q=LA%20BEGUDE%2084750%20SAINT-MARTIN-DE-CASTILLON"
-        ).to_return(
+        stub_request(:get, cleaned_request_url).to_return(
           status: 200,
           body: {
             type: "FeatureCollection",
@@ -137,10 +137,76 @@ RSpec.describe GeoCoding do
         )
       end
 
-      it "nettoie l'adresse avant d'appeler l'API IGN et retourne le résultat" do
-        result = geo_coding.get_geolocation_results(address, departement_number)
+      it "envoie l'adresse nettoyée à l'API IGN" do
+        geo_coding.get_geolocation_results(address, departement_number)
 
-        expect(result).to include(city_code: "84112")
+        expect(WebMock).to have_requested(:get, cleaned_request_url)
+      end
+    end
+
+    context "quand l'API IGN retourne un status non-success" do
+      let(:request_url) do
+        "https://data.geopf.fr/geocodage/search/?q=20%20avenue%20de%20S%C3%A9gur,%20Paris,%2075007"
+      end
+
+      before do
+        stub_request(:get, request_url).to_return(status: 400, body: "")
+        allow(Sentry).to receive(:capture_message)
+      end
+
+      it "retourne nil et signale l'erreur à Sentry" do
+        expect(Sentry).to receive(:capture_message)
+
+        expect(geo_coding.get_geolocation_results(address, departement_number)).to be_nil
+      end
+
+      it "ne met pas la réponse en cache pour permettre une nouvelle tentative" do
+        2.times { geo_coding.get_geolocation_results(address, departement_number) }
+
+        expect(WebMock).to have_requested(:get, request_url).twice
+      end
+    end
+
+    context "quand Faraday lève une exception" do
+      before do
+        stub_request(
+          :get,
+          "https://data.geopf.fr/geocodage/search/?q=20%20avenue%20de%20S%C3%A9gur,%20Paris,%2075007"
+        ).to_raise(Faraday::Error)
+      end
+
+      it "retourne nil et signale l'exception à Sentry" do
+        expect(Sentry).to receive(:capture_exception)
+
+        expect(geo_coding.get_geolocation_results(address, departement_number)).to be_nil
+      end
+    end
+
+    context "quand l'appel réussit" do
+      let(:request_url) do
+        "https://data.geopf.fr/geocodage/search/?q=20%20avenue%20de%20S%C3%A9gur,%20Paris,%2075007"
+      end
+
+      before do
+        stub_request(:get, request_url).to_return(
+          status: 200,
+          body: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                properties: { id: "75056_1234", citycode: "75056", context: "75, Paris, Île-de-France" },
+              },
+            ],
+          }.to_json
+        )
+      end
+
+      it "met le résultat en cache pour ne pas refaire l'appel une seconde fois" do
+        geo_coding.get_geolocation_results(address, departement_number)
+        geo_coding.get_geolocation_results(address, departement_number)
+
+        expect(WebMock).to have_requested(:get, request_url).once
       end
     end
   end

--- a/spec/lib/geo_coding_spec.rb
+++ b/spec/lib/geo_coding_spec.rb
@@ -108,5 +108,40 @@ RSpec.describe GeoCoding do
         expect(result).to be_nil
       end
     end
+
+    context "quand l'adresse commence par des caractères non-alphanumériques" do
+      let(:address) { ". LA BEGUDE 84750 SAINT-MARTIN-DE-CASTILLON" }
+      let(:departement_number) { "84" }
+
+      before do
+        stub_request(
+          :get,
+          "https://data.geopf.fr/geocodage/search/?q=LA%20BEGUDE%2084750%20SAINT-MARTIN-DE-CASTILLON"
+        ).to_return(
+          status: 200,
+          body: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [5.51, 43.85] },
+                properties: {
+                  id: "84112_i530ru",
+                  citycode: "84112",
+                  context: "84, Vaucluse, Provence-Alpes-Côte d'Azur",
+                },
+              },
+            ],
+          }.to_json,
+          headers: {}
+        )
+      end
+
+      it "nettoie l'adresse avant d'appeler l'API IGN et retourne le résultat" do
+        result = geo_coding.get_geolocation_results(address, departement_number)
+
+        expect(result).to include(city_code: "84112")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Contexte

  Cette PR fait suite à plusieurs allers-retours :
  - #6306 (fermée) : ajout d'un job async pour geocoder les usagers créés via l'API. Approche abandonnée car le job aurait utilisé la même lib `GeoCoding` que celle qui causait le bug d'origine
  - #6337 (mergée) : ouverture des attributs `city_code`, `post_code`, `city_name` dans l'API v1 pour que RDVI puisse les transmettre
  - gip-inclusion/rdv-insertion#3287 : tentative d'utiliser ces attributs côté RDVI. Mais ça pose un problème de désynchronisation : côté RDVI le geocoding est async, donc une mise à jour  d'adresse via API enverrait l'**ancienne** géolocalisation tant que le job de re-geocoding RDVI n'a pas tourné.

  En creusant, j'ai identifié que le **vrai bug** qui a donné lieu à ce travail vient de la lib `GeoCoding` côté RDVSP :
  - L'API IGN refuse les adresses qui ne commencent pas par un caractère alphanumérique (ex: `. LA BEGUDE 84750 ...`) avec un HTTP 400.
  - Notre lib ne vérifiait pas le statut HTTP. La réponse d'erreur est parsée comme du JSON (vide de `features`) et donc `city_code` est nil, la sectorisation au moment de la prescription agent est cassée.
  - Pire : la réponse 400 était mise en cache indéfiniment.

  ## Ce que fait cette PR

  Améliore la lib `GeoCoding` pour résoudre le bug à la racine, sans modifier l'API ni introduire de couplage entre les systèmes rdvsp / rdvi.

  - **Commit 1** : strip des caractères non-alphanumériques en début d'adresse avant l'appel API IGN, cela résout directement le cas `. LA BEGUDE...`
  - **Commit 2** : sécurise le cache (vérifie le status HTTP, ne met plus en cache les erreurs, TTL de 7 jours, remontée Sentry sur les erreurs)

  ## Question en suspend

  Vu que cette PR résout le bug côté RDVSP sans nécessiter de changement côté RDVI, **est-ce qu'on revert #6337 ?** Ces attributs sont désormais ouverts dans l'API mais aucun consommateur ne les utilise pour le moment (RDVI a abandonné l'idée pour des raisons de désync mentionnées plus haut). Garder l'API "ouverte sans usage" me paraît inutile.