### PR TITLE
Correction du job de synchronisation des nouveautés

### DIFF
--- a/app/lib/docs_numerique_changelog.rb
+++ b/app/lib/docs_numerique_changelog.rb
@@ -18,7 +18,7 @@ module DocsNumeriqueChangelog
     end
 
     def fetch_content(document_id)
-      response = connection.get("documents/#{document_id}/content/", content_format: "html")
+      response = connection.get("documents/#{document_id}/formatted-content/", content_format: "html")
       response.body.fetch("content")
     end
 
@@ -60,7 +60,7 @@ module DocsNumeriqueChangelog
       ^
       (?<title>.*)        # Vos RDV collectifs, maintenant en visio
       \p{Zs}?-\p{Zs}?     # -  (\p{Zs} = Separators: Space - handles non breaking spaces)
-      (?<date>[0-9\/]+)   # 15/01/2026
+      (?<date>[0-9/]+)    # 15/01/2026
       \p{Zs}?-\p{Zs}?     # -
       (?<category>.*)     # Nouveauté
       \p{Zs}*

--- a/spec/fixtures/files/update_docs_numerique_changelog_fixtures.rb
+++ b/spec/fixtures/files/update_docs_numerique_changelog_fixtures.rb
@@ -14,13 +14,13 @@ children["results"].each { |doc| doc.delete("abilities") }
 children["count"] = NB_DOCS
 
 File.write("#{FIXTURES_DIR}/docs_numerique_changelog_children.json", JSON.pretty_generate(children))
-puts "Updated docs_numerique_changelog_children.json"
+$stdout.puts "Updated docs_numerique_changelog_children.json"
 
 # Fetch content for each document
 children["results"].each do |doc|
-  content = connection.get("documents/#{doc['id']}/content/", content_format: "html").body
+  content = connection.get("documents/#{doc['id']}/formatted-content/", content_format: "html").body
   safe_id = doc["id"].to_s[0, 8].gsub(/[^0-9A-Za-z_-]/, "")
   filename = "docs_numerique_changelog_content_#{safe_id}.json"
   File.write("#{FIXTURES_DIR}/#{filename}", JSON.pretty_generate(content))
-  puts "Updated #{filename}"
+  $stdout.puts "Updated #{filename}"
 end

--- a/spec/jobs/cron_job/refresh_blog_posts_from_docs_job_spec.rb
+++ b/spec/jobs/cron_job/refresh_blog_posts_from_docs_job_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe CronJob::RefreshBlogPostsFromDocsJob do
       stub_request(:get, children_url)
         .to_return(status: 200, body: file_fixture("docs_numerique_changelog_children.json").read, headers: { "Content-Type" => "application/json" })
 
-      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/3cc750d1-9bcf-4b3d-82bd-d9d232cc9de7/content/")
+      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/3cc750d1-9bcf-4b3d-82bd-d9d232cc9de7/formatted-content/")
         .with(query: { content_format: "html" })
         .to_return(status: 200, body: file_fixture("docs_numerique_changelog_content_3cc750d1.json").read, headers: { "Content-Type" => "application/json" })
 
-      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/c4853a77-99ff-4393-b68e-00b4b3429b03/content/")
+      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/c4853a77-99ff-4393-b68e-00b4b3429b03/formatted-content/")
         .with(query: { content_format: "html" })
         .to_return(status: 200, body: file_fixture("docs_numerique_changelog_content_c4853a77.json").read, headers: { "Content-Type" => "application/json" })
 
-      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/3127498c-de81-41a1-b38e-3b9f0ae03083/content/")
+      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/3127498c-de81-41a1-b38e-3b9f0ae03083/formatted-content/")
         .with(query: { content_format: "html" })
         .to_return(status: 200, body: file_fixture("docs_numerique_changelog_content_3127498c.json").read, headers: { "Content-Type" => "application/json" })
     end

--- a/spec/lib/docs_numerique_changelog_spec.rb
+++ b/spec/lib/docs_numerique_changelog_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DocsNumeriqueChangelog do
         headers: { "Content-Type" => "application/json" }
       )
 
-      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/doc-1/content/")
+      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/doc-1/formatted-content/")
         .with(query: { content_format: "html" })
         .to_return(
           status: 200,
@@ -24,7 +24,7 @@ RSpec.describe DocsNumeriqueChangelog do
           headers: { "Content-Type" => "application/json" }
         )
 
-      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/doc-2/content/")
+      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/doc-2/formatted-content/")
         .with(query: { content_format: "html" })
         .to_return(
           status: 200,
@@ -32,7 +32,7 @@ RSpec.describe DocsNumeriqueChangelog do
           headers: { "Content-Type" => "application/json" }
         )
 
-      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/doc-3/content/")
+      stub_request(:get, "#{DocsNumeriqueChangelog::BASE_URL}/documents/doc-3/formatted-content/")
         .with(query: { content_format: "html" })
         .to_return(
           status: 200,


### PR DESCRIPTION
# Contexte

J’ai publié une nouveauté concernant le service secrétariat, et je me suis aperçu aujourd’hui qu’elle n’avait jamais été mise en ligne.
En creusant, je me suis rendu compte que le point d’API que nous utilisons côté Docs renvoi désormais du binaire. 
Cela fait suite à cette modification, dans la 5.0 de Docs : https://github.com/suitenumerique/docs/pull/2171/changes#diff-cc27a5de6f1d8131250e4be30d0fd4c2f1a816bdc35951a9c86e6f13cd795019L2169

# Solution

Je change donc l’URL appelé comme cela est fait côté Docs.
