### PR TITLE
Afficher les noms des jours fériés

### DIFF
--- a/app/services/off_days.rb
+++ b/app/services/off_days.rb
@@ -10,7 +10,7 @@ class OffDays
   JOURS_FERIES = [
     new(Date.new(2023, 1, 1), "Jour de l'An"),
     new(Date.new(2023, 4, 10), "Lundi de Pâques"),
-    new(Date.new(2023, 5, 1), "Fête du Travail"),
+    new(Date.new(2023, 5, 1), "Journée internationale des travailleurs"),
     new(Date.new(2023, 5, 8), "Victoire 1945"),
     new(Date.new(2023, 5, 18), "Ascension"),
     new(Date.new(2023, 5, 29), "Lundi de Pentecôte"),
@@ -22,7 +22,7 @@ class OffDays
 
     new(Date.new(2024, 1, 1), "Jour de l'An"),
     new(Date.new(2024, 4, 1), "Lundi de Pâques"),
-    new(Date.new(2024, 5, 1), "Fête du Travail"),
+    new(Date.new(2024, 5, 1), "Journée internationale des travailleurs"),
     new(Date.new(2024, 5, 8), "Victoire 1945"),
     new(Date.new(2024, 5, 9), "Ascension"),
     new(Date.new(2024, 5, 20), "Lundi de Pentecôte"),
@@ -34,7 +34,7 @@ class OffDays
 
     new(Date.new(2025, 1, 1), "Jour de l'An"),
     new(Date.new(2025, 4, 21), "Lundi de Pâques"),
-    new(Date.new(2025, 5, 1), "Fête du Travail"),
+    new(Date.new(2025, 5, 1), "Journée internationale des travailleurs"),
     new(Date.new(2025, 5, 8), "Victoire 1945"),
     new(Date.new(2025, 5, 29), "Ascension"),
     new(Date.new(2025, 7, 14), "Fête nationale"),
@@ -45,7 +45,7 @@ class OffDays
 
     new(Date.new(2026, 1, 1), "Jour de l'An"),
     new(Date.new(2026, 4, 6), "Lundi de Pâques"),
-    new(Date.new(2026, 5, 1), "Fête du Travail"),
+    new(Date.new(2026, 5, 1), "Journée internationale des travailleurs"),
     new(Date.new(2026, 5, 8), "Victoire 1945"),
     new(Date.new(2026, 5, 14), "Ascension"),
     new(Date.new(2026, 7, 14), "Fête nationale"),
@@ -56,7 +56,7 @@ class OffDays
 
     new(Date.new(2027, 1, 1), "Jour de l'An"),
     new(Date.new(2027, 3, 29), "Lundi de Pâques"),
-    new(Date.new(2027, 5, 1), "Fête du Travail"),
+    new(Date.new(2027, 5, 1), "Journée internationale des travailleurs"),
     new(Date.new(2027, 5, 6), "Ascension"),
     new(Date.new(2027, 5, 8), "Victoire 1945"),
     new(Date.new(2027, 7, 14), "Fête nationale"),

--- a/app/services/off_days.rb
+++ b/app/services/off_days.rb
@@ -1,73 +1,96 @@
 class OffDays
+  def initialize(date, label)
+    @date = date
+    @label = label
+  end
+
+  attr_reader :date, :label
+
   # https://www.service-public.fr/particuliers/vosdroits/F2405
   JOURS_FERIES = [
-    Date.new(2023, 1, 1),
-    Date.new(2023, 4, 10),
-    Date.new(2023, 5, 1),
-    Date.new(2023, 5, 8),
-    Date.new(2023, 5, 18),
-    Date.new(2023, 5, 29),
-    Date.new(2023, 7, 14),
-    Date.new(2023, 8, 15),
-    Date.new(2023, 11, 1),
-    Date.new(2023, 11, 11),
-    Date.new(2023, 12, 25),
+    new(Date.new(2023, 1, 1), "Jour de l'An"),
+    new(Date.new(2023, 4, 10), "Lundi de Pâques"),
+    new(Date.new(2023, 5, 1), "Fête du Travail"),
+    new(Date.new(2023, 5, 8), "Victoire 1945"),
+    new(Date.new(2023, 5, 18), "Ascension"),
+    new(Date.new(2023, 5, 29), "Lundi de Pentecôte"),
+    new(Date.new(2023, 7, 14), "Fête nationale"),
+    new(Date.new(2023, 8, 15), "Assomption"),
+    new(Date.new(2023, 11, 1), "Toussaint"),
+    new(Date.new(2023, 11, 11), "Armistice 1918"),
+    new(Date.new(2023, 12, 25), "Noël"),
 
-    Date.new(2024, 1, 1),
-    Date.new(2024, 4, 1),
-    Date.new(2024, 5, 1),
-    Date.new(2024, 5, 8),
-    Date.new(2024, 5, 9),
-    Date.new(2024, 5, 20),
-    Date.new(2024, 7, 14),
-    Date.new(2024, 8, 15),
-    Date.new(2024, 11, 1),
-    Date.new(2024, 11, 11),
-    Date.new(2024, 12, 25),
+    new(Date.new(2024, 1, 1), "Jour de l'An"),
+    new(Date.new(2024, 4, 1), "Lundi de Pâques"),
+    new(Date.new(2024, 5, 1), "Fête du Travail"),
+    new(Date.new(2024, 5, 8), "Victoire 1945"),
+    new(Date.new(2024, 5, 9), "Ascension"),
+    new(Date.new(2024, 5, 20), "Lundi de Pentecôte"),
+    new(Date.new(2024, 7, 14), "Fête nationale"),
+    new(Date.new(2024, 8, 15), "Assomption"),
+    new(Date.new(2024, 11, 1), "Toussaint"),
+    new(Date.new(2024, 11, 11), "Armistice 1918"),
+    new(Date.new(2024, 12, 25), "Noël"),
 
-    Date.new(2025, 1, 1),
-    Date.new(2025, 4, 21),
-    Date.new(2025, 5, 1),
-    Date.new(2025, 5, 8),
-    Date.new(2025, 5, 29),
-    # Date.new(2025, 6, 9), # le lundi de pentecôte est une journée de solidarité optionnellement fériée
-    Date.new(2025, 7, 14),
-    Date.new(2025, 8, 15),
-    Date.new(2025, 11, 1),
-    Date.new(2025, 11, 11),
-    Date.new(2025, 12, 25),
+    new(Date.new(2025, 1, 1), "Jour de l'An"),
+    new(Date.new(2025, 4, 21), "Lundi de Pâques"),
+    new(Date.new(2025, 5, 1), "Fête du Travail"),
+    new(Date.new(2025, 5, 8), "Victoire 1945"),
+    new(Date.new(2025, 5, 29), "Ascension"),
+    new(Date.new(2025, 7, 14), "Fête nationale"),
+    new(Date.new(2025, 8, 15), "Assomption"),
+    new(Date.new(2025, 11, 1), "Toussaint"),
+    new(Date.new(2025, 11, 11), "Armistice 1918"),
+    new(Date.new(2025, 12, 25), "Noël"),
 
-    Date.new(2026, 1, 1),
-    Date.new(2026, 4, 6),
-    Date.new(2026, 5, 1),
-    Date.new(2026, 5, 8),
-    Date.new(2026, 5, 14),
-    # Date.new(2026, 5, 25), # le lundi de pentecôte est une journée de solidarité optionnellement fériée
-    Date.new(2026, 7, 14),
-    Date.new(2026, 8, 15),
-    Date.new(2026, 11, 1),
-    Date.new(2026, 11, 11),
-    Date.new(2026, 12, 25),
+    new(Date.new(2026, 1, 1), "Jour de l'An"),
+    new(Date.new(2026, 4, 6), "Lundi de Pâques"),
+    new(Date.new(2026, 5, 1), "Fête du Travail"),
+    new(Date.new(2026, 5, 8), "Victoire 1945"),
+    new(Date.new(2026, 5, 14), "Ascension"),
+    new(Date.new(2026, 7, 14), "Fête nationale"),
+    new(Date.new(2026, 8, 15), "Assomption"),
+    new(Date.new(2026, 11, 1), "Toussaint"),
+    new(Date.new(2026, 11, 11), "Armistice 1918"),
+    new(Date.new(2026, 12, 25), "Noël"),
+
+    new(Date.new(2027, 1, 1), "Jour de l'An"),
+    new(Date.new(2027, 3, 29), "Lundi de Pâques"),
+    new(Date.new(2027, 5, 1), "Fête du Travail"),
+    new(Date.new(2027, 5, 6), "Ascension"),
+    new(Date.new(2027, 5, 8), "Victoire 1945"),
+    new(Date.new(2027, 7, 14), "Fête nationale"),
+    new(Date.new(2027, 8, 15), "Assomption"),
+    new(Date.new(2027, 11, 1), "Toussaint"),
+    new(Date.new(2027, 11, 11), "Armistice 1918"),
+    new(Date.new(2027, 12, 25), "Noël"),
   ].to_set.freeze
+
+  DATES = JOURS_FERIES.map(&:date).to_set.freeze
+
+  FULL_CALENDAR_ARRAY = JOURS_FERIES.map do |jour_ferie|
+    {
+      title: jour_ferie.label,
+      start: jour_ferie.date.beginning_of_day.as_json,
+      end: jour_ferie.date.end_of_day.as_json,
+      backgroundColor: AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
+      textColor: "white",
+    }
+  end.freeze
 
   def self.all_in_date_range(date_range)
     return [] if date_range.blank?
 
     date_range = CreneauxSearch::Range.ensure_range_is_date(date_range)
 
-    JOURS_FERIES.intersection(date_range)
+    DATES.intersection(date_range)
   end
 
   def self.to_full_calendar_array(agent_ids = nil)
-    JOURS_FERIES.map do |jour_ferie|
-      {
-        title: "Jour férié",
-        start: jour_ferie.beginning_of_day.as_json,
-        end: jour_ferie.end_of_day.as_json,
-        backgroundColor: AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
-        textColor: "white",
-        resourceIds: agent_ids,
-      }.compact
+    if agent_ids
+      FULL_CALENDAR_ARRAY.map { |day| day.merge(resourceIds: agent_ids) }
+    else
+      FULL_CALENDAR_ARRAY
     end
   end
 end

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -7,11 +7,11 @@ FactoryBot.define do
     sequence(:title) { |n| random_value_in(["Plage #{n}", nil]) }
     sequence(:first_day) do |n|
       day = Time.zone.today.next_week(:monday)
-      day += 1.day if OffDays::JOURS_FERIES.include?(day) || day.saturday? || day.sunday?
+      day += 1.day if OffDays::DATES.include?(day) || day.saturday? || day.sunday?
       # cet algo empêche de renvoyer un jour férié et évite de renvoyer le même jour pour 2 `n` consécutifs
       (0...n).each do
         day += 1.day
-        day += 1.day if OffDays::JOURS_FERIES.include?(day) || day.saturday? || day.sunday?
+        day += 1.day if OffDays::DATES.include?(day) || day.saturday? || day.sunday?
       end
       day
     end

--- a/spec/services/off_days_spec.rb
+++ b/spec/services/off_days_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe OffDays, type: :service do
   it "is up to date" do
     # Il faut ajouter de nouveaux jours fériés si cette spec échoue
-    expect(described_class::JOURS_FERIES.max).to be > 3.months.from_now
+    expect(described_class::DATES.max).to be > 3.months.from_now
   end
 
   describe ".all_in_date_range" do


### PR DESCRIPTION
# Contexte

Petit quick-win de vigie : afficher dans l'agenda les noms des jours fériés plutôt que "Jour férié".

# Solution

Ajouter un libellé pour chaque jour de la liste qu'on a en dur dans le code.

## Implémentation

`OffDays` devient une classe instanciable, qui prend une `date [Date]` et un `label [String]`. 

Au passage j'optimise la méthode `to_full_calendar_array` qui prend actuellement 1 ms sur ma machine. Elle prend désormais 0.05 ms si on lui passe un paramètre (agenda multi agents), et 0.0005 ms sans paramètre. Et probablement pas mal moins de RAM utilisée. Prématuré ? Un peu mais gratuit.

## Captures d'écran

Avant | Après
:- | -:
<img width="493" height="1032" alt="image" src="https://github.com/user-attachments/assets/1c74cad6-f637-49ec-91d7-e97790ff4c2c" /> | <img width="493" height="1032" alt="image" src="https://github.com/user-attachments/assets/8dab8331-b2cf-435d-bf3c-5d24a126e127" />

