### PR TITLE
Permettre aux admins d'organisation de désactiver la connexion par email lors de la prise de rdv en ligne

### DIFF
--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -47,7 +47,7 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
     authorize(@organisation, :update?, policy_class: Agent::OrganisationPolicy)
 
     if @organisation.update(permitted_params)
-      flash[:success] = "Modes de connexion mis à jour"
+      flash[:success] = "Modes d'authentification mis à jour"
       redirect_to admin_organisation_online_booking_path(@organisation)
     else
       flash[:error] = @organisation.errors.full_messages.to_sentence

--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -47,7 +47,7 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
     authorize(@organisation, :update?, policy_class: Agent::OrganisationPolicy)
 
     if @organisation.update(permitted_params)
-      flash[:success] = "Profil des usagers mis à jour"
+      flash[:success] = "Modes de connexion mis à jour"
       redirect_to admin_organisation_online_booking_path(@organisation)
     else
       flash[:error] = @organisation.errors.full_messages.to_sentence
@@ -70,6 +70,6 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
   end
 
   def permitted_params
-    params.require(:organisation).permit(:online_booking_for_particuliers, :online_booking_for_professionnels)
+    params.require(:organisation).permit(:online_booking_for_particuliers, :online_booking_for_professionnels, :online_booking_with_email)
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -118,17 +118,14 @@ class Organisation < ApplicationRecord
   end
 
   def online_booking_only_proconnect?
-    # Pour l’espace de RDV Service Public, on veut obliger les usagers à s'authentifier avec ProConnect
-    # pour éviter que des usagers prennent RDV alors que c’est un service réservé aux agents publics.
-    # Dans le futur, on permettra peut-être à d’autres organisations ou espaces de faire de même
-    domain == Domain::RDV_SERVICE_PUBLIC && territory_id == 2
+    online_booking_for_professionnels && !online_booking_for_particuliers && !online_booking_with_email
   end
 
   private
 
   def validate_at_least_one_user_type
-    return if online_booking_for_particuliers || online_booking_for_professionnels
+    return if online_booking_with_email || online_booking_for_particuliers || online_booking_for_professionnels
 
-    errors.add(:base, "Vous devez choisir au moins un type d'usager entre particulier et professionnels.")
+    errors.add(:base, "Vous devez autoriser au moins un mode de connexion.")
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -43,7 +43,7 @@ class Organisation < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :territory }
   validates :external_id, uniqueness: { scope: :territory, allow_nil: true }
   validate :validate_organisation_phone_number
-  validate :validate_at_least_one_user_type
+  validate :validate_at_least_one_user_authentication_type
   validates :time_zone,
             presence: true,
             inclusion: {
@@ -123,9 +123,9 @@ class Organisation < ApplicationRecord
 
   private
 
-  def validate_at_least_one_user_type
+  def validate_at_least_one_user_authentication_type
     return if online_booking_with_email || online_booking_for_particuliers || online_booking_for_professionnels
 
-    errors.add(:base, "Vous devez autoriser au moins un mode de connexion.")
+    errors.add(:base, "Vous devez autoriser au moins un mode d'authentification.")
   end
 end

--- a/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
+++ b/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
@@ -14,6 +14,7 @@
 
         p Comment souhaitez-vous permettre à vos usagers de se connecter lors de la prise de rendez-vous avec votre organisation ?
         = simple_form_for @organisation, url: update_user_type_admin_organisation_online_booking_path(@organisation), builder: Dsfr::FormBuilder  do |f|
+          = f.dsfr_check_box :online_booking_with_email, label: "Avec une adresse email", hint: sanitize("On leur demandera de confirmer leur adresse email, mais il n'y aura pas d'autre restrictions.", attributes: %w[href target])
           = f.dsfr_check_box :online_booking_for_particuliers, label: "FranceConnect", hint: sanitize("Recommandé si vos usagers sont des particuliers. #{dsfr_link_to('En savoir plus', 'https://franceconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
           = f.dsfr_check_box :online_booking_for_professionnels, label: "ProConnect", hint: sanitize("Recommandé si vos usagers sont des professionnels  #{dsfr_link_to('En savoir plus', 'https://www.proconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
           .d-flex.rdv-justify-content-space-between

--- a/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
+++ b/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
@@ -10,12 +10,12 @@
   .fr-col-12.fr-col-lg-10
     .card
       .card-body
-        h2.fr-h4 Profil des usagers
+        h2.fr-h4 Modes de connexion
 
-        p Qui participe aux rendez-vous avec les agents de votre organisation ?
+        p Comment souhaitez-vous permettre à vos usagers de se connecter lors de la prise de rendez-vous avec votre organisation ?
         = simple_form_for @organisation, url: update_user_type_admin_organisation_online_booking_path(@organisation), builder: Dsfr::FormBuilder  do |f|
-          = f.dsfr_check_box :online_booking_for_particuliers, label: "des particuliers", hint: sanitize("On leur proposera la connexion avec #{dsfr_link_to('FranceConnect', 'https://franceconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
-          = f.dsfr_check_box :online_booking_for_professionnels, label: "des professionnels", hint: sanitize("On leur proposera la connexion avec #{dsfr_link_to('ProConnect', 'https://www.proconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
+          = f.dsfr_check_box :online_booking_for_particuliers, label: "FranceConnect", hint: sanitize("Recommandé si vos usagers sont des particuliers. #{dsfr_link_to('En savoir plus', 'https://franceconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
+          = f.dsfr_check_box :online_booking_for_professionnels, label: "ProConnect", hint: sanitize("Recommandé si vos usagers sont des professionnels  #{dsfr_link_to('En savoir plus', 'https://www.proconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])
           .d-flex.rdv-justify-content-space-between
             = link_to("Annuler", admin_organisation_online_booking_path(current_organisation), class: "fr-btn fr-btn--tertiary-no-outline")
             = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
+++ b/app/views/admin/organisations/online_bookings/edit_user_type.html.slim
@@ -10,9 +10,9 @@
   .fr-col-12.fr-col-lg-10
     .card
       .card-body
-        h2.fr-h4 Modes de connexion
+        h2.fr-h4 Modes d'authentification
 
-        p Comment souhaitez-vous permettre à vos usagers de se connecter lors de la prise de rendez-vous avec votre organisation ?
+        p Comment préférez-vous que vos usagers s'authentifient lors de la prise de rendez-vous ?
         = simple_form_for @organisation, url: update_user_type_admin_organisation_online_booking_path(@organisation), builder: Dsfr::FormBuilder  do |f|
           = f.dsfr_check_box :online_booking_with_email, label: "Avec une adresse email", hint: sanitize("On leur demandera de confirmer leur adresse email, mais il n'y aura pas d'autre restrictions.", attributes: %w[href target])
           = f.dsfr_check_box :online_booking_for_particuliers, label: "FranceConnect", hint: sanitize("Recommandé si vos usagers sont des particuliers. #{dsfr_link_to('En savoir plus', 'https://franceconnect.gouv.fr/', target: :_blank)}", attributes: %w[href target])

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -49,12 +49,16 @@
     .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
       h2.fr-h4 Modes de connexion
       = link_to "Modifier", edit_user_type_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
-    - if @organisation.online_booking_for_particuliers && @organisation.online_booking_for_professionnels
-      p Vos usagers peuvent se connecter avec #{dsfr_link_to("FranceConnect", "https://franceconnect.gouv.fr/", target: :_blank)} ou #{dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank)}.
-    - elsif @organisation.online_booking_for_particuliers
-      p Vos usagers peuvent se connecter avec #{dsfr_link_to("FranceConnect", "https://franceconnect.gouv.fr/", target: :_blank)}.
-    - elsif @organisation.online_booking_for_professionnels
-      p Vos usagers peuvent se connecter avec #{dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank)}.
+    p
+      |> Vos usagers peuvent se connecter avec
+      ruby:
+        connexion_modes = [
+          ("leur adresse email" if @organisation.online_booking_with_email),
+          (dsfr_link_to("FranceConnect", "https://franceconnect.gouv.fr/", target: :_blank) if @organisation.online_booking_for_particuliers),
+          (dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank) if @organisation.online_booking_for_professionnels),
+        ].compact.to_sentence(two_words_connector: " ou ", last_word_connector: " ou ")
+      = sanitize(connexion_modes, attributes: %w[href target])
+      | .
 
 .card
   .card-body

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -47,14 +47,14 @@
 .card
   .card-body
     .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
-      h2.fr-h4 Profil des usagers
+      h2.fr-h4 Modes de connexion
       = link_to "Modifier", edit_user_type_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
     - if @organisation.online_booking_for_particuliers && @organisation.online_booking_for_professionnels
-      p La réservation en ligne est ouverte pour les <b>particuliers</b> et les <b>professionnels</b>. Il pourront se connecter avec #{dsfr_link_to("FranceConnect", "https://franceconnect.gouv.fr/", target: :_blank)} ou #{dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank)}.
+      p Vos usagers peuvent se connecter avec #{dsfr_link_to("FranceConnect", "https://franceconnect.gouv.fr/", target: :_blank)} ou #{dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank)}.
     - elsif @organisation.online_booking_for_particuliers
-      p La réservation en ligne est ouverte pour les <b>particuliers</b>. Il pourront se connecter avec #{dsfr_link_to("FranceConnect", "https://franceconnect.gouv.fr/", target: :_blank)}.
+      p Vos usagers peuvent se connecter avec #{dsfr_link_to("FranceConnect", "https://franceconnect.gouv.fr/", target: :_blank)}.
     - elsif @organisation.online_booking_for_professionnels
-      p La réservation en ligne est ouverte pour les <b>professionnels</b>. Il pourront se connecter avec #{dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank)}.
+      p Vos usagers peuvent se connecter avec #{dsfr_link_to("ProConnect", "https://www.proconnect.gouv.fr/", target: :_blank)}.
 
 .card
   .card-body

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -47,7 +47,7 @@
 .card
   .card-body
     .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
-      h2.fr-h4 Modes de connexion
+      h2.fr-h4 Modes d'authentification
       = link_to "Modifier", edit_user_type_admin_organisation_online_booking_path(@organisation), class: "fr-btn fr-btn--secondary"
     p
       |> Vos usagers peuvent se connecter avec

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -6,24 +6,24 @@
     organisation = @rdv_wizard&.rdv&.motif&.organisation
     for_particuliers = organisation&.online_booking_for_particuliers
     for_professionnels = organisation&.online_booking_for_professionnels
-    only_sso = organisation&.online_booking_only_proconnect?
+    email_login_allowed = organisation.nil? || organisation.online_booking_with_email?
 
   .card-body
     - if @rdv_wizard.nil? || for_particuliers
       - if display_france_connect_v2_button?
         = render "common/franceconnect_button", display_title: false
         / On affiche le « ou » si le formulaire d’identification par email est activé ou si le bouton ProConnect est affiché
-        - if !only_sso || (display_pro_connect_button? && for_professionnels)
+        - if email_login_allowed || (display_pro_connect_button? && for_professionnels)
           p.fr-hr-or ou
 
     / Contrairement à FranceConnect, on n'affiche pas le bouton ProConnect en dehors de la prise de rendez-vous
     - if display_pro_connect_button? && for_professionnels
       .rdv-text-align-center
         = render "common/proconnect_button_dsfr", user_type: "user"
-      - unless only_sso
+      - if email_login_allowed
         p.fr-hr-or ou
 
-    - unless only_sso
+    - if email_login_allowed
       = form_for @login_code_request_form, url: users_login_codes_path, method: :post, builder: Dsfr::FormBuilder, as: :login_code_request_form do |f|
         = render "model_errors", model: @login_code_request_form, form: f
         - if @rdv_wizard

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -217,6 +217,7 @@ tables:
       - disabled_at
       - online_booking_for_particuliers
       - online_booking_for_professionnels
+      - online_booking_with_email
 
   - table_name: absences
     anonymized_column_names:

--- a/db/migrate/20260518132616_add_online_booking_with_email_to_organisations.rb
+++ b/db/migrate/20260518132616_add_online_booking_with_email_to_organisations.rb
@@ -1,0 +1,12 @@
+class AddOnlineBookingWithEmailToOrganisations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :organisations, :online_booking_with_email, :boolean, default: true, null: false
+
+    change_column_comment(
+      :organisations,
+      :online_booking_with_email,
+      from: nil,
+      to: "Indique si on autorise ou non les usagers à se connecter via leur adresse email lors de la prise de rendez-vous en ligne."
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_01_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_18_132616) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -543,6 +543,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_01_000001) do
     t.string "time_zone", default: "Europe/Paris", null: false
     t.datetime "disabled_at", comment: "Date de fermeture de l'organisation"
     t.string "public_link_id", null: false
+    t.boolean "online_booking_with_email", default: true, null: false, comment: "Indique si on autorise ou non les usagers à se connecter via leur adresse email lors de la prise de rendez-vous en ligne."
     t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["name", "territory_id"], name: "index_organisations_on_name_and_territory_id", unique: true
     t.index ["public_link_id"], name: "index_organisations_on_public_link_id", unique: true

--- a/spec/features/agents/online_booking/configuration_spec.rb
+++ b/spec/features/agents/online_booking/configuration_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "Agents can configure online booking" do
     end
   end
 
-  describe "choix des modes de connexion pour les usagers d'usager qui participer au rendez-vous" do
+  describe "choix des modes d'authentification pour les usagers d'usager qui participer au rendez-vous" do
     before do
       visit edit_user_type_admin_organisation_online_booking_path(organisation)
     end
@@ -171,7 +171,7 @@ RSpec.describe "Agents can configure online booking" do
       find("label", text:  "ProConnect").click
       click_on "Enregistrer"
 
-      expect(page).to have_content "Modes de connexion mis à jour"
+      expect(page).to have_content "Modes d'authentification mis à jour"
 
       expect(organisation.reload).to have_attributes(
         online_booking_for_particuliers: false,
@@ -185,7 +185,7 @@ RSpec.describe "Agents can configure online booking" do
         find("label", text:  "FranceConnect").click
         find("label", text:  "Avec une adresse email").click
         click_on "Enregistrer"
-        expect(page).to have_content "Vous devez autoriser au moins un mode de connexion."
+        expect(page).to have_content "Vous devez autoriser au moins un mode d'authentification."
 
         expect(organisation.reload).to have_attributes(
           online_booking_for_particuliers: true,

--- a/spec/features/agents/online_booking/configuration_spec.rb
+++ b/spec/features/agents/online_booking/configuration_spec.rb
@@ -160,33 +160,37 @@ RSpec.describe "Agents can configure online booking" do
     end
   end
 
-  describe "choix du type d'usager qui participer au rendez-vous" do
+  describe "choix des modes de connexion pour les usagers d'usager qui participer au rendez-vous" do
     before do
       visit edit_user_type_admin_organisation_online_booking_path(organisation)
     end
 
     it "permet de passer de particulier à professionnel" do
-      find("label", text:  "des particuliers").click
-      find("label", text:  "des professionnels").click
+      find("label", text:  "Avec une adresse email").click
+      find("label", text:  "FranceConnect").click
+      find("label", text:  "ProConnect").click
       click_on "Enregistrer"
 
-      expect(page).to have_content "Profil des usagers mis à jour"
+      expect(page).to have_content "Modes de connexion mis à jour"
 
       expect(organisation.reload).to have_attributes(
         online_booking_for_particuliers: false,
-        online_booking_for_professionnels: true
+        online_booking_for_professionnels: true,
+        online_booking_with_email: false
       )
     end
 
     context "si on ne remplit aucune des options" do
       it "affiche un message d'erreur" do
-        find("label", text:  "des particuliers").click
+        find("label", text:  "FranceConnect").click
+        find("label", text:  "Avec une adresse email").click
         click_on "Enregistrer"
-        expect(page).to have_content "Vous devez choisir au moins un type d'usager entre particulier et professionnels."
+        expect(page).to have_content "Vous devez autoriser au moins un mode de connexion."
 
         expect(organisation.reload).to have_attributes(
           online_booking_for_particuliers: true,
-          online_booking_for_professionnels: false
+          online_booking_for_professionnels: false,
+          online_booking_with_email: true
         )
       end
     end

--- a/spec/features/autodoc/produit/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/produit/rendez_vous_entre_agents_spec.rb
@@ -99,16 +99,16 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     click_on "Enregistrer"
 
-    doc.add_screenshot(page, text: "Je clique sur Modifier dans la carte de Profil des usagers", wait_for: "Lien de réservation")
+    doc.add_screenshot(page, text: "Je clique sur Modifier dans la carte de Modes de connexion", wait_for: "Lien de réservation")
 
     click_on "Modifier", match: :first
 
-    find(:label, text: "des particuliers").click
-    find(:label, text: "des professionnels").click
+    find(:label, text: "FranceConnect").click
+    find(:label, text: "ProConnect").click
 
     doc.add_screenshot(page,
                        text: "Je sélectionne la prise de rendez-vous par des professionnels et j'enregistre.",
-                       wait_for: "Qui participe aux rendez-vous avec les agents de votre organisation ?")
+                       wait_for: "Comment souhaitez-vous permettre à vos usagers (les personnes qui prennent rendez-vous avec votre organisation) de se connecter lors de la prise de rendez-vous ?")
 
     click_on "Enregistrer"
 

--- a/spec/features/autodoc/produit/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/produit/rendez_vous_entre_agents_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     click_on "Enregistrer"
 
-    doc.add_screenshot(page, text: "Je clique sur Modifier dans la carte de Modes de connexion", wait_for: "Lien de réservation")
+    doc.add_screenshot(page, text: "Je clique sur Modifier dans la carte de Modes d'authentificiation", wait_for: "Lien de réservation")
 
     click_on "Modifier", match: :first
 
@@ -108,7 +108,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     doc.add_screenshot(page,
                        text: "Je sélectionne la prise de rendez-vous par des professionnels et j'enregistre.",
-                       wait_for: "Comment souhaitez-vous permettre à vos usagers de se connecter")
+                       wait_for: "Comment préférez-vous que vos usagers s'authentifient lors de la prise de rendez-vous")
 
     click_on "Enregistrer"
 

--- a/spec/features/autodoc/produit/rendez_vous_entre_agents_spec.rb
+++ b/spec/features/autodoc/produit/rendez_vous_entre_agents_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "Prise de rendez-vous entre agents", js: true do
 
     doc.add_screenshot(page,
                        text: "Je sélectionne la prise de rendez-vous par des professionnels et j'enregistre.",
-                       wait_for: "Comment souhaitez-vous permettre à vos usagers (les personnes qui prennent rendez-vous avec votre organisation) de se connecter lors de la prise de rendez-vous ?")
+                       wait_for: "Comment souhaitez-vous permettre à vos usagers de se connecter")
 
     click_on "Enregistrer"
 

--- a/spec/features/users/online_booking/on_rdv_service_public_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_service_public_spec.rb
@@ -42,10 +42,7 @@ RSpec.describe "User can search rdv on rdv service public" do
   end
 
   describe "quand l’organisation n’accepte que les prises de RDV par ProConnect" do
-    # Pour le moment on n’accepte que ProConnect pour le territoire qui a l’id 2 sur RDV Service Public
-    # (le territoire qui nous permet de faire les rendez-vous de démo et les webinaires).
-    let!(:territory) { create(:territory, id: 2) }
-    let!(:organisation) { create(:organisation, territory:, verticale: :rdv_mairie) }
+    let!(:organisation) { create(:organisation, online_booking_for_professionnels: true, online_booking_for_particuliers: false, online_booking_with_email: false) }
     let!(:motif) { create(:motif, :by_phone, organisation:) }
     let!(:lieu) { create(:lieu, organisation:) }
     let!(:plage_ouverture) do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -52,32 +52,24 @@ RSpec.describe Organisation, type: :model do
     end
   end
 
-  describe "#online_booking_only_sso?" do
+  describe "#online_booking_only_proconnect?" do
     subject { organisation.online_booking_only_proconnect? }
 
-    let(:territory) { build(:territory, id: territory_id) }
-    let(:organisation) { build(:organisation, territory:, verticale:) }
-    let(:motif) { build(:motif, organisation:) }
+    context "when other connexion types are allowed" do
+      let(:organisation) { build(:organisation, online_booking_for_particuliers: true) }
 
-    context "when on RDV_SERVICE_PUBLIC domain with territory_id 2" do
-      let(:territory_id) { 2 }
-      let(:verticale) { :rdv_mairie }
+      it { is_expected.to be false }
+    end
+
+    context "when only proconnect is allowed" do
+      let(:organisation) do
+        build(:organisation,
+              online_booking_for_professionnels: true,
+              online_booking_for_particuliers: false,
+              online_booking_with_email: false)
+      end
 
       it { is_expected.to be true }
-    end
-
-    context "when on RDV_SERVICE_PUBLIC domain with a different territory_id" do
-      let(:territory_id) { 123 }
-      let(:verticale) { :rdv_mairie }
-
-      it { is_expected.to be false }
-    end
-
-    context "when on RDV_SOLIDARITES domain with territory_id 2" do
-      let(:territory_id) { 2 }
-      let(:verticale) { :rdv_solidarites }
-
-      it { is_expected.to be false }
     end
   end
 end


### PR DESCRIPTION
# Contexte

On a eu plusieurs retours sur les modes de connexions autorisés par les usagers qui vont dans le même sens : 
- des agents qui nous demandent si c'est possible de désactiver la connexion par email pour les usagers lors de la prise de rendez-vous pour utiliser uniquement ProConnect. Le but est de filtrer un peu les usagers et éviter d'avoir des particuliers qui prennent des rendez-vous destinés à des professionnels .
<img width="563" height="196" alt="Screenshot 2026-05-18 at 17 42 15" src="https://github.com/user-attachments/assets/6062b505-d746-4c50-9639-533cd6f5ec6f" />

On remarquera qu'on a déjà implémenté ça pour notre propre compte dans #6182, et on appréciera que cette nouvelle PR corresponde à la prédiction d'Antoine dans la PR précédente 😍 

Certains agents nous disent qu'ils ne savaient pas que la connexion par email était possible (voir https://zammad10.ethibox.fr/#ticket/zoom/39884).



# Solution

On permet d'activer/désactiver la connexion par email, ce qui permet au passage de communiquer explicitement qu'elle est possible.

Le premier commit change les textes pour le comportement existant (j'ai l'impression que les agents comprennent beaucoup plus directement que c'est ce menu qui les intéresse si on parle de FranceConnect/ProConnect plutôt que particuliers/professionnels).
Le deuxième ajoute la possibilité de gérer la connexion par email.

# Checklist

- [x] après la mise en prod réactiver cette option manuellement sur notre espace

## Captures d'écran

Avant | Après
:- | -:
<img width="1159" height="204" alt="Screenshot 2026-05-18 at 17 38 52" src="https://github.com/user-attachments/assets/f58599a4-fc22-417d-b8b6-c9ea2df85e8e" />|<img width="1165" height="175" alt="Screenshot 2026-05-18 at 17 38 26" src="https://github.com/user-attachments/assets/74e48b79-9d61-4783-ba89-5f0ddfed6429" />
<img width="1002" height="460" alt="Screenshot 2026-05-18 at 17 39 08" src="https://github.com/user-attachments/assets/e884c99e-ae5e-4071-ab2a-0092b17e4b6c" />|<img width="995" height="537" alt="Screenshot 2026-05-18 at 17 39 21" src="https://github.com/user-attachments/assets/35a8cd75-fc60-4228-a4eb-57ee7f67df85" />