### PR TITLE
Ne pas afficher des numéros de téléphone vides

### DIFF
--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -20,7 +20,7 @@ ul.list-group.list-group-flush.fr-mb-3w.fr-mt-0
     li.list-group-item.fr-pl-0.fr-py-2w
       span.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
       = human_location(rdv)
-      - if rdv.lieu&.phone_number
+      - if rdv.lieu&.phone_number.present?
         br
         span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
         = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="465" height="70" alt="Screenshot 2026-05-19 at 15 15 59" src="https://github.com/user-attachments/assets/a49e8c7d-edbf-49d8-a3d4-61cc743ea125" />|<img width="477" height="62" alt="Screenshot 2026-05-19 at 15 16 14" src="https://github.com/user-attachments/assets/00402617-3168-4522-832f-b5cac04631d1" />

On a eu un retour sur ce mini bug sur tchap, ça vaut le coup de corriger pour montrer qu'on est réactifs.
