### PR TITLE
Marquer comme sensibles les agents des organisations rdv-insertion

### DIFF
--- a/app/jobs/cron_job/refresh_agents_sensitive_account_job.rb
+++ b/app/jobs/cron_job/refresh_agents_sensitive_account_job.rb
@@ -2,18 +2,34 @@ class CronJob::RefreshAgentsSensitiveAccountJob < CronJob
   SENSITIVE_TERRITORY_RDV_THRESHOLD = 5_000
 
   def perform
-    sensitive_territory_ids = Territory.joins(:organisations)
-      .joins("INNER JOIN rdvs ON rdvs.organisation_id = organisations.id")
+    sensitive_ids = (sensitive_territory_admin_ids + rdv_insertion_agent_ids).uniq
+
+    # rubocop:disable Rails/SkipsModelValidations
+    Agent.where(id: sensitive_ids).in_batches.update_all(sensitive_account: true)
+    Agent.where(id: territory_admin_ids).where.not(id: sensitive_ids).in_batches.update_all(sensitive_account: false)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  private
+
+  def territory_admin_ids
+    AgentTerritorialRole.distinct.pluck(:agent_id)
+  end
+
+  def sensitive_territory_admin_ids
+    AgentTerritorialRole.where(territory_id: sensitive_territory_ids).pluck(:agent_id)
+  end
+
+  def sensitive_territory_ids
+    Territory.joins(organisations: :rdvs)
       .group("territories.id")
       .having("COUNT(rdvs.id) >= ?", SENSITIVE_TERRITORY_RDV_THRESHOLD)
       .pluck(:id)
+  end
 
-    territorial_admin_agent_ids = AgentTerritorialRole.distinct.pluck(:agent_id)
-    sensitive_agent_ids = AgentTerritorialRole.where(territory_id: sensitive_territory_ids).pluck(:agent_id)
-
-    # rubocop:disable Rails/SkipsModelValidations
-    Agent.where(id: sensitive_agent_ids).in_batches.update_all(sensitive_account: true)
-    Agent.where(id: territorial_admin_agent_ids).where.not(id: sensitive_agent_ids).in_batches.update_all(sensitive_account: false)
-    # rubocop:enable Rails/SkipsModelValidations
+  def rdv_insertion_agent_ids
+    AgentRole.joins(:organisation)
+      .where(organisations: { verticale: :rdv_insertion })
+      .distinct.pluck(:agent_id)
   end
 end

--- a/app/jobs/cron_job/refresh_agents_sensitive_account_job.rb
+++ b/app/jobs/cron_job/refresh_agents_sensitive_account_job.rb
@@ -2,7 +2,7 @@ class CronJob::RefreshAgentsSensitiveAccountJob < CronJob
   SENSITIVE_TERRITORY_RDV_THRESHOLD = 5_000
 
   def perform
-    sensitive_ids = (sensitive_territory_admin_ids + rdv_insertion_agent_ids).uniq
+    sensitive_ids = (sensitive_territory_admin_ids + rdv_insertion_admin_agent_ids).uniq
 
     # rubocop:disable Rails/SkipsModelValidations
     Agent.where(id: sensitive_ids).in_batches.update_all(sensitive_account: true)
@@ -27,8 +27,9 @@ class CronJob::RefreshAgentsSensitiveAccountJob < CronJob
       .pluck(:id)
   end
 
-  def rdv_insertion_agent_ids
-    AgentRole.joins(:organisation)
+  def rdv_insertion_admin_agent_ids
+    AgentRole.access_level_admin
+      .joins(:organisation)
       .where(organisations: { verticale: :rdv_insertion })
       .distinct.pluck(:agent_id)
   end

--- a/spec/jobs/cron_job/refresh_agents_sensitive_account_job_spec.rb
+++ b/spec/jobs/cron_job/refresh_agents_sensitive_account_job_spec.rb
@@ -35,21 +35,30 @@ RSpec.describe CronJob::RefreshAgentsSensitiveAccountJob, type: :job do
       expect(agent_without_sensitive.reload.sensitive_account).to be false
     end
 
-    it "met sensitive_account à true pour un agent membre d'une organisation rdv_insertion, quel que soit le nombre de RDVs" do
+    it "met sensitive_account à true pour un agent admin d'une organisation rdv_insertion, quel que soit le nombre de RDVs" do
       organisation = create(:organisation, verticale: :rdv_insertion)
-      agent = create(:agent, basic_role_in_organisations: [organisation], sensitive_account: false)
+      agent = create(:agent, admin_role_in_organisations: [organisation], sensitive_account: false)
 
       described_class.perform_now
 
       expect(agent.reload.sensitive_account).to be true
     end
 
-    it "cumule les critères : un admin de territoire avec peu de RDVs reste sensible s'il est aussi dans une organisation rdv_insertion" do
+    it "ne marque pas comme sensible un agent avec un rôle basic dans une organisation rdv_insertion" do
+      organisation = create(:organisation, verticale: :rdv_insertion)
+      agent = create(:agent, basic_role_in_organisations: [organisation], sensitive_account: false)
+
+      described_class.perform_now
+
+      expect(agent.reload.sensitive_account).to be false
+    end
+
+    it "cumule les critères : un admin de territoire avec peu de RDVs reste sensible s'il est aussi admin d'une organisation rdv_insertion" do
       territory = create(:territory)
       organisation_rdv_insertion = create(:organisation, verticale: :rdv_insertion)
       agent = create(:agent,
                      role_in_territories: [territory],
-                     basic_role_in_organisations: [organisation_rdv_insertion],
+                     admin_role_in_organisations: [organisation_rdv_insertion],
                      sensitive_account: false)
 
       described_class.perform_now

--- a/spec/jobs/cron_job/refresh_agents_sensitive_account_job_spec.rb
+++ b/spec/jobs/cron_job/refresh_agents_sensitive_account_job_spec.rb
@@ -34,5 +34,27 @@ RSpec.describe CronJob::RefreshAgentsSensitiveAccountJob, type: :job do
       expect(agent_with_sensitive.reload.sensitive_account).to be true
       expect(agent_without_sensitive.reload.sensitive_account).to be false
     end
+
+    it "met sensitive_account à true pour un agent membre d'une organisation rdv_insertion, quel que soit le nombre de RDVs" do
+      organisation = create(:organisation, verticale: :rdv_insertion)
+      agent = create(:agent, basic_role_in_organisations: [organisation], sensitive_account: false)
+
+      described_class.perform_now
+
+      expect(agent.reload.sensitive_account).to be true
+    end
+
+    it "cumule les critères : un admin de territoire avec peu de RDVs reste sensible s'il est aussi dans une organisation rdv_insertion" do
+      territory = create(:territory)
+      organisation_rdv_insertion = create(:organisation, verticale: :rdv_insertion)
+      agent = create(:agent,
+                     role_in_territories: [territory],
+                     basic_role_in_organisations: [organisation_rdv_insertion],
+                     sensitive_account: false)
+
+      described_class.perform_now
+
+      expect(agent.reload.sensitive_account).to be true
+    end
   end
 end


### PR DESCRIPTION
Suite de https://github.com/betagouv/rdv-service-public/pull/6319

# Contexte

  La PR #6319 introduit un mécanisme de 2FA par code à 6 chiffres pour les agents ayant un compte "sensible" (flag `sensitive_account`). Aujourd'hui, ce flag est positionné uniquement pour les admins territoriaux dont le territoire a au moins 5 000 RDVs.

  On souhaite étendre ce critère pour considérer comme sensibles **tous les agents <ins>avec le role admin</ins> appartenant à au moins une organisation dont la verticale est `rdv_insertion`**, indépendamment du nombre de RDVs.

Attention : Compte tenu du fort impact UX et support que cela peut avoir ne pas merge cette PR avant d'avoir eu le go de l'équipe rdv-insertion et de Eva Laurent.

Au 17 juin cela concerne :

Nombre d'agents rdvi : 5451
Nombre d'agents rdvi admin d'une organisation : 1285
Nombre d'agents rdvi déjà identifié comme sensible : 53