### PR TITLE
Arrêter d'encourager les agents de RDV Aide Numérique à passer sur RDV Service Public

### DIFF
--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -19,13 +19,10 @@ header.header.bg-white
 
         = render "layouts/rdv_a_renseigner", organisation: defined?(current_organisation) && current_organisation
         li.list-inline-item
-          - if current_domain != Domain::RDV_AIDE_NUMERIQUE
-            = link_to agents_blog_posts_path, class: "btn text-primary-blue link-dsfr d-flex justify-content-center", data: { modal: true } do
-              | Nouveautés
-              - if BlogPost.new_content_for_agent?(current_agent)
-                .ml-1.fr-badge.fr-badge--new.fr-badge--sm.fr-pl-3v
-          - elsif defined?(current_organisation) && current_organisation && current_agent.organisations_count <= 1 && current_agent.admin_in_organisation?(current_organisation)
-            = link_to "Passer à RDV Service Public", admin_organisation_instance_exports_path(current_organisation), class: "btn text-primary-blue link-dsfr"
+          = link_to agents_blog_posts_path, class: "btn text-primary-blue link-dsfr d-flex justify-content-center", data: { modal: true } do
+            | Nouveautés
+            - if BlogPost.new_content_for_agent?(current_agent)
+              .ml-1.fr-badge.fr-badge--new.fr-badge--sm.fr-pl-3v
 
         li#rdv-account-dropdown.list-inline-item.dropdown.mr-2
           button.link-dsfr.dropdown-toggle type="button" data-toggle="dropdown" aria-expanded="false"

--- a/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
+++ b/spec/features/autodoc/migration_depuis_rdv_aide_num_spec.rb
@@ -82,13 +82,13 @@ RSpec.describe "Migration depuis RDV Aide Numérique vers RDV Service Public", j
     doc.start_section("Migration")
 
     login_as(agent_rdv_aide_num, scope: :agent)
-    visit "http://www.rdv-aide-numerique-test.localhost/"
+    visit "http://www.rdv-aide-numerique-test.localhost/admin/organisations/#{organisation_rdv_aide_num.id}/configuration"
 
     doc.add_screenshot(page,
                        text: "Depuis toutes les pages de RDV Aide Numérique, j'ai un lien vers la migration dans le header. Je clique dessus.",
-                       wait_for: "Passer à RDV Service Public")
+                       wait_for: "Migration vers RDV Service Public")
 
-    click_on "Passer à RDV Service Public"
+    click_on "Migration vers RDV Service Public"
 
     Capybara.page.current_window.resize_to(1280, 1200)
 


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="541" height="55" alt="Screenshot 2026-05-19 at 17 35 27" src="https://github.com/user-attachments/assets/7a00a002-0d13-4873-bc68-6bd9f09931c7" />|<img width="460" height="58" alt="Screenshot 2026-05-19 at 17 35 54" src="https://github.com/user-attachments/assets/252dc3c6-0350-4237-b703-225c7077628f" />



# Contexte

On sait qu'il y a plusieurs bugs sur des cas limites de la migration inter-instances RDVAN -> RDVSP, mais actuellement on a du mal à trouver le temps pour les résoudre. Ce chantier a été dépriorisé pour qu'on puisse se concentrer sur la division de l'instance RDV Service Public.

# Solution

Pour limiter le volume de cas à traiter, on enlève du header de RDV Aide Numérique le CTA qui incite à faire la migration.
On ne ferme pas complètement la migration pour éviter que des agents croient qu'ils ont "loupé le coche" et qu'ils ne pourront plus jamais la faire.