### PR TITLE
Ne plus lever d’avertissement Sentry lorsque plusieurs potentialOperators ANCT correspondent

### DIFF
--- a/app/services/espace_operateur_anct/account_creation_router.rb
+++ b/app/services/espace_operateur_anct/account_creation_router.rb
@@ -13,7 +13,6 @@ class EspaceOperateurANCT::AccountCreationRouter
     @domain = domain
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def call
     return Result.new(action: :classic) if @agent.proconnect_siret.blank?
 
@@ -29,12 +28,6 @@ class EspaceOperateurANCT::AccountCreationRouter
     if potential_operators_data.present?
       matches = potential_operators_data.select { |po| Operator.exists?(siret: po["siret"]) }
       if matches.any?
-        if matches.size > 1
-          Sentry.capture_message(
-            "ProConnectOnboardingRouter: plusieurs potentialOperators matchent notre DB",
-            extra: { agent_id: @agent.id, sirets: matches.pluck("siret") }
-          )
-        end
         return Result.new(action: :signup_via_operator, signup_url: matches.first["signupUrl"], operator_name: matches.first["name"])
       end
     end
@@ -44,7 +37,6 @@ class EspaceOperateurANCT::AccountCreationRouter
     Sentry.capture_exception(e)
     Result.new(action: :classic)
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   private
 

--- a/app/services/espace_operateur_anct/account_creation_router.rb
+++ b/app/services/espace_operateur_anct/account_creation_router.rb
@@ -15,18 +15,19 @@ class EspaceOperateurANCT::AccountCreationRouter
 
   # rubocop:disable Metrics/PerceivedComplexity
   def call
-    if @agent.proconnect_siret.present?
-      if matching_operator
-        if anct_client.admin?
-          attach_or_create_territory
-          return Result.new(action: :attached_as_admin)
-        elsif anct_client.can_access?
-          return Result.new(action: :contact_admin)
-        end
-      elsif matching_potential_operator
-        return Result.new(action: :signup_via_operator, signup_url: matching_potential_operator["signupUrl"], operator_name: matching_potential_operator["name"])
+    return Result.new(action: :classic) if @agent.proconnect_siret.blank?
+
+    if matching_operator
+      if anct_client.admin?
+        attach_or_create_territory
+        return Result.new(action: :attached_as_admin)
+      elsif anct_client.can_access?
+        return Result.new(action: :contact_admin)
       end
+    elsif matching_potential_operator
+      return Result.new(action: :signup_via_operator, signup_url: matching_potential_operator["signupUrl"], operator_name: matching_potential_operator["name"])
     end
+
     Result.new(action: :classic)
   rescue StandardError => e
     Sentry.capture_exception(e)

--- a/app/services/espace_operateur_anct/account_creation_router.rb
+++ b/app/services/espace_operateur_anct/account_creation_router.rb
@@ -13,21 +13,20 @@ class EspaceOperateurANCT::AccountCreationRouter
     @domain = domain
   end
 
+  # rubocop:disable Metrics/PerceivedComplexity
   def call
-    return Result.new(action: :classic) if @agent.proconnect_siret.blank?
-
-    if matching_operator
+    if @agent.proconnect_siret.blank?
+      return Result.new(action: :classic)
+    elsif matching_operator
       if anct_client.admin?
         attach_or_create_territory
-        Result.new(action: :attached_as_admin)
+        return Result.new(action: :attached_as_admin)
       elsif anct_client.can_access?
-        Result.new(action: :contact_admin)
+        return Result.new(action: :contact_admin)
       else
-        Result.new(action: :classic)
+        return Result.new(action: :classic)
       end
-    end
-
-    if matching_potential_operator
+    elsif matching_potential_operator
       return Result.new(action: :signup_via_operator, signup_url: matching_potential_operator["signupUrl"], operator_name: matching_potential_operator["name"])
     end
 
@@ -36,6 +35,7 @@ class EspaceOperateurANCT::AccountCreationRouter
     Sentry.capture_exception(e)
     Result.new(action: :classic)
   end
+  # rubocop:enable Metrics/PerceivedComplexity
 
   private
 

--- a/app/services/espace_operateur_anct/account_creation_router.rb
+++ b/app/services/espace_operateur_anct/account_creation_router.rb
@@ -16,20 +16,12 @@ class EspaceOperateurANCT::AccountCreationRouter
   def call
     return Result.new(action: :classic) if @agent.proconnect_siret.blank?
 
-    operator_data = anct_client.operator
-
-    if operator_data.present?
-      operator = Operator.find_by(siret: operator_data["siret"])
-      return handle_operator_case(anct_client, operator) if operator
+    if matching_operator
+      return handle_operator_case(anct_client, matching_operator)
     end
 
-    potential_operators_data = anct_client.potential_operators
-
-    if potential_operators_data.present?
-      matches = potential_operators_data.select { |po| Operator.exists?(siret: po["siret"]) }
-      if matches.any?
-        return Result.new(action: :signup_via_operator, signup_url: matches.first["signupUrl"], operator_name: matches.first["name"])
-      end
+    if matching_potential_operator
+      return Result.new(action: :signup_via_operator, signup_url: matching_potential_operator["signupUrl"], operator_name: matching_potential_operator["name"])
     end
 
     Result.new(action: :classic)
@@ -39,6 +31,21 @@ class EspaceOperateurANCT::AccountCreationRouter
   end
 
   private
+
+  def matching_operator
+    return @matching_operator if defined?(@matching_operator)
+
+    @matching_operator = nil
+    return if anct_client.operator.nil?
+
+    @matching_operator = Operator.find_by(siret: anct_client.operator["siret"])
+  end
+
+  def matching_potential_operator
+    return @matching_potential_operator if defined?(@matching_potential_operator)
+
+    @matching_potential_operator = anct_client.potential_operators.find { |po| Operator.exists?(siret: po["siret"]) }
+  end
 
   def anct_client
     @anct_client ||= EspaceOperateurANCT::ApiClient.new(@agent.proconnect_siret, @agent.email)

--- a/app/services/espace_operateur_anct/account_creation_router.rb
+++ b/app/services/espace_operateur_anct/account_creation_router.rb
@@ -15,21 +15,18 @@ class EspaceOperateurANCT::AccountCreationRouter
 
   # rubocop:disable Metrics/PerceivedComplexity
   def call
-    if @agent.proconnect_siret.blank?
-      return Result.new(action: :classic)
-    elsif matching_operator
-      if anct_client.admin?
-        attach_or_create_territory
-        return Result.new(action: :attached_as_admin)
-      elsif anct_client.can_access?
-        return Result.new(action: :contact_admin)
-      else
-        return Result.new(action: :classic)
+    if @agent.proconnect_siret.present?
+      if matching_operator
+        if anct_client.admin?
+          attach_or_create_territory
+          return Result.new(action: :attached_as_admin)
+        elsif anct_client.can_access?
+          return Result.new(action: :contact_admin)
+        end
+      elsif matching_potential_operator
+        return Result.new(action: :signup_via_operator, signup_url: matching_potential_operator["signupUrl"], operator_name: matching_potential_operator["name"])
       end
-    elsif matching_potential_operator
-      return Result.new(action: :signup_via_operator, signup_url: matching_potential_operator["signupUrl"], operator_name: matching_potential_operator["name"])
     end
-
     Result.new(action: :classic)
   rescue StandardError => e
     Sentry.capture_exception(e)

--- a/app/services/espace_operateur_anct/account_creation_router.rb
+++ b/app/services/espace_operateur_anct/account_creation_router.rb
@@ -17,7 +17,14 @@ class EspaceOperateurANCT::AccountCreationRouter
     return Result.new(action: :classic) if @agent.proconnect_siret.blank?
 
     if matching_operator
-      return handle_operator_case(anct_client, matching_operator)
+      if anct_client.admin?
+        attach_or_create_territory
+        Result.new(action: :attached_as_admin)
+      elsif anct_client.can_access?
+        Result.new(action: :contact_admin)
+      else
+        Result.new(action: :classic)
+      end
     end
 
     if matching_potential_operator
@@ -51,20 +58,9 @@ class EspaceOperateurANCT::AccountCreationRouter
     @anct_client ||= EspaceOperateurANCT::ApiClient.new(@agent.proconnect_siret, @agent.email)
   end
 
-  def handle_operator_case(anct_client, operator)
-    if anct_client.admin?
-      attach_or_create_territory(operator, anct_client)
-      Result.new(action: :attached_as_admin)
-    elsif anct_client.can_access?
-      Result.new(action: :contact_admin)
-    else
-      Result.new(action: :classic)
-    end
-  end
-
-  def attach_or_create_territory(operator, anct_client)
+  def attach_or_create_territory
     ActiveRecord::Base.transaction do
-      existing_territories = Territory.where(operator: operator, siret: @agent.proconnect_siret)
+      existing_territories = Territory.where(operator: matching_operator, siret: @agent.proconnect_siret)
 
       if existing_territories.many?
         raise "ProConnectOnboardingRouter: plusieurs territoires avec le même SIRET et opérateur (#{existing_territories.pluck(:id).join(', ')})"
@@ -73,7 +69,7 @@ class EspaceOperateurANCT::AccountCreationRouter
       existing_territory = existing_territories.first
 
       territory = existing_territory || Territory.create!(
-        operator: operator,
+        operator: matching_operator,
         category: ANCT_TYPE_TO_CATEGORY.fetch(anct_client.organization&.fetch("type", nil), "Inconnu"),
         siret: @agent.proconnect_siret
       )
@@ -85,7 +81,7 @@ class EspaceOperateurANCT::AccountCreationRouter
         verticale: @domain.verticale
       )
 
-      capture_attach_sentry_message(operator, territory, organisation, new_account: existing_territory.nil? || existing_organisation.nil?)
+      capture_attach_sentry_message(matching_operator, territory, organisation, new_account: existing_territory.nil? || existing_organisation.nil?)
 
       AgentRole.create!(agent: @agent, organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN)
       AgentTerritorialRole.create!(agent: @agent, territory: territory)

--- a/app/services/espace_operateur_anct/api_client.rb
+++ b/app/services/espace_operateur_anct/api_client.rb
@@ -18,7 +18,7 @@ class EspaceOperateurANCT::ApiClient
   end
 
   def potential_operators
-    parsed_response["potentialOperators"]
+    parsed_response.fetch("potentialOperators", [])
   end
 
   def entitlements

--- a/spec/services/espace_operateur_anct/account_creation_router_spec.rb
+++ b/spec/services/espace_operateur_anct/account_creation_router_spec.rb
@@ -141,15 +141,7 @@ RSpec.describe EspaceOperateurANCT::AccountCreationRouter do
 
       around { |ex| VCR.use_cassette("espace_operateur_anct/entitlements_with_potential_operators") { ex.run } }
 
-      it "envoie un message Sentry" do
-        expect(Sentry).to receive(:capture_message).with(
-          "ProConnectOnboardingRouter: plusieurs potentialOperators matchent notre DB",
-          extra: { agent_id: agent.id, sirets: %w[13002603200016 12345678901234] }
-        )
-        handler.call
-      end
-
-      it "retourne quand même :signup_via_operator avec le premier match" do
+      it "retourne :signup_via_operator avec le premier opérateur qu'on retrouve dans notre DB" do
         allow(Sentry).to receive(:capture_message)
         result = handler.call
         expect(result.action).to eq(:signup_via_operator)

--- a/spec/services/espace_operateur_anct/api_client_spec.rb
+++ b/spec/services/espace_operateur_anct/api_client_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe EspaceOperateurANCT::ApiClient do
     end
 
     it "n’a pas d’opérateurs potentiels" do
-      expect(service.potential_operators).to be_nil
+      expect(service.potential_operators).to be_empty
     end
 
     it "retourne les entitlements" do


### PR DESCRIPTION
# Contexte

Lorsqu’un agent de collectivité se ProConnect sur RDVSP, on interroge l’API opérateur de l’ANCT avec l’email de l’agent et le SIRET de la collectivité.

L’API nous dit si la commune est explicitement rattachée (adhérente) d'un OPSN. Si ce n’est pas le cas l’API nous dit qui sont les « potentiels » opérateurs. Cela peut-être des OPSN présents sur le territoire. Il semble y avoir toujours l’ANCT elle-même en dernier `potentialOperator` retourné par cette API. 

Si je comprends bien cela indique que si la collectivité refuse d’adhérer à un OPSN, ou n'en n’a pas sur son territoire elle peut toujours demander à l’ANCT en propre.

Aussi, on commence à voir arriver des ouvertures de compte RDVSP pour des communes depuis l’espace opérateur avec l’ANCT comme opérateur. Je viens de créer un compte Opérateur ANCT correspondant dans notre DB de prod, ce n’était pas encore le cas. 

Jusqu’à maintenant, on envoie un warning sentry lorsqu’il y a plusieurs `potentialOperators` correspondant à des opérateurs dans notre DB. c’est en fait un cas normal qui ne devrait rien lever.

# Solution

Je supprime l’avertissement sentry et on choisit le premier opérateur potentiel qui correspond dans notre DB.

Après je fais un grand refacto pas indispensable 🤷 j'avais besoin de coder un peu je crois