### PR TITLE
Désactiver toutes les règles Metrics de rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,29 +46,40 @@ Lint/AssignmentInCondition:
   Exclude:
     - 'db/migrate/20211215182150_add_service_name_to_active_storage_blobs.active_storage.rb'
 
+# disable all Metrics Length cops. They don’t provide an explicit way to improve code.
+# cf https://docs.rubocop.org/rubocop/latest/cops.html#department-metrics
+
 Metrics/AbcSize:
   Enabled: false
 
-Metrics/CyclomaticComplexity:
-  Max: 8 # default is 7
-
-
-# disable all Metrics Length cops. They don’t provide an explicit way to improve code.
-
 Metrics/BlockLength:
+  Enabled: false
+
+Metrics/BlockNesting:
   Enabled: false
 
 Metrics/ClassLength:
   Enabled: false
 
-Metrics/ModuleLength:
+Metrics/CollectionLiteralLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
   Enabled: false
 
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/ModuleLength:
+  Enabled: false
+
 Metrics/ParameterLists:
   Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+# Rails cops
 
 Rails/ApplicationController:
   Exclude:

--- a/app/controllers/admin/territories/motifs_controller.rb
+++ b/app/controllers/admin/territories/motifs_controller.rb
@@ -37,7 +37,7 @@ class Admin::Territories::MotifsController < Admin::Territories::BaseController
     custom_cancel_warning_message
   ].freeze
 
-  def batch_update # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
+  def batch_update
     @motifs = Motif.where(id: params[:motif_ids])
     @motifs.each do |motif|
       authorize(motif, :update?, policy_class: Agent::MotifPolicy)

--- a/app/controllers/api/v1/plage_ouvertures_controller.rb
+++ b/app/controllers/api/v1/plage_ouvertures_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
-  def create # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+  def create
     plage_ouverture = PlageOuverture.new(create_params)
 
     # On ne documente pas encore la possibilité d'utiliser le param recurrence, puisqu'on s'en sert uniquement

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
   before_action :normalize_array_params, only: %i[index]
 
-  def index # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+  def index
     rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).where(params.permit(:organisation_id))
 
     rdvs = rdvs.starts_after(Time.zone.parse(params[:starts_after])) if params[:starts_after].present?

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -1,7 +1,7 @@
 # cf docs/interconnexions/visioplainte.md
 
 class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
-  def index # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
+  def index
     if params[:ids].blank? && (params[:date_debut].blank? || params[:date_fin].blank?)
       errors = ["Vous devez préciser le paramètre ids ou les paramètres date_debut et date_fin"]
       render(json: { errors: errors }, status: :bad_request) and return

--- a/app/controllers/pro_connect_controller.rb
+++ b/app/controllers/pro_connect_controller.rb
@@ -25,7 +25,6 @@ class ProConnectController < ApplicationController
     redirect_to auth_client.redirect_url(pro_connect_callback_url, force_2fa:), allow_other_host: true
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def callback
     if params[:error] == "server_error"
       flash[:error] = "L'authentification a échoué en raison d'une erreur côté ProConnect. Nous vous invitons à contacter leur support."

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -23,7 +23,7 @@ class SearchController < ApplicationController
     end
   end
 
-  def search_rdv # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+  def search_rdv
     if search_on_migrated_organisation
       redirect_to migrated_organisation_booking_url, allow_other_host: true
     elsif current_agent && params[:prescripteur] == Prescripteur::INTERNE && params[:current_organisation]

--- a/app/form_models/admin/rdv_search_form.rb
+++ b/app/form_models/admin/rdv_search_form.rb
@@ -34,7 +34,7 @@ class Admin::RdvSearchForm
     false
   end
 
-  def applied_filters # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def applied_filters
     @applied_filters ||= begin
       filters = []
       filters << :agent if agent.present?

--- a/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
+++ b/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
@@ -33,7 +33,7 @@ module Admin::RdvWizardFormConcern
     end
   end
 
-  def to_query # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def to_query
     hash = {
       motif_id: rdv.motif&.id,
       duration_in_min: rdv.duration_in_min,

--- a/app/helpers/recurrence_helper.rb
+++ b/app/helpers/recurrence_helper.rb
@@ -11,7 +11,7 @@ module RecurrenceHelper
     [every_part, time_part, range_part]
   end
 
-  def display_every(recurrent_record) # rubocop:disable Metrics/PerceivedComplexity
+  def display_every(recurrent_record)
     recurrence_hash = recurrent_record.recurrence.to_hash
 
     interval = "#{recurrence_hash[:interval]} " if recurrence_hash[:interval]&.>(1)

--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -25,7 +25,7 @@ class TransferEmailReplyJob < ApplicationJob
     email_address.match(UUID_EXTRACTOR)&.captures&.first
   end
 
-  def perform(sendinblue_hash) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def perform(sendinblue_hash)
     @sendinblue_hash = sendinblue_hash.with_indifferent_access
 
     if rdv&.agents&.pluck(:email)&.compact&.any?

--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -1,7 +1,6 @@
 module Rdv::Updatable
   extend ActiveSupport::Concern
 
-  # rubocop:disable Metrics/PerceivedComplexity
   def update_and_notify(author, attributes, &block)
     Rdv.transaction do
       @old_agent_ids = agent_ids.to_a

--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -49,7 +49,6 @@ module Outlook
     # payload (hash): a JSON hash representing the API call's payload. Only used
     #                 for POST or PATCH.
 
-    # rubocop:disable Metrics/CyclomaticComplexity
     def call_events_api(method, path, event_payload = {})
       headers = {
         "Authorization" => "Bearer #{@agent.microsoft_graph_token}",

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -282,8 +282,6 @@ class Rdv < ApplicationRecord
     ""
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def self.search_for(organisations, options)
     rdvs = joins(:organisation).where(organisation: organisations)
     options = options.with_indifferent_access.select { |_, value| Array(value).compact_blank.present? }

--- a/app/services/create_rdv_in_new_instance.rb
+++ b/app/services/create_rdv_in_new_instance.rb
@@ -20,7 +20,7 @@ class CreateRdvInNewInstance
 
   private
 
-  def build_rdv # rubocop:disable Metrics/PerceivedComplexity
+  def build_rdv
     # On crée le rendez-vous via ActiveRecord sans lancer les Notifiers, ce qui évite de déclencher des callbacks de notifications pour les agents et les usager
     rdv = Rdv.new(
       params.permit(%w[starts_at status cancelled_at context ends_at name max_participants_count])

--- a/app/services/espace_operateur_anct/account_creation_router.rb
+++ b/app/services/espace_operateur_anct/account_creation_router.rb
@@ -13,7 +13,6 @@ class EspaceOperateurANCT::AccountCreationRouter
     @domain = domain
   end
 
-  # rubocop:disable Metrics/PerceivedComplexity
   def call
     return Result.new(action: :classic) if @agent.proconnect_siret.blank?
 
@@ -33,7 +32,6 @@ class EspaceOperateurANCT::AccountCreationRouter
     Sentry.capture_exception(e)
     Result.new(action: :classic)
   end
-  # rubocop:enable Metrics/PerceivedComplexity
 
   private
 

--- a/app/services/ical/rrule_expander.rb
+++ b/app/services/ical/rrule_expander.rb
@@ -3,7 +3,7 @@ class Ical::RruleExpander
     @raw_ical = raw_ical
   end
 
-  def compute_occurrences_within(time_range) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def compute_occurrences_within(time_range)
     all_occurrences = []
     calendars = Icalendar::Calendar.parse(@raw_ical)
 

--- a/app/services/ical_formatters/ics.rb
+++ b/app/services/ical_formatters/ics.rb
@@ -36,7 +36,6 @@ module IcalFormatters
       cal
     end
 
-    # rubocop:disable Metrics/PerceivedComplexity
     def self.populate_event(event, payload, tzid)
       event.uid = payload[:ical_uid]
       event.status = if payload[:action].present? && payload[:action] == :destroy

--- a/app/services/plage_ouverture_overlap.rb
+++ b/app/services/plage_ouverture_overlap.rb
@@ -6,7 +6,7 @@ class PlageOuvertureOverlap
     @po2 = po2
   end
 
-  def exists? # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def exists?
     return false if po1.agent != po2.agent
 
     if po1.ponctuelle? && po2.ponctuelle?
@@ -49,7 +49,7 @@ class PlageOuvertureOverlap
     !options1.day.intersect?(options2.day)
   end
 
-  def both_monthly_but_different_days? # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def both_monthly_but_different_days?
     return false unless po1.recurring? && po2.recurring?
 
     # both PO are monthly

--- a/app/services/rdv_exporter.rb
+++ b/app/services/rdv_exporter.rb
@@ -62,8 +62,6 @@ module RdvExporter
     end
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def self.row_array_from(rdv)
     [
       rdv.created_at.year,

--- a/spec/support/autodoc.rb
+++ b/spec/support/autodoc.rb
@@ -55,7 +55,7 @@ class Autodoc
     # On zoome artificiellement pour avoir des captures d'écran en haute résolution, mais cela peut fausser l'affichage
     # des pages qui utilisent un layout centré verticalement.
     # Dans ce cas, il faut passer l'option `disable_high_res_zoom: true` pour avoir un affichage correct (mais une capture d'écran en basse définition)
-    def add_screenshot(page_or_email, text: nil, wait_for: nil, accessibility_checks: true, disable_high_res_zoom: false) # rubocop:disable Metrics/PerceivedComplexity
+    def add_screenshot(page_or_email, text: nil, wait_for: nil, accessibility_checks: true, disable_high_res_zoom: false)
       if wait_for
         @example.expect(page_or_email).to(@example.have_content(wait_for))
       end


### PR DESCRIPTION
J’ouvre cette PR pour discussion :) 

# Contexte

Dans https://github.com/betagouv/rdv-service-public/pull/4585 on avait déjà désactivé les règles `Metrics/.*Length`. On avait fait le choix conscient de garder les règles sur `Complexity` comme l'indique le commentaire de François dans cette PR. 

Or : 
- depuis fort longtemps on a remonté le défaut de `CyclomaticComplexity.Max` de 7 à 8, je crois que c'était en 2020 dans #648
- Dans notre code on a 20 fichiers où on désactive manuellement sur des lignes ou des blocs `PerceivedComplexity` ou `CyclomaticComplexity`. 

J’ai l’impression que souvent ces règles de complexité ne nous aident pas pour écrire du code plus clair mais qu'elle nous encourage à extraire des choses de manière un peu arbitraire et souvent détrimentale à la lecture.

# Solution

Je propose de désactiver __toutes__ les règles Metrics, même celles qu'on n'a pas encore désactivé manuellement sur des fichiers.