### PR TITLE
Ignorer les erreurs permanentes sur la synchro outlook

### DIFF
--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -30,6 +30,8 @@ module Outlook
 
     def update_event!(outlook_event_id, payload)
       call_events_api("PATCH", "me/Events/#{outlook_event_id}", payload)
+    rescue NotFoundError => e
+      Rails.logger.error("Outlook error while updating event: #{e.message}")
     end
 
     def delete_event!(outlook_event_id)

--- a/spec/models/outlook/api_client_spec.rb
+++ b/spec/models/outlook/api_client_spec.rb
@@ -65,26 +65,52 @@ RSpec.describe Outlook::ApiClient do
     end
 
     context "when the error is permanent" do
-      before do
-        stub_request(:delete, "https://graph.microsoft.com/v1.0/me/Events/abc")
-          .to_return(
-            status: 404,
-            body: {
-              error: {
-                code: "ErrorItemNotFound", # this error is permanent
-                message: "The specified object was not found in the store",
-              },
-            }.to_json,
-            headers: {}
-          )
+      context "for a deletion" do
+        before do
+          stub_request(:delete, "https://graph.microsoft.com/v1.0/me/Events/abc")
+            .to_return(
+              status: 404,
+              body: {
+                error: {
+                  code: "ErrorItemNotFound", # this error is permanent
+                  message: "The specified object was not found in the store",
+                },
+              }.to_json,
+              headers: {}
+            )
+        end
+
+        it "logs the error but does not warn Sentry" do
+          allow(Rails.logger).to receive(:error)
+          described_class.new(agent).delete_event!("abc")
+
+          expect(Rails.logger).to have_received(:error).with("Outlook error while deleting event: The specified object was not found in the store")
+          expect(sentry_events).to be_empty
+        end
       end
 
-      it "logs the error but does not warn Sentry" do
-        allow(Rails.logger).to receive(:error)
-        described_class.new(agent).delete_event!("abc")
+      context "for an update" do
+        before do
+          stub_request(:patch, "https://graph.microsoft.com/v1.0/me/Events/abc")
+            .to_return(
+              status: 404,
+              body: {
+                error: {
+                  code: "ErrorItemNotFound", # this error is permanent
+                  message: "The specified object was not found in the store",
+                },
+              }.to_json,
+              headers: {}
+            )
+        end
 
-        expect(Rails.logger).to have_received(:error).with("Outlook error while deleting event: The specified object was not found in the store")
-        expect(sentry_events).to be_empty
+        it "logs the error but does not warn Sentry" do
+          allow(Rails.logger).to receive(:error)
+          described_class.new(agent).update_event!("abc", expected_body)
+
+          expect(Rails.logger).to have_received(:error).with("Outlook error while updating event: The specified object was not found in the store")
+          expect(sentry_events).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
fixes https://sentry.incubateur.net/organizations/betagouv/issues/131315

# Contexte

Cette PR est la suite de https://github.com/betagouv/rdv-service-public/issues/3512 : on ignore la même erreur définitive dans le cas des updates pour limiter le bruit dans sentry.

Si on voulait reprendre le travail sur la synchro outlook, on pourrait enregistrer que le rdv n'est pas synchronisé, afficher un message d'erreur quelque part, et proposer à l'agent de réessayer la synchronisation (ou de dismiss le message d'erreur), mais je pense que c'est probablement pas très utile : si le rdv a été supprimé de l'agenda externe, c'est sans doute volontaire dans la plupart des cas.


