### PR TITLE
Refactor préalable aux intervalles après les RDV

### DIFF
--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -8,7 +8,7 @@ class CreneauxSearch::Calculator
     @lieu = lieu
     @date_range = date_range
     @agents = agents
-    @duration_in_min = duration_in_min
+    @duration_in_min = duration_in_min || motif.default_duration_in_min
   end
 
   def available_slots
@@ -34,8 +34,9 @@ class CreneauxSearch::Calculator
         work_on_off_days:
       ).perform
 
-      creneaux = SplitFreeTimeRangesIntoCreneaux.new(free_times, @motif, duration_in_min: @duration_in_min).perform(@datetime_range)
+      creneaux = SplitFreeTimeRangesIntoCreneaux.new(free_times, duration_in_min: @duration_in_min).perform(@datetime_range)
       creneaux.each do |creneau|
+        creneau.motif = @motif
         creneau.agent = plage_ouverture.agent
         creneau.lieu_id = plage_ouverture.lieu_id
       end

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -34,7 +34,11 @@ class CreneauxSearch::Calculator
         work_on_off_days:
       ).perform
 
-      SplitFreeTimeRangesIntoCreneaux.new(free_times, @motif, plage_ouverture, duration_in_min: @duration_in_min).perform(@datetime_range)
+      creneaux = SplitFreeTimeRangesIntoCreneaux.new(free_times, @motif, duration_in_min: @duration_in_min).perform(@datetime_range)
+      creneaux.each do |creneau|
+        creneau.agent = plage_ouverture.agent
+        creneau.lieu_id = plage_ouverture.lieu_id
+      end
     end.flatten
   end
 

--- a/app/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux.rb
+++ b/app/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux.rb
@@ -1,8 +1,7 @@
 class CreneauxSearch::Calculator::SplitFreeTimeRangesIntoCreneaux
-  def initialize(free_time_ranges, motif, plage_ouverture, duration_in_min:)
+  def initialize(free_time_ranges, motif, duration_in_min:)
     @free_time_ranges = free_time_ranges
     @motif = motif
-    @plage_ouverture = plage_ouverture
     @duration_in_min = duration_in_min
   end
 
@@ -33,9 +32,7 @@ class CreneauxSearch::Calculator::SplitFreeTimeRangesIntoCreneaux
       slots << Creneau.new(
         starts_at: possible_slot_start,
         motif: @motif,
-        duration_in_min:,
-        lieu_id: @plage_ouverture.lieu_id,
-        agent: @plage_ouverture.agent
+        duration_in_min:
       )
       possible_slot_start += duration_in_min.minutes
     end

--- a/app/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux.rb
+++ b/app/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux.rb
@@ -8,7 +8,7 @@ class CreneauxSearch::Calculator::SplitFreeTimeRangesIntoCreneaux
     slots = []
 
     @free_time_ranges.each do |free_time|
-      slots += calculate_slots(free_time, duration_in_min:)
+      slots += calculate_slots(free_time)
     end
 
     slots.select do |slot|
@@ -18,20 +18,18 @@ class CreneauxSearch::Calculator::SplitFreeTimeRangesIntoCreneaux
 
   private
 
-  attr_reader :duration_in_min
-
-  def calculate_slots(free_time, duration_in_min: nil)
+  def calculate_slots(free_time)
     possible_slot_start = earliest_possible_slot_start(free_time)
-    last_possible_slot_start = free_time.end - duration_in_min.minutes
+    last_possible_slot_start = free_time.end - @duration_in_min.minutes
 
     slots = []
 
     while possible_slot_start <= last_possible_slot_start
       slots << Creneau.new(
         starts_at: possible_slot_start,
-        duration_in_min:
+        duration_in_min: @duration_in_min
       )
-      possible_slot_start += duration_in_min.minutes
+      possible_slot_start += @duration_in_min.minutes
     end
     slots
   end

--- a/app/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux.rb
+++ b/app/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux.rb
@@ -1,7 +1,6 @@
 class CreneauxSearch::Calculator::SplitFreeTimeRangesIntoCreneaux
-  def initialize(free_time_ranges, motif, duration_in_min:)
+  def initialize(free_time_ranges, duration_in_min:)
     @free_time_ranges = free_time_ranges
-    @motif = motif
     @duration_in_min = duration_in_min
   end
 
@@ -23,7 +22,6 @@ class CreneauxSearch::Calculator::SplitFreeTimeRangesIntoCreneaux
 
   def calculate_slots(free_time, duration_in_min: nil)
     possible_slot_start = earliest_possible_slot_start(free_time)
-    duration_in_min ||= @motif.default_duration_in_min
     last_possible_slot_start = free_time.end - duration_in_min.minutes
 
     slots = []
@@ -31,7 +29,6 @@ class CreneauxSearch::Calculator::SplitFreeTimeRangesIntoCreneaux
     while possible_slot_start <= last_possible_slot_start
       slots << Creneau.new(
         starts_at: possible_slot_start,
-        motif: @motif,
         duration_in_min:
       )
       possible_slot_start += duration_in_min.minutes

--- a/spec/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux_spec.rb
+++ b/spec/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe CreneauxSearch::Calculator::SplitFreeTimeRangesIntoCreneaux do
   subject(:creneaux) do
-    described_class.new(free_time_ranges, motif, plage_ouverture, duration_in_min:).perform(search_datetime_range)
+    described_class.new(free_time_ranges, motif, duration_in_min:).perform(search_datetime_range)
   end
 
   let(:friday) { Time.zone.parse("20210430 8:00") }
@@ -8,7 +8,6 @@ RSpec.describe CreneauxSearch::Calculator::SplitFreeTimeRangesIntoCreneaux do
     Time.zone.parse("20211027 0:00")..Time.zone.parse("20211028 0:00")
   end
   let(:motif) { build(:motif, default_duration_in_min: 30) }
-  let(:plage_ouverture) { build(:plage_ouverture, motifs: [motif], first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)) }
   let(:duration_in_min) { nil }
 
   before { travel_to(friday) }

--- a/spec/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux_spec.rb
+++ b/spec/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux_spec.rb
@@ -1,14 +1,13 @@
 RSpec.describe CreneauxSearch::Calculator::SplitFreeTimeRangesIntoCreneaux do
   subject(:creneaux) do
-    described_class.new(free_time_ranges, motif, duration_in_min:).perform(search_datetime_range)
+    described_class.new(free_time_ranges, duration_in_min:).perform(search_datetime_range)
   end
 
   let(:friday) { Time.zone.parse("20210430 8:00") }
   let(:search_datetime_range) do
     Time.zone.parse("20211027 0:00")..Time.zone.parse("20211028 0:00")
   end
-  let(:motif) { build(:motif, default_duration_in_min: 30) }
-  let(:duration_in_min) { nil }
+  let(:duration_in_min) { 30 }
 
   before { travel_to(friday) }
 

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -15,13 +15,24 @@ RSpec.describe CreneauxSearch::Calculator do
   end
 
   context "with a plage d'ouverture lasting 2 hours" do
-    before do
+    let!(:plage_ouverture) do
       create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
     end
 
     it "returns 2 slots" do
       expect(available_slots.map(&:starts_at).map { _1.strftime("%H:%M") }).to eq(["09:00", "10:00"])
       expect(available_slots.first.class.to_s).to eq("Creneau")
+    end
+
+    it "builds a Creneau with full details (motif, agent, plage)" do
+      expected_attrs = {
+        starts_at: Time.zone.parse("2021-05-03 09:00:00"),
+        duration_in_min: plage_ouverture.motifs.sole.default_duration_in_min,
+        lieu_id: plage_ouverture.lieu_id,
+        agent: plage_ouverture.agent,
+        motif: plage_ouverture.motifs.sole,
+      }
+      expect(available_slots.first).to have_attributes(expected_attrs)
     end
 
     context "when passing a duration_in_min" do


### PR DESCRIPTION
# Contexte

En synthèse : cette PR a pour but de ne garder que la logique de découpage dans `SplitFreeTimeRangesIntoCreneaux`, et ainsi de lui retirer ses dépendances sur les notions de plage, de lieu, d'agent et de motif. Cela permet de simplifier les tests en vue de #6305.

---

Alors que j'essayais d'écrire des tests pour #6305, j'ai réalisé que la classe `SplitFreeTimeRangesIntoCreneaux` prenait comme paramètres : 
- une plage, dont elle tirait le lieu et l'agent
- un motif, dont elle tirait une durée par défaut

Or, cette classe n'a pas besoin de ces informations pour générer des créneaux : elle sert seulement de passe-plat dans l'instanciation d'objets `Creneau`. Je propose donc que ces attributs soient définis en dehors de `SplitFreeTimeRangesIntoCreneaux`.

Le truc qui m'a fait tiquer et motivé à refactoriser, c'est que dans le test actuel à `spec/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux_spec.rb:11`, on définit des horaires pour la plage, mais que ces horaires ne sont jamais utilisés.

# Solution

Lecture par commit : 

1. J'ajoute une spec dans `Calculator` qui vérifie qu'on obtient bien des `Creneau` avec les bons attributs `lieu_id`, `agent` et `motif`
2. Je sors les notions de lieu et d'agent
3. Je sors la notion de motif, la logique qui prend la durée du motif par défaut est désormais dans `Calculator`
4. Petite préférence pour une variable d'instance, car j'ai mis 10 minutes à réaliser qu'on avait un `attr_reader` privé et donc qu'on pouvait faire l'appel à `app/services/creneaux_search/calculator/split_free_time_ranges_into_creneaux.rb:13`.
