### PR TITLE
Correctif sur la bannière de prescription externe

### DIFF
--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -11,21 +11,22 @@
         / Incitation à l'utilisation de la prescription interne
         - if @rdv_wizard.present? && show_agent_prescription_incitation?
           - territory = @rdv_wizard.motif.organisation.territory
-          .fr-alert.fr-alert--info.fr-mb-2w
-            | Nouvelle fonctionnalité&nbsp;: Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
-            / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
-            - if !territory.sectorized?
-              / Le lien de prescription interne redirige vers la premiére organisation de l'agent dans le même espace
-              = link_to user_selection_admin_organisation_prescription_path( \
-                  current_agent.organisations.find_by(territory: territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
-                ) do
-                | &nbsp;en cliquant ici.
-            - else
-              | .
+          - if current_agent.organisations.where(territory_id: territory.id).any?
+            .fr-alert.fr-alert--info.fr-mb-2w
+              | Nouvelle fonctionnalité&nbsp;: Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
+              / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
+              - if !territory.sectorized?
+                / Le lien de prescription interne redirige vers la premiére organisation de l'agent dans le même espace
+                = link_to user_selection_admin_organisation_prescription_path( \
+                    current_agent.organisations.find_by(territory: territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
+                  ) do
+                  | &nbsp;en cliquant ici.
+              - else
+                | .
 
-            p.mb-0
-            span> Pour en savoir plus consultez
-            = link_to "la documentation", "https://aide.rdv-service-public.fr/documentation-utilisateur/faq#la-prescription", target: "_blank"
+              p.mb-0
+              span> Pour en savoir plus consultez
+              = link_to "la documentation", "https://aide.rdv-service-public.fr/documentation-utilisateur/faq#la-prescription", target: "_blank"
 
         p
           |> Ces informations permettront à l'agent qui assure le rendez-vous de savoir qui l'a planifié,

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -284,7 +284,6 @@ RSpec.describe "un prescripteur peut prendre rendez-vous pour un usager" do
         click_on lieu.name
         click_on "08:00"
         click_on "Je suis un prescripteur"
-        raise "hello"
         expect(page).not_to have_content("Nouvelle fonctionnalité :\nla prescription dans l'espace agent")
       end
     end

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -270,6 +270,25 @@ RSpec.describe "un prescripteur peut prendre rendez-vous pour un usager" do
       expect(page).not_to have_content("Nouvelle fonctionnalité :\nla prescription dans l'espace agent")
     end
 
+    context "when the agent is not part of the territory" do
+      let!(:organisation2) { create(:organisation, territory: create(:territory)) }
+
+      before do
+        # On crée ce motif pour entrer dans la condition d'affichage de la bannière
+        create(:motif, bookable_by: "everyone", organisation: organisation2)
+      end
+
+      it "doesn't display internal prescription incitation" do
+        visit public_link_to_motif_url(public_link_id: motif.public_link_id, motif_slug: motif.slug)
+
+        click_on lieu.name
+        click_on "08:00"
+        click_on "Je suis un prescripteur"
+        raise "hello"
+        expect(page).not_to have_content("Nouvelle fonctionnalité :\nla prescription dans l'espace agent")
+      end
+    end
+
     context "when the agent belongs to a sectorized territory" do
       before do
         allow_any_instance_of(Territory).to receive(:sectorized?).and_return(true) # rubocop:disable RSpec/AnyInstance


### PR DESCRIPTION
fixes https://sentry.incubateur.net/organizations/betagouv/issues/282256/?project=74&referrer=webhooks_plugin


# Contexte

Un agent a eu une erreur parce qu'il est tombé dans un edge case de prescription : il est connecté, mais il n'a pas de compte dans le territoire pour lequel il prend un rendez-vous.

# Solution

Une spec pour reproduire le bug, et le correctif qui va avec.
