### PR TITLE
Rendre traçable les suppressions de comptes d'agents et d'usagers

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -181,7 +181,7 @@ class Agent < ApplicationRecord
         uid: deleted_email
       )
       skip_reconfirmation!
-      save
+      save(validate: false)
     end
   end
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -180,7 +180,14 @@ class Agent < ApplicationRecord
         email: deleted_email,
         uid: deleted_email
       )
+      # On ne veut pas envoyer de notification Devise pour le changement d'adresse email.
       skip_reconfirmation!
+
+      # C'est pas évident de représenter un soft_delete via notre système actuel de webhooks,
+      # et si on envoyait un évènement, ça nécessiterait des développements supplémentaires pour RDV Insertion,
+      # qui est le seul service qui consomme des webhooks sur les agents
+      self.skip_webhooks = true
+
       save(validate: false)
     end
   end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -174,12 +174,14 @@ class Agent < ApplicationRecord
       referent_assignations.destroy_all
       sector_attributions.destroy_all
 
-      update_columns(
+      assign_attributes(
         deleted_at: Time.zone.now,
         email_original: email,
         email: deleted_email,
         uid: deleted_email
       )
+      skip_reconfirmation!
+      save
     end
   end
 

--- a/app/models/concerns/user/soft_delete_concern.rb
+++ b/app/models/concerns/user/soft_delete_concern.rb
@@ -39,12 +39,16 @@ module User::SoftDeleteConcern
       .each { |r| Anonymizer.anonymize_record!(r) }
     annotations.destroy_all
     versions.destroy_all
-    update(
+    update_columns( # rubocop:disable Rails/SkipsModelValidations
       first_name: "Usager supprimé",
       last_name: "Usager supprimé",
-      deleted_at: Time.zone.now,
       email: "user_#{id}@deleted.rdv-solidarites.fr"
     )
+
+    # Pour avoir une traçabilité de qui a anonymisé l'usager, on fait un update
+    # simple ici pour avoir une version Papertrail
+    update(deleted_at: Time.zone.now)
+
     reload # anonymizer operates outside the realm of rails knowledge
   end
 end

--- a/app/models/concerns/user/soft_delete_concern.rb
+++ b/app/models/concerns/user/soft_delete_concern.rb
@@ -39,11 +39,11 @@ module User::SoftDeleteConcern
       .each { |r| Anonymizer.anonymize_record!(r) }
     annotations.destroy_all
     versions.destroy_all
-    update_columns( # rubocop:disable Rails/SkipsModelValidations
+    update(
       first_name: "Usager supprimé",
       last_name: "Usager supprimé",
       deleted_at: Time.zone.now,
-      email: deleted_email
+      email: "user_#{id}@deleted.rdv-solidarites.fr"
     )
     reload # anonymizer operates outside the realm of rails knowledge
   end

--- a/app/models/concerns/user/soft_delete_concern.rb
+++ b/app/models/concerns/user/soft_delete_concern.rb
@@ -47,7 +47,8 @@ module User::SoftDeleteConcern
 
     # Pour avoir une traçabilité de qui a anonymisé l'usager, on fait un update
     # simple ici pour avoir une version Papertrail
-    update(deleted_at: Time.zone.now)
+    assign_attributes(deleted_at: Time.zone.now)
+    save(validate: false)
 
     reload # anonymizer operates outside the realm of rails knowledge
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -168,10 +168,6 @@ class User < ApplicationRecord
     rdv.participations.to_a.find { |participation| participation.user_id.in?(self_and_relatives_and_responsible.map(&:id)) }
   end
 
-  def deleted_email
-    "user_#{id}@deleted.rdv-solidarites.fr"
-  end
-
   def upcoming_rdvs_for_self_or_relatives
     Rdv.not_cancelled.future.joins(:users).where(users: self_and_relatives)
   end

--- a/spec/models/concerns/user/soft_delete_concern_spec.rb
+++ b/spec/models/concerns/user/soft_delete_concern_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe User::SoftDeleteConcern do
       expect(user.address).to match %([valeur unique anonymisée \\d+])
       expect(user.deleted_at).to be_within(5.seconds).of(Time.zone.now)
 
+      # On a une version papertrail qui donne de la traçabilité sur la suppression
+      expect(user.versions.last.event).to eq "update"
+      # On n'envoie pas de notification de changement d'adresse email
+      expect(enqueued_jobs).to be_empty
+
       # on n'anonymise pas un autre utilisateur
       expect(other_user.reload.email).to eq("other_user@test.com")
     end

--- a/spec/models/concerns/user/soft_delete_concern_spec.rb
+++ b/spec/models/concerns/user/soft_delete_concern_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe User::SoftDeleteConcern do
 
       expect(receipt.reload.sms_phone_number).to match %([valeur unique anonymisée \\d+])
       expect(rdv.reload.context).to match %([valeur unique anonymisée \\d+])
-      expect(user.versions).to be_empty
+      expect(user.versions.count).to eq 1
+
+      expect(user.versions.last.object_changes.keys).to eq ["deleted_at"]
     end
 
     it "interdit lorsqu’un RDV à venir existe" do

--- a/spec/services/agent_removal_spec.rb
+++ b/spec/services/agent_removal_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AgentRemoval, type: :service do
     it "succeeds destroy absences and plages ouvertures, and soft delete, but without sending email change confirmation notifications" do
       service = described_class.new(agent, organisation)
       expect(service).to be_valid
-      expect { service.remove! }.not_to change(enqueued_jobs, :count)
+      expect { service.remove! }.not_to have_enqueued_mail
       agent.reload
       expect(agent.organisations).to be_empty
       expect(agent.absences).to be_empty

--- a/spec/services/agent_removal_spec.rb
+++ b/spec/services/agent_removal_spec.rb
@@ -7,10 +7,15 @@ RSpec.describe AgentRemoval, type: :service do
     let!(:plage_ouvertures) { create_list(:plage_ouverture, 2, agent: agent, organisation: organisation) }
     let!(:absences) { create_list(:absence, 2, agent: agent) }
 
+    before { create(:webhook_endpoint, organisation:, subscriptions: [:agent]) }
+
     it "succeeds destroy absences and plages ouvertures, and soft delete, but without sending email change confirmation notifications" do
       service = described_class.new(agent, organisation)
       expect(service).to be_valid
-      expect { service.remove! }.not_to have_enqueued_mail
+
+      service.remove!
+
+      expect(enqueued_jobs).to be_empty # On n'envoie pas de mails ni de webhooks
       agent.reload
       expect(agent.organisations).to be_empty
       expect(agent.absences).to be_empty

--- a/spec/services/agent_removal_spec.rb
+++ b/spec/services/agent_removal_spec.rb
@@ -7,15 +7,20 @@ RSpec.describe AgentRemoval, type: :service do
     let!(:plage_ouvertures) { create_list(:plage_ouverture, 2, agent: agent, organisation: organisation) }
     let!(:absences) { create_list(:absence, 2, agent: agent) }
 
-    it "succeeds destroy absences and plages ouvertures, and soft delete" do
+    it "succeeds destroy absences and plages ouvertures, and soft delete, but without sending email change confirmation notifications" do
       service = described_class.new(agent, organisation)
       expect(service).to be_valid
-      service.remove!
+      expect { service.remove! }.not_to change(enqueued_jobs, :count)
       agent.reload
       expect(agent.organisations).to be_empty
       expect(agent.absences).to be_empty
       expect(agent.plage_ouvertures).to be_empty
       expect(agent.deleted_at).not_to be_nil
+
+      # On a une version PaperTrail qui permet de tracer la suppression
+      expect(agent.versions.last.event).to eq "update"
+
+      expect(agent.versions.last.object_changes.keys).to eq %w[email deleted_at]
     end
   end
 


### PR DESCRIPTION
# Contexte

On a un.e agent qui nous a demandé au support pourquoi iel ne pouvait plus se connecter. Son compte semble avoir été supprimé par un.e admin de son organisation, mais on ne peut pas savoir qui parce qu'on n'a pas de version papertrail.

# Solution

Cette PR permet de garder une version papertrail de qui a fait la suppression, ce qui sera visible dans le super admin, et qui permettra donc au support de gérer ce cas en autonomie.

Au passage je fais la même chose pour les usagers.

# Prochaines étapes possible

Je me demande si on ne devrait pas envoyer un mail aux agents lorsque leur compte est supprimé pour résoudre le problème encore plus à la racine (ils pourraient directement contacter leur admin plutôt que notre support), mais ça dépasse un peu le cadre de ce correctif