### PR TITLE
Permettre les numéros de téléphone des DROM pour les organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -106,7 +106,7 @@ class Organisation < ApplicationRecord
 
   def phone_number_is_valid?
     # Blank, Valid Phone, 4 digits phone (organisations only)
-    phone_number.blank? || Phonelib.parse(phone_number).valid? || phone_number.match(/^\d{4}$/)
+    phone_number.blank? || PhoneNumberValidation.parsed_number(phone_number).present? || phone_number.match(/^\d{4}$/)
   end
 
   def humanized_phone_number

--- a/app/validators/phone_number_validation.rb
+++ b/app/validators/phone_number_validation.rb
@@ -13,7 +13,7 @@ module PhoneNumberValidation
   # https://www.arcep.fr/uploads/tx_gsavis/05-1085.pdf  “Numéros mobiles à 10 chiffres”, page 6
   #
   # On ajoute aussi NC pour la Nouvelle Calédonie et PF pour la Polynésie Française
-  COUNTRY_CODES = %i[FR GP GF MQ RE YT].freeze
+  COUNTRY_CODES = %i[FR GP GF MQ RE YT NC PF].freeze
 
   def self.parsed_number(phone_number)
     return if phone_number.blank?

--- a/app/validators/phone_number_validation.rb
+++ b/app/validators/phone_number_validation.rb
@@ -11,6 +11,8 @@ module PhoneNumberValidation
   # Mayotte    | YT | +262 | 0692XXXXXX, 0693XXXXXX
   # Cf: Plan national de numérotation téléphonique,
   # https://www.arcep.fr/uploads/tx_gsavis/05-1085.pdf  “Numéros mobiles à 10 chiffres”, page 6
+  #
+  # On ajoute aussi NC pour la Nouvelle Calédonie et PF pour la Polynésie Française
   COUNTRY_CODES = %i[FR GP GF MQ RE YT].freeze
 
   def self.parsed_number(phone_number)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe Organisation, type: :model do
       organisation = build(:organisation, phone_number: "3949")
       expect(organisation).to be_valid
     end
+
+    it "autorise les numéros de téléphone des DROM" do
+      organisation = build(:organisation, phone_number: "0262 94 07 07")
+      expect(organisation).to be_valid
+    end
   end
 
   describe "#online_booking_only_proconnect?" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe Organisation, type: :model do
       organisation = build(:organisation, phone_number: "0262 94 07 07")
       expect(organisation).to be_valid
     end
+
+    it "autorise le numéro de téléphone de l'ambassade de France en Allemagne" do
+      organisation = build(:organisation, phone_number: "+49(30)590039000")
+      expect(organisation).to be_valid
+    end
   end
 
   describe "#online_booking_only_proconnect?" do


### PR DESCRIPTION
# Contexte

Au support on a eux deux organisations différentes de DROM qui n'ont pas pu indiquer leur numéro de téléphone.

# Solution

On ne permettait pas les numéros de téléphones hors France Métropolitaine parce qu'on n'utilisait pas exactement la bonne validation.
Au passage j'ajoute aussi les country codes manquants pour la Nouvelle Calédonie et la Polynésie Française (merci à la codebase de Démarches Numériques dans laquelle j'ai pu trouver cette info), et une spec pour vérifier que les numéros internationaux fonctionnent quand ils sont formattés correctement.