### PR TITLE
Update bundler to 4.0.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1173,4 +1173,4 @@ RUBY VERSION
   ruby 3.4.9
 
 BUNDLED WITH
-  4.0.8
+  4.0.12


### PR DESCRIPTION
# Contexte

Dans la PR #6393 de dependabot, la ligne de checksum de bundle de bundler a été ajoutée, vraisemblablement car la version de bundler utilisée par dependabot contient cette feature : https://github.com/ruby/rubygems/pull/9366

# Solution

Je propose de mettre à jour bundler pour avoir nous aussi en local la feature ci-dessus, on verra si ça cause d'autres problèmes. :shrug: 

J'ai lancé `bundle update --bundler`