### PR TITLE
Améliorer le message d'erreur pour les numéros de téléphone étrangers

### DIFF
--- a/config/locales/models/lieu.fr.yml
+++ b/config/locales/models/lieu.fr.yml
@@ -24,3 +24,6 @@ fr:
               format: "%{message}"
             address:
               must_be_valid: doit être valide
+            phone_number:
+              invalid: "Le numero de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
+              format: "%{message}"

--- a/config/locales/models/lieu.fr.yml
+++ b/config/locales/models/lieu.fr.yml
@@ -25,5 +25,5 @@ fr:
             address:
               must_be_valid: doit être valide
             phone_number:
-              invalid: "Le numero de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
+              invalid: "Le numéro de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
               format: "%{message}"

--- a/config/locales/models/organisation.fr.yml
+++ b/config/locales/models/organisation.fr.yml
@@ -9,3 +9,10 @@ fr:
         website: Site web
         horaires: Horaires
         territory: Espace
+    errors:
+      models:
+        organisation:
+          attributes:
+            phone_number:
+              invalid: "Le numero de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
+              format: "%{message}"

--- a/config/locales/models/organisation.fr.yml
+++ b/config/locales/models/organisation.fr.yml
@@ -14,5 +14,5 @@ fr:
         organisation:
           attributes:
             phone_number:
-              invalid: "Le numero de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
+              invalid: "Le numéro de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
               format: "%{message}"

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -59,7 +59,7 @@ fr:
               invalid_format: doit comporter 10 chiffres et lettres
               unexpected_api_error: n'a pas pu être validé à cause d'une erreur inattendue. Merci de réessayer dans 30 secondes.
             phone_number:
-              invalid: "Le numéro de téléphone n'est pas valide"
+              invalid: "Le numero de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
               missing_for_phone_motif: "Le numéro de téléphone est obligatoire car le RDV aura lieu par téléphone"
               format: "%{message}"
     warnings:

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -59,7 +59,7 @@ fr:
               invalid_format: doit comporter 10 chiffres et lettres
               unexpected_api_error: n'a pas pu être validé à cause d'une erreur inattendue. Merci de réessayer dans 30 secondes.
             phone_number:
-              invalid: "Le numero de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
+              invalid: "Le numéro de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
               missing_for_phone_motif: "Le numéro de téléphone est obligatoire car le RDV aura lieu par téléphone"
               format: "%{message}"
     warnings:

--- a/spec/form_models/users/rdv_booking_form_spec.rb
+++ b/spec/form_models/users/rdv_booking_form_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Users::RdvBookingForm do
         it "affiche un message d'erreur complet incluant le nom du champ" do
           form = described_class.new(user:, rdv_builder:, user_attributes:, domain:)
           form.save
-          expect(form.errors.full_messages).to include("Le numéro de téléphone est invalide")
+          expect(form.errors.full_messages).to include("Le numéro de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique).")
         end
       end
 

--- a/spec/form_models/users/rdv_booking_form_spec.rb
+++ b/spec/form_models/users/rdv_booking_form_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Users::RdvBookingForm do
         it "affiche un message d'erreur complet incluant le nom du champ" do
           form = described_class.new(user:, rdv_builder:, user_attributes:, domain:)
           form.save
-          expect(form.errors.full_messages).to include("Le numéro de téléphone n'est pas valide")
+          expect(form.errors.full_messages).to include("Le numéro de téléphone est invalide")
         end
       end
 

--- a/spec/lib/phone_number_validation_spec.rb
+++ b/spec/lib/phone_number_validation_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe PhoneNumberValidation do
 
           expect(object.errors).to include(:phone_number)
 
-          expect(object.errors.full_messages.to_sentence).to eq "Le numero de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
+          expect(object.errors.full_messages.to_sentence).to eq "Le numéro de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
         end
 
         it "is valid when number is good" do

--- a/spec/lib/phone_number_validation_spec.rb
+++ b/spec/lib/phone_number_validation_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe PhoneNumberValidation do
           object.validate
 
           expect(object.errors).to include(:phone_number)
+
+          expect(object.errors.full_messages.to_sentence).to eq "Le numero de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
         end
 
         it "is valid when number is good" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Organisation, type: :model do
     it "invalid phone" do
       organisation = build(:organisation, phone_number: "12345")
       expect(organisation).to be_invalid
-      expect(organisation.errors.full_messages.to_sentence).to eq "Le numero de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
+      expect(organisation.errors.full_messages.to_sentence).to eq "Le numéro de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
     end
 
     it "blank phone is valid" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Organisation, type: :model do
     it "invalid phone" do
       organisation = build(:organisation, phone_number: "12345")
       expect(organisation).to be_invalid
+      expect(organisation.errors.full_messages.to_sentence).to eq "Le numero de téléphone est invalide. S'il s'agit d'un numéro étranger, saisissez l'indicatif du pays (ex : +32 pour la Belgique)."
     end
 
     it "blank phone is valid" do


### PR DESCRIPTION
# Contexte

On a eu un ticket zammad de quelqu'un qui n'arrivait pas à prendre un rendez-vous en utilisant un numéros de téléphone canadien.
On permet pourtant les numéros de téléphone étrangers, mais il faut penser à ajouter l'indicateur.


# Solution

Pour éviter d'avoir ce genre de ticket à nouveau, on améliore le texte du message d'erreur pour que les usagers puissent s'en sortir sans avoir à contacter le support.
