### PR TITLE
Correctif pour éviter les absences récurrentes sur plusieurs jours

### DIFF
--- a/app/controllers/admin/planning/absences_controller.rb
+++ b/app/controllers/admin/planning/absences_controller.rb
@@ -60,7 +60,16 @@ class Admin::Planning::AbsencesController < AgentAuthController
 
   def update
     authorize(@absence, policy_class: Agent::AbsencePolicy)
-    if @absence.update(absence_params)
+
+    @absence.assign_attributes(absence_params)
+
+    if @absence.recurrence && @absence.end_day
+      @absence.end_day = nil
+    end
+
+    authorize(@absence, policy_class: Agent::AbsencePolicy)
+
+    if @absence.save
       Notifiers::AbsenceUpdated.new(@absence).perform
       flash[:success] = t(".absence_updated")
       redirect_to admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent_id)

--- a/app/javascript/components/recurrence-form.js
+++ b/app/javascript/components/recurrence-form.js
@@ -12,6 +12,8 @@ class RecurrenceForm {
     this.untilTarget = document.querySelector('.js-recurrence-until')
     this.firstDayTarget = document.querySelector('.js-recurrence-first-day')
     this.monthlyTarget = document.querySelector('.js-recurrence-monthly')
+    this.endDay = document.querySelector('.js-recurrence-end-day')
+    this.endDayWithLabel = document.querySelector('.js-recurrence-end-day-with-label')
 
     document.querySelectorAll('.js-recurrence-input').
       forEach(i => i.addEventListener('change', this.updateRecurrence))
@@ -101,6 +103,16 @@ class RecurrenceForm {
     }
 
     setLabel('label[for="recurrence-source"]', model.every ? 'Premier jour ' : 'Date ')
+
+    if (this.endDay) {
+      if (model.every) {
+        this.endDay.disable
+        this.endDayWithLabel.classList.add("hidden")
+      } else {
+        this.endDay.enable
+        this.endDayWithLabel.classList.remove("hidden")
+      }
+    }
   }
 
   getWeekday = (date) => {

--- a/app/javascript/components/recurrence-form.js
+++ b/app/javascript/components/recurrence-form.js
@@ -106,10 +106,10 @@ class RecurrenceForm {
 
     if (this.endDay) {
       if (model.every) {
-        this.endDay.disable
+        this.endDay.disabled = true
         this.endDayWithLabel.classList.add("hidden")
       } else {
-        this.endDay.enable
+        this.endDay.disabled = false
         this.endDayWithLabel.classList.remove("hidden")
       }
     }

--- a/app/javascript/components/recurrence-form.js
+++ b/app/javascript/components/recurrence-form.js
@@ -107,10 +107,10 @@ class RecurrenceForm {
     if (this.endDay) {
       if (model.every) {
         this.endDay.disabled = true
-        this.endDayWithLabel.classList.add("hidden")
+        this.endDayWithLabel.hidden = true
       } else {
         this.endDay.disabled = false
-        this.endDayWithLabel.classList.remove("hidden")
+        this.endDayWithLabel.hidden = false
       }
     }
   }

--- a/app/views/admin/planning/absences/edit.html.slim
+++ b/app/views/admin/planning/absences/edit.html.slim
@@ -26,10 +26,10 @@
         span.fr-notice__desc
         | Cette indisponibilité correspond à un rendez-vous pris sur RDV Aide Numérique avant la migration sur RDV Service Public.
 
-.row.justify-content-center
-  .col-md-6
+.fr-grid-row.justify-content-center
+  .fr-col-12.fr-col-lg-8
     = render "form", absence: @absence, agent: @agent
 
-.row.justify-content-center
-  .col-md-12.col-lg-8
+.fr-grid-row.justify-content-center.fr-pt-2w
+  .fr-col-md-12.fr-col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: policy(@absence, policy_class: Agent::AbsencePolicy), resource: @absence

--- a/app/views/admin/planning/absences/new.html.slim
+++ b/app/views/admin/planning/absences/new.html.slim
@@ -14,6 +14,6 @@
               titles_and_paths: [["Indisponibilités de #{@absence.agent.full_name_or_email}", admin_organisation_planning_absences_path(current_organisation, agent_id: @absence.agent)]],
               current_page_title: yield(:title)
 
-.row.justify-content-center
-  .col-md-6
+.fr-grid-row.justify-content-center
+  .fr-col-12.fr-col-lg-8
     = render "form", absence: @absence, agent: @agent

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -27,7 +27,7 @@
       = date_input(f, :first_day, input_html: { id: "recurrence-source", class: "js-recurrence-first-day js-recurrence-input"} )
     - if defined?(model.end_day)
       .col
-        = date_input(f, :end_day)
+        = date_input(f, :end_day, input_html: { class: "js-recurrence-end-day"}, wrapper_html: { class: "js-recurrence-end-day-with-label"})
 
   .row
     .col = f.input :start_time, as: :time, ignore_date: true, minute_step: 5

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -66,4 +66,4 @@
 
       .fr-grid-row
         .fr-col-6.until-select
-          = date_input(n, :until, required: false, label: "Date de fin", hint: "Facultatif", input_html: { id: "recurrence-until", class: "js-recurrence-until js-recurrence-input" } )
+          = date_input(n, :until, required: false, label: "Date de fin de la récurrence", hint: "Facultatif", input_html: { id: "recurrence-until", class: "js-recurrence-until js-recurrence-input" } )

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -24,10 +24,11 @@
 
   .row
     .col
-      = date_input(f, :first_day, input_html: { id: "recurrence-source", class: "js-recurrence-first-day js-recurrence-input"} )
+      / La marge et le padding permettent d'être aligné avec le champs "Termine à" (pour les absences), et d'ajouter un peu de whitespace par rapport au composant au-dessus (pour tous les cas)
+      = date_input(f, :first_day, input_html: { id: "recurrence-source", class: "js-recurrence-first-day js-recurrence-input"}, label_html: { class: "fr-mt-2w fr-pt-1v" } )
     - if defined?(model.end_day)
       .col
-        = date_input(f, :end_day, input_html: { class: "js-recurrence-end-day"}, wrapper_html: { class: "js-recurrence-end-day-with-label"})
+        = date_input(f, :end_day, input_html: { class: "js-recurrence-end-day"}, wrapper_html: { class: "js-recurrence-end-day-with-label"}, hint: "Facultatif")
 
   .row
     .col = f.input :start_time, as: :time, ignore_date: true, minute_step: 5

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -65,4 +65,4 @@
         span.js-recurrence-monthly Tous les X du mois
 
       .until-select
-        = date_input(n, :until, required: false, label: "Finir la répétition le (si aucune laisser vide)", input_html: { id: "recurrence-until", class: "js-recurrence-until js-recurrence-input" } )
+        = date_input(n, :until, required: false, label: "Date de fin", hint: "Facultatif", input_html: { id: "recurrence-until", class: "js-recurrence-until js-recurrence-input" } )

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -64,5 +64,6 @@
       .monthly-select.form-group
         span.js-recurrence-monthly Tous les X du mois
 
-      .until-select
-        = date_input(n, :until, required: false, label: "Date de fin", hint: "Facultatif", input_html: { id: "recurrence-until", class: "js-recurrence-until js-recurrence-input" } )
+      .fr-grid-row
+        .fr-col-6.until-select
+          = date_input(n, :until, required: false, label: "Date de fin", hint: "Facultatif", input_html: { id: "recurrence-until", class: "js-recurrence-until js-recurrence-input" } )

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -40,9 +40,9 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
     b.use :label, class: "form-control-label"
+    b.use :hint, wrap_with: { tag: "span", class: "fr-hint-text fr-mb-1w" }
     b.use :input, class: "form-control", error_class: "is-invalid"
     b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
-    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # vertical input for boolean

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -40,7 +40,7 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
     b.use :label, class: "form-control-label"
-    b.use :hint, wrap_with: { tag: "span", class: "fr-hint-text fr-mb-1w" }
+    b.use :hint, wrap_with: { tag: "span", class: "fr-hint-text fr-mb-1w", html: { style: "margin-top: -8px" } } # La margin négative permet d'avoir le même rendu que celui du DSFR.
     b.use :input, class: "form-control", error_class: "is-invalid"
     b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
   end

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -39,9 +39,9 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: "form-control-label"
-    b.use :hint, wrap_with: { tag: "span", class: "fr-hint-text fr-mb-1w", html: { style: "margin-top: -8px" } } # La margin négative permet d'avoir le même rendu que celui du DSFR.
-    b.use :input, class: "form-control", error_class: "is-invalid"
+    b.use :label, class: "form-control-label fr-mb-0"
+    b.use :hint, wrap_with: { tag: "span", class: "fr-hint-text" }
+    b.use :input, class: "form-control fr-mt-1w", error_class: "is-invalid"
     b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
   end
 

--- a/spec/features/agents/planning/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/planning/agent_can_crud_absences_spec.rb
@@ -135,4 +135,19 @@ RSpec.describe "Agent can CRUD absences" do
       expect(absence.reload.recurrence).to be_present
     end
   end
+
+  describe "switching from a single day weekly absence to a multi-day non-recurring absence using the dynamic form" do
+    let!(:absence) { create(:absence, :weekly_on_monday, agent: agent, first_day: Time.zone.today) }
+
+    it "correctly disables the right field when editing the recurrence type", js: true do
+      visit edit_admin_organisation_planning_absence_path(organisation.id, absence.id)
+      find("label", text: "Ponctuelle").click
+      fill_in "absence[end_day]", with: Time.zone.today + 2
+
+      click_on "Enregistrer"
+
+      expect(page).to have_content "L'indisponibilité a été modifiée."
+      expect(absence.reload.recurrence).to be_blank
+    end
+  end
 end

--- a/spec/features/agents/planning/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/planning/agent_can_crud_absences_spec.rb
@@ -131,7 +131,8 @@ RSpec.describe "Agent can CRUD absences" do
       find("label", text: "Mardi").click
       click_on "Enregistrer"
 
-      expect(page).to have_content "asdf"
+      expect(page).to have_content "L'indisponibilité a été modifiée."
+      expect(absence.reload.recurrence).to be_present
     end
   end
 end

--- a/spec/features/agents/planning/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/planning/agent_can_crud_absences_spec.rb
@@ -2,15 +2,13 @@ RSpec.describe "Agent can CRUD absences" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
 
-  before do
-    login_as(agent, scope: :agent)
-    visit authenticated_agent_root_path
-  end
+  before { login_as(agent, scope: :agent) }
 
   context "for an agent" do
     let!(:absence) { create(:absence, agent: agent) }
 
     it "can crud a absence" do
+      visit authenticated_agent_root_path
       click_link "Indisponibilités"
 
       expect(page).to have_link("Créer une indisponibilité") # vue liste
@@ -95,6 +93,7 @@ RSpec.describe "Agent can CRUD absences" do
     let!(:past_absence) { create(:absence, first_day: Date.new(2019, 7, 4), agent: agent) }
 
     it do
+      visit authenticated_agent_root_path
       click_link "Indisponibilités"
       expect(page).to have_link("Créer une indisponibilité") # vue liste
 
@@ -112,7 +111,7 @@ RSpec.describe "Agent can CRUD absences" do
     let!(:absence) { create(:absence, agent: agent, start_time: Tod::TimeOfDay.new(8, 30), end_time: Tod::TimeOfDay.new(9, 30)) }
 
     it "works" do
-      click_link "Indisponibilités"
+      visit admin_organisation_planning_absences_path(organisation.id)
       expect { click_link("Supprimer") }.to change(enqueued_jobs, :size).by(1)
       expect { perform_enqueued_jobs }.to change { emails_sent_to(absence.agent.email).size }.by(1)
       open_email(absence.agent.email)
@@ -120,6 +119,19 @@ RSpec.describe "Agent can CRUD absences" do
       expect(current_email.body).to include(absence.title)
       expect(current_email.body).to include(absence.agent.full_name)
       expect(current_email.body).to include("de 08:30 à 09:30") # on s'assure que les heures sont bien sérialisées et dé-sérialisées (objets Tod::TimeOfDay)
+    end
+  end
+
+  describe "switching from a multi-day non-recurring absence to a single day weekly absence using the dynamic form" do
+    let!(:absence) { create(:absence, :no_recurrence, agent: agent, first_day: Time.zone.today, end_day: 3.days.from_now) }
+
+    it "correctly disables the right field when editing the recurrence type", js: true do
+      visit edit_admin_organisation_planning_absence_path(organisation.id, absence.id)
+      find("label", text: "Récurrente").click
+      find("label", text: "Mardi").click
+      click_on "Enregistrer"
+
+      expect(page).to have_content "asdf"
     end
   end
 end


### PR DESCRIPTION
Review app : https://rdv-service-public-review-app-pr6404.osc-secnum-fr1.scalingo.io/

# Contexte

Lors d'un webinaire, un agent a eu cette erreur assez difficile à comprendre :

<img width="678" height="659" alt="Capture d’écran 2026-05-28 à 11 05 21" src="https://github.com/user-attachments/assets/2bf3ad88-16ae-4356-b4e8-2d42358deba9" />

En fait, c'est parce qu'on a deux champs redondants sur ce formulaire : "Termine le" qui permet de faire une indispo ponctuelle de plusieurs jours, et "Finir la répétition le" qui indique la date de fin d'une indispo récurrente.




# Solution
On fait au plus simple : on cache (et on désactive) le champs "Termine le" si on choisit une indispo récurrente.


## Captures d'écran

Avant | Après
:- | -:
<img width="2850" height="3418" alt="www rdv-mairie localhost_3000_admin_organisations_4_planning_absences_2_edit" src="https://github.com/user-attachments/assets/c42b474c-7c4d-413c-a9d2-fc6f31ae27ef" />|<img width="2850" height="3516" alt="www rdv-mairie localhost_3000_admin_organisations_4_planning_absences_2_edit (3)" src="https://github.com/user-attachments/assets/2d4fa914-de73-4dba-b8ee-942c70be5086" />


Au passage, on propose quelques modifications d'interface mineure :
- Le label "Finir la répétition le (si aucune laisse vide)" devient "Date de fin" avec le hint "Facultatif" ☺️ 
- Je fais un petit changement sur la configuration `SimpleForm` pour que les hints suivent le modèle du DSFR et s'affichent entre le label et le champs plutôt que juste après le champs (ça s'applique donc sur tous les formulaires de l'appli).
- On passe le formulaire sur 8 colonnes à la place de 6 (pour être raccord avec la plupart de nos autres formulaires), ce qui permet d'être aligné correctement avec le bloc "Historique de changements"
- Le champs de date de fin de la récurrence passe sur 6 colonnes, à la place de prendre toute la largeur.



