### PR TITLE
Améliorations de la doc et de l'env.sample pour ProConnect

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,8 +33,14 @@ FRANCECONNECT_V2_CLIENT_SECRET=change_me
 # On a des identifiants ProConnect différents pour nos trois marques en production, mais en local c'est la même valeur pour les trois
 # pour récupérer le client secret du FS local : https://vaultwarden.incubateur.net/#/vault?organizationId=2662d2f2-17f4-49c2-907c-0e7049c28cb7&collectionId=e5e23afd-18f2-4da1-af4a-77d97bbb2684&itemId=2d8626d9-62cc-4b03-a62f-11a07eb67c46
 PRO_CONNECT_BASE_URL="https://fca.integ01.dev-agentconnect.fr/api/v2"
+PRO_CONNECT_RDVS_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
+PRO_CONNECT_RDVS_CLIENT_SECRET=""
+PRO_CONNECT_RDVAN_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
+PRO_CONNECT_RDVAN_CLIENT_SECRET=""
 PRO_CONNECT_RDVSP_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
 PRO_CONNECT_RDVSP_CLIENT_SECRET=""
+PRO_CONNECT_RDVSP_ETAT_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
+PRO_CONNECT_RDVSP_ETAT_CLIENT_SECRET=""
 # PRO_CONNECT_DISABLED=true
 
 ## Microsoft Graph (Users for Calendar)

--- a/.env.sample
+++ b/.env.sample
@@ -30,6 +30,7 @@ FRANCECONNECT_V2_CLIENT_SECRET=change_me
 
 ## ProConnect (Agents & Users)
 # cf docs/interconnexions/proconnect.md
+PRO_CONNECT_BASE_URL="https://fca.integ01.dev-agentconnect.fr/api/v2"
 PRO_CONNECT_RDVS_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
 PRO_CONNECT_RDVS_CLIENT_SECRET=""
 PRO_CONNECT_RDVAN_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"

--- a/.env.sample
+++ b/.env.sample
@@ -22,10 +22,20 @@ SKYLIGHT_AUTHENTICATION=change_me
 SKYLIGHT_DISABLE_DEV_WARNING=true
 
 # Third-party authentication services
+# cf docs/interconnexions/franceconnect.md
 ## FranceConnect (Users)
 FRANCECONNECT_V2_BASE_URL=https://fcp-low.sbx.dev-franceconnect.fr/api/v2
 FRANCECONNECT_V2_CLIENT_ID=change_me
 FRANCECONNECT_V2_CLIENT_SECRET=change_me
+
+## ProConnect (Agents & Users)
+# cf docs/interconnexions/proconnect.md
+# On a des identifiants ProConnect différents pour nos trois marques en production, mais en local c'est la même valeur pour les trois
+# pour récupérer le client secret du FS local : https://vaultwarden.incubateur.net/#/vault?organizationId=2662d2f2-17f4-49c2-907c-0e7049c28cb7&collectionId=e5e23afd-18f2-4da1-af4a-77d97bbb2684&itemId=2d8626d9-62cc-4b03-a62f-11a07eb67c46
+PRO_CONNECT_BASE_URL="https://fca.integ01.dev-agentconnect.fr/api/v2"
+PRO_CONNECT_RDVSP_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
+PRO_CONNECT_RDVSP_CLIENT_SECRET=""
+# PRO_CONNECT_DISABLED=true
 
 ## Microsoft Graph (Users for Calendar)
 AZURE_APPLICATION_CLIENT_ID=c8bdd6de-569d-434a-a39f-f369e32276af
@@ -62,17 +72,6 @@ ANTS_API_AUTH_TOKEN=fake_ants_api_auth_token
 ANTS_RDV_API_MOCK_RESPONSES="true" # par défaut, aucun appel n'est fait à l'API externe de l'ANTS
 ANTS_RDV_OPT_AUTH_TOKEN="voir https://vaultwarden.incubateur.net/#/vault?itemId=f5a2605f-f706-4560-a70d-8c4cdc4fe1fe"
 ANTS_RDV_API_URL="https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api"
-
-PRO_CONNECT_BASE_URL="https://fca.integ01.dev-agentconnect.fr/api/v2"
-
-# On a des identifiants ProConnect différents pour nos trois marques en production, mais en local c'est la même valeur pour les trois
-PRO_CONNECT_RDVSP_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
-# pour récupérer la clé suivante en local https://vaultwarden.incubateur.net/#/vault?organizationId=2662d2f2-17f4-49c2-907c-0e7049c28cb7&collectionId=e5e23afd-18f2-4da1-af4a-77d97bbb2684&itemId=2d8626d9-62cc-4b03-a62f-11a07eb67c46
-# cf docs/interconnexions/proconnect.md
-PRO_CONNECT_RDVSP_CLIENT_SECRET=""
-
-# Décommenter s'il y a besoin de désactiver le bouton ProConnect
-# PRO_CONNECT_DISABLED=true
 
 VISIOPLAINTE_API_KEY="visioplainte-api-test-key-123456"
 VISIOPLAINTE_API_KEY_READ_ONLY="visioplainte-api-test-key-read-only-456789"

--- a/.env.sample
+++ b/.env.sample
@@ -30,9 +30,6 @@ FRANCECONNECT_V2_CLIENT_SECRET=change_me
 
 ## ProConnect (Agents & Users)
 # cf docs/interconnexions/proconnect.md
-# On a des identifiants ProConnect différents pour nos trois marques en production, mais en local c'est la même valeur pour les trois
-# pour récupérer le client secret du FS local : https://vaultwarden.incubateur.net/#/vault?organizationId=2662d2f2-17f4-49c2-907c-0e7049c28cb7&collectionId=e5e23afd-18f2-4da1-af4a-77d97bbb2684&itemId=2d8626d9-62cc-4b03-a62f-11a07eb67c46
-PRO_CONNECT_BASE_URL="https://fca.integ01.dev-agentconnect.fr/api/v2"
 PRO_CONNECT_RDVS_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"
 PRO_CONNECT_RDVS_CLIENT_SECRET=""
 PRO_CONNECT_RDVAN_CLIENT_ID="4ec41582-1d60-4f11-a63b-d8abaece16aa"

--- a/docs/interconnexions/proconnect.md
+++ b/docs/interconnexions/proconnect.md
@@ -9,10 +9,11 @@ Pour tester ProConnect en local, il y a 2 possibilités :
 
 ### 1. utiliser les credentials de test de l’app de dev partagée
 
-- Récupérer les clés secrètes de l’appli ProConnect de dev depuis Vaultwarden. L’entrée Vaultwarden s’appelle : « Fichier .env de développement local »
-- Rappatrier les variables d’env dans votre .env local : `PRO_CONNECT_RDVSP_CLIENT_SECRET` et autres.
 - Assurez vous d’avoir les variables d’env `PRO_CONNECT_BASE_URL` et `PRO_CONNECT_RDVSP_CLIENT_ID` (etc…) dans votre `.env` local. Si ce n’est pas le cas, recopiez les depuis `.env.sample`.
-- Connectez vous depuis l’URL http://www.rdv-solidarites.localhost:3000/agents/sign_in
+- Récupérer les clés secrètes de l’appli ProConnect de dev depuis Vaultwarden.
+  L’entrée Vaultwarden s’appelle : « Fichier .env de développement local » :
+  Définissez les dans votre .env local : `PRO_CONNECT_RDVSP_CLIENT_SECRET` et autres.
+- Connectez vous depuis l’URL http://www.rdv-solidarites.localhost:3000/agents/sign_in (⚠️ le port est important)
 
 
 ### 2. créer une nouvelle app de dev


### PR DESCRIPTION
suite à la PR d'ajout du nouveau domaine RDV ETAT #6397  

- je centralise et unifie la doc dans le fichier markdown plutot que dans les commentaires de l'env
- je rajoute les variables d'env pour les autres domaines ProConnect en local dans le .env.sample
- je déplace tout le bloc dans .env.sample pour être proche de FranceConnect qui va devenir son symétrique dans la PR suivante