### PR TITLE
Correction demande d’ouverture de compte État

### DIFF
--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -8,30 +8,41 @@ class Agents::PagesController < AgentAuthController
 
     accessible_organisations = policy_scope(Organisation, policy_scope_class: Agent::OrganisationPolicy::Scope)
 
-    if accessible_organisations.count == 1
+    if accessible_organisations.one?
       redirect_to admin_organisation_planning_agenda_path(accessible_organisations.first)
-    elsif accessible_organisations.count > 1
+    elsif accessible_organisations.many?
       redirect_to admin_organisations_path
     else
-      policy = Agent::TerritoryPolicy.new(current_agent, Territory.new)
-      if current_agent.possible_duplicate_organisations.empty? && policy.new?
-        redirect_to new_agents_territory_path
-      else
-        result = EspaceOperateurANCT::AccountCreationRouter.new(current_agent, current_domain).call
-        case result.action
-        when :attached_as_admin
-          redirect_to admin_organisation_planning_agenda_path(current_agent.organisations.first)
-        when :contact_admin
-          @needs_permission_from_admin = true
-        when :signup_via_operator
-          session[:inscription_via_operateur] = { "operator_name" => result.operator_name, "signup_url" => result.signup_url }
-          redirect_to agents_inscription_via_operateur_path
-        end
-      end
+      redirect_for_agent_without_organisation
     end
   end
 
   private
+
+  def redirect_for_agent_without_organisation
+    if Agent::TerritoryPolicy.new(current_agent, Territory.new).new?
+      if current_agent.possible_duplicate_organisations.empty?
+        redirect_to new_agents_territory_path
+      else
+        redirect_to new_agents_territory_creation_request_path
+      end
+    else
+      redirect_via_anct_router
+    end
+  end
+
+  def redirect_via_anct_router
+    result = EspaceOperateurANCT::AccountCreationRouter.new(current_agent, current_domain).call
+    case result.action
+    when :attached_as_admin
+      redirect_to admin_organisation_planning_agenda_path(current_agent.organisations.first)
+    when :contact_admin
+      @needs_permission_from_admin = true
+    when :signup_via_operator
+      session[:inscription_via_operateur] = { "operator_name" => result.operator_name, "signup_url" => result.signup_url }
+      redirect_to agents_inscription_via_operateur_path
+    end
+  end
 
   def pundit_user
     current_agent

--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -23,8 +23,6 @@ class Agents::PagesController < AgentAuthController
     if Agent::TerritoryPolicy.new(current_agent, Territory.new).new?
       if current_agent.possible_duplicate_organisations.empty?
         redirect_to new_agents_territory_path
-      else
-        redirect_to new_agents_territory_creation_request_path
       end
     else
       redirect_via_anct_router

--- a/spec/controllers/agents/pages_controller_spec.rb
+++ b/spec/controllers/agents/pages_controller_spec.rb
@@ -11,6 +11,29 @@ RSpec.describe Agents::PagesController, type: :controller do
         get :home
         expect(response).to render_template("home")
       end
+
+      context "et que l’agent peut créer un territory (email vérifié)" do
+        let(:agent) { create(:agent, email: "agent@example.gouv.fr") }
+
+        context "sans organisations doublons possibles" do
+          it "redirige vers la création d’un territory" do
+            get :home
+            expect(response).to redirect_to(new_agents_territory_path)
+          end
+        end
+
+        context "avec des organisations doublons possibles" do
+          before do
+            other_agent = create(:agent, email: "other@example.gouv.fr")
+            create(:organisation, agents: [other_agent])
+          end
+
+          it "redirige vers la demande d’ouverture de compte" do
+            get :home
+            expect(response).to redirect_to(new_agents_territory_creation_request_path)
+          end
+        end
+      end
     end
 
     context "quand l’agent a une seule organisation accessible" do

--- a/spec/controllers/agents/pages_controller_spec.rb
+++ b/spec/controllers/agents/pages_controller_spec.rb
@@ -23,14 +23,17 @@ RSpec.describe Agents::PagesController, type: :controller do
         end
 
         context "avec des organisations doublons possibles" do
+          render_views
+
           before do
             other_agent = create(:agent, email: "other@example.gouv.fr")
             create(:organisation, agents: [other_agent])
           end
 
-          it "redirige vers la demande d’ouverture de compte" do
+          it "rend la page d’accueil, qui permet à l’agent de demander une ouverture de compte" do
             get :home
-            expect(response).to redirect_to(new_agents_territory_creation_request_path)
+            expect(response).to render_template("home")
+            expect(response.body).to include("Ouvrir un espace")
           end
         end
       end


### PR DESCRIPTION
# Contexte

Lorsqu’un agent de l’état avec un SIRET ou un domaine d’email déjà connu de nos services essayaient d’ouvrir un compte, on essayait de fallback sur le routeur ANCT. Ceci n’est pas correct, on devrait le rediriger vers la demande d’ouverture de compte (pour que notre équipe gère le potentiel doublon).

# Solution

Le fix : 

```diff
-      if current_agent.possible_duplicate_organisations.empty? && policy.new?
-        redirect_to new_agents_territory_path
+      if policy.new?
+        redirect_to new_agents_territory_path if current_agent.possible_duplicate_organisations.empty?
```

Mais j’ai fais un peu de refacto, ce qui explique qu’il y a une diff plus grande.
