### PR TITLE
Corrige l'usage de cleanup_preserved_jobs_before_seconds_ago (GoodJob)

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,7 +1,9 @@
 Rails.application.configure do
   config.active_job.default_priority = 0
 
+  # La durée de conservation (2 semaines par défaut) est configurable via GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO
   config.good_job.preserve_job_records = true
+
   config.good_job.on_thread_error = ->(exception) { Sentry.capture_exception(exception) } # this is never called !
   config.good_job.execution_mode = :external
   config.good_job.queues = "latency_30s:1; latency_5m,latency_30s:2; *:2"

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -2,7 +2,6 @@ Rails.application.configure do
   config.active_job.default_priority = 0
 
   config.good_job.preserve_job_records = true
-  config.cleanup_preserved_jobs_before_seconds_ago = ENV.fetch("GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO", 1.week.in_seconds)
   config.good_job.on_thread_error = ->(exception) { Sentry.capture_exception(exception) } # this is never called !
   config.good_job.execution_mode = :external
   config.good_job.queues = "latency_30s:1; latency_5m,latency_30s:2; *:2"


### PR DESCRIPTION


TLDR : on utilise `config` au lieu de `config.good_job` et donc la ligne 5 n'a aucun effet.

# Contexte

J'ai remarqué que nous avions plus de 800 000 jobs en base sur l'instance `production-rdv-mairie` contre 192 000 sur `production-rdv-solidarites`. Cette différence m'a intrigué car à ma connaissance nous avions :
- plus de volume de jobs sur RDV Solidarités
- 3 jours avant cleanup sur RDV Solidarités (via `GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO`)
- 1 semaine avant cleanup sur RDV SP (via `1.week.in_seconds` en fallback dans l'initializer)

Et donc on ne devrait pas avoir 4 fois plus de jobs préservés sur RDV-SP, mais environ le même nombre que sur Soli.

J'ai donc lancé une console sur RDV-SP pour vérifier la config et :

```ruby
GoodJob.configuration.cleanup_preserved_jobs_before_seconds_ago.seconds.in_weeks
# => 2.0
```

2 semaines c'est la valeur par défaut de la librairie. J'ai alors compris que cette ligne n'a jamais fonctionné depuis son introduction dans #3630 car elle utilise `config` au lieu de `config.good_job`.

# Solution

Initialement je pensais corriger `config` en `config.good_job`, puis je me suis dit que c'était redondant d'utiliser la variable officielle de la gem, et que nous n'avions pas besoin d'introduire un nouvelle valeur par défaut à 1 semaine.

Je propose donc d'utiliser `GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO` et de supprimer cette ligne de config.
