### PR TITLE
Correction de l’effet du bouton « Annuler » lors d’une annulation

### DIFF
--- a/app/views/admin/participations/_participation_status_dropdown_item.html.slim
+++ b/app/views/admin/participations/_participation_status_dropdown_item.html.slim
@@ -1,7 +1,7 @@
 /# locals: (participation:, status:, contextual_agents:)
 
 = link_to admin_organisation_rdv_participation_path(participation.rdv.organisation, participation.rdv, participation, participation: { status: status }, contextual_agent_ids: contextual_agents&.map(&:id)),
-  class: "dropdown-item", data: { turbo_method: :put, confirm: change_status_confirmation_message(participation.rdv, status) } do
+  class: "dropdown-item", data: { turbo_method: :put, turbo_confirm: change_status_confirmation_message(participation.rdv, status) } do
   span
     => icon("fr-icon-circle-fill", class: "rdv-status-#{status}")
     = Participation.human_attribute_value(:status, status, context: :action)

--- a/app/views/admin/rdvs/_collective_rdv_status_dropdown_item.html.slim
+++ b/app/views/admin/rdvs/_collective_rdv_status_dropdown_item.html.slim
@@ -1,5 +1,5 @@
 = link_to admin_organisation_rdv_path(rdv.organisation, rdv, rdv: { status: status, ignore_benign_errors: true }),
-  class: "dropdown-item", data: { turbo_method: :put, confirm: change_status_confirmation_message(rdv, status) } do
+  class: "dropdown-item", data: { turbo_method: :put, turbo_confirm: change_status_confirmation_message(rdv, status) } do
   span
     => icon("fr-icon-circle-fill", class: "rdv-status-#{status}")
     = Rdv.human_attribute_value(:status, status, context: :collective_action)

--- a/app/views/admin/rdvs/_individual_rdv_status_dropdown_item.html.slim
+++ b/app/views/admin/rdvs/_individual_rdv_status_dropdown_item.html.slim
@@ -1,7 +1,7 @@
 /# locals: (rdv:, status:, quick_update:)
 
 = link_to admin_organisation_rdv_path(rdv.organisation, rdv, rdv: { status: status, ignore_benign_errors: true }, quick_update: quick_update ),
-  class: "dropdown-item", data: { turbo_method: :put, confirm: change_status_confirmation_message(rdv, status) } do
+  class: "dropdown-item", data: { turbo_method: :put, turbo_confirm: change_status_confirmation_message(rdv, status) } do
   span
     => icon("fr-icon-circle-fill", class: "rdv-status-#{status}")
     = Rdv.human_attribute_value(:status, status, context: :action)

--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -117,4 +117,24 @@ RSpec.describe "Agent can organize a rdv collectif", js: true do
       expect(page).to have_content("L'intitulé est trop long et sera abrégé ainsi dans les notifications SMS : Organiser ses fichiers et ses dossiers sur son ord...")
     end
   end
+
+  describe "changing a participation's status" do
+    before { stub_netsize_ok }
+
+    it "works", js: true do
+      rdv_collectif = create(:rdv, organisation:, motif:, agents: [agent], users: [user1])
+      visit admin_organisation_rdv_path(organisation_id: organisation.id, id: rdv_collectif.id)
+
+      # on vérifie qu'un clic sur "Annuler" dans la boite de confirmation annuler bien l'action
+      all("td .dropdown-toggle").first.click
+      dismiss_confirm do
+        expect { all("a.dropdown-item").first.click and sleep 0.5 }.not_to change { rdv_collectif.participations.sole.reload.status }
+      end
+
+      all("td .dropdown-toggle").first.click
+      accept_confirm do
+        expect { all("a.dropdown-item").first.click and sleep 0.5 }.to change { rdv_collectif.participations.sole.reload.status }
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

Suite à une remontée d’un agent 

> En tant qu'administrateur, sur la page d'un rdv collectif, lorsque je clique sur "Supprimer l'inscription du participant" puis "Annuler", l'inscription est tout de même supprimée. Est-ce un bug ?

# Solution

Il y avait effectivement un bug qui me semble venir d’un conflit Rails UJS vs Turbo. J’ai corrigé en utilisant turbo partout.
