### PR TITLE
Ne plus polluer le namespace global (Tod::TimeOfDay)

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -68,8 +68,8 @@ class Agents::CaldavSyncController < AgentAuthController
     cal.prodid = "RDV Service Public"
     cal.event do |event|
       event.uid = "rdvsp-connection-test-#{SecureRandom.uuid}"
-      event.dtstart = Icalendar::Values::DateTime.new(Time.now.change(hour: 0, min: 0, sec: 0).utc)
-      event.dtend = Icalendar::Values::DateTime.new(Time.now.change(hour: 1, min: 0, sec: 0).utc)
+      event.dtstart = Icalendar::Values::DateTime.new(Time.now.change(hour: 0).utc)
+      event.dtend = Icalendar::Values::DateTime.new(Time.now.change(hour: 1).utc)
       event.summary = "Test de connexion RDV Service Public"
     end
     cal.to_ical

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,6 @@ require "action_mailer/railtie"
 require "active_job/railtie"
 require "action_cable/engine"
 
-require "tod/core_extensions"
 require "dsfr/assets"
 require "dsfr/components"
 

--- a/spec/controllers/admin/api/agenda/external_calendar_events_controller_spec.rb
+++ b/spec/controllers/admin/api/agenda/external_calendar_events_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Admin::Api::Agenda::ExternalCalendarEventsController, type: :cont
     event_within_time_range = ExternalCalendarEvent.create!(
       agent:,
       url: "1234",
-      starts_at: Time.zone.today.at(Tod::TimeOfDay.parse("10:30")),
-      ends_at: Time.zone.today.at(Tod::TimeOfDay.parse("12:00"))
+      starts_at: today_at("10:30"),
+      ends_at: today_at("12:00")
     )
 
     # Event out of time range, should not be in response

--- a/spec/controllers/admin/api/agenda/external_calendar_events_controller_spec.rb
+++ b/spec/controllers/admin/api/agenda/external_calendar_events_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Admin::Api::Agenda::ExternalCalendarEventsController, type: :cont
     event_within_time_range = ExternalCalendarEvent.create!(
       agent:,
       url: "1234",
-      starts_at: today_at("10:30"),
-      ends_at: today_at("12:00")
+      starts_at: today_at(10, 30),
+      ends_at: today_at(12)
     )
 
     # Event out of time range, should not be in response

--- a/spec/factories/external_calendar_event.rb
+++ b/spec/factories/external_calendar_event.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :external_calendar_event do
     agent { association(:agent) }
     url { "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/#{SecureRandom.uuid}.ics" }
-    starts_at { Time.zone.today.at(Tod::TimeOfDay.parse("09:00")) }
-    ends_at { Time.zone.today.at(Tod::TimeOfDay.parse("11:00")) }
+    starts_at { today_at("09:00") }
+    ends_at { today_at("11:00") }
   end
 
   trait :recurring_on_weekdays do

--- a/spec/factories/external_calendar_event.rb
+++ b/spec/factories/external_calendar_event.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :external_calendar_event do
     agent { association(:agent) }
     url { "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/#{SecureRandom.uuid}.ics" }
-    starts_at { today_at("09:00") }
-    ends_at { today_at("11:00") }
+    starts_at { today_at(9) }
+    ends_at { today_at(11) }
   end
 
   trait :recurring_on_weekdays do

--- a/spec/features/agents/rdvs_collectifs/agent_can_add_users_to_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_add_users_to_rdv_collectif_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Un agent peut ajouter des usagers à un RDV Collectif", js: true
   let!(:agent_noe) { create(:agent, first_name: "Noé", email: "noe@service.fr", service:, admin_role_in_organisations: [organisation]) }
   let!(:motif) { create(:motif, :collectif, service:, organisation:, name: "Atelier Collectif") }
   let!(:lieu) { create(:lieu, organisation:) }
-  let(:starts_at) { Time.zone.today.next_occurring(:wednesday).at(Tod::TimeOfDay.parse("09:00")) }
+  let(:starts_at) { Tod::TimeOfDay.parse("09:00").on(Time.zone.today.next_occurring(:wednesday)) }
   let!(:rdv) { create(:rdv, :without_users, motif:, organisation:, agents: [agent_noe], lieu:, starts_at:) }
 
   describe "ajout d’un usager de l’orga courante" do

--- a/spec/features/agents/rdvs_collectifs/agent_can_remove_users_from_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_remove_users_from_rdv_collectif_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Un agent peut retirer des usagers d’un RDV Collectif", js: tru
   let!(:agent_bouba) { create(:agent, first_name: "Bouba", email: "bouba@service.fr", service:, basic_role_in_organisations: [organisation]) }
   let!(:motif) { create(:motif, :collectif, service:, organisation:, name: "Atelier Collectif") }
   let!(:lieu) { create(:lieu, organisation:) }
-  let(:starts_at) { now.to_date.next_occurring(:wednesday).at(Tod::TimeOfDay.parse("09:00")) }
+  let(:starts_at) { Tod::TimeOfDay.parse("09:00").on(now.to_date.next_occurring(:wednesday)) }
   let!(:user_amine) { create(:user, first_name: "Amine", last_name: "BENCHEIK", email: "amine@bencheik.com", organisations: [organisation]) }
   let!(:user_lea) { create(:user, first_name: "Léa", last_name: "O", organisations: [organisation]) }
   let!(:rdv) { create(:rdv, users: [user_amine, user_lea], motif:, organisation:, agents: [agent_bouba], lieu:, starts_at:) }

--- a/spec/features/autodoc/produit/planning_multi_agents_spec.rb
+++ b/spec/features/autodoc/produit/planning_multi_agents_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Nouveau planning / planning multi-agents", js: true do
   let!(:agent_basique) { create(:agent, first_name: "Loïc", last_name: "Basique", basic_role_in_organisations: [organisation]) }
 
   before do
-    monday_at_9 = Time.zone.now.beginning_of_week.to_date.at(Tod::TimeOfDay.parse("09:00"))
+    monday_at_9 = Tod::TimeOfDay.parse("09:00").on(Time.zone.now.beginning_of_week.to_date)
     create(:rdv, :no_service, organisation:, starts_at: monday_at_9, agents: [agent_admin], users: [create(:user, last_name: "DEJUSTINE")])
     create(:rdv, :no_service, organisation:, starts_at: monday_at_9, agents: [agent_basique], users: [create(:user, last_name: "DELOIC")])
 

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         documents_number: 2
       )
 
-      time = Time.zone.now.change(hour: 9, min: 0o0)
+      time = Time.zone.now.change(hour: 9)
 
       expect(json_response).to eq(
         {
@@ -168,7 +168,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
     end
 
     it "permet de réserver sans avertissement", js: true do
-      time = Time.zone.now.change(hour: 9, min: 0)
+      time = Time.zone.now.change(hour: 9)
       visit creneaux_url(
         starts_at: time.strftime("%Y-%m-%d %H:%M"),
         lieu_id: lieu.id,
@@ -235,7 +235,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
     end
 
     it "permet de réserver avec un avertissement contournable", js: true do
-      time = Time.zone.now.change(hour: 9, min: 0)
+      time = Time.zone.now.change(hour: 9)
       visit creneaux_url(
         starts_at: time.strftime("%Y-%m-%d %H:%M"),
         lieu_id: lieu.id,
@@ -275,7 +275,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
 
   context "when using a pre-demande number with invalid format (too short)" do
     it "detects wrong format without calling ANTS API an warns user" do
-      time = Time.zone.now.change(hour: 9, min: 0)
+      time = Time.zone.now.change(hour: 9)
       visit creneaux_url(
         starts_at: time.strftime("%Y-%m-%d %H:%M"),
         lieu_id: lieu.id,
@@ -296,7 +296,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
       let!(:call_to_status_with_upcased_number) { stub_ants_status_ok("ABCD1234EF", meeting_point_id: lieu.id, appointments: []) }
 
       it "considers it as uppercase when calling ANTS API and saving it in user" do
-        time = Time.zone.now.change(hour: 9, min: 0)
+        time = Time.zone.now.change(hour: 9)
         visit creneaux_url(
           starts_at: time.strftime("%Y-%m-%d %H:%M"),
           lieu_id: lieu.id,
@@ -318,7 +318,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
 
     context "when trying to bypass the front-end validation" do
       it "performs back-end validation and displays error" do
-        time = Time.zone.now.change(hour: 9, min: 0)
+        time = Time.zone.now.change(hour: 9)
         visit creneaux_url(
           starts_at: time.strftime("%Y-%m-%d %H:%M"),
           lieu_id: lieu.id,
@@ -342,7 +342,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
       end
 
       it "detects wrong format without calling ANTS API an warns user" do
-        time = Time.zone.now.change(hour: 9, min: 0)
+        time = Time.zone.now.change(hour: 9)
         visit creneaux_url(
           starts_at: time.strftime("%Y-%m-%d %H:%M"),
           lieu_id: lieu.id,
@@ -364,7 +364,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
   describe "Displaying the input field for ANTS PREDEMANDE NUMBER" do
     context "when the motif requires ants_predemande_number" do
       it "shows input for ants_predemande_number" do
-        time = Time.zone.now.change(hour: 9, min: 0)
+        time = Time.zone.now.change(hour: 9)
         visit creneaux_url(
           starts_at: time.strftime("%Y-%m-%d %H:%M"),
           lieu_id: lieu.id,
@@ -390,7 +390,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
       end
 
       it "does not show input for ants_predemande_number" do
-        time = Time.zone.now.change(hour: 15, min: 0)
+        time = Time.zone.now.change(hour: 15)
         visit creneaux_url(
           starts_at: time.strftime("%Y-%m-%d %H:%M"),
           lieu_id: lieu.id,
@@ -412,7 +412,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         end
 
         it "does not show input for ants_predemande_number" do
-          time = Time.zone.now.change(hour: 15, min: 0)
+          time = Time.zone.now.change(hour: 15)
           visit creneaux_url(
             starts_at: time.strftime("%Y-%m-%d %H:%M"),
             lieu_id: lieu.id,

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
       ExternalCalendarEvent.create(
         agent:,
         url: "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/c766aa62-c76e-48eb-a6a1-c5a496ec740b.ics",
-        starts_at: Time.zone.tomorrow.change(hour: 9, min: 0),
-        ends_at: Time.zone.tomorrow.change(hour: 10, min: 0)
+        starts_at: Time.zone.tomorrow.change(hour: 9),
+        ends_at: Time.zone.tomorrow.change(hour: 10)
       )
 
       VCR.use_cassette("caldav/transparent_event") do
@@ -106,8 +106,8 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
         ExternalCalendarEvent.create(
           agent:,
           url: "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/event_signaled_as_deleted.ics",
-          starts_at: Time.zone.tomorrow.change(hour: 9, min: 0),
-          ends_at: Time.zone.tomorrow.change(hour: 10, min: 0)
+          starts_at: Time.zone.tomorrow.change(hour: 9),
+          ends_at: Time.zone.tomorrow.change(hour: 10)
         )
 
         VCR.use_cassette("caldav/sync_with_empty_calendar_data") do

--- a/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_accounts_job_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_accounts_job_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe CronJob::DestroyOldRdvsAndInactiveAccountsJob do
   end
 
   it "only destroys Rdvs that are more than 2 years old and inactive users created more than 2 years ago" do
-    rdv_occurring_25_months_ago = travel_to(25.months.ago) { create(:rdv, starts_at: Time.zone.today.change(hour: 16)) }
-    rdv_occurring_23_months_ago = travel_to(23.months.ago) { create(:rdv, starts_at: Time.zone.today.change(hour: 16)) }
-    rdv_occurring_11_months_ago = travel_to(11.months.ago) { create(:rdv, starts_at: Time.zone.today.change(hour: 16)) }
+    rdv_occurring_25_months_ago = travel_to(25.months.ago) { create(:rdv, starts_at: Time.zone.now.change(hour: 16)) }
+    rdv_occurring_23_months_ago = travel_to(23.months.ago) { create(:rdv, starts_at: Time.zone.now.change(hour: 16)) }
+    rdv_occurring_11_months_ago = travel_to(11.months.ago) { create(:rdv, starts_at: Time.zone.now.change(hour: 16)) }
 
     user_without_rdv_created_23_months_ago = travel_to(23.months.ago) { create(:user) }
 
@@ -66,7 +66,7 @@ RSpec.describe CronJob::DestroyOldRdvsAndInactiveAccountsJob do
   end
 
   it "calls the webhooks" do
-    travel_to(25.months.ago) { create(:rdv, organisation: organisation, starts_at: Time.zone.today.change(hour: 16)) }
+    travel_to(25.months.ago) { create(:rdv, organisation: organisation, starts_at: today_at(16)) }
     expect do
       described_class.new.perform
     end.to have_enqueued_job(WebhookJob).with(json_payload_with_meta("webhook_reason", "rgpd"), webhook_endpoint.id)

--- a/spec/mailers/previews/agents/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/agents/rdv_mailer_preview.rb
@@ -42,7 +42,7 @@ class Agents::RdvMailerPreview < ActionMailer::Preview
         organisation:,
         users: [user],
         agents: [Agent.new(first_name: "Karim", last_name: "FERN", email: "karim@demo.rdv-solidarites.fr").tap(&:readonly!)],
-        starts_at: Time.zone.today.next_occurring(:wednesday).at(Tod::TimeOfDay.parse("10:30")),
+        starts_at: Tod::TimeOfDay.parse("10:30").on(Time.zone.today.next_occurring(:wednesday)),
         duration_in_min: 30,
         motif: Motif.new(organisation:, name: "Atelier éducation canine", collectif: true).tap(&:readonly!),
         lieu: Lieu.new(organisation:, name: "Parc des bruyères, 13005 Marseille").tap(&:readonly!)

--- a/spec/services/creneaux_search/next_availability_spec.rb
+++ b/spec/services/creneaux_search/next_availability_spec.rb
@@ -177,11 +177,11 @@ RSpec.describe CreneauxSearch::NextAvailability, type: :service do
 
       specify do
         next_available_default = described_class.find(motif, lieu, [], from: today)
-        expect(next_available_default.starts_at).to eq((today + 8.days).at(Tod::TimeOfDay.parse("09:30")))
+        expect(next_available_default.starts_at).to eq(Tod::TimeOfDay.parse("09:30").on(today + 8.days))
         next_available_30min = described_class.find(motif, lieu, [], from: today, duration_in_min: 30)
-        expect(next_available_30min.starts_at).to eq((today + 8.days).at(Tod::TimeOfDay.parse("09:30")))
+        expect(next_available_30min.starts_at).to eq(Tod::TimeOfDay.parse("09:30").on(today + 8.days))
         next_available_1h00 = described_class.find(motif, lieu, [], from: today, duration_in_min: 60)
-        expect(next_available_1h00.starts_at).to eq((today + 16.days).at(Tod::TimeOfDay.parse("08:30")))
+        expect(next_available_1h00.starts_at).to eq(Tod::TimeOfDay.parse("08:30").on(today + 16.days))
       end
     end
   end

--- a/spec/support/datetime_helpers.rb
+++ b/spec/support/datetime_helpers.rb
@@ -1,11 +1,7 @@
-def date_and_time(date, time)
-  Tod::TimeOfDay.parse(time).on(date)
+def today_at(hour, min = 0)
+  Time.zone.now.change(hour:, min:)
 end
 
-def today_at(time)
-  Tod::TimeOfDay.parse(time).on(Time.zone.today)
-end
-
-def tomorrow_at(time)
-  Tod::TimeOfDay.parse(time).on(Time.zone.tomorrow)
+def tomorrow_at(hour)
+  Time.zone.tomorrow.to_time.change(hour:)
 end

--- a/spec/support/datetime_helpers.rb
+++ b/spec/support/datetime_helpers.rb
@@ -3,5 +3,5 @@ def today_at(hour, min = 0)
 end
 
 def tomorrow_at(hour)
-  Time.zone.tomorrow.to_time.change(hour:)
+  1.day.from_now.change(hour:)
 end

--- a/spec/support/datetime_helpers.rb
+++ b/spec/support/datetime_helpers.rb
@@ -1,3 +1,11 @@
-def tomorrow_at(hour)
-  Time.zone.tomorrow.at(Tod::TimeOfDay(hour))
+def date_and_time(date, time)
+  Tod::TimeOfDay.parse(time).on(date)
+end
+
+def today_at(time)
+  Tod::TimeOfDay.parse(time).on(Time.zone.today)
+end
+
+def tomorrow_at(time)
+  Tod::TimeOfDay.parse(time).on(Time.zone.tomorrow)
 end


### PR DESCRIPTION
J'étais tombé sur le README de `tod` et je n'ai pas résisté à faire le bon élève, et au passage homogénéiser nos pratiques.

# Contexte

La gem `tod` offre du monkey patching optionnel de `Date` et `Time`. Depuis sa version 2.0 la gem recommande de ne plus y avoir recours : https://github.com/jackc/tod#upgrading-from-versions-prior-to-200

Nous utilisons uniquement la méthode `Date#at`, et uniquement dans les tests, donc on peut facilement faire sans.

# Solution

On supprime `require "tod/core_extensions"` dans `config/application.rb` et on adapte les usages.
