### PR TITLE
Corrige une flaky spec liée aux prénoms aléatoires

### DIFF
--- a/spec/features/super_admin/can_search_user_spec.rb
+++ b/spec/features/super_admin/can_search_user_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Un super admin peut chercher un utilisateur", js: true do
   let(:super_admin) { create(:super_admin) }
-  let!(:user) { create(:user) }
-  let!(:another_user) { create(:user) } # On crée un autre utilisateur pour s’assurer que la recherche fonctionne correctement
+  let!(:user) { create(:user, first_name: "Katia", last_name: "Garcia") }
+  let!(:another_user) { create(:user, first_name: "Tanguy", last_name: "Laverdure") } # On crée un autre utilisateur pour s’assurer que la recherche fonctionne correctement
 
   it "par email" do
     login_as(super_admin, scope: :super_admin)


### PR DESCRIPTION
https://github.com/betagouv/rdv-service-public/actions/runs/26884377900/job/79292477185

La spec échoue quand les deux users ont le même prénom, car nous nous servons du prénom pour détermine l'affichage du bon user sur la page.