### PR TITLE
[Sécurité] Fixer par hash les versions des GH Actions

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -11,7 +11,7 @@ runs:
         echo "PLAYWRIGHT_VERSION=$(jq -r '.devDependencies["playwright"]' package.json)" >> $GITHUB_ENV
     - name: Cache Playwright Chromium browser
       id: playwright-cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/ms-playwright
         key: playwright-browsers-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
     name: Ruby linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -25,9 +27,11 @@ jobs:
     name: Slim Linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -36,14 +40,16 @@ jobs:
     name: Lint SCSS with Prettier
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
       - run: corepack enable
       - name: Cache js dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
@@ -53,9 +59,11 @@ jobs:
     name: Security Checker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -77,9 +85,11 @@ jobs:
           --health-retries 5
         ports: ["5432:5432"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -141,21 +151,23 @@ jobs:
           --health-retries 5
         ports: ["6379:6379"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Prevent https://github.com/rails/rails/issues/53661
         run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
       - run: corepack enable
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
       - name: Cache js dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
@@ -163,7 +175,7 @@ jobs:
         run: yarn install --immutable
       - name: Cache precompiled assets
         id: cache-precompiled-assets
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: assets-invalid-${{ hashFiles('yarn.lock', 'Gemfile.lock', 'app/javascript/**', 'app/assets/**') }}
           path: |
@@ -176,7 +188,7 @@ jobs:
       - name: Prepare runtime log cache key
         run: "ls spec/${{ matrix.dirname }}/**/*.rb > tmp/spec_${{ matrix.name }}_files.txt"
       - name: Cache parallel test feature spec runtime log
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: specs-runtime-log-${{ hashFiles(format('tmp/spec_{0}_files.txt', matrix.name)) }}
           path: tmp/parallel_runtime_rspec.log
@@ -190,7 +202,7 @@ jobs:
           POSTGRES_USER: lapin_test
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: tests-results-${{ matrix.name }}
@@ -223,19 +235,21 @@ jobs:
           --health-retries 5
         ports: ["6379:6379"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
       - run: corepack enable
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
       - name: Cache js dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
@@ -243,7 +257,7 @@ jobs:
         run: yarn install --immutable
       - name: Cache precompiled assets
         id: cache-precompiled-assets
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: assets-invalid-${{ hashFiles('yarn.lock', 'Gemfile.lock', 'app/javascript/**', 'app/assets/**') }}
           path: |
@@ -264,12 +278,12 @@ jobs:
           POSTGRES_DB: lapin_test
           UPLOAD_TO_GH_PAGES: true
       - name: Upload static files as artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: tmp/capybara/autodoc
         continue-on-error: true # On ne veut pas faire échouer le build si l'upload de l’artifact de la doc échoue
         if: ${{ github.ref == 'refs/heads/production' }}
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: artifacts-capybara-spec-to-doc
@@ -284,25 +298,27 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/deploy-pages@v5
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
         continue-on-error: true
   test_boot_without_db:
     name: Boot web server without database
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
       - run: corepack enable
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
       - name: Cache js dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
@@ -316,7 +332,7 @@ jobs:
     needs: [rubocop, lint_slim, lint_prettier, brakeman, active_record_doctor, tests, test_boot_without_db]
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/production' }}
     steps:
-      - uses: mattermost/action-mattermost-notify@master
+      - uses: mattermost/action-mattermost-notify@ae31bb6f9e26a54336e79696f108a2c91cf55b4e # v2.1.0
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
           TEXT: |

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -9,9 +9,11 @@ jobs:
    runs-on: ubuntu-latest
    steps:
    - name: 'Checkout Repository'
-     uses: actions/checkout@v6
+     uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+     with:
+       persist-credentials: false
    - name: Dependency Review
-     uses: actions/dependency-review-action@v3
+     uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
      with:
        # Possible values: "critical", "high", "moderate", "low"
        fail-on-severity: high

--- a/.github/workflows/pull_requests_reminder.yml
+++ b/.github/workflows/pull_requests_reminder.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull requests reminder
-        uses: betagouv/pr-reviews-reminder-action@master
+        uses: betagouv/pr-reviews-reminder-action@fb8f561286f429438f50092f8f0101150c085759 # master
         env:
           GITHUB_TOKEN: ${{ secrets.PR_REMINDER_GH_TOKEN }}
         with:


### PR DESCRIPTION
# Contexte

L'incubateur beta (la personne de Julien B.) a recommandé aujourd'hui d'utiliser des hashes pour références les versions des GitHub Actions que l'on utilise.

En effet, un numéro de version "vague" peut pointer vers une version de l'Action comportant du code malveillant (attaque de supply chain).

# Solution

J'ai fait les remplacements à la main. 

Note : c'est un peu moins pratique pour mettre à jour mais au moins on sait vers quelle version précise on pointe.