### PR TITLE
Permettre d'envoyer des mails avec le nouveau nom de domaine

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -315,6 +315,8 @@ class Agent < ApplicationRecord
   def domain
     @domain ||= if organisations.where(verticale: :rdv_aide_numerique).any?
                   Domain::RDV_AIDE_NUMERIQUE
+                elsif organisations.where(verticale: :rdv_etat).any?
+                  Domain::RDV_SERVICE_PUBLIC_ETAT
                 elsif organisations.where(verticale: :rdv_mairie).any?
                   Domain::RDV_SERVICE_PUBLIC
                 else

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,6 +10,7 @@ class Organisation < ApplicationRecord
     rdv_solidarites: "rdv_solidarites",
     rdv_aide_numerique: "rdv_aide_numerique",
     rdv_mairie: "rdv_mairie",
+    rdv_etat: "rdv_etat",
   }
 
   # Relations
@@ -87,6 +88,8 @@ class Organisation < ApplicationRecord
     case verticale.to_sym
     when :rdv_aide_numerique
       Domain::RDV_AIDE_NUMERIQUE
+    when :rdv_etat
+      Domain::RDV_SERVICE_PUBLIC_ETAT
     when :rdv_mairie
       Domain::RDV_SERVICE_PUBLIC
     else

--- a/db/migrate/20260603152307_add_rdv_etat_to_organisation_verticale_enum.rb
+++ b/db/migrate/20260603152307_add_rdv_etat_to_organisation_verticale_enum.rb
@@ -1,0 +1,5 @@
+class AddRdvEtatToOrganisationVerticaleEnum < ActiveRecord::Migration[8.0]
+  def change
+    add_enum_value :verticale, "rdv_etat"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_18_132616) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_03_152307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -36,7 +36,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_18_132616) do
   create_enum "sms_provider", ["netsize", "send_in_blue", "contact_experience", "sfr_mail2sms", "clever_technologies", "orange_contact_everyone"]
   create_enum "user_created_through", ["unknown", "agent_creation", "user_sign_up", "franceconnect_sign_up", "user_relative_creation", "agent_creation_api", "prescripteur", "auto_through_login"]
   create_enum "user_invited_through", ["devise_email", "external"]
-  create_enum "verticale", ["rdv_insertion", "rdv_solidarites", "rdv_aide_numerique", "rdv_mairie"]
+  create_enum "verticale", ["rdv_insertion", "rdv_solidarites", "rdv_aide_numerique", "rdv_mairie", "rdv_etat"]
 
   create_table "absences", force: :cascade do |t|
     t.bigint "agent_id", null: false

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -198,6 +198,13 @@ RSpec.describe Agent, type: :model do
         it { is_expected.to eq(Domain::RDV_SERVICE_PUBLIC) }
       end
     end
+
+    context "when the agent is in an organisation using the état domain name" do
+      let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let(:organisation) { create(:organisation, verticale: "rdv_etat") }
+
+      it { is_expected.to eq(Domain::RDV_SERVICE_PUBLIC_ETAT) }
+    end
   end
 
   describe "#proconnect_siret" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -83,4 +83,14 @@ RSpec.describe Organisation, type: :model do
       it { is_expected.to be true }
     end
   end
+
+  describe "#domain" do
+    subject { organisation.domain }
+
+    context "when the verticale is set to état" do
+      let(:organisation) { build(:organisation, verticale: "rdv_etat") }
+
+      it { is_expected.to eq(Domain::RDV_SERVICE_PUBLIC_ETAT) }
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

Pour le moment, on peut commencer à naviguer sur `rdv.numerique.gouv.fr`, mais les emails (et les sms) qu'on envoient ont encore des liens qui pointent vers `rdv.anct.gouv.fr`.

# Solution

J'ai redécouvert que c'est la colonne `organisations.verticale` qui décide du nom de domaine depuis lequel on envoie les emails (une complexité liée au fait qu'on a plusieurs marques sur la même instance).
Mais ça nous donne une manière pratique de changer le nom de domaine utilisé dans les emails. On peut changer la valeur de cette colonne pour que les emails partent correctement.
Le fait de le contrôler de cette manière permet de faire des tests progressifs (on va changer les valeurs en base, ce qui sera aussi une manière pratique de savoir qui reste sur celle instance).

On pourra par exemple utiliser le résultat de https://github.com/betagouv/rdv-service-public/pull/6377 pour écrire dans cette colonne (et non pas en créer une nouvelle)