### PR TITLE
Garder les mêmes ajustements d'interface entre les deux nouveaux noms de domaine.

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,7 +15,7 @@ class SearchController < ApplicationController
       return
     end
 
-    if [Domain::RDV_SERVICE_PUBLIC, Domain::RDV_SERVICE_PUBLIC_ETAT].include?(current_domain)
+    if current_domain.rdv_service_public?
       @site_vitrine_page = true
       render "dsfr/rdv_mairie/homepage"
     else

--- a/app/form_models/concerns/users/user_form_concern.rb
+++ b/app/form_models/concerns/users/user_form_concern.rb
@@ -22,7 +22,7 @@ module Users::UserFormConcern
   end
 
   def show_birth_name_field?
-    !signed_in_with_invitation_token? && domain != Domain::RDV_SERVICE_PUBLIC && !pro_connect_openid_sub
+    !signed_in_with_invitation_token? && !domain.rdv_service_public? && !pro_connect_openid_sub
   end
 
   def birth_name_frozen? = connected_with_sso?

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -274,4 +274,8 @@ class Domain
   def to_s
     name
   end
+
+  def rdv_service_public?
+    in?([RDV_SERVICE_PUBLIC, RDV_SERVICE_PUBLIC_ETAT])
+  end
 end

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -10,7 +10,7 @@
   .col-md-6= f.input :last_name, **input_opts
 
 .form-row
-  - if current_domain != Domain::RDV_SERVICE_PUBLIC
+  - unless current_domain.rdv_service_public?
     .col-md-6= f.input :birth_name, **input_opts.deep_merge(frozen_fields_opts)
   - if current_territory.enable_birth_date_field?
     .col-md-6= date_input(f, :birth_date, **input_opts.deep_merge(frozen_fields_opts))

--- a/app/views/aide/pages/aiguillage_usager.html.slim
+++ b/app/views/aide/pages/aiguillage_usager.html.slim
@@ -23,7 +23,7 @@
       - content_for :subtitle, "Prendre un RDV"
       h6 Étapes pour prendre un RDV
       ol
-        - if current_domain == Domain::RDV_SERVICE_PUBLIC
+        - if current_domain.rdv_service_public?
           li Cliquez sur votre lien de prise de RDV : vous l’avez peut-être trouvé sur le site de l’organisation ou bien il vous a été communiqué par email.
         - else
           li Sur la page d’accueil, dans la barre de recherche, saisissez votre adresse et cliquez sur « Rechercher ».
@@ -34,7 +34,7 @@
         li Identifiez-vous : la connexion se fait par la création d'un compte ou via France Connect.
         li Confirmez le rendez-vous : un SMS et/ou un email seront envoyés quelques minutes après la confirmation du rendez-vous. Pour les emails, pensez à vérifier vos spams si besoin.
 
-      - unless current_domain == Domain::RDV_SERVICE_PUBLIC
+      - unless current_domain.rdv_service_public?
         .fr-mb-4w
           = link_to "Faire une recherche de RDV depuis l’accueil", root_path, class: "fr-btn"
 

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -10,7 +10,7 @@ header.header.bg-white
     #navbarSupportedContent.collapse.navbar-collapse
       ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
         li.list-inline-item
-          - if current_domain == Domain::RDV_SERVICE_PUBLIC
+          - if current_domain.rdv_service_public?
             = link_to "Donnez votre avis", "https://tally.so/r/obBope", class: "btn text-primary-blue link-dsfr", target: "_blank"
           - elsif current_domain == Domain::RDV_SOLIDARITES
             = link_to "Donnez votre avis", "https://tally.so/r/5BkP56", class: "btn text-primary-blue link-dsfr", target: "_blank"
@@ -39,7 +39,7 @@ header.header.bg-white
             li = link_to destroy_agent_session_path, method: :delete, class: "dropdown-item-dsfr dropdown-item" do
               span.fr-icon--sm.fr-mr-2v.fr-icon-logout-box-r-line[aria-hidden="true"]
               | Se déconnecter
-        - if current_domain == Domain::RDV_SERVICE_PUBLIC && current_agent.lagaufre_access?
+        - if current_domain.rdv_service_public? && current_agent.lagaufre_access?
           li.list-inline-item.fr-mr-6v.fr-mt-n1v
             = render "layouts/lagaufre_button"
 

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -25,7 +25,7 @@ html lang="fr"
 
       # Sur RDV Service Public, la page d’accueil n’est pas à destination des usagers qui prennent rendez-vous
       # On veut donc éviter d’avoir un lien qui mène vers la page d’accueil pendant la prise de rendez-vous
-      if current_domain == Domain::RDV_SERVICE_PUBLIC
+      if current_domain.rdv_service_public?
         if current_page?("/prendre_rdv") || @rdv_wizard
           home_path = nil
         end
@@ -42,7 +42,7 @@ html lang="fr"
         elsif current_agent
           header.with_tool_link title: "Espace Agent", path: root_path
           header.with_tool_link title: current_agent.full_name, path: edit_agent_registration_path
-        elsif current_domain == Domain::RDV_SERVICE_PUBLIC && request.path == "/"
+        elsif current_domain.rdv_service_public? && request.path == "/"
           header.with_tool_link title: "Centre d’aide", path: "https://aide.rdv-service-public.fr", html_attributes: { class: "fr-icon-questionnaire-line" }
           header.with_tool_link title: "Connexion Agent", path: new_agent_session_path, html_attributes: { class: "fr-icon-admin-line" }
           header.with_tool_link title: "Connexion Usager", path: new_user_session_path, html_attributes: { class: "fr-icon-account-line" }
@@ -51,7 +51,7 @@ html lang="fr"
           header.with_tool_link title: "Connexion Usager", path: new_user_session_path, html_attributes: { class: "fr-icon-account-line" }
         end
 
-        if current_domain == Domain::RDV_SERVICE_PUBLIC  && @site_vitrine_page
+        if current_domain.rdv_service_public? && @site_vitrine_page
           header.with_direct_link_simple title: "Accueil", path: root_path, html_attributes: current_page?(root_path) ? { "aria-current": "page" } : {}
           header.with_direct_link_simple title: "Notre impact", path: stats_path, html_attributes: current_page?(stats_path) ? { "aria-current": "page" } : {}
         end

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -5,5 +5,5 @@
   = f.dsfr_text_field :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
   = f.hidden_field :ants_pre_demande_number_required, value: "true"
   = f.hidden_field :ants_meeting_point_id
-- if current_domain != Domain::RDV_SERVICE_PUBLIC # TODO: trouver un moyen d'avoir le contexte du rdv_wizard, pour ensuite se baser sur current_territory.enable_birth_date_field?
+- unless current_domain.rdv_service_public? # TODO: trouver un moyen d'avoir le contexte du rdv_wizard, pour ensuite se baser sur current_territory.enable_birth_date_field?
   = f.dsfr_text_field :birth_date, type: :date, input_html: { type: "date" }, autocomplete: "bday"


### PR DESCRIPTION
Suite de https://github.com/betagouv/rdv-service-public/pull/6397

On s'assure que tous les points de détails spécifiques à RDV Service Public continuent de fonctionner avec le nouveau nom de domaine.

Je m'étais posé la question de nommer la méthode plutôt `#rdv_service_public_or_rdv_service_public_etat?`, mais c'était à la fois pas très lisible, et ça donnait l'impression que la valeur retournée allait être `RDV_SERVICE_PUBLIC` ou `RDV_SERVICE_PUBLIC_ETAT` à la place d'un booléen.