### PR TITLE
Correction de l’activation des données perso sync CalDAV

### DIFF
--- a/app/views/agents/caldav_sync/calendar_selection.html.slim
+++ b/app/views/agents/caldav_sync/calendar_selection.html.slim
@@ -13,6 +13,7 @@ p Veuillez sélectionner ci-dessous l'agenda que vous souhaitez synchroniser ave
 = form_tag agents_calendar_sync_caldav_sync_path, method: :put do
   = hidden_field_tag :caldav_username, params[:caldav_username]
   = hidden_field_tag :caldav_password, params[:caldav_password]
+  = hidden_field_tag :caldav_include_sensitive_data, params[:caldav_include_sensitive_data]
 
   fieldset.fr-fieldset
     legend.fr-fieldset__legend.fr-fieldset__legend--regular


### PR DESCRIPTION
# Contexte



Lorsque j’ai repris la PR sur la sélection d’agenda (#6172), j’ai oublié que nous avions rajouté la case pour activer les données perso. Suite au retour de @mekaidmekaid je me suis aperçu que lorsqu’on demandait la synchronisation des données personnelles ça n’avait aucun effet.

# Solution

Je passe donc le params qui va bien corriger.
