### PR TITLE
Correction de la synchronisation CalDAV avec Zimbra

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -86,8 +86,9 @@ class Agents::CaldavSyncController < AgentAuthController
     end
 
     begin
-      identifier = "rdvsp-connection-test-#{SecureRandom.uuid}.ics"
-      test_event = client.events.create(agenda_url, identifier, test_event_ics)
+      uuid = SecureRandom.uuid
+      identifier = "rdvsp-connection-test-#{uuid}.ics"
+      test_event = client.events.create(agenda_url, identifier, test_event_ics(uuid))
       client.events.delete(test_event.url) # On nettoie l’événement de test qu’on vient de créer
     rescue StandardError
       return "L’accès en écriture au calendrier a échoué. Veuillez vérifier vos droits d’accès à l’agenda."
@@ -96,11 +97,11 @@ class Agents::CaldavSyncController < AgentAuthController
     nil
   end
 
-  def test_event_ics
+  def test_event_ics(uuid)
     cal = Icalendar::Calendar.new
     cal.prodid = "RDV Service Public"
     cal.event do |event|
-      event.uid = "rdvsp-connection-test-#{SecureRandom.uuid}"
+      event.uid = "rdvsp-connection-test-#{uuid}"
       event.dtstart = Icalendar::Values::DateTime.new(Time.now.change(hour: 0).utc)
       event.dtend = Icalendar::Values::DateTime.new(Time.now.change(hour: 1).utc)
       event.summary = "Test de connexion RDV Service Public"

--- a/app/jobs/caldav/export_rdv_to_caldav_job.rb
+++ b/app/jobs/caldav/export_rdv_to_caldav_job.rb
@@ -30,7 +30,7 @@ module Caldav
     def create_event
       payload = agents_rdv.rdv.payload(action: :create, recipient: agents_rdv.agent, sensitive_data: agent.caldav_include_sensitive_data)
       ics = IcalFormatters::Ics.from_payload(payload).to_ical
-      identifier = "agents_rdv-#{agents_rdv.id}.ics"
+      identifier = "#{agents_rdv.rdv.uuid}.ics"
       event = agent.caldav_client.events.create(agent.caldav_agenda_url, identifier, ics)
       # Le provider Caldav n’utilise pas forcément l’identifiant qu’on lui donne pour créer l’event
       # on stocke donc l’url complète de l’event créé pour être sûr de pouvoir le retrouver.

--- a/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
+++ b/spec/jobs/caldav/export_rdv_to_caldav_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Caldav::ExportRdvToCaldavJob do
     before { allow(caldav_events).to receive(:create).and_return(created_event) }
 
     it "crée l'événement sur le serveur caldav" do
-      expect(caldav_events).to receive(:create).with(agent.caldav_agenda_url, "agents_rdv-#{agents_rdv.id}.ics", "BEGIN:VCALENDAR...")
+      expect(caldav_events).to receive(:create).with(agent.caldav_agenda_url, "#{agents_rdv.rdv.uuid}.ics", "BEGIN:VCALENDAR...")
       described_class.new.perform(agents_rdv.id, agent.id)
     end
 


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6417.osc-secnum-fr1.scalingo.io/)

# Contexte

La configuration CalDAV échouait sur les serveurs Zimbra : lors de la vérification des droits en écriture, le job d'export et la validation de configuration créaient un événement de test avec un nom de fichier `.ics` différent du `UID` contenu dans l'ICS. Zimbra exige que les deux correspondent — il rejetait le PUT avec un 302, provoquant l'échec.

# Solution

Alignement du nom de fichier `.ics` sur le `UID` de l'événement ICS, côté vérification de configuration (`caldav_config_error`) et côté job d'export (`ExportRdvToCaldavJob`). Les deux utilisent désormais le même UUID.

La solution a été testée grâce à la mise en place d’un compte de test sur le Zimbra de l’organisation de l’agent qui nous a remonté le problème.

J’ai également re-testé la synchro avec LaSuite pour vérifier que ça n’avait pas d’incidence. 

De plus, il me semble qu’il n’y a pas de problème pour tous les événements déjà existants, car nous utilisons les caldav_url stockés en base.
