### PR TITLE
Remplacement acronyme Mon Suivi Social

### DIFF
--- a/app/views/mailers/agents/territory_creation_request_mailer/refused.html.slim
+++ b/app/views/mailers/agents/territory_creation_request_mailer/refused.html.slim
@@ -12,7 +12,7 @@ p
       | Les collectivités territoriales :
       ul
         li communes de moins de 3500 habitants avec un dispositif de recueil
-        li CCAS utilisant MSS
+        li CCAS utilisant Mon Suivi Social
         li France Services
         li Conseils départementaux
     li Les associations mandatées dans le cadre d’une mission de service public


### PR DESCRIPTION
MSS -> Mon Suivi Social dans le mail de refus d'ouverture de compte. 