### PR TITLE
Envoi de debug à Sentry lors d'erreurs Caldav au setup initial

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -22,6 +22,7 @@ class Agents::CaldavSyncController < AgentAuthController
       preselected_url = params[:caldav_agenda_url].to_s.chomp("/")
       render locals: { calendars: calendars, preselected_url: preselected_url }
     rescue Calendav::RequestError => e
+      Sentry.capture_exception(e)
       flash[:alert] = case e.response.status
                       when 401, 403
                         "L'authentification a échoué : #{e.message}. Veuillez vérifier votre identifiant et votre mot de passe."


### PR DESCRIPTION
Un agent rencontre une erreur 501 et nous aimerions connaître quelle commande Caldav l'a provoquée et quelle a été la réponse complète.

Note : nous avons juste à appeler `Sentry.capture_exception` car le contenu des requêtes / réponses HTTP est automatiquement ajouté au contexte Sentry depuis #6066. :man_dancing: 

---

https://zammad10.ethibox.fr/#ticket/zoom/40580/61450

<img width="1800" height="676" alt="image" src="https://github.com/user-attachments/assets/d59b2bff-9486-405a-9838-66194e30bb17" />