### PR TITLE
Corrige les flaky spec des connections ActionCable

### DIFF
--- a/spec/features/agents/planning/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/planning/agent_has_a_calendar_spec.rb
@@ -93,6 +93,9 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
   describe "realtime refreshes" do
     let!(:organisation) { create(:organisation) }
     let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+    let(:agenda_channel_confirmed) do
+      ->(data) { data.include?('"type":"confirm_subscription"') && data.include?("AgendaChannel") }
+    end
 
     before do
       login_as(agent, scope: :agent)
@@ -105,8 +108,9 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       motif = create(:motif, organisation: organisation, name: "Atelier collectif")
       francis = create(:user, first_name: "Francis", last_name: "Factice")
 
-      visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
-      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
+      wait_for_websocket_frame(agenda_channel_confirmed) do
+        visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+      end
 
       rdv = create(:rdv, agents: [agent], motif:, organisation:, users: [francis], starts_at:)
       expect(page).to have_selector(".fc-event", text: "14:00 - 14:45\nFrancis FACTICE")
@@ -134,9 +138,9 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
     end
 
     it "refreshes plages", js: true do
-      visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
-      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
-
+      wait_for_websocket_frame(agenda_channel_confirmed) do
+        visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+      end
       plage = create(:plage_ouverture, organisation:, agent:, title: "Ma plage", first_day: Time.zone.now.beginning_of_week.to_date)
       expect(page).to have_selector(".fc-event.fc-bg-event", text: "Ma plage")
 
@@ -148,8 +152,9 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
     end
 
     it "refreshes absence", js: true do
-      visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
-      sleep 0.1 # on attend 100ms que la connexion Websocket se fasse
+      wait_for_websocket_frame(agenda_channel_confirmed) do
+        visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
+      end
 
       absence = create(:absence, agent:, title: "Mon indispo", first_day: Time.zone.now.beginning_of_week.to_date)
       expect(page).to have_selector(".fc-event", text: "Mon indispo")
@@ -168,10 +173,12 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       click_on "Statistiques"
       expect(page).to have_content("Statistiques de")
 
-      click_on "Planning"
+      wait_for_websocket_frame(agenda_channel_confirmed) do
+        click_on "Planning"
+      end
       expect(page).to have_content("Planning de")
-      sleep 0.5 # on attend que la connexion Websocket se fasse
 
+      expect(page).not_to have_selector(".fc-event", text: "Mon indispo")
       create(:absence, agent:, title: "Mon indispo", first_day: Time.zone.now.beginning_of_week.to_date)
       expect(page).to have_selector(".fc-event", text: "Mon indispo")
     end

--- a/spec/features/agents/planning/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/planning/agent_has_a_calendar_spec.rb
@@ -93,9 +93,6 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
   describe "realtime refreshes" do
     let!(:organisation) { create(:organisation) }
     let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-    let(:agenda_channel_confirmed) do
-      ->(data) { data.include?('"type":"confirm_subscription"') && data.include?("AgendaChannel") }
-    end
 
     before do
       login_as(agent, scope: :agent)
@@ -108,7 +105,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       motif = create(:motif, organisation: organisation, name: "Atelier collectif")
       francis = create(:user, first_name: "Francis", last_name: "Factice")
 
-      wait_for_websocket_frame(agenda_channel_confirmed) do
+      wait_for_action_cable_subscription_to("AgendaChannel") do
         visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
       end
 
@@ -138,7 +135,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
     end
 
     it "refreshes plages", js: true do
-      wait_for_websocket_frame(agenda_channel_confirmed) do
+      wait_for_action_cable_subscription_to("AgendaChannel") do
         visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
       end
       plage = create(:plage_ouverture, organisation:, agent:, title: "Ma plage", first_day: Time.zone.now.beginning_of_week.to_date)
@@ -152,7 +149,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
     end
 
     it "refreshes absence", js: true do
-      wait_for_websocket_frame(agenda_channel_confirmed) do
+      wait_for_action_cable_subscription_to("AgendaChannel") do
         visit admin_organisation_planning_agenda_path(organisation, agent_id: agent.id)
       end
 
@@ -173,7 +170,7 @@ RSpec.describe "Agent calendar displays rdvs and plages" do
       click_on "Statistiques"
       expect(page).to have_content("Statistiques de")
 
-      wait_for_websocket_frame(agenda_channel_confirmed) do
+      wait_for_action_cable_subscription_to("AgendaChannel") do
         click_on "Planning"
       end
       expect(page).to have_content("Planning de")

--- a/spec/support/page_spec_helper.rb
+++ b/spec/support/page_spec_helper.rb
@@ -3,16 +3,23 @@ module PageSpecHelper
     expect(page).to have_selector("h1.fr-h2", text: title)
   end
 
+  def wait_for_action_cable_subscription_to(channel_name, &wait_block)
+    predicate_block = lambda do |web_socket_frame|
+      web_socket_frame.include?('"type":"confirm_subscription"') && web_socket_frame.include?(channel_name)
+    end
+    wait_for_websocket_frame(predicate_block, &wait_block)
+  end
+
   def wait_for_websocket_frame(predicate_block, &wait_block)
     queue = Queue.new
     page.driver.with_playwright_page do |playwright_page|
       playwright_page.on("websocket", lambda { |ws|
-        ws.on("framereceived", lambda { |data|
-          queue << true if predicate_block.call(data)
+        ws.on("framereceived", lambda { |web_socket_frame|
+          queue << true if predicate_block.call(web_socket_frame)
         })
       })
     end
-    wait_block&.call
-    Timeout.timeout(10) { queue.pop }
+    wait_block.call
+    Timeout.timeout(5) { queue.pop }
   end
 end

--- a/spec/support/page_spec_helper.rb
+++ b/spec/support/page_spec_helper.rb
@@ -2,4 +2,17 @@ module PageSpecHelper
   def expect_page_title(title)
     expect(page).to have_selector("h1.fr-h2", text: title)
   end
+
+  def wait_for_websocket_frame(predicate_block, &wait_block)
+    queue = Queue.new
+    page.driver.with_playwright_page do |playwright_page|
+      playwright_page.on("websocket", lambda { |ws|
+        ws.on("framereceived", lambda { |data|
+          queue << true if predicate_block.call(data)
+        })
+      })
+    end
+    wait_block&.call
+    Timeout.timeout(10) { queue.pop }
+  end
 end


### PR DESCRIPTION
La spec qui vérifie que les connections temps-réel ActionCable sont bien fonctionnelle est flaky, car nous utilisions des `sleep` pour attendre (en croisant les doigts) que la connexion WebSocket se fasse.

Cette PR propose d'introduire un helper qui permet d'utiliser un listener Playwright pour attendre la connexion WebSocket.

Le code est assez exotique mais reste compréhensible. Si vous avez des suggestions pour le rendre plus clair, je suis preneur !