### PR TITLE
Rendre obligatoire les chamsp de synchro Caldav

### DIFF
--- a/app/controllers/agents/caldav_sync_controller.rb
+++ b/app/controllers/agents/caldav_sync_controller.rb
@@ -1,5 +1,6 @@
 class Agents::CaldavSyncController < AgentAuthController
   layout "application_agent_config"
+  before_action { @active_agent_preferences_menu_item = :synchronisation }
 
   def show
     skip_authorization

--- a/app/views/agents/caldav_sync/show.html.slim
+++ b/app/views/agents/caldav_sync/show.html.slim
@@ -47,16 +47,16 @@ p
         | Identifiant de l’agenda CalDAV
         span.fr-hint-text
           = external_link_to "voir la documentation", "https://aide.rdv-service-public.fr/documentation-utilisateur/faq#synchronisation-avec-la-suite-numerique-caldav"
-      input#caldav_username.fr-input type="text" name="caldav_username"
+      input#caldav_username.fr-input[type="text" name="caldav_username" required]
     .fr-input-group
       label.fr-label for="caldav_password"
         | Mot de passe de l’agenda CalDAV
         span.fr-hint-text
           = external_link_to "voir la documentation", "https://aide.rdv-service-public.fr/documentation-utilisateur/faq#synchronisation-avec-la-suite-numerique-caldav"
-      input#caldav_password.fr-input type="password" name="caldav_password"
+      input#caldav_password.fr-input[type="password" name="caldav_password" required]
     .fr-input-group
       label.fr-label for="caldav_agenda_url" URL du serveur ou de l’agenda CalDAV
-      input#caldav_agenda_url.fr-input type="text" name="caldav_agenda_url"
+      input#caldav_agenda_url.fr-input[type="text" name="caldav_agenda_url" required]
     fieldset.fr-fieldset
       legend.fr-fieldset__legend--regular.fr-fieldset__legend
         | Données personnelles dans l'agenda externe


### PR DESCRIPTION
On a eu une erreur Sentry à cause d'un agent qui a entré un lien webcal (et non pas caldav) en tant que "URL du serveur ou de l’agenda CalDAV", et a laissé son username et son mot de passe vide.

Plutôt que de laisser remplir un formulaire incomplet et d'avoir une erreur sentry, on rend les champs obligatoires pour obliger l'agent à trouver son username et mot de passe.

Au passage, on corrige aussi la sélection de la bonne entrée dans le side menu.