### PR TITLE
Ajout d'une flèche sur les cards de motifs pour les rendre plus découvrables

### DIFF
--- a/app/views/admin/organisations/online_bookings/_motif_card.html.slim
+++ b/app/views/admin/organisations/online_bookings/_motif_card.html.slim
@@ -6,21 +6,23 @@
       .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
         h3.fr-h5 = link_to motif.name, admin_organisation_online_booking_motif_path(@organisation, motif)
         = render "admin/organisations/online_booking/motifs/availability_badge", motif:, availabilities_count:
-      p.fr-mb-0
-        = location_type_icon(motif.location_type, class: "fr-mr-1w")
-        = motif.human_attribute_value(:location_type)
-        = " · "
-        = "#{motif.default_duration_in_min} mn"
-
-        - if availabilities_count
+      .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
+        p.fr-mb-0
+          = location_type_icon(motif.location_type, class: "fr-mr-1w")
+          = motif.human_attribute_value(:location_type)
           = " · "
-          - if motif.collectif?
-            - if availabilities_count > 0
-              | #{availabilities_count} rendez-vous avec des places disponibles
+          = "#{motif.default_duration_in_min} mn"
+
+          - if availabilities_count
+            = " · "
+            - if motif.collectif?
+              - if availabilities_count > 0
+                | #{availabilities_count} rendez-vous avec des places disponibles
+              - else
+                | Pas de rendez-vous avec des places disponibles
             - else
-              | Pas de rendez-vous avec des places disponibles
-          - else
-            - if availabilities_count > 0
-              | #{availabilities_count} #{"plage".pluralize(availabilities_count)} d'ouverture
-            - else
-              | Pas de plage d'ouverture
+              - if availabilities_count > 0
+                | #{availabilities_count} #{"plage".pluralize(availabilities_count)} d'ouverture
+              - else
+                | Pas de plage d'ouverture
+        = icon("fr-icon-arrow-right-line", class: "rdv-color-text-action-high-blue-france")


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1159" height="567" alt="Screenshot 2026-06-10 at 15 58 55" src="https://github.com/user-attachments/assets/14719d72-16dd-42a4-b3ac-3e316d9bcba6" />|<img width="1164" height="566" alt="Screenshot 2026-06-10 at 15 58 36" src="https://github.com/user-attachments/assets/85bdc275-3fa2-48d6-9751-bb94329652b1" />


Vu avec Mehdi et Téo : en entretien utilisateurs, les gens ne se rendent pas compte qu'ils peuvent cliquer sur les cards de motifs sur la page de réservation en ligne.

Heureusement la solution est déjà dans le DSFR : on peut ajouter la petit flèche des cards et tuiles du DSFR pour indiquer ça.