### PR TITLE
Limiter la longueur des noms de service

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -19,9 +19,9 @@ class Service < ApplicationRecord
   has_many :territories, through: :territory_services
 
   # Validations
-  validates :name, :short_name, presence: true, uniqueness: { case_sensitive: false }
-  validates :name, length: { in: 2..60 }
-  validates :short_name, length: { in: 2..40 }
+  validates :name, :short_name, uniqueness: { case_sensitive: false }
+  validate :validate_name_length
+  validate :validate_short_name_length
 
   # Scopes
   default_scope { order(Arel.sql("unaccent(LOWER(services.name))")) }
@@ -54,5 +54,27 @@ class Service < ApplicationRecord
 
   def related_to_social?
     service_social? || name.parameterize.include?("social")
+  end
+
+  private
+
+  def validate_name_length
+    if name.to_s.length > 60
+      errors.add(:name, "ne doit pas dépasser 60 caractères.")
+    end
+
+    if name.to_s.length < 2
+      errors.add(:name, "doit contenir au moins 2 caractères.")
+    end
+  end
+
+  def validate_short_name_length
+    if short_name.to_s.length > 40
+      errors.add(:short_name, "ne doit pas dépasser 40 caractères.")
+    end
+
+    if short_name.to_s.length < 2
+      errors.add(:short_name, "doit contenir au moins 2 caractères.")
+    end
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -20,6 +20,8 @@ class Service < ApplicationRecord
 
   # Validations
   validates :name, :short_name, presence: true, uniqueness: { case_sensitive: false }
+  validates :name, length: { in: 2..60 }
+  validates :short_name, length: { in: 2..40 }
 
   # Scopes
   default_scope { order(Arel.sql("unaccent(LOWER(services.name))")) }

--- a/config/locales/models/service.fr.yml
+++ b/config/locales/models/service.fr.yml
@@ -5,3 +5,11 @@ fr:
     attributes:
       service:
         short_name: Nom raccourci (SMS)
+    errors:
+      models:
+        service:
+          attributes:
+            name:
+              format: "Le nom du service %{message}"
+            short_name:
+              format: "Le nom raccourci pour les SMS %{message}"

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     name { generate(:service_name) }
 
     after(:build) do |service|
-      service.short_name ||= service.name.truncate(40)
+      service.short_name ||= service.name&.truncate(40)
     end
 
     trait :social do

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     name { generate(:service_name) }
 
     after(:build) do |service|
-      service.short_name = service.name if service.short_name.blank?
+      service.short_name ||= service.name.truncate(40)
     end
 
     trait :social do

--- a/spec/features/territory_admins/territory_admin_can_manage_agents_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_agents_spec.rb
@@ -92,9 +92,9 @@ RSpec.describe "territory admin can manage agents", type: :feature do
   end
 
   describe "changing agent service" do
-    let(:service_a) { create(:service, name: "A", territories: [territory]) }
-    let(:service_b) { create(:service, name: "B", territories: [territory]) }
-    let(:service_c) { create(:service, name: "C", territories: [territory]) }
+    let(:service_a) { create(:service, name: "Service A", territories: [territory]) }
+    let(:service_b) { create(:service, name: "Service B", territories: [territory]) }
+    let(:service_c) { create(:service, name: "Service C", territories: [territory]) }
     let!(:edited_agent) { create(:agent, admin_role_in_organisations: [organisation], services: [service_a, service_b]) }
 
     before do
@@ -120,13 +120,13 @@ RSpec.describe "territory admin can manage agents", type: :feature do
       create(:plage_ouverture, agent: edited_agent, motifs: [create(:motif, service: service_b)])
       unselect service_b.name, from: "Services"
       expect { click_on "Enregistrer les services" }.not_to change { edited_agent.reload.services.to_set }
-      expect(page).to have_content("Le retrait du service n'a pu aboutir car l'agent a toujours des plages d'ouverture actives sur le service : B")
+      expect(page).to have_content("Le retrait du service n'a pu aboutir car l'agent a toujours des plages d'ouverture actives sur le service : Service B")
     end
   end
 
   describe "un agent appartient à un service désactivé" do
-    let!(:service_a) { create(:service, name: "A", territories: [territory]) }
-    let!(:service_b) { create(:service, name: "B") }
+    let!(:service_a) { create(:service, name: "Service A", territories: [territory]) }
+    let!(:service_b) { create(:service, name: "Service B") }
     let!(:edited_agent) { create(:agent, admin_role_in_organisations: [organisation], services: [service_b]) }
 
     before do
@@ -141,8 +141,8 @@ RSpec.describe "territory admin can manage agents", type: :feature do
     end
 
     it "permet de supprimer le service désactivé de l’agent et le réaffecter à un autre" do
-      unselect "B (désactivé dans l'espace courant)", from: "Services"
-      select "A", from: "Services"
+      unselect "Service B (désactivé dans l'espace courant)", from: "Services"
+      select "Service A", from: "Services"
       expect { click_on "Enregistrer les services" }.to change { edited_agent.reload.services.to_set }
         .from([service_b])
         .to([service_a])

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,4 +1,26 @@
 RSpec.describe Service, type: :model do
+  describe "validations" do
+    it "limits the length of #name to 2-60 characters" do
+      expect(build(:service, name: "")).to be_invalid
+      expect(build(:service, name: "a")).to be_invalid
+      expect(build(:service, name: "aa")).to be_valid
+      expect(build(:service, name: "aaa")).to be_valid
+      expect(build(:service, name: "a" * 59)).to be_valid
+      expect(build(:service, name: "a" * 60)).to be_valid
+      expect(build(:service, name: "a" * 61)).to be_invalid
+    end
+
+    it "limits the length of #short_name to 2-40 characters" do
+      expect(build(:service, name: "")).to be_invalid
+      expect(build(:service, name: "a")).to be_invalid
+      expect(build(:service, name: "aa")).to be_valid
+      expect(build(:service, name: "aaa")).to be_valid
+      expect(build(:service, short_name: "a" * 39)).to be_valid
+      expect(build(:service, short_name: "a" * 40)).to be_valid
+      expect(build(:service, short_name: "a" * 41)).to be_invalid
+    end
+  end
+
   describe "#pmi?" do
     it "returns false when social service" do
       expect(build(:service, :social).pmi?).to be false

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,23 +1,30 @@
 RSpec.describe Service, type: :model do
   describe "validations" do
     it "limits the length of #name to 2-60 characters" do
-      expect(build(:service, name: "")).to be_invalid
-      expect(build(:service, name: "a")).to be_invalid
-      expect(build(:service, name: "aa")).to be_valid
-      expect(build(:service, name: "aaa")).to be_valid
-      expect(build(:service, name: "a" * 59)).to be_valid
-      expect(build(:service, name: "a" * 60)).to be_valid
-      expect(build(:service, name: "a" * 61)).to be_invalid
+      expect(described_class.new(short_name: "Valide", name: nil)).to be_invalid
+      expect(described_class.new(short_name: "Valide", name: "")).to be_invalid
+      expect(described_class.new(short_name: "Valide", name: "a")).to be_invalid
+      expect(described_class.new(short_name: "Valide", name: "aa")).to be_valid
+      expect(described_class.new(short_name: "Valide", name: "aaa")).to be_valid
+      expect(described_class.new(short_name: "Valide", name: "a" * 59)).to be_valid
+      expect(described_class.new(short_name: "Valide", name: "a" * 60)).to be_valid
+      expect(described_class.new(short_name: "Valide", name: "a" * 61)).to be_invalid
+
+      expect(described_class.new(short_name: "Valide", name: "a").tap(&:validate).errors.full_messages).to include("Le nom du service doit contenir au moins 2 caractères.")
+      expect(described_class.new(short_name: "Valide", name: "a" * 61).tap(&:validate).errors.full_messages).to include("Le nom du service ne doit pas dépasser 60 caractères.")
     end
 
     it "limits the length of #short_name to 2-40 characters" do
-      expect(build(:service, short_name: "")).to be_invalid
-      expect(build(:service, short_name: "a")).to be_invalid
-      expect(build(:service, short_name: "aa")).to be_valid
-      expect(build(:service, short_name: "aaa")).to be_valid
-      expect(build(:service, short_name: "a" * 39)).to be_valid
-      expect(build(:service, short_name: "a" * 40)).to be_valid
-      expect(build(:service, short_name: "a" * 41)).to be_invalid
+      expect(described_class.new(name: "Valide", short_name: "")).to be_invalid
+      expect(described_class.new(name: "Valide", short_name: "a")).to be_invalid
+      expect(described_class.new(name: "Valide", short_name: "aa")).to be_valid
+      expect(described_class.new(name: "Valide", short_name: "aaa")).to be_valid
+      expect(described_class.new(name: "Valide", short_name: "a" * 39)).to be_valid
+      expect(described_class.new(name: "Valide", short_name: "a" * 40)).to be_valid
+      expect(described_class.new(name: "Valide", short_name: "a" * 41)).to be_invalid
+
+      expect(described_class.new(name: "Valide", short_name: "a").tap(&:validate).errors.full_messages).to include("Le nom raccourci pour les SMS doit contenir au moins 2 caractères.")
+      expect(described_class.new(name: "Valide", short_name: "a" * 41).tap(&:validate).errors.full_messages).to include("Le nom raccourci pour les SMS ne doit pas dépasser 40 caractères.")
     end
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Service, type: :model do
     end
 
     it "limits the length of #short_name to 2-40 characters" do
-      expect(build(:service, name: "")).to be_invalid
-      expect(build(:service, name: "a")).to be_invalid
-      expect(build(:service, name: "aa")).to be_valid
-      expect(build(:service, name: "aaa")).to be_valid
+      expect(build(:service, short_name: "")).to be_invalid
+      expect(build(:service, short_name: "a")).to be_invalid
+      expect(build(:service, short_name: "aa")).to be_valid
+      expect(build(:service, short_name: "aaa")).to be_valid
       expect(build(:service, short_name: "a" * 39)).to be_valid
       expect(build(:service, short_name: "a" * 40)).to be_valid
       expect(build(:service, short_name: "a" * 41)).to be_invalid

--- a/spec/services/creneau_wizard_for_users/steps/motif_selection_spec.rb
+++ b/spec/services/creneau_wizard_for_users/steps/motif_selection_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe CreneauWizardForUsers::Steps::MotifSelection do
   context "when motifs from multiple services are available" do
     let(:motif_a) { create(:motif, service: service_a) }
     let(:motif_b) { create(:motif, service: service_b) }
-    let(:service_b) { create(:service, name: "B") }
-    let(:service_a) { create(:service, name: "A") }
+    let(:service_b) { create(:service, name: "Service B") }
+    let(:service_a) { create(:service, name: "Service A") }
     let(:matching_motifs) { Motif.where(id: [motif_a.id, motif_b.id]) }
 
     describe "#services" do
@@ -42,8 +42,8 @@ RSpec.describe CreneauWizardForUsers::Steps::MotifSelection do
     let(:motif_a) { create(:motif, service: service_a) }
     let(:motif_b) { create(:motif, service: service_b) }
     let(:motif_c) { create(:motif, service: nil) }
-    let(:service_b) { create(:service, name: "B") }
-    let(:service_a) { create(:service, name: "A") }
+    let(:service_b) { create(:service, name: "Service B") }
+    let(:service_a) { create(:service, name: "Service A") }
     let(:matching_motifs) { Motif.where(id: [motif_a.id, motif_b.id, motif_c.id]) }
 
     it "sorts the services properly" do


### PR DESCRIPTION
# Contexte

Nous concevons actuellement avec @mekaidmekaid et @Teodora-Stanki une solution qui permet à un agent admin de créer un nouveau service de façon autonome.

Dans ce cadre, nous avons réalisé qu'il est très raisonnable de limiter la longueur du nom et du nom court, car actuellement il est de 1 GB soit 1 000 000 000 caractères, ce qui commence à faire long dans un SMS.

# Solution

- Valider que le nom mesure entre 2 et 60 caractères
- Valider que le nom court mesure entre 2 et 40 caractères

## Captures d'écran

<img width="1902" height="569" alt="image" src="https://github.com/user-attachments/assets/1d1bf3c5-8718-4aba-96a4-21cfa3a595e4" />

<img width="1902" height="569" alt="image" src="https://github.com/user-attachments/assets/fdef794b-f6f8-45b0-9eee-7103df08586f" />


<img width="1902" height="569" alt="image" src="https://github.com/user-attachments/assets/2f952bbd-6075-4881-9545-2366e66f9550" />
