### PR TITLE
Ajout des instructions pour les usagers dans la réservation en ligne

### DIFF
--- a/app/controllers/admin/organisations/online_booking/motifs_controller.rb
+++ b/app/controllers/admin/organisations/online_booking/motifs_controller.rb
@@ -7,7 +7,7 @@ class Admin::Organisations::OnlineBooking::MotifsController < AgentAuthControlle
   def edit; end
 
   def update
-    @motif.assign_attributes(params.require(:motif).permit(:min_public_booking_delay, :max_public_booking_delay, :rdvs_editable_by_user, :restriction_for_rdv, :instruction_for_rdv))
+    @motif.assign_attributes(params.require(:motif).permit(:min_public_booking_delay, :max_public_booking_delay, :rdvs_editable_by_user))
 
     # On fait un deuxième authorize pour s'assurer que les permissions sont encore valides sur la nouvelle version du motif.
     # C'est pas strictement nécessaire ici vu qu'on ne change pas d'association, mais on le met quand même au cas où des changements de permissions soient ajoutés plus tard.
@@ -18,6 +18,19 @@ class Admin::Organisations::OnlineBooking::MotifsController < AgentAuthControlle
       redirect_to admin_organisation_online_booking_motif_path(current_organisation, motif_id: @motif.id)
     else
       render :edit
+    end
+  end
+
+  def edit_instructions; end
+
+  def update_instructions
+    @motif.assign_attributes(params.require(:motif).permit(:restriction_for_rdv, :instruction_for_rdv))
+
+    if @motif.save
+      flash[:success] = "Les consignes pour les usagers ont été mises à jour."
+      redirect_to admin_organisation_online_booking_motif_path(current_organisation, motif_id: @motif.id)
+    else
+      render :edit_instructions
     end
   end
 

--- a/app/controllers/admin/organisations/online_booking/motifs_controller.rb
+++ b/app/controllers/admin/organisations/online_booking/motifs_controller.rb
@@ -7,7 +7,7 @@ class Admin::Organisations::OnlineBooking::MotifsController < AgentAuthControlle
   def edit; end
 
   def update
-    @motif.assign_attributes(params.require(:motif).permit(:min_public_booking_delay, :max_public_booking_delay, :rdvs_editable_by_user))
+    @motif.assign_attributes(params.require(:motif).permit(:min_public_booking_delay, :max_public_booking_delay, :rdvs_editable_by_user, :restriction_for_rdv, :instruction_for_rdv))
 
     # On fait un deuxième authorize pour s'assurer que les permissions sont encore valides sur la nouvelle version du motif.
     # C'est pas strictement nécessaire ici vu qu'on ne change pas d'association, mais on le met quand même au cas où des changements de permissions soient ajoutés plus tard.

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -135,10 +135,10 @@ module MotifsHelper
   end
 
   def restriction_for_rdv_to_html(motif)
-    auto_link(simple_format(motif.restriction_for_rdv, {}, wrapper_tag: "span"), html: { target: "_blank" })
+    auto_link(simple_format(motif.restriction_for_rdv, {}, wrapper_tag: "p"), html: { target: "_blank" })
   end
 
   def instruction_for_rdv_to_html(motif)
-    auto_link(simple_format(motif.instruction_for_rdv, {}, wrapper_tag: "span"), html: { target: "_blank" })
+    auto_link(simple_format(motif.instruction_for_rdv, {}, wrapper_tag: "p"), html: { target: "_blank" })
   end
 end

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -30,6 +30,8 @@ class Agent::MotifPolicy < ApplicationPolicy
   alias create? agent_can_manage_motif?
   alias edit? agent_can_manage_motif?
   alias update? agent_can_manage_motif?
+  alias edit_instructions? agent_can_manage_motif?
+  alias update_instructions? agent_can_manage_motif?
   alias archive? agent_can_manage_motif?
   alias unarchive? agent_can_manage_motif?
   alias destroy? agent_can_manage_motif?

--- a/app/views/admin/organisations/online_booking/motifs/edit.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/edit.html.slim
@@ -22,23 +22,6 @@
           h2.fr-h6.fr-mt-6w Déplacement des rendez-vous par les usagers
           = f.dsfr_check_box :rdvs_editable_by_user, label: "Autoriser les usagers à déplacer les rendez-vous jusqu'à 48 heures avant leur début"
 
-          h2.fr-h6.fr-mt-6w Consignes pour les usagers
-
-          span.fr-hint-text Vous pouvez paramétrer des messages par défaut, qui s’afficheront avant la prise de rendez-vous et/ou après la confirmation du rendez-vous
-
-          .fr-fieldset__element.fr-mt-2w.fr-px-0
-            = f.dsfr_text_area :restriction_for_rdv,
-                    label: sanitize("Instructions à accepter <strong>avant</strong> la prise du RDV"),
-                    placeholder: "Laissez vide si vous ne souhaitez pas donner d’instruction.",
-                    rows: 5,
-                    hint: link_to("Voir un exemple", image_path("motif_form/restriction_for_rdv.png"), target: "_blank")
-          .fr-fieldset__element.fr-mt-4w.fr-px-0
-            = f.dsfr_text_area :instruction_for_rdv,
-                    label: sanitize("Instructions affichées <strong>après</strong> la prise du RDV"),
-                    placeholder: "Laissez vide si vous ne souhaitez pas donner d’instruction.",
-                    rows: 5,
-                    hint: link_to("Voir un exemple", image_path("motif_form/instruction_for_rdv.png"), target: "_blank")
-
           .d-flex.rdv-justify-content-space-between
             = link_to("Annuler", admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--tertiary-no-outline")
             = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/organisations/online_booking/motifs/edit.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/edit.html.slim
@@ -9,18 +9,35 @@
   .fr-col-12.fr-col-lg-10
     .card
       .card-body
-        = simple_form_for @motif, url: admin_organisation_online_booking_motif_path(current_organisation, @motif) do |f|
+        = form_for @motif, url: admin_organisation_online_booking_motif_path(current_organisation, @motif), builder: Dsfr::FormBuilder do |f|
           = render "model_errors", model: @motif, f: f
 
           h2.fr-h6= Motif.human_attribute_name("booking_delay")
           p= Motif.human_attribute_name("booking_delay_hint")
 
           .fr-grid-row.fr-grid-row--gutters
-            .fr-col-md-6= f.input :min_public_booking_delay, label: "Délai minimum avant le RDV", collection: min_max_delay_options
-            .fr-col-md-6= f.input :max_public_booking_delay, label: "Délai maximum avant le RDV", collection: min_max_delay_options
+            .fr-col-md-6= f.dsfr_select :min_public_booking_delay, min_max_delay_options, label: "Délai minimum avant le RDV"
+            .fr-col-md-6= f.dsfr_select :max_public_booking_delay, min_max_delay_options, label: "Délai maximum avant le RDV"
 
-          h2.fr-h6.fr-mt-3w Déplacement des rendez-vous par les usagers
-          = f.input :rdvs_editable_by_user, label: "Autoriser les usagers à déplacer les rendez-vous jusqu'à 48 heures avant leur début"
+          h2.fr-h6.fr-mt-6w Déplacement des rendez-vous par les usagers
+          = f.dsfr_check_box :rdvs_editable_by_user, label: "Autoriser les usagers à déplacer les rendez-vous jusqu'à 48 heures avant leur début"
+
+          h2.fr-h6.fr-mt-6w Consignes pour les usagers
+
+          span.fr-hint-text Vous pouvez paramétrer des messages par défaut, qui s’afficheront avant la prise de rendez-vous et/ou après la confirmation du rendez-vous
+
+          .fr-fieldset__element.fr-mt-2w.fr-px-0
+            = f.dsfr_text_area :restriction_for_rdv,
+                    label: sanitize("Instructions à accepter <strong>avant</strong> la prise du RDV"),
+                    placeholder: "Laissez vide si vous ne souhaitez pas donner d’instruction.",
+                    rows: 5,
+                    hint: link_to("Voir un exemple", image_path("motif_form/restriction_for_rdv.png"), target: "_blank")
+          .fr-fieldset__element.fr-mt-4w.fr-px-0
+            = f.dsfr_text_area :instruction_for_rdv,
+                    label: sanitize("Instructions affichées <strong>après</strong> la prise du RDV"),
+                    placeholder: "Laissez vide si vous ne souhaitez pas donner d’instruction.",
+                    rows: 5,
+                    hint: link_to("Voir un exemple", image_path("motif_form/instruction_for_rdv.png"), target: "_blank")
 
           .d-flex.rdv-justify-content-space-between
             = link_to("Annuler", admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--tertiary-no-outline")

--- a/app/views/admin/organisations/online_booking/motifs/edit_instructions.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/edit_instructions.html.slim
@@ -1,0 +1,32 @@
+- content_for :fil_ariane do
+  - titles_and_paths = [["Configuration", admin_organisation_configuration_path(current_organisation)], ["Réservation en ligne", admin_organisation_online_booking_path(current_organisation)], [@motif.name, admin_organisation_online_booking_motif_path(current_organisation, @motif)]]
+  = render "common/fil_ariane", titles_and_paths: titles_and_paths, current_page_title: "Consignes pour les usagers"
+
+- content_for :title do
+  | Consignes pour les usagers pour #{@motif.name}
+
+.fr-grid-row
+  .fr-col-12.fr-col-lg-10
+    .card
+      .card-body
+        = form_for @motif, url: update_instructions_admin_organisation_online_booking_motif_path(current_organisation, @motif), builder: Dsfr::FormBuilder do |f|
+          = render "model_errors", model: @motif, f: f
+
+          span.fr-hint-text Vous pouvez paramétrer des messages par défaut, qui s’afficheront avant la prise de rendez-vous et/ou après la confirmation du rendez-vous
+
+          .fr-fieldset__element.fr-mt-2w.fr-px-0
+            = f.dsfr_text_area :restriction_for_rdv,
+                    label: sanitize("Instructions à accepter <strong>avant</strong> la prise du RDV"),
+                    placeholder: "Laissez vide si vous ne souhaitez pas donner d’instruction.",
+                    rows: 5,
+                    hint: link_to("Voir un exemple", image_path("motif_form/restriction_for_rdv.png"), target: "_blank")
+          .fr-fieldset__element.fr-mt-4w.fr-px-0
+            = f.dsfr_text_area :instruction_for_rdv,
+                    label: sanitize("Instructions affichées <strong>après</strong> la prise du RDV"),
+                    placeholder: "Laissez vide si vous ne souhaitez pas donner d’instruction.",
+                    rows: 5,
+                    hint: link_to("Voir un exemple", image_path("motif_form/instruction_for_rdv.png"), target: "_blank")
+
+          .d-flex.rdv-justify-content-space-between
+            = link_to("Annuler", admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--tertiary-no-outline")
+            = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -53,22 +53,22 @@
             - else
               li.fr-my-2w Les usagers ne sont pas autorisés à déplacer le rendez-vous.
 
-          h2.fr-h6 Instructions pour les usagers
+          h2.fr-h6.fr-mt-6w Instructions pour les usagers
           - if @motif.restriction_for_rdv.blank?
             p
               i Pas d'instructions à accepter avant la prise de rendez-vous
           - else
             p Instructions à accepter avant la prise de rendez-vous :
-            .fr-highlight
-              = restriction_for_rdv_to_html(@motif)
+            .fr-highlight.fr-mb-2w
+              i= restriction_for_rdv_to_html(@motif)
 
           - if @motif.instruction_for_rdv.blank?
-            p
+            p.fr-mt-4w
               i Pas d'instructions à afficher après la prise de rendez-vous
           - else
-            p Instructions à afficher après la prise de rendez-vous :
-            .fr-highlight
-              = instruction_for_rdv_to_html(@motif)
+            p.fr-mt-4w Instructions à afficher après la prise de rendez-vous :
+            .fr-highlight.fr-mb-2w
+              i= instruction_for_rdv_to_html(@motif)
 
     - if @motif.bookable_by_everyone?
       .card

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -53,7 +53,11 @@
             - else
               li.fr-my-2w Les usagers ne sont pas autorisés à déplacer le rendez-vous.
 
-          h2.fr-h6.fr-mt-6w Instructions pour les usagers
+      .card
+        .card-body
+          .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
+            h2.fr-h4 Consignes pour les usagers
+            = link_to "Modifier", edit_instructions_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn fr-btn--secondary"
           - if @motif.restriction_for_rdv.blank?
             p
               i Pas d'instructions à accepter avant la prise de rendez-vous

--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -25,7 +25,7 @@
     - unless @motif.bookable_by_everyone?
       .card
         .card-body
-          p Ce motif n'est pas ouvert à la réservation en ligne
+          p Ce motif n'est pas ouvert à la réservation en ligne.
           = button_to "Ouvrir à la réservation en ligne", open_admin_organisation_online_booking_motif_path(current_organisation, @motif), class: "fr-btn", method: :post
 
     - if @motif.bookable_by_everyone? && !current_organisation.sectorized?
@@ -52,6 +52,23 @@
               li.fr-my-2w Les usagers sont autorisés à déplacer le rendez-vous jusqu'à 48 heures avant celui-ci.
             - else
               li.fr-my-2w Les usagers ne sont pas autorisés à déplacer le rendez-vous.
+
+          h2.fr-h6 Instructions pour les usagers
+          - if @motif.restriction_for_rdv.blank?
+            p
+              i Pas d'instructions à accepter avant la prise de rendez-vous
+          - else
+            p Instructions à accepter avant la prise de rendez-vous :
+            .fr-highlight
+              = restriction_for_rdv_to_html(@motif)
+
+          - if @motif.instruction_for_rdv.blank?
+            p
+              i Pas d'instructions à afficher après la prise de rendez-vous
+          - else
+            p Instructions à afficher après la prise de rendez-vous :
+            .fr-highlight
+              = instruction_for_rdv_to_html(@motif)
 
     - if @motif.bookable_by_everyone?
       .card

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -320,6 +320,8 @@ Rails.application.routes.draw do
               member do
                 post :open
                 post :close
+                get :edit_instructions
+                patch :update_instructions
               end
             end
           end

--- a/spec/features/agents/online_booking/motif_spec.rb
+++ b/spec/features/agents/online_booking/motif_spec.rb
@@ -24,11 +24,19 @@ RSpec.describe "Réservation en ligne pour un motif en particulier" do
 
     select "2 jours", from: "Délai maximum avant le RDV"
 
+    fill_in :motif_restriction_for_rdv, with: "Rendez-vous réservé aux usagers élibibles"
+
+    fill_in :motif_instruction_for_rdv, with: "Pensez à prendre un justificatif de domicile"
+
     click_on "Enregistrer"
 
     expect(page).to have_content("Les options de réservation en ligne ont été mises à jour.")
 
     expect(page).to have_content("Les rendez-vous seront pris au moins 1 jour à l'avance.")
+
+    expect(page).to have_content "Rendez-vous réservé aux usagers élibibles"
+
+    expect(page).to have_content "Pensez à prendre un justificatif de domicile"
   end
 
   context "quand il n'y a pas de disponibilités" do

--- a/spec/features/agents/online_booking/motif_spec.rb
+++ b/spec/features/agents/online_booking/motif_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Réservation en ligne pour un motif en particulier" do
 
     expect(page).to have_content("Ce motif est ouvert à la réservation en ligne")
 
-    click_on "Modifier"
+    click_on "Modifier", match: :first
 
     select "1 jour", from: "Délai minimum avant le RDV"
     select "6 heures", from: "Délai maximum avant le RDV"
@@ -24,15 +24,25 @@ RSpec.describe "Réservation en ligne pour un motif en particulier" do
 
     select "2 jours", from: "Délai maximum avant le RDV"
 
-    fill_in :motif_restriction_for_rdv, with: "Rendez-vous réservé aux usagers élibibles"
-
-    fill_in :motif_instruction_for_rdv, with: "Pensez à prendre un justificatif de domicile"
-
     click_on "Enregistrer"
 
     expect(page).to have_content("Les options de réservation en ligne ont été mises à jour.")
 
     expect(page).to have_content("Les rendez-vous seront pris au moins 1 jour à l'avance.")
+  end
+
+  it "permet de modifier les consignes pour les usagers" do
+    visit admin_organisation_online_booking_motif_path(organisation, motif)
+
+    expect(page).to have_content "Pas d'instructions à accepter avant la prise de rendez-vous"
+    expect(page).to have_content "Pas d'instructions à afficher après la prise de rendez-vous"
+
+    visit edit_instructions_admin_organisation_online_booking_motif_path(organisation, motif)
+    fill_in :motif_restriction_for_rdv, with: "Rendez-vous réservé aux usagers élibibles"
+    fill_in :motif_instruction_for_rdv, with: "Pensez à prendre un justificatif de domicile"
+
+    click_on "Enregistrer"
+    expect(page).to have_content("Les consignes pour les usagers ont été mises à jour.")
 
     expect(page).to have_content "Rendez-vous réservé aux usagers élibibles"
 


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="988" height="442" alt="Screenshot 2026-06-10 at 16 54 16" src="https://github.com/user-attachments/assets/2c7c4f64-3542-43eb-96c5-e8472ebb8077" />|<img width="997" height="637" alt="Screenshot 2026-06-10 at 16 54 04" src="https://github.com/user-attachments/assets/8bac2c00-734f-43fb-abca-ba4381dc6e94" />



Edition | Affichage
:- | -:
<img width="1229" height="749" alt="Screenshot 2026-06-10 at 16 54 44" src="https://github.com/user-attachments/assets/c6775ed4-b5aa-4005-b03c-6a49946f801e" />|<img width="989" height="542" alt="Screenshot 2026-06-10 at 16 56 01" src="https://github.com/user-attachments/assets/7c088ca7-9cb8-4802-a179-de5e7aea3386" />

Vu avec Mehdi et Téo : on ajoute les instructions avant/après les rendez-vous sur la page de détails d'un motif dans le menu de réservation en ligne.

Ces options sont utiles pour les gens qui ont envie d'activer la prise de rendez-vous en ligne.

On met ça dans une card et un formulaire séparés par rapport aux options de réservation.