### PR TITLE
Ajoute min/max_public_booking_delay au blueprint des motifs

### DIFF
--- a/app/blueprints/motif_blueprint.rb
+++ b/app/blueprints/motif_blueprint.rb
@@ -1,6 +1,8 @@
 class MotifBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :location_type, :deleted_at, :bookable_publicly, :service_id, :organisation_id, :collectif, :follow_up, :instruction_for_rdv, :bookable_by, :default_duration_in_min
+  fields :name, :location_type, :deleted_at, :bookable_publicly, :service_id, :organisation_id, :collectif,
+         :follow_up, :instruction_for_rdv, :bookable_by, :default_duration_in_min,
+         :min_public_booking_delay, :max_public_booking_delay
   association :motif_category, blueprint: MotifCategoryBlueprint
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -385,8 +385,10 @@ RSpec.configure do |config|
               bookable_publicly: { type: "boolean" },
               bookable_by: { type: "string", enum: %w[agents agents_and_prescripteurs agents_and_prescripteurs_and_invited_users everyone] },
               service_id: { type: "integer", nullable: true },
+              min_public_booking_delay: { type: "integer", description: "Les premiers créneaux proposés aux usagers et aux prescripteurs ne commenceront pas avant ce délai minimum (en secondes)." },
+              max_public_booking_delay: { type: "integer", description: "Les derniers créneaux proposés aux usagers et aux prescripteurs n'iront pas au delà de ce délai maximum (en secondes)." },
             },
-            required: %w[id deleted_at location_type name organisation_id bookable_publicly bookable_by service_id],
+            required: %w[id deleted_at location_type name organisation_id bookable_publicly bookable_by service_id min_public_booking_delay max_public_booking_delay],
           },
           motif_categories: {
             type: "object",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -725,6 +725,14 @@
           "service_id": {
             "type": "integer",
             "nullable": true
+          },
+          "min_public_booking_delay": {
+            "type": "integer",
+            "description": "Les premiers créneaux proposés aux usagers et aux prescripteurs ne commenceront pas avant ce délai minimum (en secondes)."
+          },
+          "max_public_booking_delay": {
+            "type": "integer",
+            "description": "Les derniers créneaux proposés aux usagers et aux prescripteurs n'iront pas au delà de ce délai maximum (en secondes)."
           }
         },
         "required": [
@@ -735,7 +743,9 @@
           "organisation_id",
           "bookable_publicly",
           "bookable_by",
-          "service_id"
+          "service_id",
+          "min_public_booking_delay",
+          "max_public_booking_delay"
         ]
       },
       "motif_categories": {
@@ -2339,6 +2349,8 @@
                           "follow_up": false,
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
+                          "max_public_booking_delay": 15778476,
+                          "min_public_booking_delay": 1800,
                           "motif_category": {
                             "id": 7,
                             "name": "Catégorie de motif n°1",
@@ -2358,6 +2370,8 @@
                           "follow_up": false,
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
+                          "max_public_booking_delay": 15778476,
+                          "min_public_booking_delay": 1800,
                           "motif_category": {
                             "id": 8,
                             "name": "Catégorie de motif n°2",
@@ -3155,6 +3169,8 @@
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
+                            "max_public_booking_delay": 15778476,
+                            "min_public_booking_delay": 1800,
                             "motif_category": {
                               "id": 50,
                               "name": "Catégorie de motif n°1",
@@ -3395,6 +3411,8 @@
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
+                            "max_public_booking_delay": 15778476,
+                            "min_public_booking_delay": 1800,
                             "motif_category": {
                               "id": 56,
                               "name": "Catégorie de motif n°1",
@@ -3512,6 +3530,8 @@
                             "follow_up": false,
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
+                            "max_public_booking_delay": 15778476,
+                            "min_public_booking_delay": 1800,
                             "motif_category": {
                               "id": 60,
                               "name": "Catégorie de motif n°5",


### PR DESCRIPTION
Ajoute `min_public_booking_delay` et `max_public_booking_delay` au `MotifBlueprint` pour les exposer dans l'API v1, et les documente dans le schéma.
On a besoin de l'information coté rdv-insertion pour afficher l'info dans les nouvelles fonctionnalités liées à la visibilité des créneaux.
Une fois cette PR merged et son équivalent coté rdv-insertion il faudra backfill les anciennes données via l'envoi des webhooks, je ciblerai uniquement les webhooks de rdv-insertion. 