### PR TITLE
Utiliser un accordéon DSFR (légèrement customisé) pour les composants d'historique de version et de notifs

### DIFF
--- a/app/views/admin/receipts/_receipts.html.slim
+++ b/app/views/admin/receipts/_receipts.html.slim
@@ -2,7 +2,7 @@
   .rdv-accordion-card.fr-accordion
     h2.fr-accordion__title
       button.fr-accordion__btn aria-expanded="false" aria-controls="receipts"
-        => icon("fr-icon-message-2-line", class: "fr-mr-2w")
+        => icon("fr-icon-message-2-line", class: "fr-mr-1w")
         = Receipt.model_name.human(count: 2)
     .fr-collapse id="receipts"
       = render "admin/receipts/receipts_table", receipts: rdv.receipts.most_recent_first

--- a/app/views/admin/receipts/_receipts.html.slim
+++ b/app/views/admin/receipts/_receipts.html.slim
@@ -1,16 +1,13 @@
 .card
-  .card-header
-    button.btn.btn-link data-toggle="collapse" data-target="#receipts-collapse"
-      h5.header
-        => icon("fr-icon-message-2-line")
+  .rdv-accordion-card.fr-accordion
+    h2.fr-accordion__title
+      button.fr-accordion__btn aria-expanded="false" aria-controls="receipts"
+        => icon("fr-icon-message-2-line", class: "fr-mr-2w")
         = Receipt.model_name.human(count: 2)
-  .collapse.hide#receipts-collapse
-    .card-body
+    .fr-collapse id="receipts"
       = render "admin/receipts/receipts_table", receipts: rdv.receipts.most_recent_first
-    .card-footer
       - if rdv.starts_at > Time.zone.now
-        = link_to t("admin.receipts.send_reminder_manually"), send_reminder_manually_admin_organisation_rdv_path(current_organisation, @rdv), method: :post, class: "btn btn-outline-primary", data: { disable_with: "Veuillez patienter…"}
+        = link_to t("admin.receipts.send_reminder_manually"), send_reminder_manually_admin_organisation_rdv_path(current_organisation, @rdv), method: :post, class: "fr-btn fr-btn--secondary", data: { disable_with: "Veuillez patienter…"}
       - else
-        = link_to t("admin.receipts.send_reminder_manually"), nil, class: "btn btn-light", disabled: true
-        .mt-2
+        .fr-mt-2w
           span.text-muted.font-14= t("admin.receipts.cant_send_reminder_manually")

--- a/app/views/admin/versions/_resource_versions_row.html.slim
+++ b/app/views/admin/versions/_resource_versions_row.html.slim
@@ -1,16 +1,15 @@
 - if resource_policy.versions?
   .card
-    .card-header
-      button.btn.btn-link data-toggle="collapse" data-target="#history-collapse"
-        h5.header
-          = icon("fr-icon-ri-history-line", class: "fr-mr-1v")
-          = t("admin.versions.title")
-    .collapse.hide#history-collapse
-      .card-body
-        = cache([resource, resource.class.paper_trail_options[:only]], expires_in: 7.days) do
-          - versions = PaperTrailAugmentedVersion.for_resource(resource)
-          = render "admin/versions/versions", versions: versions.reverse
-        p.text-muted.font-14
-          - unless resource.class.name.in?(CronJob::DestroyOldVersions::MODEL_NAMES_WITH_NO_PERSONAL_INFORMATION)
-            - if resource.created_at < 1.year.ago
-              | Dans le cadre du RGPD, l'historique des changements n'est plus conservé au delà d'un an
+    .rdv-accordion-card.fr-accordion
+      h2.fr-accordion__title
+      button.fr-accordion__btn aria-expanded="false" aria-controls="history"
+        = icon("fr-icon-ri-history-line", class: "fr-mr-1v")
+        = t("admin.versions.title")
+    .fr-mx-2w.fr-collapse id="history"
+      = cache([resource, resource.class.paper_trail_options[:only]], expires_in: 7.days) do
+        - versions = PaperTrailAugmentedVersion.for_resource(resource)
+        = render "admin/versions/versions", versions: versions.reverse
+      p.text-muted.font-14
+        - unless resource.class.name.in?(CronJob::DestroyOldVersions::MODEL_NAMES_WITH_NO_PERSONAL_INFORMATION)
+          - if resource.created_at < 1.year.ago
+            | Dans le cadre du RGPD, l'historique des changements n'est plus conservé au delà d'un an


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="726" height="231" alt="Screenshot 2026-06-11 at 14 35 20" src="https://github.com/user-attachments/assets/4c56ff6a-3577-485e-8d83-66b611deef36" />|<img width="731" height="205" alt="Screenshot 2026-06-11 at 14 34 57" src="https://github.com/user-attachments/assets/4d338a3e-234b-44ae-9db2-1bca87599353" />
<img width="722" height="224" alt="Screenshot 2026-06-11 at 14 35 24" src="https://github.com/user-attachments/assets/e7db8ccb-37ce-47ca-bea5-4c8462167c5b" />|<img width="724" height="199" alt="Screenshot 2026-06-11 at 14 35 02" src="https://github.com/user-attachments/assets/0bd4ce9c-7e40-4aea-bcc5-20ca5aea042d" />
<img width="954" height="882" alt="Screenshot 2026-06-11 at 14 35 41" src="https://github.com/user-attachments/assets/39bb876d-b7a7-4d20-b7b3-07f147d0e79f" />|<img width="914" height="817" alt="Screenshot 2026-06-11 at 14 38 17" src="https://github.com/user-attachments/assets/0d57eb32-da1b-4b8c-8168-a42ff75a4a64" />

Vu avec Téo : on gagne en accessibilité (et en beauté d'interface) en utilisant des accordéon DSFR légèrement customisés plutôt que nos anciens composants pour les historiques de changement et de notifications.


