### PR TITLE
Désactiver les rendez-vous d'accompagnement pour les espaces ouverts avec le compte opérateur

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -3,7 +3,7 @@ module AgentsHelper
     if defined?(current_territory)
       # Si un opérateur est rattaché au territoire et qu’il assure le support, c’est lui qui se charge de l’accompagnement
       # de ses adhérents.
-      return false if current_territory.operator&.support_link
+      return false if current_territory.operator
 
       Rdv.joins(:organisation).where(organisation: { territory_id: current_territory.id }).limit(5).count < 5
     end


### PR DESCRIPTION
L'anct ne propose pas ces rendez-vous d'accompagnement pour le moment, et nous ne pouvons pas les assurer, donc on désactive ce bandeau pour les espaces ouverts via un opérateur.