### PR TITLE
Ajout de l'email du beneficiaire au parcours de prescription

### DIFF
--- a/app/form_models/beneficiaire_form.rb
+++ b/app/form_models/beneficiaire_form.rb
@@ -6,6 +6,7 @@ class BeneficiaireForm
     first_name
     last_name
     phone_number
+    email
     ignore_benign_errors
     ants_pre_demande_number
     ants_meeting_point_id
@@ -22,8 +23,8 @@ class BeneficiaireForm
   def warn_no_contact_information
     return if ignore_benign_errors
 
-    if phone_number.blank?
-      add_benign_error("Sans numéro de téléphone, aucune notification ne sera envoyée au bénéficiaire")
+    if phone_number.blank? && email.blank?
+      add_benign_error("Sans numéro de téléphone ni adresse email, aucune notification ne sera envoyée au bénéficiaire")
     end
   end
 

--- a/app/views/prescripteur_rdv_wizard/_rdv.html.slim
+++ b/app/views/prescripteur_rdv_wizard/_rdv.html.slim
@@ -1,47 +1,48 @@
 /# locals: (prescripteur:)
 - rdv = prescripteur.rdv
-ul.list-group.list-group-flush.fr-mt-0
-  li.list-group-item
-    span.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
-    = rdv_title(rdv)
-    = rdv_tag(rdv)
+.fr-mb-2w
+  span.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
+  = rdv_title(rdv)
 
-  - if rdv.public_office?
-    li.list-group-item
-      span.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
-      = human_location(rdv)
-      - if rdv.lieu&.phone_number
-        br
-        span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
-        = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"
-
-  - elsif rdv.phone?
-    li.list-group-item
+- if rdv.public_office?
+  .fr-mb-2w
+    span.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
+    = human_location(rdv)
+    - if rdv.lieu&.phone_number
+      br
       span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
-      | RDV Téléphonique
+      = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"
 
-  li.list-group-item
-    span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
-    = prescripteur.user.full_name
-    = " (#{prescripteur.user.phone_number})" if prescripteur.user.phone_number.present?
-  li.list-group-item
-    span.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
-    = rdv.motif.name
-  - if rdv.motif.instruction_for_rdv.present?
-    li.list-group-item
-      span.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
-      strong Informations supplémentaires&nbsp;:
-      .pl-3.pt-1
-        = instruction_for_rdv_to_html(rdv.motif)
-.fr-mt-4v
+- elsif rdv.phone?
+  .fr-mb-2w
+    span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
+    | RDV Téléphonique
+
+.fr-mb-2w
+  span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
+  = prescripteur.user.full_name
+  = " (#{prescripteur.user.phone_number})" if prescripteur.user.phone_number.present?
+  = " (#{prescripteur.user.email})" if prescripteur.user.email.present?
+
+.fr-mb-2w
+  span.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
+  = rdv.motif.name
+- if rdv.motif.instruction_for_rdv.present?
+  .fr-mb-2w
+    span.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
+    strong Informations supplémentaires&nbsp;:
+    .pl-3.pt-1
+      = instruction_for_rdv_to_html(rdv.motif)
+
+.fr-mt-2w
   - if prescripteur.rdv.cancellable_by_user?
-    - if prescripteur.user.phone_number.blank?
+    - if prescripteur.user.phone_number.blank? && prescripteur.user.email.blank?
       .fr-callout.fr-icon-alert-line.fr-callout--yellow-moutarde
-        | Vous n’avez pas renseigné de numéro de téléphone pour l’usager. En cas d’annulation, il ne recevra pas de notification automatique.
+        | Vous n’avez pas renseigné de coordonnées de contact pour l’usager. En cas d’annulation, il ne recevra pas de notification automatique.
     ul.fr-btns-group.fr-btns-group--inline
       li
-        = link_to "Annuler le rendez-vous", prescripteur_cancel_rdv_path, class: "fr-btn fr-btn--secondary", data: { confirm: prescripteur.user.phone_number.blank? ? "Attention ! L’usager ne recevera pas notification d’annulation. Êtes-vous sûr de vouloir annuler ce rendez-vous ?" : "Êtes-vous sûr de vouloir annuler ce rendez-vous ?", method: :delete }
-p
+        = link_to "Annuler le rendez-vous", prescripteur_cancel_rdv_path, class: "fr-btn fr-btn--tertiary", data: { confirm: prescripteur.user.phone_number.blank? ? "Attention ! L’usager ne recevera pas notification d’annulation. Êtes-vous sûr de vouloir annuler ce rendez-vous ?" : "Êtes-vous sûr de vouloir annuler ce rendez-vous ?", method: :delete }
+p.fr-mt-4w
   |> Besoin de corriger un détail ?
   = link_to "Contactez-nous", new_aide_demande_support_path(role: :agent,
           sujet: "Corriger un RDV pris via prescription (RDV ID: #{rdv.id})",
@@ -49,4 +50,4 @@ p
           last_name: prescripteur.last_name,
           phone_number: prescripteur.phone_number,
           email: prescripteur.phone_number)
-.fr-mt-6v.rdv-text-align-center= link_to "Retour à l'accueil", prendre_rdv_prescripteur_path(departement: rdv.territory.departement_number)
+.fr-mt-3w.rdv-text-align-center= link_to "Retour à l'accueil", prendre_rdv_prescripteur_path(departement: rdv.territory.departement_number)

--- a/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
@@ -19,6 +19,7 @@
               .fr-col-12= f.dsfr_text_field :ants_pre_demande_number, required: true, input_html: {style: "text-transform: uppercase;"}
 
             .fr-col-12= f.dsfr_phone_field :phone_number, label: "Téléphone mobile", hint: "Format attendu : 0639980130. Un SMS de confirmation et un SMS de rappel seront envoyés à ce numéro"
+            .fr-col-12= f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@exemple.fr"
 
           = render("model_errors", model: @beneficiaire, f: f)
 

--- a/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
@@ -8,7 +8,7 @@
       = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body
         h2 Bénéficiaire
-        p Indiquez les coordonnées de la personne qui viendra au rendez-vous
+        p Indiquez les coordonnées de la personne qui viendra au rendez-vous.
 
         = form_for @beneficiaire, url: prescripteur_create_rdv_path, builder: Dsfr::FormBuilder do |f|
           .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
@@ -18,8 +18,11 @@
               = f.hidden_field :ants_meeting_point_id, value: @rdv_wizard.lieu_id
               .fr-col-12= f.dsfr_text_field :ants_pre_demande_number, required: true, input_html: {style: "text-transform: uppercase;"}
 
-            .fr-col-12= f.dsfr_phone_field :phone_number, label: "Téléphone mobile", hint: "Format attendu : 0639980130. Un SMS de confirmation et un SMS de rappel seront envoyés à ce numéro"
             .fr-col-12= f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@exemple.fr"
+            .fr-col-12= f.dsfr_phone_field :phone_number, label: "Téléphone mobile", hint: "Format attendu : 0639980130"
+            .fr-col-12
+              - if @rdv_wizard.motif.visible_and_notified?
+                p.fr-hint-text Des notifications de confirmation et de rappel seront envoyées automatiquement.
 
           = render("model_errors", model: @beneficiaire, f: f)
 

--- a/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
+++ b/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "prescripteur can add a user to a RDV collectif" do
     fill_in "Nom", with: "Duroy"
 
     click_on "Confirmer le rendez-vous"
-    expect(page).to have_content("Sans numéro de téléphone, aucune notification ne sera envoyée au bénéficiaire")
+    expect(page).to have_content("Sans numéro de téléphone ni adresse email, aucune notification ne sera envoyée au bénéficiaire")
     click_on "Annuler et modifier"
     fill_in "Téléphone", with: "0123456789"
     click_on "Confirmer le rendez-vous"

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "un prescripteur peut prendre rendez-vous pour un usager" do
     expect(page).to have_content("Sans numéro de téléphone ni adresse email, aucune notification ne sera envoyée au bénéficiaire")
     click_on "Annuler et modifier"
     fill_in "Téléphone", with: "0123456789"
+    fill_in "Adresse email", with: "patricia.duroy@exemple.fr"
 
     click_on "Confirmer le rendez-vous"
     expect(page).to have_content("Téléphone doit être un numéro de mobile")
@@ -78,6 +79,7 @@ RSpec.describe "un prescripteur peut prendre rendez-vous pour un usager" do
       full_name: "Patricia DUROY",
       created_through: "prescripteur",
       phone_number: "0611223344",
+      email: "patricia.duroy@exemple.fr",
       organisation_ids: [organisation.id]
     )
     expect(created_participation.created_by).to have_attributes(

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "un prescripteur peut prendre rendez-vous pour un usager" do
     fill_in "Prénom", with: "Patricia"
     fill_in "Nom", with: "Duroy"
     click_on "Confirmer le rendez-vous"
-    expect(page).to have_content("Sans numéro de téléphone, aucune notification ne sera envoyée au bénéficiaire")
+    expect(page).to have_content("Sans numéro de téléphone ni adresse email, aucune notification ne sera envoyée au bénéficiaire")
     click_on "Annuler et modifier"
     fill_in "Téléphone", with: "0123456789"
 

--- a/spec/form_models/beneficiaire_form_spec.rb
+++ b/spec/form_models/beneficiaire_form_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe BeneficiaireForm do
 
     it do
       expect(form).to be_invalid
-      expect(form.benign_errors.first).to eq("Sans numéro de téléphone, aucune notification ne sera envoyée au bénéficiaire")
+      expect(form.benign_errors.first).to eq("Sans numéro de téléphone ni adresse email, aucune notification ne sera envoyée au bénéficiaire")
     end
   end
 


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="839" height="427" alt="Screenshot 2026-06-15 at 16 42 45" src="https://github.com/user-attachments/assets/3f25e541-d36e-453a-b589-1ebb04477a40" />|<img width="834" height="598" alt="Screenshot 2026-06-15 at 16 42 24" src="https://github.com/user-attachments/assets/f014e32f-206e-47df-bb51-4c08ff8a3771" />

# Contexte

Demande arrivée via le support : Un agent fait de la prescription pour des rendez-vous en visio, et ça serait pratique que l'usager reçoive la confirmation par email plutôt que téléphone pour pouvoir participer à la visio.

# Solution

On ajoute le champs email aux infos de l'usager pendant la prescription.
A la base on ne l'avait pas mis parce que c'était pour de la médiation numérique pour des usagers qui n'avaient pas d'adresse mail.


