### PR TITLE
Utiliser des cards DSFR dans la recherche de créneaux côté agents

### DIFF
--- a/app/javascript/stylesheets/components/_cards.scss
+++ b/app/javascript/stylesheets/components/_cards.scss
@@ -26,13 +26,6 @@
   font-size: 1.25rem;
 }
 
-.card-hoverable {
-  border: 1px solid transparent;
-  &:hover {
-    border-color: $blue;
-  }
-}
-
 .light-gray-card {
   background-color: #f6f6f6;
 }

--- a/app/views/admin/creneaux_search/_lieu_search_results.html.slim
+++ b/app/views/admin/creneaux_search/_lieu_search_results.html.slim
@@ -1,9 +1,9 @@
-.card.fr-enlarge-link
+.card.fr-enlarge-link.fr-card--shadow
   .card-body
-    = link_to admin_organisation_creneaux_search_selection_creneaux_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [next_availability.lieu.id])), class: "d-block stretched-link" do
       .fr-grid-row
         .fr-col
-          h3.fr-h4.rdv-color-text-action-high-blue-france
+          h3.fr-h4
+            = link_to admin_organisation_creneaux_search_selection_creneaux_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [next_availability.lieu.id])), class: "d-block stretched-link" do
               = next_availability.lieu.name
           p.fr-mb-0= next_availability.lieu.address
         .fr-col

--- a/app/views/admin/creneaux_search/_lieu_search_results.html.slim
+++ b/app/views/admin/creneaux_search/_lieu_search_results.html.slim
@@ -11,5 +11,5 @@
             div
               | Prochain créneau le
               br
-              strong= l(next_availability.starts_at, format: :human)
-            = icon("fr-icon-arrow-right-line", class: "fr-mt-7w")
+              strong= human_date_format(next_availability.starts_at)
+            = icon("fr-icon-arrow-right-line", class: "fr-mt-7w rdv-color-text-action-high-blue-france")

--- a/app/views/admin/creneaux_search/_lieu_search_results.html.slim
+++ b/app/views/admin/creneaux_search/_lieu_search_results.html.slim
@@ -1,16 +1,15 @@
-.card.mb-3.card-hoverable
+.card.fr-enlarge-link
   .card-body
-    .row
-      .col-md
-        h4.card-title.mb-3.mt-0.text-success.font-weight-bold= next_availability.lieu.name
-        p.card-subtitle.text-black-50= next_availability.lieu.address
-      .col-md.align-self-center.pt-3.pt-md-0.position-static
-        = link_to admin_organisation_creneaux_search_selection_creneaux_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [next_availability.lieu.id])),
-                class: "d-block stretched-link" do
-          .row
-            .col
+    = link_to admin_organisation_creneaux_search_selection_creneaux_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [next_availability.lieu.id])), class: "d-block stretched-link" do
+      .fr-grid-row
+        .fr-col
+          h3.fr-h4.rdv-color-text-action-high-blue-france
+              = next_availability.lieu.name
+          p.fr-mb-0= next_availability.lieu.address
+        .fr-col
+          .d-flex.rdv-justify-content-space-between
+            div
               | Prochain créneau le
               br
               strong= l(next_availability.starts_at, format: :human)
-            .col-auto.align-self-center
-              = icon("fr-icon-arrow-right-s-line")
+            = icon("fr-icon-arrow-right-line", class: "fr-mt-7w")

--- a/app/views/admin/creneaux_search/_no_slot_available.html.slim
+++ b/app/views/admin/creneaux_search/_no_slot_available.html.slim
@@ -1,3 +1,2 @@
 .rdv-text-align-center.mt-2
   p= "Aucun créneau disponible dans l'organisation #{@form.organisation.name} pour les filtres sélectionnés."
-  = render "admin/creneaux_search/prescription_cta"

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -84,7 +84,7 @@
           .col-md-4
             = f.input :lieu_ids, collection: @lieux, label: "Lieu(x)", input_html: { multiple: true, class: "select2-input" }
         .text-right
-          = f.submit "Afficher les créneaux", class: "fr-btn", data: { disable_with: "Récupération des créneaux…"}
+          = f.submit "Afficher les créneaux", class: "fr-btn #{'fr-btn--secondary' if params[:commit]}", data: { disable_with: "Récupération des créneaux…"}
 
     #creneaux
       - if @next_availabilities&.any?

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -86,14 +86,13 @@
         .text-right
           = f.submit "Afficher les créneaux", class: "fr-btn", data: { disable_with: "Récupération des créneaux…"}
 
-#creneaux
-  .rdv-text-align-center
-    - if @next_availabilities&.any?
-      h3.font-weight-bold= t(".available_places_with_slots", count: @next_availabilities.length)
-      - @next_availabilities.each do |next_availability|
-        = render "lieu_search_results", next_availability: next_availability
-      = render "admin/creneaux_search/prescription_cta"
-    - elsif motif_selected? && params[:commit].present?
-      = render partial: "admin/creneaux_search/no_slot_available"
-    - else
-      = render "admin/creneaux_search/prescription_cta"
+    #creneaux
+      - if @next_availabilities&.any?
+        h2.fr-h4= t(".available_places_with_slots", count: @next_availabilities.length)
+        - @next_availabilities.each do |next_availability|
+          = render "lieu_search_results", next_availability: next_availability
+      - elsif motif_selected? && params[:commit].present?
+        .rdv-text-align-center
+          = render partial: "admin/creneaux_search/no_slot_available"
+.rdv-text-align-center
+  = render "admin/creneaux_search/prescription_cta"

--- a/app/views/admin/creneaux_search/selection_creneaux.html.slim
+++ b/app/views/admin/creneaux_search/selection_creneaux.html.slim
@@ -12,7 +12,7 @@
          / lien très utilisé pour la duplication de RDV
          / il permet de reprendre un RDV, éventuellement pour un autre motif
          / https://zammad10.ethibox.fr/#ticket/zoom/3044
-         = link_to t(".place_index"), admin_organisation_creneaux_search_path(current_organisation, creneaux_search_params(@form)), class: "btn btn-outline-primary m-2"
+         = link_to t(".place_index"), admin_organisation_creneaux_search_path(current_organisation, creneaux_search_params(@form)), class: "fr-btn fr-btn--tertiary fr-my-2w fr-btn--icon-left fr-icon-arrow-left-line"
 
     - if @form.motif.individuel?
       .card-body

--- a/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
+++ b/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Agent can find a creneau for a rdv collectif" do
       click_button "Afficher les créneaux"
 
       expect(page).to have_content("2 lieux proposent des créneaux")
-      click_link("Prochain créneau", match: :first)
+      click_link(lieu.name, match: :first)
 
       expect(page).to have_content("Créneaux disponibles pour Atelier participatif")
     end


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1423" height="738" alt="Screenshot 2026-06-15 at 12 57 04" src="https://github.com/user-attachments/assets/8f1e9a39-bc39-46f8-94eb-9a7f5702ce3e" />|<img width="1425" height="749" alt="Screenshot 2026-06-15 at 13 07 46" src="https://github.com/user-attachments/assets/ee195bc7-ff90-413e-8588-89ed15811953" />


En travaillant sur les cards pour la réservation en ligne, je me suis dit que ça serait bien de passer ce composant aussi en cards au passage (histoire d'avoir une interface plus cohérente à travers les différentes pages du produit.

J'en profite aussi pour faire quelques améliorations mineures :
- on passe le bouton de recherche en secondary quand on a des résultats puisque logiquement la prochaine action est de choisir un lieu, pas de relancer une recherche
- on met les résultats dans la card des filtre de recherche, pour montrer qu'ils sont liés à ces filtres
- vu qu'on neste une card dans une, pour avoir quand même un peu de contraste (notamment sur des écrans de mauvaise qualité comme c'est malheureusement le cas parfois sur le terrain), j'ai ajouté une ombre en utilisant le modifier `fr-card--shadow` du dsfr. Je me demande si ça vaudrait pas le coup de faire la même chose pour la page de liste des motifs dans la réservation en ligne.
- ma passion : on ne met pas l'année de la prochaine dispo si c'est l'année courante
