### PR TITLE
Retire la contrainte d'unicité sur Service#short_name

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -19,7 +19,7 @@ class Service < ApplicationRecord
   has_many :territories, through: :territory_services
 
   # Validations
-  validates :name, :short_name, uniqueness: { case_sensitive: false }
+  validates :name, uniqueness: { case_sensitive: false }
   validate :validate_name_length
   validate :validate_short_name_length
 

--- a/db/migrate/20260610142439_remove_uniqueness_on_services_short_name.rb
+++ b/db/migrate/20260610142439_remove_uniqueness_on_services_short_name.rb
@@ -1,0 +1,13 @@
+class RemoveUniquenessOnServicesShortName < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :services, name: "index_services_on_lower_short_name"
+    add_index :services, "lower(short_name)", name: "index_services_on_lower_short_name", algorithm: :concurrently
+  end
+
+  def down
+    remove_index :services, name: "index_services_on_lower_short_name"
+    add_index :services, "lower(short_name)", unique: true, name: "index_services_on_lower_short_name", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_03_152307) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_10_142439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -730,7 +730,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_03_152307) do
     t.datetime "updated_at", null: false
     t.string "short_name", null: false
     t.index "lower((name)::text)", name: "index_services_on_lower_name", unique: true
-    t.index "lower((short_name)::text)", name: "index_services_on_lower_short_name", unique: true
+    t.index "lower((short_name)::text)", name: "index_services_on_lower_short_name"
     t.index ["name"], name: "index_services_on_name"
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,5 +1,16 @@
 RSpec.describe Service, type: :model do
   describe "validations" do
+    it "ensures the name's uniqueness" do
+      create(:service, name: "Service Social", short_name: "Serv. Soc.")
+      expect(build(:service, name: "Service Social")).to be_invalid
+      expect(build(:service, name: "Autre")).to be_valid
+    end
+
+    it "allow for duplicate short names" do
+      create(:service, name: "Protection Maternelle et Infantile", short_name: "PMI")
+      create(:service, name: "Philip Morris International", short_name: "PMI")
+    end
+
     it "limits the length of #name to 2-60 characters" do
       expect(described_class.new(short_name: "Valide", name: nil)).to be_invalid
       expect(described_class.new(short_name: "Valide", name: "")).to be_invalid


### PR DESCRIPTION
# Contexte

Avec @mekaidmekaid et @Teodora-Stanki , lors de nos réflexions sur la création en autonomie des services, nous avons réalisé qu'il y avait une contrainte d'unicité sur le nom court.

Nous pensons que cette contrainte n'est pas nécessaire, et pourrait même bloquer la création légitime d'une nouveau service qui se trouve avoir le même nom court qu'un autre.

# Solution

- Retrait de l'index unique en base
- retrait de la validation ActiveRecord
- ajout de specs
