### PR TITLE
Utiliser des cards pour les choix de motifs pour la création d'un nouveau rendez-vous collectif

### DIFF
--- a/app/views/admin/rdvs_collectifs/motifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/motifs/index.html.slim
@@ -6,10 +6,9 @@
 .row.justify-content-md-center
   .col-md-12.col-lg-8
     .card
-      .card-header
-        h3.rdv-text-align-center Choisissez un motif
-
       .card-body
+        h2.fr-h4 Choisissez un motif
+
         - if @motifs.empty?
           - if Agent::MotifPolicy.new(current_agent, Motif.new(organisation_id: current_organisation.id)).new?
             div Il n'existe aucun motif de RDV collectif. Veuillez en créer un pour continuer.
@@ -19,8 +18,15 @@
             div Il n'existe aucun motif de RDV collectif et vous ne pouvez pas en créer un. Demandez à un administrateur ou une administratrice.
         - else
           - @motifs.each do |motif|
-            = link_to new_admin_organisation_rdvs_collectif_path(current_organisation, { motif_id: motif.id }) do
-              .mb-3
-                = motif.name
-                br
-                = "#{motif.default_duration_in_min} minutes"
+            .card.fr-enlarge-link.fr-card--shadow
+              .card-body
+                .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
+                  h3.fr-h5 = link_to motif.name, new_admin_organisation_rdvs_collectif_path(current_organisation, { motif_id: motif.id })
+                .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
+                  p.fr-mb-0
+                    = location_type_icon(motif.location_type, class: "fr-mr-1w")
+                    = motif.human_attribute_value(:location_type)
+                    = " · "
+                    = "#{motif.default_duration_in_min} mn"
+
+                  = icon("fr-icon-arrow-right-line", class: "rdv-color-text-action-high-blue-france")

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -7,9 +7,8 @@
   .col-md-12.col-lg-8
     = form_for(@rdv, url: admin_organisation_rdvs_collectifs_path(current_organisation), method: :post, builder: Dsfr::FormBuilder) do |f|
       .card
-        .card-header
-          h3.rdv-text-align-center #{motif_name_and_service(@rdv.motif)}
         .card-body.px-3
+          h2.fr-h4 #{motif_name_and_service(@rdv.motif)}
           = render "model_errors", model: @rdv, f: f
 
           .fr-grid-row.fr-grid-row--gutters.fr-mb-4v


### PR DESCRIPTION
Dans la continuité de https://github.com/betagouv/rdv-service-public/pull/6437, je reviens quatre ans plus tard sur cette page un peu triste


Avant | Après
:- | -:
<img width="1433" height="659" alt="Screenshot 2026-06-15 at 17 38 54" src="https://github.com/user-attachments/assets/20dae3dc-01ef-4cb7-8563-d39d4fce18ac" />|<img width="1415" height="742" alt="Screenshot 2026-06-15 at 17 38 44" src="https://github.com/user-attachments/assets/54f4bc80-9736-492e-8375-9c1ecce54f7b" />
