### PR TITLE
Ajoute l'espace manquant dans le titre de page sur un motif (#6365)

### DIFF
--- a/app/views/admin/organisations/online_booking/motifs/show.html.slim
+++ b/app/views/admin/organisations/online_booking/motifs/show.html.slim
@@ -6,7 +6,7 @@
 - count = @motif.upcoming_availabilities.count
 
 - content_for :title do
-  | #{@motif.name}
+  |> #{@motif.name}
   = render "availability_badge", motif: @motif, availabilities_count: count
 
 .fr-grid-row


### PR DESCRIPTION
Closes #6365

Je suis allé au plus direct : j'ajoute un espace à la fin du nom du motif.

Cela permet de corriger les 2 problèmes : 
- manque d'espace visuel entre le titre et le tag
- manque un caractère espace (` `) dans le `<title>` de la page

Idéalement je pense qu'il faudrait sortir le tag du titre, et peut-être changer le titre de la page.

Mais pour le moment ce petit pas me semble acceptable. :rocket: 

## Captures d'écran

Avant | Après
:- | -:
<img width="1117" height="470" alt="image" src="https://github.com/user-attachments/assets/49af971a-f40c-4581-b8c8-bf9ab20ff8b1" /> | <img width="1117" height="470" alt="image" src="https://github.com/user-attachments/assets/bc458177-e35e-4233-9eb3-c61225bc2334" />
<img width="1005" height="257" alt="image" src="https://github.com/user-attachments/assets/53f62e68-4a0b-4669-bdaa-b413538e670c" /> | <img width="1005" height="257" alt="image" src="https://github.com/user-attachments/assets/062a66c7-7a16-4963-bda6-c82346f98da0" />

