### PR TITLE
Afficher le nom de l'usager connecté

### DIFF
--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -36,8 +36,8 @@ html lang="fr"
         header.with_operator_image title: "", src: asset_path(current_domain.dark_logo_path), alt: "Accueil - #{current_domain.name}", href: home_path
         if current_user.present? && !current_user.signed_in_with_invitation_token?
           header.with_tool_link title: "Vos rendez-vous", path: users_rdvs_path, html_attributes: { class: "fr-icon-calendar-fill" }
-          header.with_tool_link title: "Vos informations", path: users_informations_path
           header.with_tool_link title: "Votre compte", path: edit_user_registration_path
+          header.with_tool_link title: current_user.full_name, path: users_informations_path
           header.with_tool_link title: "Déconnexion", path: destroy_user_session_path, html_attributes: { "data-method": "delete", class: "fr-icon-lock-fill" }
         elsif current_agent
           header.with_tool_link title: "Espace Agent", path: root_path

--- a/spec/features/users/account/user_can_login_using_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_code_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
   include_context "enable rack-attack" # en l’activant ici on teste que le cas normal fonctionne aussi
 
-  before { create(:user, email: "marco@lolmail.fr", first_name: "Marco") }
+  let!(:user) { create(:user, email: "marco@lolmail.fr", first_name: "Marco") }
 
   specify do
     visit new_user_session_path
@@ -48,7 +48,7 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
       click_on "Valider"
       click_on territory_1.name
       expect(page).to have_content("Connexion réussie")
-      click_on user.full_name
+      click_on user_1.full_name
       expect(page).to have_field("user_first_name", with: user_1.first_name)
     end
 
@@ -59,7 +59,7 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
       click_on "Valider"
       click_on territory_2.name
       expect(page).to have_content("Connexion réussie")
-      click_on user.full_name
+      click_on user_2.full_name
       expect(page).to have_field("user_first_name", with: user_2.first_name)
     end
   end

--- a/spec/features/users/account/user_can_login_using_code_spec.rb
+++ b/spec/features/users/account/user_can_login_using_code_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
 
     expect(page).to have_content("Connexion réussie")
     expect(page).to have_current_path("/users/rdvs")
-    click_on "Vos informations"
+    click_on user.full_name
     expect(page).to have_field("user_first_name", with: "Marco")
   end
 
@@ -48,7 +48,7 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
       click_on "Valider"
       click_on territory_1.name
       expect(page).to have_content("Connexion réussie")
-      click_on "Vos informations"
+      click_on user.full_name
       expect(page).to have_field("user_first_name", with: user_1.first_name)
     end
 
@@ -59,7 +59,7 @@ RSpec.describe "Un usager peut se logger via un code à 6 chiffres" do
       click_on "Valider"
       click_on territory_2.name
       expect(page).to have_content("Connexion réussie")
-      click_on "Vos informations"
+      click_on user.full_name
       expect(page).to have_field("user_first_name", with: user_2.first_name)
     end
   end

--- a/spec/features/users/account/user_can_update_their_information_spec.rb
+++ b/spec/features/users/account/user_can_update_their_information_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "User can update their information" do
 
     before do
       visit root_path
-      click_link "Vos informations"
+      click_link user.full_name
     end
 
     it "shows the user information" do


### PR DESCRIPTION
Pour la validation du nouveau nom de domaine avec France Connect, l'équipe France Connect nous a fait ce retour :
```
L'usager doit pouvoir identifier clairement qu'il est connecté et son profil accessible. Cela se traduit généralement par le nom et prénom de l'utilisateur (ou ses initiales) dans le header, au niveau de "mon compte" ou à la place.
```

On remplace donc l'entrée "Vos informations" par le nom de l'usager connecté, et on le place à côté du bouton de déconnexion.

Avant | Après
:- | -:
<img width="1212" height="132" alt="Screenshot 2026-06-16 at 14 54 43" src="https://github.com/user-attachments/assets/beec3f5b-c1ab-49e6-b085-d7bcb1a55a85" />|<img width="1212" height="131" alt="Screenshot 2026-06-16 at 14 54 26" src="https://github.com/user-attachments/assets/86a13af8-66c5-40e7-bdb5-1a61af2c2209" />

