### PR TITLE
Tests: Ne pas filtrer les valeurs des attributs AR

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,6 +25,8 @@ require "sentry/test_helper"
 Rails.root.glob("spec/support/**/*.rb").each { |f| require f }
 Rails.root.glob("spec/factories/**/*.rb").each { |f| require f }
 
+ActiveRecord::Base.filter_attributes = []
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin


### PR DESCRIPTION
comme dans l'initializer de la console https://github.com/betagouv/rdv-service-public/blob/chore%2Fprevent-filter-attributes-test/config/initializers/console.rb