### PR TITLE
Variable d'env pour afficher les login codes sur les review apps

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -116,3 +116,6 @@ DB_SEEDS_USERS_AND_AGENTS_PASSWORD=Rdvservicepublictest1!
 
 # optional basic auth for health routes that could DDOS Sentry
 HEALTH_CONTROLLER_BASIC_AUTH=lerdvest:partout
+
+# affiche les codes à 6 chiffres de connexion pour les usagers et les agents pour faciliter les tests
+DISPLAY_LOGIN_CODES=true

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,10 @@ review_app: ## Create Scalingo review app for the PR linked to the current branc
 	ruby scripts/devtools/create_review_app.rb
 
 enable_emails_on_review_app:
-	/bin/sh scripts/enable_emails_on_review_app.sh
+	/bin/sh scripts/devtools/enable_emails_on_review_app.sh
+
+display_login_codes_on_review_app:
+	/bin/sh scripts/devtools/display_login_codes_on_review_app.sh
 
 help: ## Display available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/app/views/agents/sessions_by_code/new.html.slim
+++ b/app/views/agents/sessions_by_code/new.html.slim
@@ -11,13 +11,13 @@
         b> #{@existing_login_code.email}
         | à #{l(@existing_login_code.created_at, format: :time_only)}
 
-      - if Rails.env.development?
+      - if ENV["DISPLAY_LOGIN_CODES"] == "true" && (Rails.env.development? || ENV["IS_REVIEW_APP"] == "true")
         .fr-mb-4w
           = button_tag class: "fr-btn fr-btn--tertiary fr-btn--sm fr-mr-1w js-copy-to-clipboard", data: { "clipboard-content": @existing_login_code.code }
             = icon("fr-icon-survey-line fr-icon--sm", class: "fr-mr-1w")
             | copier le code #{@existing_login_code.code}
           span.fr-text--sm
-            | (visible uniquement en env de dev)
+            | (visible uniquement en dev ou en review app avec DISPLAY_LOGIN_CODES=true)
 
     .rdv-legible-code-form
       = form_for LoginCode.new(email: @email), url: agents_sessions_by_code_path, method: :post, builder: Dsfr::FormBuilder do |form|

--- a/app/views/users/sessions_by_code/new.html.slim
+++ b/app/views/users/sessions_by_code/new.html.slim
@@ -13,13 +13,13 @@
         b> #{@existing_login_code.email}
         | à #{l(@existing_login_code.created_at, format: :time_only)}
 
-      - if Rails.env.development?
+      - if ENV["DISPLAY_LOGIN_CODES"] == "true" && (Rails.env.development? || ENV["IS_REVIEW_APP"] == "true")
         .fr-mb-4w
           = button_tag class: "fr-btn fr-btn--tertiary fr-btn--sm fr-mr-1w js-copy-to-clipboard", data: { "clipboard-content": @existing_login_code.code }
             = icon("fr-icon-survey-line fr-icon--sm", class: "fr-mr-1w")
             | copier le code #{@existing_login_code.code}
           span.fr-text--sm
-            | (visible uniquement en env de dev)
+            | (visible uniquement en dev ou en review app avec DISPLAY_LOGIN_CODES=true)
 
     .rdv-legible-code-form
       = form_for LoginCode.new(email: @email), url: users_sessions_by_code_path, method: :post, builder: Dsfr::FormBuilder do |form|

--- a/docs/4-notes-techniques.md
+++ b/docs/4-notes-techniques.md
@@ -110,29 +110,15 @@ Il faut donc les mettre à jour simultanément. Un script permet de faire ça : 
 ## Review apps
 
 Les review apps ne sont pas créées automatiquement pour chaque PR pour économiser des ressources.
-
-La commande pour créer une review app pour la PR #4242 est
-
-```bash
-scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app integration-link-manual-review-app 4242
-```
-
-Un raccourci existe pour retrouver le numéro de la PR correspondant à la branche courante automatiquement : `make review_app`
-
-Par défaut, seul un worker web est activé, si vous souhaitez que les jobs s’exécutent il faut activer un worker jobs depuis le dashboard ou avec cette commande :
-
-```sh
-scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app-pr4242 scale jobs:1
-```
-
 Le fichier `scalingo.json` décrit la configuration initiale et les variables d’environnement des review apps.
 Les review apps sont détruites automatiquement à la fermeture de la PR ou après 48h sans déploiement.
 On ne peut pas empêcher une PR spécifique d’être automatiquement détruite après ces 48h.
 En revanche, on peut en recréer une nouvelle sans problème.
 
-L’envoi d’email est désactivé par défaut sur les review apps.
-Pour l’activer vous pouvez utiliser cette commande : `make enable_emails_on_review_app`
-
+- La commande pour créer une review app pour la PR ouverte pour la branche courante est `make review_app`.
+- Par défaut, seul un worker web est activé, si vous souhaitez que les jobs s’exécutent : `scalingo --region osc-secnum-fr1 --app rdv-service-public-review-app-pr4242 scale jobs:1`
+- L’envoi d’email est désactivé par défaut sur les review apps. Pour l’activer : `make enable_emails_on_review_app` (active aussi un worker jobs)
+- L'affichage des codes de login est désactivé par défaut. Pour l'activer : `make display_login_codes_on_review_app`
 
 ## Search Contexts
 

--- a/scalingo.json
+++ b/scalingo.json
@@ -42,6 +42,9 @@
     "IS_REVIEW_APP": {
       "value": "true"
     },
+    "DISPLAY_LOGIN_CODES": {
+      "description": "Mettre à 'true' pour afficher le code de connexion sur la page de saisie du code (review app uniquement, sans effet si IS_REVIEW_APP != true)"
+    },
     "SENTRY_CURRENT_ENV": {
       "value": "review_app"
     },

--- a/scripts/devtools/display_login_codes_on_review_app.sh
+++ b/scripts/devtools/display_login_codes_on_review_app.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGION="osc-secnum-fr1"
+
+log() {
+  echo -e "\033[1;34m[INFO]\033[0m $*"
+}
+
+log "Fetching PR number..."
+PR_NUMBER=$(gh pr view --json number --jq '.number')
+if [[ -z "$PR_NUMBER" ]]; then
+  echo "Error: Unable to get PR number."
+  exit 1
+fi
+
+APP_NAME="rdv-service-public-review-app-pr${PR_NUMBER}"
+log "Review app name: ${APP_NAME}"
+
+log "Setting DISPLAY_LOGIN_CODES=true on review app..."
+scalingo --region "$REGION" --app "$APP_NAME" env-set DISPLAY_LOGIN_CODES=true
+
+log "Restarting web processes..."
+scalingo --region "$REGION" --app "$APP_NAME" restart web
+
+log "✅ Login code display enabled on ${APP_NAME}."


### PR DESCRIPTION
# Contexte

Je bosse sur la PR #6421 où on va vouloir faire beaucoup de tests de parcours usagers en review app. Vu qu'il n'y a plus de mot de passe pour les usagers, on doit passer à chaque fois par des envois de codes de connexions par mail. c'est fastidieux et lent. 

Aussi, j'aimerais bien proposer des comptes usagers préconfigurés pour les testeurs, comme on le faisait pour les agents en disant `martine@demo.rdv-solidarites.fr : Rdvservicepublictest1!` . Actuellement ce n'est pas possible de dire aux testeurs des review apps d'utiliser `adrien+cas1@gmail.com` car il faut avoir accès à cette adresse email pour récupérer le code de connexion. (ceci dit on pourrait utiliser yopmail pour ce probleme)

# Solution

Je propose de permettre d'afficher les login codes sur les review apps comme en développement.

Je ne l'active pas par défaut car je pense que c'est bien de tester le cas avec le code envoyé par email et voir ses lenteurs

# Review app

https://rdv-service-public-review-app-pr6454.osc-secnum-fr1.scalingo.io/users/sign_in

utilisez `patricia_duroy@demo.rdv-solidarites.fr`
