### PR TITLE
Permettre aux admins d'espace de créer un nouveau service

### DIFF
--- a/app/controllers/admin/territories/services_controller.rb
+++ b/app/controllers/admin/territories/services_controller.rb
@@ -1,6 +1,25 @@
 class Admin::Territories::ServicesController < Admin::Territories::BaseController
+  def new
+    authorize(current_territory, :manage_services?, policy_class: Agent::TerritoryPolicy)
+    @service = Service.new
+  end
+
+  def create
+    authorize(current_territory, :manage_services?, policy_class: Agent::TerritoryPolicy)
+    permitted_params = params.require(:service).permit(:name, :short_name)
+    @service = Service.new(permitted_params)
+
+    if @service.save
+      current_territory.territory_services.find_or_create_by!(service_id: @service.id)
+      flash[:success] = %(Le service "#{@service.name} (#{@service.short_name})" vient d'être créé et activé dans votre espace.)
+      redirect_to edit_admin_territory_services_path(territory_id: current_territory.id)
+    else
+      render :new
+    end
+  end
+
   def edit
-    authorize(current_territory, policy_class: Agent::TerritoryPolicy)
+    authorize(current_territory, :manage_services?, policy_class: Agent::TerritoryPolicy)
 
     activated_services = format_for_checkboxes(current_territory.services.reject(&:secretariat?))
     other_services = format_for_checkboxes(Service.where.not(id: current_territory.service_ids).reject(&:secretariat?))
@@ -9,7 +28,7 @@ class Admin::Territories::ServicesController < Admin::Territories::BaseControlle
   end
 
   def update
-    authorize(current_territory, policy_class: Agent::TerritoryPolicy)
+    authorize(current_territory, :manage_services?, policy_class: Agent::TerritoryPolicy)
     current_territory.update!(services_params)
     flash[:success] = "Liste des services disponibles mise à jour"
 

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -162,6 +162,12 @@
   object-fit: contain;
 }
 
+// SPACING
+
+.rdv-margin-top-negative-8px {
+  margin-top: -8px;
+}
+
 // OTHERS
 
 // utile pour désactiver le soulignement des liens du DSFR

--- a/app/policies/agent/territory_policy.rb
+++ b/app/policies/agent/territory_policy.rb
@@ -9,6 +9,7 @@ class Agent::TerritoryPolicy
     @current_agent.territorial_roles.exists?(territory_id: @territory.id)
   end
 
+  alias manage_services? territorial_admin?
   alias update? territorial_admin?
   alias edit? territorial_admin?
 

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -16,9 +16,9 @@
 
           = f.association :services, collection: @services, label: "", as: :check_boxes, label_method: :first, value_method: :second
 
-          p.text-muted.font-14
-            |> Si vous avez besoin d'un service qui n'apparaît pas dans cette liste,
-            = link_to "contactez-nous via ce formulaire", new_aide_demande_support_path(role: "agent", sujet: "Ajout d’un service")
+          p
+            |> Vous ne trouvez pas votre service dans la liste ?
+            = link_to "Créer un nouveau service", new_admin_territory_services_path(territory_id: current_territory.id)
             | .
 
           = dsfr_callout do

--- a/app/views/admin/territories/services/new.html.slim
+++ b/app/views/admin/territories/services/new.html.slim
@@ -1,0 +1,12 @@
+.fr-grid-row.fr-grid-row--center
+  .fr-col-12.fr-col-lg-8
+    .fr-card.py-4.px-2
+      .fr-card__body
+        h1.dsfr-card-title.mb-3 Ajouter un nouveau service
+        = form_with(model: @service, url: admin_territory_services_path(territory_id: current_territory.id), builder: Dsfr::FormBuilder) do |f|
+          = f.dsfr_text_field :name, label: "Intitulé du nouveau service", hint: "60 caractères max", minlength: 2, maxlength: 60
+          = f.dsfr_text_field :short_name, label: "Intitulé court du nouveau service", hint: "40 caractères max", minlength: 2, maxlength: 40
+          p.fr-message.fr-message--info[style="margin-top: -8px"] L’intitulé court est l’intitulé qui sera affiché dans les notifications SMS
+          .float-right.mt-3
+            = link_to("Annuler", edit_admin_territory_services_path(territory_id: current_territory.id), class: "fr-btn fr-btn--tertiary mr-2")
+            = f.submit "Ajouter le nouveau service", class: "fr-btn fr-btn-primary"

--- a/app/views/admin/territories/services/new.html.slim
+++ b/app/views/admin/territories/services/new.html.slim
@@ -2,7 +2,7 @@
 
 .fr-grid-row.fr-grid-row--center
   .fr-col-12.fr-col-lg-8
-    .fr-card.py-4.px-2
+    .fr-card.py-4.fr-px-2w
       .fr-card__body
         h1.dsfr-card-title.mb-3 Ajouter un nouveau service
         = form_with(model: @service, url: admin_territory_services_path(territory_id: current_territory.id), builder: Dsfr::FormBuilder) do |f|

--- a/app/views/admin/territories/services/new.html.slim
+++ b/app/views/admin/territories/services/new.html.slim
@@ -1,14 +1,14 @@
-= territory_navigation("Ajouter un nouveau service", [["Services", edit_admin_territory_services_path(territory_id: current_territory.id)]])
+= territory_navigation("Créer un nouveau service", [["Services", edit_admin_territory_services_path(territory_id: current_territory.id)]])
 
 .fr-grid-row.fr-grid-row--center
   .fr-col-12.fr-col-lg-8
     .fr-card.py-4.fr-px-2w
       .fr-card__body
-        h1.dsfr-card-title.mb-3 Ajouter un nouveau service
+        h1.dsfr-card-title.mb-3 Créer un nouveau service
         = form_with(model: @service, url: admin_territory_services_path(territory_id: current_territory.id), builder: Dsfr::FormBuilder) do |f|
-          = f.dsfr_text_field :name, label: "Intitulé du nouveau service", hint: "60 caractères max", minlength: 2, maxlength: 60
-          = f.dsfr_text_field :short_name, label: "Intitulé court du nouveau service", hint: "40 caractères max", minlength: 2, maxlength: 40
-          p.fr-message.fr-message--info.rdv-margin-top-negative-8px L’intitulé court est l’intitulé qui sera affiché dans les notifications SMS
+          = f.dsfr_text_field :name, label: "Nom du service", hint: %(60 caractères maximum. Exemple: "Ressources Humaines"), minlength: 2, maxlength: 60
+          = f.dsfr_text_field :short_name, label: "Nom court du service", hint: %(40 caractères maximum. Exemple: "RH"), minlength: 2, maxlength: 40
+          p.fr-message.fr-message--info.rdv-margin-top-negative-8px L’intitulé court est l’intitulé qui sera affiché dans les notifications SMS.
           .float-right.mt-3
             = link_to("Annuler", edit_admin_territory_services_path(territory_id: current_territory.id), class: "fr-btn fr-btn--tertiary mr-2")
-            = f.submit "Ajouter le nouveau service", class: "fr-btn fr-btn-primary"
+            = f.submit "Créer le service", class: "fr-btn fr-btn-primary"

--- a/app/views/admin/territories/services/new.html.slim
+++ b/app/views/admin/territories/services/new.html.slim
@@ -8,7 +8,7 @@
         = form_with(model: @service, url: admin_territory_services_path(territory_id: current_territory.id), builder: Dsfr::FormBuilder) do |f|
           = f.dsfr_text_field :name, label: "Intitulé du nouveau service", hint: "60 caractères max", minlength: 2, maxlength: 60
           = f.dsfr_text_field :short_name, label: "Intitulé court du nouveau service", hint: "40 caractères max", minlength: 2, maxlength: 40
-          p.fr-message.fr-message--info[style="margin-top: -8px"] L’intitulé court est l’intitulé qui sera affiché dans les notifications SMS
+          p.fr-message.fr-message--info.rdv-margin-top-negative-8px L’intitulé court est l’intitulé qui sera affiché dans les notifications SMS
           .float-right.mt-3
             = link_to("Annuler", edit_admin_territory_services_path(territory_id: current_territory.id), class: "fr-btn fr-btn--tertiary mr-2")
             = f.submit "Ajouter le nouveau service", class: "fr-btn fr-btn-primary"

--- a/app/views/admin/territories/services/new.html.slim
+++ b/app/views/admin/territories/services/new.html.slim
@@ -1,3 +1,5 @@
+= territory_navigation("Ajouter un nouveau service", [["Services", edit_admin_territory_services_path(territory_id: current_territory.id)]])
+
 .fr-grid-row.fr-grid-row--center
   .fr-col-12.fr-col-lg-8
     .fr-card.py-4.px-2

--- a/config/locales/models/service.fr.yml
+++ b/config/locales/models/service.fr.yml
@@ -11,5 +11,6 @@ fr:
           attributes:
             name:
               format: "Le nom du service %{message}"
+              taken: est déjà présent dans la liste de services existants
             short_name:
               format: "Le nom raccourci pour les SMS %{message}"

--- a/config/locales/models/service.fr.yml
+++ b/config/locales/models/service.fr.yml
@@ -11,6 +11,6 @@ fr:
           attributes:
             name:
               format: "Le nom du service %{message}"
-              taken: existe déjà, sélectionnez-le dans la liste ou renseignez un autre intitulé.
+              taken: existe déjà, sélectionnez-le dans la liste ou renseignez un autre nom.
             short_name:
               format: "Le nom raccourci pour les SMS %{message}"

--- a/config/locales/models/service.fr.yml
+++ b/config/locales/models/service.fr.yml
@@ -11,6 +11,6 @@ fr:
           attributes:
             name:
               format: "Le nom du service %{message}"
-              taken: est déjà présent dans la liste de services existants
+              taken: existe déjà, sélectionnez-le dans la liste ou renseignez un autre intitulé.
             short_name:
               format: "Le nom raccourci pour les SMS %{message}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,7 +250,7 @@ Rails.application.routes.draw do
         resource :motif_categories, only: %i[update]
         resources :zone_imports, only: %i[new create]
         resources :zones, only: [:index] # exports only
-        resource :services, only: %i[edit update]
+        resource :services, only: %i[new create edit update]
         resource :sectorization, only: [:show]
         resources :sectors do
           resources :zones

--- a/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
@@ -1,14 +1,11 @@
-RSpec.describe "territory admin can manage agents", type: :feature do
-  # L'espace doit avoir au moins un agent admin d'espace restant
-  let!(:territory) { create(:territory, :mairies).tap { |t| t.roles.create!(agent: create(:agent)) } }
+RSpec.describe "territory admin can manage services", type: :feature do
+  let!(:territory) { create(:territory) }
   let!(:agent) { create(:agent, role_in_territories: [territory]) }
   let!(:service_a) { create(:service) }
   let!(:service_b) { create(:service) }
   let!(:service_c) { create(:service) }
 
   before do
-    create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
-    create(:agent_role, agent: agent, access_level: "basic")
     login_as(agent, scope: :agent)
   end
 

--- a/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "territory admin can manage services", type: :feature do
         fill_in "Intitulé du nouveau service", with: "Protection maternelle et infantile"
         fill_in "Intitulé court du nouveau service", with: "PMI"
         click_on("Ajouter le nouveau service")
-        expect(page).to have_content("Le nom du service est déjà présent dans la liste de services existants")
+        expect(page).to have_content("Le nom du service existe déjà, sélectionnez-le dans la liste ou renseignez un autre intitulé")
       end
     end
   end

--- a/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe "territory admin can manage services", type: :feature do
   describe "creating a new service" do
     it "works" do
       visit new_admin_territory_services_path(territory_id: territory.id)
-      fill_in "Intitulé du nouveau service", with: "Protection maternelle et infantile"
-      fill_in "Intitulé court du nouveau service", with: "PMI"
-      expect { click_on("Ajouter le nouveau service") }.to change(Service, :count).by(1).and(change { territory.services.reload.size }.by(1))
+      fill_in "Nom du service", with: "Protection maternelle et infantile"
+      fill_in "Nom court du service", with: "PMI"
+      expect { click_on("Créer le service") }.to change(Service, :count).by(1).and(change { territory.services.reload.size }.by(1))
       expect(Service.last).to have_attributes(name: "Protection maternelle et infantile", short_name: "PMI")
       expect(page).to have_content(%(Le service "Protection maternelle et infantile (PMI)" vient d'être créé et activé dans votre espace.))
     end
@@ -70,10 +70,10 @@ RSpec.describe "territory admin can manage services", type: :feature do
       it "displays error message if the name already exists" do
         create(:service, name: "Protection maternelle et infantile")
         visit new_admin_territory_services_path(territory_id: territory.id)
-        fill_in "Intitulé du nouveau service", with: "Protection maternelle et infantile"
-        fill_in "Intitulé court du nouveau service", with: "PMI"
-        click_on("Ajouter le nouveau service")
-        expect(page).to have_content("Le nom du service existe déjà, sélectionnez-le dans la liste ou renseignez un autre intitulé")
+        fill_in "Nom du service", with: "Protection maternelle et infantile"
+        fill_in "Nom court du service", with: "PMI"
+        click_on("Créer le service")
+        expect(page).to have_content("Le nom du service existe déjà, sélectionnez-le dans la liste ou renseignez un autre nom")
       end
     end
   end

--- a/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
@@ -1,15 +1,16 @@
 RSpec.describe "territory admin can manage services", type: :feature do
   let!(:territory) { create(:territory) }
   let!(:agent) { create(:agent, role_in_territories: [territory]) }
-  let!(:service_a) { create(:service) }
-  let!(:service_b) { create(:service) }
-  let!(:service_c) { create(:service) }
 
   before do
     login_as(agent, scope: :agent)
   end
 
   describe "Listing services" do
+    let!(:service_a) { create(:service) }
+    let!(:service_b) { create(:service) }
+    let!(:service_c) { create(:service) }
+
     it "works" do
       visit edit_admin_territory_services_path(territory)
 
@@ -21,6 +22,10 @@ RSpec.describe "territory admin can manage services", type: :feature do
   end
 
   describe "Activating/Deactivating services" do
+    let!(:service_a) { create(:service) }
+    let!(:service_b) { create(:service) }
+    let!(:service_c) { create(:service) }
+
     it "works" do
       visit edit_admin_territory_services_path(territory)
       check service_a.name
@@ -38,6 +43,38 @@ RSpec.describe "territory admin can manage services", type: :feature do
         territory.reload.services.ids
       }.from([service_a.id, service_b.id]).to([service_a.id, service_c.id])
       expect(page).to have_content("Liste des services disponibles mise à jour")
+    end
+  end
+
+  describe "creating a new service" do
+    it "works" do
+      visit new_admin_territory_services_path(territory_id: territory.id)
+      fill_in "Intitulé du nouveau service", with: "Protection maternelle et infantile"
+      fill_in "Intitulé court du nouveau service", with: "PMI"
+      expect { click_on("Ajouter le nouveau service") }.to change(Service, :count).by(1).and(change { territory.services.reload.size }.by(1))
+      expect(Service.last).to have_attributes(name: "Protection maternelle et infantile", short_name: "PMI")
+      expect(page).to have_content(%(Le service "Protection maternelle et infantile (PMI)" vient d'être créé et activé dans votre espace.))
+    end
+
+    describe "validations" do
+      it "displays error message if the names are too short or too long", type: :request do
+        post admin_territory_services_path(territory_id: territory.id), params: { service: { name: "a" } }
+        expect(response.body).to include("Le nom du service doit contenir au moins 2 caractères.")
+        expect(response.body).to include("Le nom raccourci pour les SMS doit contenir au moins 2 caractères.")
+
+        post admin_territory_services_path(territory_id: territory.id), params: { service: { name: "a" * 70, short_name: "a" * 50 } }
+        expect(response.body).to include("Le nom du service ne doit pas dépasser 60 caractères.")
+        expect(response.body).to include("Le nom raccourci pour les SMS ne doit pas dépasser 40 caractères.")
+      end
+
+      it "displays error message if the name already exists" do
+        create(:service, name: "Protection maternelle et infantile")
+        visit new_admin_territory_services_path(territory_id: territory.id)
+        fill_in "Intitulé du nouveau service", with: "Protection maternelle et infantile"
+        fill_in "Intitulé court du nouveau service", with: "PMI"
+        click_on("Ajouter le nouveau service")
+        expect(page).to have_content("Le nom du service est déjà présent dans la liste de services existants")
+      end
     end
   end
 end


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6455.osc-secnum-fr1.scalingo.io/)

```
alain.mairie@rdv-mairie-demo.fr
```

```
Rdvservicepublictest1!
```

# Contexte

Nous recevons régulièrement des demandes au support d'agent qui souhaitent ajouter un nouveau service à la liste.

Nous ajoutons donc ici une feature qui permet à un admin d'espace d'ajouter un service à la liste.

La spec, conçue en trio avec @mekaidmekaid et @Teodora-Stanki est la suivante : 
- la page qui liste les services d'un espace offre un nouveau lien vers un formulaire de création
- ce formulaire permet de créer un nouveau service et de le lier automatiquement à l'espace
- ce formulaire respecte les validations courantes sur les services : nom de 60 chars max, nom court de 40 chars max, nom unique en ignorant la casse (minuscules / majuscules)

## Maquettes

https://www.figma.com/design/qKzmEmKOb11pRjnzJthXQV/Interface-Agent?node-id=1607-5137&p=f&t=eUgKhYsQ1S7BwAQD-0

<img width="1324" height="1177" alt="image" src="https://github.com/user-attachments/assets/6aadd85d-dea2-46d2-8825-83d7a4fb2cdb" />

## La suite

Comme convenu avec le trio, la prochaine étape consistera à ajouter un filtre sur la liste des services afin de les trouver plus facilement : 

<img width="2056" height="1262" alt="image" src="https://github.com/user-attachments/assets/f525b382-939c-47a1-93a0-7ed1c1473304" />

# Solution

Rien d'exotique dans l'implémentation : un simple formulaire Rails moderne (`form_with` plutôt que du SimpleForm), et un tout petit peu de logique dans le controller afin de lier à l'espace courant le service nouvellement créé. 

### Nommage des champs

Jusqu'ici, les services ont toujours eu un "Nom" et un "Nom court". Ici on envisage d'utiliser des `<label>` "Intitulé du nouveau service" et "Intitulé court du nouveau service". Le trio est en cours de réflexion sur le meilleur choix pour la cohérence.

## Captures d'écran

Avant | Après
:- | -:
<img width="1094" height="237" alt="image" src="https://github.com/user-attachments/assets/3fd36094-a557-4bfe-b991-2ababb71275a" />| <img width="1017" height="234" alt="image" src="https://github.com/user-attachments/assets/2476b872-c462-4001-8037-07271734fbc4" />
N/A | <img width="1104" height="876" alt="image" src="https://github.com/user-attachments/assets/7e13fee9-d744-4dd4-8faf-fcf79703084a" />



