### PR TITLE
Refactos de css pour limiter la dépendance à bootstrap

### DIFF
--- a/app/javascript/stylesheets/components/_calendar.scss
+++ b/app/javascript/stylesheets/components/_calendar.scss
@@ -39,7 +39,7 @@ $rdvs-fc-header-bg-color: $gray-200;
     &.fc-button:active {
       color: var(--blue-france-sun-113-625);
       background-color: white;
-      border: 1px solid #000091;
+      border: 1px solid var(--blue-france-sun-113-625);
       margin: -1px; // Pour compenser le changement de taille causé par le border
       border-radius: 4px;
     }

--- a/app/javascript/stylesheets/components/_forms.scss
+++ b/app/javascript/stylesheets/components/_forms.scss
@@ -170,11 +170,6 @@ input:placeholder-shown {
   font-style: italic;
 }
 
-.big-label {
-  color: $blue;
-  font-size: 1.5rem;
-}
-
 .rdv-legible-code-form input[type="text"] {
   text-transform: uppercase;
   letter-spacing: 1rem;

--- a/app/javascript/stylesheets/components/_rdv_status.scss
+++ b/app/javascript/stylesheets/components/_rdv_status.scss
@@ -29,10 +29,6 @@ $status_colors: (
   }
 }
 
-.text-primary-blue {
-  color: $blue;
-}
-
 .rdv-status-print {
   display: flex;
   align-items: center;

--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -65,7 +65,7 @@ a[disabled] {
 }
 
 .rdv-color-active-blue {
-  color: var(--background-active-blue-france);
+  color: var(--text-action-high-blue-france);
 }
 
 // GRID

--- a/app/javascript/stylesheets/structure/_authentication.scss
+++ b/app/javascript/stylesheets/structure/_authentication.scss
@@ -23,15 +23,6 @@
     @include media-breakpoint-up(lg) {
       padding: 6rem 3rem 0rem 3rem;
     }
-
-    body.agents & {
-      background-color: $blue;
-      color: $white;
-      .agent-profile {
-        border: 3px solid $white;
-        border-radius: 100%;
-      }
-    }
   }
   .auth-fluid-left--agent-preferences {
     @include media-breakpoint-up(lg) {

--- a/app/javascript/stylesheets/structure/_footer.scss
+++ b/app/javascript/stylesheets/structure/_footer.scss
@@ -1,22 +1,3 @@
-// common : users & agents
-footer {
-  color: $blue;
-  text-decoration: none;
-  h2 {
-    font-size: 1.125rem;
-  }
-}
-
-// only used for users
-footer.main-footer {
-  padding: 3rem 0 0;
-  .brand {
-    font-weight: 800;
-    font-size: 1.7rem;
-    color: #222;
-    margin-bottom: 20px;
-  }
-}
 @media (max-width: 991px) {
   footer.main-footer {
     padding: 100px 0 0;

--- a/app/javascript/stylesheets/structure/_header.scss
+++ b/app/javascript/stylesheets/structure/_header.scss
@@ -57,7 +57,7 @@ a[href].link-dsfr {
   font-weight: 500;
 
   line-height: 1.5rem;
-  color: $blue;
+  color: var(--text-action-high-blue-france);
   border: 2px solid transparent;
 
   &:hover {

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -41,8 +41,8 @@
       &.active {
         border-left-width: 2px;
         border-left-style: solid;
-        border-left-color: $blue;
-        color: $blue;
+        border-left-color:  var(--text-action-high-blue-france);
+        color: var(--text-action-high-blue-france);
       }
 
       &.side-menu__item--small {

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -41,7 +41,7 @@
       &.active {
         border-left-width: 2px;
         border-left-style: solid;
-        border-left-color:  var(--text-action-high-blue-france);
+        border-left-color: var(--text-action-high-blue-france);
         color: var(--text-action-high-blue-france);
       }
 

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -28,7 +28,7 @@ turbo-frame.card.rdv-item[id= "rdv-#{rdv.id}" target="_top"]
             = link_to("Voir sur #{rdv.rdv_plan.oauth_application&.name}", rdv.rdv_plan&.dossier_url, target: :_blank, class: "fr-btn fr-btn--tertiary fr-mb-2w")
         .d-flex.justify-content-between.flex-wrap.mb-1
           p.card-text
-            = calendar_icon(class: "text-primary-blue fr-mr-1w")
+            = calendar_icon(class: "rdv-color-active-blue fr-mr-1w")
             = rdv_starts_at_and_duration(rdv, :time_only)
             - if rdv.agents.first
               |&nbsp;
@@ -46,7 +46,7 @@ turbo-frame.card.rdv-item[id= "rdv-#{rdv.id}" target="_top"]
   - if rdv.users.any?
     div class=("users-details collapse fr-mx-3w fr-mb-0")
       h5.fr-mb-2w
-        = icon("fr-icon-team-fill", class: "text-primary-blue fr-mr-1w")
+        = icon("fr-icon-team-fill", class: "rdv-color-active-blue fr-mr-1w")
         |> Participants&nbsp;:
       .fr-grid-row.fr-grid-row--gutters
         - rdv.users.sort_by { _1.last_name.downcase }.each do |user|

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -2,16 +2,16 @@
 
 - if rdv.phone?
   p.card-text
-    = phone_icon(class: "text-primary-blue fr-mr-1w")
+    = phone_icon(class: "rdv-color-active-blue fr-mr-1w")
     = display_user_phone_number_for_rdv(rdv, current_agent)
 - elsif rdv.motif.visio?
   p.card-text.mb-0
-    = visio_icon(class: "text-primary-blue fr-mr-1w")
+    = visio_icon(class: "rdv-color-active-blue fr-mr-1w")
     |> Par visioconférence
     = link_to("démarrer la visioconférence ", rdv.visio_url, target: :_blank)
 - else
   .d-flex.mb-1
-    = location_type_icon(rdv.motif.location_type, class: "text-primary-blue fr-mr-1w")
+    = location_type_icon(rdv.motif.location_type, class: "rdv-color-active-blue fr-mr-1w")
     - if rdv.home?
       |> RDV à domicile&nbsp;:
       = human_location(rdv)
@@ -19,7 +19,7 @@
       = human_location(rdv)
 
 .d-flex.card-text.fr-mt-3w
-  = user_icon(class: "text-primary-blue fr-mr-1w")
+  = user_icon(class: "rdv-color-active-blue fr-mr-1w")
   div
     = "Agent".pluralize(rdv.agents.size)
     |> &nbsp;:
@@ -28,17 +28,17 @@
 / Puis on affiche les informations sur ce qui va se passer pendant le rendez-vous : le motif et les éléments de contexte
 
 .d-flex.fr-mb-1w.fr-mt-3w
-  = motif_icon(class: "text-primary-blue fr-mr-1w")
+  = motif_icon(class: "rdv-color-active-blue fr-mr-1w")
   |> Motif&nbsp;:
   = motif_name_with_status(rdv.motif)
 
 - if rdv.created_by_user?
   p
-    = icon("fr-icon-global-line", class: "text-primary-blue fr-mr-1w")
+    = icon("fr-icon-global-line", class: "rdv-color-active-blue fr-mr-1w")
     | RDV pris sur Internet
 
 - if current_organisation.territory.enable_context_field
-  = icon("fr-icon-message-2-line", class: "text-primary-blue fr-mr-1w")
+  = icon("fr-icon-message-2-line", class: "rdv-color-active-blue fr-mr-1w")
   - if rdv.context.blank?
     i= t(".empty_context")
   - else

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -62,18 +62,18 @@
       div
         - case rdv.motif.location_type.to_sym
         - when :visio
-          = visio_icon(class: "text-primary-blue fr-mr-1w")
+          = visio_icon(class: "rdv-color-active-blue fr-mr-1w")
           |> RDV par visioconférence
           span[style="line-break: anywhere;"]
             = rdv.visio_url
         - when :phone
-          = phone_icon(class: "text-primary-blue fr-mr-1w")
+          = phone_icon(class: "rdv-color-active-blue fr-mr-1w")
           |> RDV par téléphone
           - rdv.participations.filter_map { |p| p.user.user_to_notify&.phone_number_formatted }.each do |phone_number|
             |> -
             = phone_number
         - else
-            = icon("fr-icon-map-pin-2-fill", class: "text-primary-blue fr-mr-1w")
+            = icon("fr-icon-map-pin-2-fill", class: "rdv-color-active-blue fr-mr-1w")
             = human_location(rdv)
 
       div

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -6,20 +6,20 @@ header.header.bg-white
     = link_to root_path, class: "header-brand ml-4" do
       = image_tag current_domain.dark_logo_path, alt: current_domain.name, class: "logo-dsfr logo-dsfr--compactable"
     button.navbar-toggler.navbar-toggler-right aria-controls="navbarSupportedContent" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarSupportedContent" data-toggle="collapse" type="button"
-      i.fr-icon-menu-fill.text-primary-blue
+      i.fr-icon-menu-fill.rdv-color-active-blue
     #navbarSupportedContent.collapse.navbar-collapse
       ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
         li.list-inline-item
           - if current_domain.rdv_service_public?
-            = link_to "Donnez votre avis", "https://tally.so/r/obBope", class: "btn text-primary-blue link-dsfr", target: "_blank"
+            = link_to "Donnez votre avis", "https://tally.so/r/obBope", class: "btn rdv-color-active-blue link-dsfr", target: "_blank"
           - elsif current_domain == Domain::RDV_SOLIDARITES
-            = link_to "Donnez votre avis", "https://tally.so/r/5BkP56", class: "btn text-primary-blue link-dsfr", target: "_blank"
+            = link_to "Donnez votre avis", "https://tally.so/r/5BkP56", class: "btn rdv-color-active-blue link-dsfr", target: "_blank"
           - else
-            = link_to "Donnez votre avis", "https://tally.so/r/0QMR5N", class: "btn text-primary-blue link-dsfr", target: "_blank"
+            = link_to "Donnez votre avis", "https://tally.so/r/0QMR5N", class: "btn rdv-color-active-blue link-dsfr", target: "_blank"
 
         = render "layouts/rdv_a_renseigner", organisation: defined?(current_organisation) && current_organisation
         li.list-inline-item
-          = link_to agents_blog_posts_path, class: "btn text-primary-blue link-dsfr d-flex justify-content-center", data: { modal: true } do
+          = link_to agents_blog_posts_path, class: "btn rdv-color-active-blue link-dsfr d-flex justify-content-center", data: { modal: true } do
             | Nouveautés
             - if BlogPost.new_content_for_agent?(current_agent)
               .ml-1.fr-badge.fr-badge--new.fr-badge--sm.fr-pl-3v

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -1,6 +1,6 @@
 /# locals: (home_path: root_path)
 
-footer.fr-footer.main-footer.fr-pb-12w#footer[role="contentinfo"]
+footer.fr-footer.main-footer#footer[role="contentinfo"]
   .fr-container
     .fr-footer__body
       .fr-footer__brand.fr-enlarge-link

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -5,7 +5,7 @@ nav.left-side-menu-wrapper
         a.d-flex.align-items-center data-toggle="collapse" href="#menu-agent"
           span> Menu
           span.h3.ml-1
-            = icon("fr-icon-menu-fill", class: "text-primary-blue")
+            = icon("fr-icon-menu-fill", class: "rdv-color-active-blue")
     - if content_for? :side_nav_menu
       = yield :side_nav_menu
     - else

--- a/app/views/layouts/_rdv_a_renseigner.html.slim
+++ b/app/views/layouts/_rdv_a_renseigner.html.slim
@@ -5,6 +5,6 @@
   - organisation_id = organisation&.id || current_agent.rdvs.a_renseigner.first&.organisation_id
   - if organisation_id
     li.list-inline-item.fr-mr-2w
-      = link_to a_renseigner_admin_organisation_rdvs_path(organisation_id), class: "btn text-primary-blue link-dsfr" do
+      = link_to a_renseigner_admin_organisation_rdvs_path(organisation_id), class: "btn rdv-color-active-blue link-dsfr" do
         span.fr-icon--sm.fr-mr-1v.fr-icon-warning-fill[aria-hidden="true"]
         = "#{current_agent.unknown_past_rdv_count} RDV à renseigner"


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6457.osc-secnum-fr1.scalingo.io/)

(Je suis off aujourd'hui, mais j'ouvre cette pr en tant que contributeur open source)

On a commencé à utiliser le dsfr côté agent, mais on inclut encore beaucoup de CSS de Boostrap. A terme, on voudrait avoir uniquement le dsfr, et éventuellement quelques customisations, mais pas tout bootstrap.

Cette PR propose don quelques refactos pour moins dépendre de la variable scss `$blue` définie dans la config bootstrap, en la remplaçant par `var(--text-action-high-blue-france)`.

Le rendu ne change pas, puisque la valeur est la même (on avait changé la config bootstrap pour se rapprocher progressivement du dsfr).

Au passage, on nettoie un peu de vieux css, et on privilégie l'usage de la nouvelle classe `.rdv-color-active-blue` plutôt que l'ancien `.text-primary-blue`.

Seul changement visible : Pour une raison qui m'échappe on avait un énorme padding sous le footer dans l'interface usagers (c'est présent depuis la première version de ce composant). Je l'ai supprimé vu qu'il n'est pas censé être là dans la version dsfr du footer, et j'ai vraiment du mal à trouver pourquoi on voudrait avoir ça.
