### PR TITLE
Ignorer les benign errors quand on crée une plage par API

### DIFF
--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
   before_action :authenticate_agent
   before_action :log_api_call_in_database
   before_action :set_paper_trail_whodunnit
+  before_action :set_sentry_context
 
   def pundit_user
     AgentOrganisationContext.new(current_agent, current_organisation)
@@ -126,6 +127,10 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
 
   def user_for_paper_trail
     "#{current_agent.name_for_paper_trail} (via API)"
+  end
+
+  def set_sentry_context
+    Sentry.set_user(id: current_agent.id, email: current_agent.email)
   end
 
   def log_api_call_in_database

--- a/app/controllers/api/v1/plage_ouvertures_controller.rb
+++ b/app/controllers/api/v1/plage_ouvertures_controller.rb
@@ -30,6 +30,7 @@ class Api::V1::PlageOuverturesController < Api::V1::AgentAuthBaseController
 
     authorize(plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
     plage_ouverture.transaction do
+      plage_ouverture.ignore_benign_errors = true
       plage_ouverture.save!
 
       if params[:external_reference].present?

--- a/spec/requests/api/v1/plage_ouvertures_spec.rb
+++ b/spec/requests/api/v1/plage_ouvertures_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Plage ouvertures API" do
     end
 
     it "creates the plage_ouverture" do
-      expect { post "/api/v1/plage_ouvertures", headers:, params:, as: :json }.to change(PlageOuverture, :count)
+      expect { post "/api/v1/plage_ouvertures", headers:, params:, as: :json }.to change(PlageOuverture, :count).by(1)
 
       expect(response.status).to eq 200
       expect(parsed_response_body["title"]).to eq "Dispo"
@@ -42,6 +42,13 @@ RSpec.describe "Plage ouvertures API" do
         lieu_id: lieu.id,
         motif_ids: [motif.id]
       )
+    end
+
+    context "quand le la plage a une benign_error" do
+      it "les ignore et crée la plage" do
+        _existing_plage_at_the_same_time = create(:plage_ouverture, agent:, **params.slice(:first_day, :start_time, :end_time, :organisation_id))
+        expect { post "/api/v1/plage_ouvertures", headers:, params:, as: :json }.to change(PlageOuverture, :count).by(1)
+      end
     end
 
     context "quand on ne trouve pas le lieu par l'external id" do


### PR DESCRIPTION
# Contexte

Nous avons une erreur ce matin dans le job qui copie la config d'un agent (conseiller numérique à la bibliothèque de Rennes). Lorsque le job appelle l'API de création de plage de RDV-SP, le `save!` échoue et on renvoie un 422 avec l'erreur suivante en body : 

> {"errors":{"_benign":[{"error":"Conflit de dates et d'horaires avec d'autres plages d'ouvertures"}]},"error_messages":["_benign Conflit de dates et d'horaires avec d'autres plages d'ouvertures"]}

https://sentry.incubateur.net/organizations/betagouv/issues/288723

# Solution

Je propose d'ignorer les benign errors lorsque l'on crée une plage par API.

Il faudra peut-être faire de même pour d'autres modèles, mais pour l'instant je le fais sur les plages pour débloquer l'agent au plus vite.

Note : au passage j'ajoute l'agent en contexte dans le logging Sentry dans notre classe mère `Api::V1::AgentAuthBaseController`.