### PR TITLE
Remplace les ACR custom ProConnect par des ACR standards

### DIFF
--- a/app/services/pro_connect_open_id_client/auth.rb
+++ b/app/services/pro_connect_open_id_client/auth.rb
@@ -2,7 +2,7 @@
 module ProConnectOpenIdClient
   class Auth
     SCOPES = "openid email given_name usual_name siret idp_id".freeze
-    ACR_FOR_2FA = %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa].freeze
+    ACR_FOR_2FA = %w[eidas0-mfa eidas1-mfa eidas2 eidas3].freeze
 
     def initialize(client_id:, client_secret:, login_hint: nil, prompt: nil)
       @login_hint = login_hint

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ProConnectController do
           id_token: {
             acr: {
               essential: false,
-              values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
+              values: %w[eidas0-mfa eidas1-mfa eidas2 eidas3],
             },
           },
         }.to_json
@@ -49,7 +49,7 @@ RSpec.describe ProConnectController do
             id_token: {
               acr: {
                 essential: false,
-                values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
+                values: %w[eidas0-mfa eidas1-mfa eidas2 eidas3],
               },
             },
           }.to_json
@@ -78,7 +78,7 @@ RSpec.describe ProConnectController do
           id_token: {
             acr: {
               essential: true,
-              values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
+              values: %w[eidas0-mfa eidas1-mfa eidas2 eidas3],
             },
           },
         }.to_json
@@ -277,7 +277,7 @@ RSpec.describe ProConnectController do
                                                                           id_token: {
                                                                             acr: {
                                                                               essential: true,
-                                                                              values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
+                                                                              values: %w[eidas0-mfa eidas1-mfa eidas2 eidas3],
                                                                             },
                                                                           },
                                                                         }.to_json)

--- a/spec/features/agents/account/proconnect_silent_login_spec.rb
+++ b/spec/features/agents/account/proconnect_silent_login_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Agent is automatically logged in with pro connect" do
           id_token: {
             acr: {
               essential: false,
-              values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
+              values: %w[eidas0-mfa eidas1-mfa eidas2 eidas3],
             },
           },
         }.to_json
@@ -157,7 +157,7 @@ RSpec.describe "Agent is automatically logged in with pro connect" do
           id_token: {
             acr: {
               essential: false,
-              values: %w[eidas2 eidas3 https://proconnect.gouv.fr/assurance/consistency-checked-2fa https://proconnect.gouv.fr/assurance/self-asserted-2fa],
+              values: %w[eidas0-mfa eidas1-mfa eidas2 eidas3],
             },
           },
         }.to_json

--- a/spec/support/pro_connect_stubs.rb
+++ b/spec/support/pro_connect_stubs.rb
@@ -11,7 +11,7 @@ module ProConnectStubs
     stub_and_run_discover_request
 
     if with_2fa
-      stub_token_request(code, acr: "https://proconnect.gouv.fr/assurance/self-asserted-2fa", host:)
+      stub_token_request(code, acr: "eidas0-mfa", host:)
     else
       stub_token_request(code, host:)
     end


### PR DESCRIPTION
Nous rencontrons depuis cette après-midi cette erreur lors de connexions ProConnect **avec** 2FA : 

 - code erreur : Y020032 (AuthorizationResponseErrorException)
- id erreur : c74645a5-419a-4af4-a6de-10959f1eeb70
- message erreur : "access_denied (none of the requested ACRs could be obtained)" 

Après consultation du support ProConnect, nous avons eu une réponse en privé : 

> Nous avons ce midi effectué une mise à jour de nos attibuts ACR de notre MFA. [...]
> 
> Actuellement, les connexions MFA donnent lieu à des erreurs, car nous avons modifié nos ACR pour les remplacer par les nouveaux standards.
> 
> Pour résoudre, c'est relativement simple : il faut remplacer les acr `https://proconnect.gouv.fr/assurance/self-asserted-2fa` et `https://proconnect.gouv.fr/assurance/consistency-checked-2fa` par `eidas0-mfa` et `eidas1-mfa`. Plus de détails dans notre doc : https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/double_authentification

Je remplace donc ici les valeurs custom par les nouvelles valeurs standard.