### PR TITLE
Simplification du rdv wizard pour les rendez-vous téléphoniques

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -42,6 +42,8 @@ module RdvsHelper
   end
 
   def human_location(rdv)
+    return "" if rdv.phone? || rdv.visio?
+
     text = rdv.full_address
     text = safe_join([text, "Adresse non renseignée"], " - ") if rdv.address.blank?
     safe_join([text, unavailability_tag(rdv.lieu)])

--- a/app/views/admin/creneaux_search/_slots.html.slim
+++ b/app/views/admin/creneaux_search/_slots.html.slim
@@ -28,7 +28,7 @@ div id="creneaux-lieu-#{lieu&.id}"
                     span.strong.font-weight-bold= l(creneau.starts_at, format: "%H:%M")
                     br
                     = user_icon(class:  "fr-icon--sm fr-mr-1w #{agent_color(agents.index(creneau.agent))}")
-                    small.text-dark= creneau.agent.short_name
+                    small.fr-text-default--grey= creneau.agent.short_name
 
     - if next_availability
       - if form.date_range.end < next_availability.starts_at.to_date && creneaux.empty?

--- a/app/views/admin/rdv_wizard_steps/_card.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_card.html.slim
@@ -4,5 +4,5 @@
     .card
       - if local_assigns[:previous_steps]
         = render "admin/rdv_wizard_steps/stepper", rdv_wizard_form: rdv_wizard_form, steps: previous_steps
-      .card-body.px-3
+      .card-body.fr-p-2w
         = yield

--- a/app/views/admin/rdv_wizard_steps/_stepper.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_stepper.html.slim
@@ -1,15 +1,8 @@
 ul.list-group.list-group-flush
   - steps.each do |step|
-    - if step[:value].present?
-      li.list-group-item.hover-bg-light.px-3
-        = link_to rdv_wizard_form.path_for_step(step[:step]), class: "text-dark" do
-          .d-flex.align-items-center
-            = icon("fr-icon-success-line", class: "fr-icon--sm fr-mr-1w")
-            div.flex-shrink-0.mr-1= t("admin.rdv_wizard_steps.step#{step[:step]}.step_title")
-            div.text-muted.text-truncate= step[:value]
-    - else
-      li.list-group-item.px-3
-        .d-flex.align-items-center
-          = icon("fr-icon-success-line", class: "fr-icon--sm fr-mr-1w")
-          div.flex-shrink-0.mr-1= t("admin.rdv_wizard_steps.step#{step[:step]}.step_title")
-          div.text-muted.text-truncate= step[:value]
+    li.list-group-item.hover-bg-light.fr-p-0
+      = link_to rdv_wizard_form.path_for_step(step[:step]) do
+        .d-flex.align-items-center.fr-p-2w
+          = icon("fr-icon-success-line", class: "fr-icon--sm fr-mr-1w fr-text-mention--grey")
+          div.fr-text-mention--grey.flex-shrink-0.mr-1= t("admin.rdv_wizard_steps.step#{step[:step]}.step_title")
+          div.text-dark.text-truncate= step[:value]

--- a/app/views/admin/rdv_wizard_steps/_stepper.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_stepper.html.slim
@@ -5,4 +5,4 @@ ul.list-group.list-group-flush
         .d-flex.align-items-center.fr-p-2w
           = icon("fr-icon-success-line", class: "fr-icon--sm fr-mr-1w fr-text-mention--grey")
           div.fr-text-mention--grey.flex-shrink-0.mr-1= t("admin.rdv_wizard_steps.step#{step[:step]}.step_title")
-          div.text-dark.text-truncate= step[:value]
+          div.fr-text-default--grey.text-truncate= step[:value]

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -31,8 +31,6 @@ ruby:
               = t(".existing_lieu_hint_html")
       - elsif @rdv.home?
         = f.dsfr_text_field :address, label: "Lieu (RDV à domicile)", disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}", data: { "address-autocomplete": "on" }, dir: "ltr"
-      - elsif @rdv.phone?
-        = f.dsfr_text_field :address, label: "Lieu (RDV téléphonique)", disabled: true, hint: "Il n'y a pas d'adresse car le RDV est téléphonique", data: { "address-autocomplete": "on" }, dir: "ltr"
       .fr-input-group
         = f.label :agents, class: "fr-label"
         = f.select :agent_ids, @rdv.motif.authorized_agents.collect { |a| [a.reverse_full_name_and_service, a.id] }, {}, multiple: true, class: "select2-input fr-select", data: { "auto-select-sole-option": true }

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -1,5 +1,5 @@
 .text-center.m-auto
-  h4.text-dark-50.text-center.mt-0.font-weight-bold.mb-4 Définir mon mot de passe
+  h4.fr-text-title--grey.text-center.mt-0.font-weight-bold.mb-4 Définir mon mot de passe
 
 - if @from_confirmation
   p.text-muted Pour finaliser votre inscription, veuillez définir un mot de passe.

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,6 +1,6 @@
 = form_for resource, as: resource_name, url: password_path(resource_name), builder: Dsfr::FormBuilder do |f|
   .text-center.w-75.m-auto
-    h4.text-dark-50.text-center.mt-0.font-weight-bold Mot de passe oublié ?
+    h2.fr-h4.text-center.fr-mt-0 Mot de passe oublié ?
     p.text-muted.mb-4 Entrez votre email pour recevoir un lien de réinitialisation de mot de passe
   = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr", required: true, autofocus: true, autocomplete: "email"
   .text-center

--- a/app/views/layouts/application_agent_config.html.slim
+++ b/app/views/layouts/application_agent_config.html.slim
@@ -60,7 +60,7 @@ html lang="fr"
                   = render "layouts/flash"
                   - if content_for :title
                     .text-center.m-auto
-                      h1.card-title.text-dark-50.text-center.mt-0.font-weight-bold.mb-4
+                      h1.fr-h3.text-center.fr-mt-0.fr-mb-3w
                         = content_for :title
 
                   = yield


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="771" height="529" alt="Screenshot 2026-06-19 at 10 41 27" src="https://github.com/user-attachments/assets/707b15b3-81ba-4856-a05e-648442d0baab" />|<img width="798" height="427" alt="Screenshot 2026-06-19 at 10 41 03" src="https://github.com/user-attachments/assets/bb0818e2-905b-4a09-ad96-d83ea3d31994" />

On fait une toute petite simplification sur le rdv wizard : on arrête d'afficher un champs "Lieu" désactivé pour les rendez-vous téléphoniques (et quelques autres améliorations marginales)
