### PR TITLE
Afficher le bon message d’erreur quand le créneau n’est plus dispo

### DIFF
--- a/app/controllers/concerns/can_have_rdv_wizard_context.rb
+++ b/app/controllers/concerns/can_have_rdv_wizard_context.rb
@@ -18,8 +18,11 @@ module CanHaveRdvWizardContext
     return if rdv_wizard.motif&.follow_up?
 
     if rdv_wizard.creneau.blank?
-      @stale_rdv_wizard = rdv_wizard
       session.delete(:user_return_to)
+      redirect_to(
+        prendre_rdv_path(rdv_wizard.to_query),
+        flash: { error: "Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement." }
+      )
       return
     end
 

--- a/app/controllers/concerns/can_have_rdv_wizard_context.rb
+++ b/app/controllers/concerns/can_have_rdv_wizard_context.rb
@@ -3,34 +3,48 @@ module CanHaveRdvWizardContext
 
   included do
     before_action :set_rdv_wizard_from_devise_return_path
+    before_action :redirect_if_creneau_unavailable
   end
 
   def set_rdv_wizard_from_devise_return_path
-    return if session[:user_return_to].blank?
+    @rdv_wizard = rdv_wizard_from_session if rdv_wizard_from_session&.creneau.present?
+  end
 
-    parsed_uri = URI.parse(session[:user_return_to])
-    return if parsed_uri.path != "/users/rdv_wizard_step/new"
+  def redirect_if_creneau_unavailable
+    return unless rdv_wizard_from_session
+    return if rdv_wizard_from_session.creneau.present?
 
-    parsed_params = Rack::Utils.parse_nested_query(parsed_uri.query).to_h.symbolize_keys
-    Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: "parsed_params", data: { parsed_params:, ip: request.remote_ip }))
-    rdv_wizard = Users::RdvBuilder.new(nil, parsed_params)
-    # L'usager doit être connecté afin de voir les créneaux pour un motif de Follow Up
-    return if rdv_wizard.motif&.follow_up?
+    session.delete(:user_return_to)
+    redirect_to(
+      prendre_rdv_path(rdv_wizard_from_session.to_query),
+      flash: { error: "Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement." }
+    )
+  end
 
-    if rdv_wizard.creneau.blank?
-      session.delete(:user_return_to)
-      redirect_to(
-        prendre_rdv_path(rdv_wizard.to_query),
-        flash: { error: "Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement." }
-      )
-      return
+  private
+
+  def rdv_wizard_from_session
+    return @rdv_wizard_from_session if instance_variable_defined?(:@rdv_wizard_from_session)
+
+    @rdv_wizard_from_session = begin
+      return if session[:user_return_to].blank?
+
+      parsed_uri = URI.parse(session[:user_return_to])
+      return unless parsed_uri.path == "/users/rdv_wizard_step/new"
+
+      parsed_params = Rack::Utils.parse_nested_query(parsed_uri.query).to_h.symbolize_keys
+      Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: "parsed_params", data: { parsed_params:, ip: request.remote_ip }))
+      rdv_wizard = Users::RdvBuilder.new(nil, parsed_params)
+      # L'usager doit être connecté afin de voir les créneaux pour un motif de Follow Up
+      return if rdv_wizard.motif&.follow_up?
+
+      rdv_wizard
+    rescue ArgumentError => e
+      # on a des erreurs sur la recherche de créneau et j'aimerais avoir plus de contexte pour comprendre ce qui se passe
+      # https://sentry.incubateur.net/organizations/betagouv/issues/108784
+      Sentry.set_context(:rdv_wizard_context, { user_return_to: session[:user_return_to] })
+      Sentry.capture_exception(e)
+      nil
     end
-
-    @rdv_wizard = rdv_wizard
-  rescue ArgumentError => e
-    # on a des erreurs sur la recherche de créneau et j’aimerais avoir plus de contexte pour comprendre ce qui se passe
-    # https://sentry.incubateur.net/organizations/betagouv/issues/108784
-    Sentry.set_context(:rdv_wizard_context, { user_return_to: session[:user_return_to] })
-    Sentry.capture_exception(e)
   end
 end

--- a/app/controllers/concerns/can_have_rdv_wizard_context.rb
+++ b/app/controllers/concerns/can_have_rdv_wizard_context.rb
@@ -18,6 +18,7 @@ module CanHaveRdvWizardContext
     return if rdv_wizard.motif&.follow_up?
 
     if rdv_wizard.creneau.blank?
+      @stale_rdv_wizard = rdv_wizard
       session.delete(:user_return_to)
       return
     end

--- a/app/controllers/users/sessions_by_code_controller.rb
+++ b/app/controllers/users/sessions_by_code_controller.rb
@@ -60,10 +60,6 @@ class Users::SessionsByCodeController < ApplicationController
     else
       # Aucune fiche existante sur ce territoire : création d'une nouvelle fiche (wizard uniquement).
       # En login spontané, LoginCodeRequestForm bloque l'envoi du code si aucun compte n'existe.
-      if @stale_rdv_wizard
-        error = "Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement."
-        return redirect_to prendre_rdv_path(@stale_rdv_wizard.to_query), flash: { error: }
-      end
       return redirect_to new_user_session_path, flash: { error: "Échec de la connexion" } unless @rdv_wizard
 
       login_user(User.create_from_login_code!(email:, login_code: valid_login_code))

--- a/app/controllers/users/sessions_by_code_controller.rb
+++ b/app/controllers/users/sessions_by_code_controller.rb
@@ -60,6 +60,10 @@ class Users::SessionsByCodeController < ApplicationController
     else
       # Aucune fiche existante sur ce territoire : création d'une nouvelle fiche (wizard uniquement).
       # En login spontané, LoginCodeRequestForm bloque l'envoi du code si aucun compte n'existe.
+      if @stale_rdv_wizard
+        error = "Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement."
+        return redirect_to prendre_rdv_path(@stale_rdv_wizard.to_query), flash: { error: }
+      end
       return redirect_to new_user_session_path, flash: { error: "Échec de la connexion" } unless @rdv_wizard
 
       login_user(User.create_from_login_code!(email:, login_code: valid_login_code))

--- a/app/views/search/_nothing_to_show.html.slim
+++ b/app/views/search/_nothing_to_show.html.slim
@@ -12,7 +12,7 @@
       = render "search/nothing_to_show_invitation", context: context
     - else
       p.fr-text--bold.fr-mb-0
-        | Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.
+        | Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé. Veuillez réessayer ultérieurement.
       - if context.organisation_id.present?
         - organisation = Organisation.find(context.organisation_id)
         = render "/users/organisations/contact_info", phone_number: organisation.humanized_phone_number,  organisation: organisation

--- a/spec/controllers/users/sessions_by_code_controller_spec.rb
+++ b/spec/controllers/users/sessions_by_code_controller_spec.rb
@@ -2,14 +2,14 @@ RSpec.describe Users::SessionsByCodeController, type: :controller do
   before { request.env["devise.mapping"] = Devise.mappings[:user] }
 
   describe "#new" do
-    context "dans le contexte d'un rdv wizard, quand le créneau a été pris par quelqu'un d'autre" do
+    context "dans le contexte d'un rdv wizard, quand le créneau n'est plus disponible" do
       let(:motif) { create(:motif) }
-      let(:lieu) { create(:lieu, organisation: motif.organisation) }
       let(:rdv_builder) { instance_double(Users::RdvBuilder, motif: motif, creneau: nil, to_query: {}) }
 
       before do
+        travel_to(Time.zone.parse("2026-01-15 10:00:00"))
         allow(Users::RdvBuilder).to receive(:new).and_return(rdv_builder)
-        session[:user_return_to] = "/users/rdv_wizard_step/new?#{{ motif_id: motif.id, lieu_id: lieu.id, starts_at: 1.week.from_now }.to_query}"
+        session[:user_return_to] = "/users/rdv_wizard_step/new?motif_id=#{motif.id}"
         get :new, params: { email: "nouvel_usager@test.fr" }
       end
 
@@ -21,16 +21,16 @@ RSpec.describe Users::SessionsByCodeController, type: :controller do
   end
 
   describe "#create" do
-    context "dans le contexte d'un rdv wizard, quand le créneau a été pris par quelqu'un d'autre entre l'envoi du code et sa saisie" do
+    context "dans le contexte d'un rdv wizard, quand le créneau n'est plus disponible" do
       let(:email) { "nouvel_usager@test.fr" }
       let!(:login_code) { create(:login_code, email: email, code: "123456") }
       let(:motif) { create(:motif) }
-      let(:lieu) { create(:lieu, organisation: motif.organisation) }
       let(:rdv_builder) { instance_double(Users::RdvBuilder, motif: motif, creneau: nil, to_query: {}) }
 
       before do
+        travel_to(Time.zone.parse("2026-01-15 10:00:00"))
         allow(Users::RdvBuilder).to receive(:new).and_return(rdv_builder)
-        session[:user_return_to] = "/users/rdv_wizard_step/new?#{{ motif_id: motif.id, lieu_id: lieu.id, starts_at: 1.week.from_now }.to_query}"
+        session[:user_return_to] = "/users/rdv_wizard_step/new?motif_id=#{motif.id}"
         post :create, params: { login_code: { email:, code: "123456" } }
       end
 

--- a/spec/controllers/users/sessions_by_code_controller_spec.rb
+++ b/spec/controllers/users/sessions_by_code_controller_spec.rb
@@ -1,43 +1,43 @@
 RSpec.describe Users::SessionsByCodeController, type: :controller do
   before { request.env["devise.mapping"] = Devise.mappings[:user] }
 
-  shared_context "créneau indisponible dans le wizard" do
-    let(:mock_motif) { instance_double(Motif, follow_up?: false) }
-    let(:mock_rdv_builder) { instance_double(Users::RdvBuilder, motif: mock_motif, creneau: nil, to_query: {}) }
-
-    before do
-      session[:user_return_to] = "/users/rdv_wizard_step/new?motif_id=1&lieu_id=1&starts_at=#{1.week.from_now}"
-      allow(Users::RdvBuilder).to receive(:new).and_return(mock_rdv_builder)
-    end
-  end
-
-  shared_examples "redirection créneau indisponible" do
-    it "informe l'usager que le créneau n'est plus disponible et le redirige vers la sélection de créneau" do
-      expect(flash[:error]).to eq("Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement.")
-      expect(response).to redirect_to(prendre_rdv_path)
-    end
-  end
-
   describe "#new" do
     context "dans le contexte d'un rdv wizard, quand le créneau a été pris par quelqu'un d'autre" do
-      include_context "créneau indisponible dans le wizard"
+      let(:motif) { create(:motif) }
+      let(:lieu) { create(:lieu, organisation: motif.organisation) }
+      let(:rdv_builder) { instance_double(Users::RdvBuilder, motif: motif, creneau: nil, to_query: {}) }
 
-      before { get :new, params: { email: "nouvel_usager@test.fr" } }
+      before do
+        allow(Users::RdvBuilder).to receive(:new).and_return(rdv_builder)
+        session[:user_return_to] = "/users/rdv_wizard_step/new?#{{ motif_id: motif.id, lieu_id: lieu.id, starts_at: 1.week.from_now }.to_query}"
+        get :new, params: { email: "nouvel_usager@test.fr" }
+      end
 
-      include_examples "redirection créneau indisponible"
+      it "informe l'usager que le créneau n'est plus disponible et le redirige vers la sélection de créneau" do
+        expect(flash[:error]).to eq("Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement.")
+        expect(response.location).to include(prendre_rdv_path)
+      end
     end
   end
 
   describe "#create" do
     context "dans le contexte d'un rdv wizard, quand le créneau a été pris par quelqu'un d'autre entre l'envoi du code et sa saisie" do
-      include_context "créneau indisponible dans le wizard"
-
       let(:email) { "nouvel_usager@test.fr" }
       let!(:login_code) { create(:login_code, email: email, code: "123456") }
+      let(:motif) { create(:motif) }
+      let(:lieu) { create(:lieu, organisation: motif.organisation) }
+      let(:rdv_builder) { instance_double(Users::RdvBuilder, motif: motif, creneau: nil, to_query: {}) }
 
-      before { post :create, params: { login_code: { email:, code: "123456" } } }
+      before do
+        allow(Users::RdvBuilder).to receive(:new).and_return(rdv_builder)
+        session[:user_return_to] = "/users/rdv_wizard_step/new?#{{ motif_id: motif.id, lieu_id: lieu.id, starts_at: 1.week.from_now }.to_query}"
+        post :create, params: { login_code: { email:, code: "123456" } }
+      end
 
-      include_examples "redirection créneau indisponible"
+      it "informe l'usager que le créneau n'est plus disponible et le redirige vers la sélection de créneau" do
+        expect(flash[:error]).to eq("Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement.")
+        expect(response.location).to include(prendre_rdv_path)
+      end
     end
   end
 

--- a/spec/controllers/users/sessions_by_code_controller_spec.rb
+++ b/spec/controllers/users/sessions_by_code_controller_spec.rb
@@ -1,23 +1,43 @@
 RSpec.describe Users::SessionsByCodeController, type: :controller do
   before { request.env["devise.mapping"] = Devise.mappings[:user] }
 
+  shared_context "créneau indisponible dans le wizard" do
+    let(:mock_motif) { instance_double(Motif, follow_up?: false) }
+    let(:mock_rdv_builder) { instance_double(Users::RdvBuilder, motif: mock_motif, creneau: nil, to_query: {}) }
+
+    before do
+      session[:user_return_to] = "/users/rdv_wizard_step/new?motif_id=1&lieu_id=1&starts_at=#{1.week.from_now}"
+      allow(Users::RdvBuilder).to receive(:new).and_return(mock_rdv_builder)
+    end
+  end
+
+  shared_examples "redirection créneau indisponible" do
+    it "informe l'usager que le créneau n'est plus disponible et le redirige vers la sélection de créneau" do
+      expect(flash[:error]).to eq("Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement.")
+      expect(response).to redirect_to(prendre_rdv_path)
+    end
+  end
+
+  describe "#new" do
+    context "dans le contexte d'un rdv wizard, quand le créneau a été pris par quelqu'un d'autre" do
+      include_context "créneau indisponible dans le wizard"
+
+      before { get :new, params: { email: "nouvel_usager@test.fr" } }
+
+      include_examples "redirection créneau indisponible"
+    end
+  end
+
   describe "#create" do
     context "dans le contexte d'un rdv wizard, quand le créneau a été pris par quelqu'un d'autre entre l'envoi du code et sa saisie" do
+      include_context "créneau indisponible dans le wizard"
+
       let(:email) { "nouvel_usager@test.fr" }
       let!(:login_code) { create(:login_code, email: email, code: "123456") }
-      let(:mock_motif) { instance_double(Motif, follow_up?: false) }
-      let(:mock_rdv_builder) { instance_double(Users::RdvBuilder, motif: mock_motif, creneau: nil, to_query: {}) }
 
-      before do
-        session[:user_return_to] = "/users/rdv_wizard_step/new?motif_id=1&lieu_id=1&starts_at=#{1.week.from_now}"
-        allow(Users::RdvBuilder).to receive(:new).and_return(mock_rdv_builder)
-      end
+      before { post :create, params: { login_code: { email:, code: "123456" } } }
 
-      it "informe l'usager que le créneau n'est plus disponible et le redirige vers la sélection de créneau" do
-        post :create, params: { login_code: { email:, code: "123456" } }
-        expect(flash[:error]).to eq("Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement.")
-        expect(response).to redirect_to(prendre_rdv_path)
-      end
+      include_examples "redirection créneau indisponible"
     end
   end
 

--- a/spec/controllers/users/sessions_by_code_controller_spec.rb
+++ b/spec/controllers/users/sessions_by_code_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Users::SessionsByCodeController, type: :controller do
 
       it "informe l'usager que le créneau n'est plus disponible et le redirige vers la sélection de créneau" do
         post :create, params: { login_code: { email:, code: "123456" } }
-        expect(flash[:error]).to eq("Ce créneau n'est plus disponible. Veuillez en sélectionner un autre.")
+        expect(flash[:error]).to eq("Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement.")
         expect(response).to redirect_to(prendre_rdv_path)
       end
     end

--- a/spec/controllers/users/sessions_by_code_controller_spec.rb
+++ b/spec/controllers/users/sessions_by_code_controller_spec.rb
@@ -1,6 +1,26 @@
 RSpec.describe Users::SessionsByCodeController, type: :controller do
   before { request.env["devise.mapping"] = Devise.mappings[:user] }
 
+  describe "#create" do
+    context "dans le contexte d'un rdv wizard, quand le créneau a été pris par quelqu'un d'autre entre l'envoi du code et sa saisie" do
+      let(:email) { "nouvel_usager@test.fr" }
+      let!(:login_code) { create(:login_code, email: email, code: "123456") }
+      let(:mock_motif) { instance_double(Motif, follow_up?: false) }
+      let(:mock_rdv_builder) { instance_double(Users::RdvBuilder, motif: mock_motif, creneau: nil, to_query: {}) }
+
+      before do
+        session[:user_return_to] = "/users/rdv_wizard_step/new?motif_id=1&lieu_id=1&starts_at=#{1.week.from_now}"
+        allow(Users::RdvBuilder).to receive(:new).and_return(mock_rdv_builder)
+      end
+
+      it "informe l'usager que le créneau n'est plus disponible et le redirige vers la sélection de créneau" do
+        post :create, params: { login_code: { email:, code: "123456" } }
+        expect(flash[:error]).to eq("Ce créneau n'est plus disponible. Veuillez en sélectionner un autre.")
+        expect(response).to redirect_to(prendre_rdv_path)
+      end
+    end
+  end
+
   describe "#choix_fiche_usager" do
     context "sans cookie de sélection" do
       it "redirige vers la page de connexion avec une erreur" do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -2,14 +2,14 @@ RSpec.describe Users::SessionsController do
   describe "#new" do
     before { request.env["devise.mapping"] = Devise.mappings[:user] }
 
-    context "dans le contexte d'un rdv wizard, quand le créneau a été pris par quelqu'un d'autre" do
+    context "dans le contexte d'un rdv wizard, quand le créneau n'est plus disponible" do
       let(:motif) { create(:motif) }
-      let(:lieu) { create(:lieu, organisation: motif.organisation) }
       let(:rdv_builder) { instance_double(Users::RdvBuilder, motif: motif, creneau: nil, to_query: {}) }
 
       before do
+        travel_to(Time.zone.parse("2026-01-15 10:00:00"))
         allow(Users::RdvBuilder).to receive(:new).and_return(rdv_builder)
-        session[:user_return_to] = "/users/rdv_wizard_step/new?#{{ motif_id: motif.id, lieu_id: lieu.id, starts_at: 1.week.from_now }.to_query}"
+        session[:user_return_to] = "/users/rdv_wizard_step/new?motif_id=#{motif.id}"
       end
 
       it "informe l'usager que le créneau n'est plus disponible et le redirige vers la sélection de créneau" do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -3,18 +3,19 @@ RSpec.describe Users::SessionsController do
     before { request.env["devise.mapping"] = Devise.mappings[:user] }
 
     context "dans le contexte d'un rdv wizard, quand le créneau a été pris par quelqu'un d'autre" do
-      let(:mock_motif) { instance_double(Motif, follow_up?: false) }
-      let(:mock_rdv_builder) { instance_double(Users::RdvBuilder, motif: mock_motif, creneau: nil, to_query: {}) }
+      let(:motif) { create(:motif) }
+      let(:lieu) { create(:lieu, organisation: motif.organisation) }
+      let(:rdv_builder) { instance_double(Users::RdvBuilder, motif: motif, creneau: nil, to_query: {}) }
 
       before do
-        session[:user_return_to] = "/users/rdv_wizard_step/new?motif_id=1&lieu_id=1&starts_at=#{1.week.from_now}"
-        allow(Users::RdvBuilder).to receive(:new).and_return(mock_rdv_builder)
+        allow(Users::RdvBuilder).to receive(:new).and_return(rdv_builder)
+        session[:user_return_to] = "/users/rdv_wizard_step/new?#{{ motif_id: motif.id, lieu_id: lieu.id, starts_at: 1.week.from_now }.to_query}"
       end
 
       it "informe l'usager que le créneau n'est plus disponible et le redirige vers la sélection de créneau" do
         get :new
         expect(flash[:error]).to eq("Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement.")
-        expect(response).to redirect_to(prendre_rdv_path)
+        expect(response.location).to include(prendre_rdv_path)
       end
     end
   end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -1,4 +1,24 @@
 RSpec.describe Users::SessionsController do
+  describe "#new" do
+    before { request.env["devise.mapping"] = Devise.mappings[:user] }
+
+    context "dans le contexte d'un rdv wizard, quand le créneau a été pris par quelqu'un d'autre" do
+      let(:mock_motif) { instance_double(Motif, follow_up?: false) }
+      let(:mock_rdv_builder) { instance_double(Users::RdvBuilder, motif: mock_motif, creneau: nil, to_query: {}) }
+
+      before do
+        session[:user_return_to] = "/users/rdv_wizard_step/new?motif_id=1&lieu_id=1&starts_at=#{1.week.from_now}"
+        allow(Users::RdvBuilder).to receive(:new).and_return(mock_rdv_builder)
+      end
+
+      it "informe l'usager que le créneau n'est plus disponible et le redirige vers la sélection de créneau" do
+        get :new
+        expect(flash[:error]).to eq("Ce créneau n'est plus disponible. Veuillez en sélectionner un autre ou refaire votre recherche ultérieurement.")
+        expect(response).to redirect_to(prendre_rdv_path)
+      end
+    end
+  end
+
   describe "#create" do
     it "does not allow to login an agent anymore", type: :request do
       existing_agent = create(:agent, password: "CorrectH0rse!")

--- a/spec/features/users/online_booking/creneaux_selection_spec.rb
+++ b/spec/features/users/online_booking/creneaux_selection_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "User can select a creneau" do
 
       find("a", text: motif.name).click
 
-      expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
+      expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé. Veuillez réessayer ultérieurement.")
     end
 
     context "when the user is invited" do

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -474,23 +474,23 @@ RSpec.describe "User can search for rdvs" do
 
     it "isn't shown to the users" do
       visit root_path(departement: "92")
-      expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
+      expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé. Veuillez réessayer ultérieurement.")
 
       motif.update!(bookable_by: "everyone") # to make sure this spec isn't a false positive
 
       visit root_path(departement: "92")
-      expect(page).not_to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
+      expect(page).not_to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé. Veuillez réessayer ultérieurement.")
     end
 
     it "isn't shown to the users when bookable_by is agents_and_prescripteurs_and_invited_users" do
       motif.update!(bookable_by: "agents_and_prescripteurs_and_invited_users")
       visit root_path(departement: "92")
-      expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
+      expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé. Veuillez réessayer ultérieurement.")
 
       motif.update!(bookable_by: "everyone") # to make sure this spec isn't a false positive
 
       visit root_path(departement: "92")
-      expect(page).not_to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
+      expect(page).not_to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé. Veuillez réessayer ultérieurement.")
     end
   end
 

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -331,14 +331,14 @@ RSpec.describe "Adding a user to a collective RDV" do
         rdv.status = "revoked"
         rdv.save
         select_motif
-        expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
+        expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé. Veuillez réessayer ultérieurement.")
 
         rdv2.max_participants_count = 2
         create(:participation, rdv: rdv2)
         create(:participation, rdv: rdv2)
         rdv2.save
         visit root_path(params)
-        expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
+        expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé. Veuillez réessayer ultérieurement.")
       end
 
       it "correctly display message of participation already existing" do


### PR DESCRIPTION
# Contexte

Nous avons parfois des retours d’usagers qui ne comprenne pas pourquoi ils n’arrivent pas à se connecter avec le code envoyé par email. En investiguant, on se rend compte qu’il s’agit notamment des motifs de RDV qui sont très demandés.
Lorsque je reproduis en local, je me rends compte qu’à partir du moment où l’usager a cliqué sur le créneau souhaité, on ne vérifie plus la disponibilité de celui-ci jusqu’à la validation du code à 6 chiffres. Si le code nous est envoyé et que le créneau n’est plus disponible, on affiche alors :

<img width="874" height="195" alt="image" src="https://github.com/user-attachments/assets/51676988-1cba-4cf3-878a-45a5a02dcca8" />

# Solution

Je propose donc ici de vérifier la disponibilité du créneau à chaque étape de la connexion pendant la prise de RDV.
De plus, lorsque le créneau n’est plus disponible, je redirige l’usager vers la page de sélection de créneau, avec un message d’erreur explicite. Auparavant, l’usager était à nouveau renvoyé vers le login, donc il ne comprenait pas pourquoi il était bloqué et il ne savait pas quoi faire.

## Captures d'écran

Avant | Après
:- | -:
<img width="874" height="195" alt="image" src="https://github.com/user-attachments/assets/052821d9-34ac-449a-adfb-c053aea8ec83" /> | <img width="1207" height="545" alt="image" src="https://github.com/user-attachments/assets/9530a54c-ad7e-4fb4-a494-ddb8e27f3f09" />

