### PR TITLE
correction lien raccourci créneaux libres pour file d'attente

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -423,6 +423,11 @@ Rails.application.routes.draw do
   # tkn est obligatoire pour s'assurer qu'il est possible de se connecter
   get "r/:tkn" => "redirect#rdv_short_from_token", as: "rdv_short_from_token"
 
+  get "r/:id/cr", to: (redirect do |path_params, req|
+    query_params = format_redirect_params(req.params)
+    "users/rdvs/#{path_params[:id]}/creneaux#{query_params}"
+  end), as: "creneaux_users_rdv_short"
+
   # << REMOVE AFTER 01/01/2027
   # On préserve la route courte avec id pour la rétrocompatibilité des anciens SMS
   get "r/:id/:tkn" => "redirect#rdv_short", as: "rdv_short"
@@ -432,11 +437,6 @@ Rails.application.routes.draw do
     query_params = format_redirect_params(req.params)
     "prendre_rdv#{query_params}"
   end), as: "prendre_rdv_short"
-
-  get "r/:id/cr", to: (redirect do |path_params, req|
-    query_params = format_redirect_params(req.params)
-    "users/rdvs/#{path_params[:id]}/creneaux#{query_params}"
-  end), as: "creneaux_users_rdv_short"
 
   def format_redirect_params(params)
     # we rename the short parameter tkn

--- a/spec/requests/users/creneaux_short_link_spec.rb
+++ b/spec/requests/users/creneaux_short_link_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe "Lien court vers les créneaux d'un RDV collectif", type: :request do
+  let(:rdv) { create(:rdv) }
+  let(:token) { rdv.participations.first.restricted_auth_token }
+
+  it "redirige vers la page des créneaux avec le bon token" do
+    get "/r/#{rdv.id}/cr?tkn=#{token}"
+    expect(response).to redirect_to("/users/rdvs/#{rdv.id}/creneaux?invitation_token=#{token}")
+  end
+end


### PR DESCRIPTION
# Contexte

https://zammad10.ethibox.fr/#ticket/zoom/41452

Les usagers qui cliquent sur le lien **"Pour voir les disponibilités"** reçu dans les SMS de files d'attentes tombent sur l’erreur « Votre invitation n'est pas valide ». Il s'agit de l’URL `https://rdv.anct.gouv.fr/r/{rdv_id}/cr?tkn={token}`

Les SMS ressemblent à ça 

> RDV PMI: des créneaux se sont libérés.
> Pour voir les disponibilités: http://www.rdv-solidarites.localhost/r/8043/cr?tkn=6IL6ZCFO

## Investigation

Il y a un problème d'ordre des routes dans `config/routes.rb`. 

```ruby
get "r/:id/:tkn" => "redirect#rdv_short"   # ← définie en premier
...
get "r/:id/cr" ...                          # ← jamais atteinte
```

Rails capture donc le segment littéral `cr` comme valeur de `:tkn`, puis redirige vers :

```
/users/rdvs/12345?invitation_token=cr
```

Le vrai token (passé en query param `?tkn=…`) est totalement ignoré. La validation du token échoue car `cr` n'est pas un token valide.

## Archéologie

Il semble que ce bug ait été introduit dans la [PR #3183 Correctif pour les tokens envoyés dans les sms aux responsables](https://github.com/betagouv/rdv-service-public/pull/3183) (décembre 2022)

Cette PR a inséré `r/:id/:tkn` **avant** `r/:id/cr` (qui existait déjà depuis la PR #2197), créant le conflit.

# Solution 

- Déplacer `r/:id/cr` avant `r/:id/:tkn` dans `config/routes.rb`
- Ajout d'un test de non-régression : `spec/requests/users/creneaux_short_link_spec.rb`
