### PR TITLE
Améliorations du script pour merger des agents

### DIFF
--- a/scripts/merge_two_agents.rb
+++ b/scripts/merge_two_agents.rb
@@ -49,16 +49,25 @@ Agent.transaction do
   source.agent_teams.reload.destroy_all
 
   puts "---Merging Agent Rdvs---"
-  source.agents_rdvs.update!(agent_id: dest.id)
+  rdv_ids_already_with_dest = dest.agents_rdvs.pluck(:rdv_id)
+  source.agents_rdvs.where(rdv_id: rdv_ids_already_with_dest).destroy_all
+  source.agents_rdvs.reload.update!(agent_id: dest.id)
 
   puts "---Merging Plage Ouvertures---"
-  source.plage_ouvertures.update!(agent_id: dest.id)
+  source.plage_ouvertures.each do |po|
+    po.ignore_benign_errors = true
+    po.update!(agent_id: dest.id)
+  end
 
   puts "---Merging Referent Assignations---"
   source.referent_assignations.update!(agent_id: dest.id)
 
   puts "---Merging Sector Attributions---"
   source.sector_attributions.update!(agent_id: dest.id)
+
+  puts "---Merging Territorial Roles---"
+  source.territorial_roles.where.not(territory_id: dest.territorial_roles.pluck(:territory_id)).update!(agent_id: dest.id)
+  source.territorial_roles.reload.destroy_all
 
   puts "---Deleting Source Agent---"
 

--- a/scripts/merge_two_agents.rb
+++ b/scripts/merge_two_agents.rb
@@ -72,8 +72,8 @@ Agent.transaction do
   source.territorial_roles.reload.destroy_all
 
   puts "---Merging Exports---"
-  Export.where(agent_id: source.id).update_all(agent_id: dest.id)
-  source.instance_exports.update_all(agent_id: dest.id)
+  Export.where(agent_id: source.id).update!(agent_id: dest.id)
+  source.instance_exports.update!(agent_id: dest.id)
 
   puts "---Deleting Source Agent---"
 

--- a/scripts/merge_two_agents.rb
+++ b/scripts/merge_two_agents.rb
@@ -7,6 +7,8 @@
 # agent_territorial_access_rights
 # agent_territorial_roles
 # agents_rdvs
+# exports
+# instance_exports
 # plage_ouvertures
 # referent_assignations
 # sector_attributions
@@ -68,6 +70,10 @@ Agent.transaction do
   puts "---Merging Territorial Roles---"
   source.territorial_roles.where.not(territory_id: dest.territorial_roles.pluck(:territory_id)).update!(agent_id: dest.id)
   source.territorial_roles.reload.destroy_all
+
+  puts "---Merging Exports---"
+  Export.where(agent_id: source.id).update_all(agent_id: dest.id)
+  source.instance_exports.update_all(agent_id: dest.id)
 
   puts "---Deleting Source Agent---"
 


### PR DESCRIPTION
# Contexte

J’ai du fusionner des comptes agents en prod et j'ai reçu des erreurs

# Solution

- gérer le cas où l'agent source a déjà été ajouté à certains RDV avec l'agent target
- ignorer les erreurs bénignes des PO, comme « horaires en conflit »
- déplacer les rôles territoriaux pour éviter une erreur lors de la suppression de l'agent
- déplacer les exports