### PR TITLE
Ajout d'un mock numéro ANTS RDVSPUB020 qui a des appointments

### DIFF
--- a/app/validators/ants_pre_demande_number_status_validation.rb
+++ b/app/validators/ants_pre_demande_number_status_validation.rb
@@ -18,6 +18,14 @@ MOCK_RESPONSES = {
   "RDVSPUB010" => { status: "expired", appointments: [] },
   "RDVSPUB011" => { status: "expired", appointments: [] },
   "RDVSPUB012" => { status: "expired", appointments: [] },
+  "RDVSPUB020" => {
+    status: "validated",
+    appointments: [{
+      "management_url" => "https://gerer-rdv.com",
+      "meeting_point" => "Mairie de Sannois",
+      "appointment_date" => "2027-04-03T08:45:00",
+    }],
+  },
 }.freeze
 
 class AntsPreDemandeNumberStatusValidation < ActiveModel::Validator


### PR DESCRIPTION
# Contexte

Dans le cadre de la PR qui simplifie le parcours de prise de RDV usager, c'est pratique de pouvoir tester facilement tous les cas ANTS

# Solution

Je propose de rajouter un numéro de pré-demande mocké `RDVSPUB020` qui renvoie un statut `validated` mais des `appointments`.

(c'est le cas qui génère actuellement une erreur contournable « un RDV a déjà été réservé avec ce numéro »)