### PR TITLE
Correction d'un bug JS dans l'interface d'ajout usagers à un RDV

### DIFF
--- a/app/javascript/controllers/destroyable_controller.js
+++ b/app/javascript/controllers/destroyable_controller.js
@@ -7,9 +7,24 @@ export default class extends Controller {
   ]
 
   destroyItem = (event) => {
+    const userId = this.destroyInputTarget.closest("[data-controller=destroyable]").querySelector("input[name*=user_id]")?.value
     event.preventDefault();
     this.element.classList.add("d-none");
     this.destroyInputTarget.value = true;
+
+    if (userId) {
+      let url = new URL(window.location.href);
+      // user_ids est supporté par Admin::RdvsCollectifsController mais peut-être déprécié
+      for (const paramName of ["add_user[]", "user_ids[]"]) {
+        const userIds = url.searchParams.getAll(paramName)
+        if (userIds.includes(userId)) {
+          url.searchParams.delete(paramName, userId)
+          window.location.href = url
+          return
+        }
+      }
+    }
+
   }
 }
 


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6477.osc-secnum-fr1.scalingo.io/)

# Contexte

https://zammad10.ethibox.fr/#ticket/zoom/41284

https://github.com/user-attachments/assets/b531617d-e06f-4b13-86a1-8aaf1c34507c

Le bug se produit dans :
- l'interface d'ajout d'usager à un RDV collectif
- l'interface de modification des usagers d'un RDV classique

Pour reproduire : 
- chercher puis ajouter un usager « Jean »
- cliquer sur « supprimer » à côté de « Jean »
- chercher puis ajouter un usager « Martine »
- « Jean » a réapparu ! 

Le problème vient du fait que ce bouton supprimer en JS a été prévu uniquement pour supprimer les usagers existants sur des RDV, mais pas pour supprimer les usagers en cours d'ajout. 

# Solution

Il faut mettre à jour l’URL en modifiant les query params pour retirer le userId supprimé du param `add_user[]`

## Tests

je n'ai pas rajouté de specs car je pense qu'il faut revoir intégralement cette interface d'ajout d'usagers elle me semble vraiment bancale
