### PR TITLE
Correction du bug de retrait de catégorie sur un motif

### DIFF
--- a/app/views/admin/motifs/form/_advanced_options.html.slim
+++ b/app/views/admin/motifs/form/_advanced_options.html.slim
@@ -57,4 +57,4 @@
 - if current_territory.motif_categories.present?
   .card
     .card-body
-      = f.dsfr_select :motif_category_id, current_territory.motif_categories.collect { |motif_categorie| [motif_categorie.name, motif_categorie.id] }, label: MotifCategory.model_name.human, hint: MotifCategory.human_attribute_name("category_hint"), include_blank: "Aucune"
+      = f.dsfr_select :motif_category_id, current_territory.motif_categories.collect { |motif_categorie| [motif_categorie.name, motif_categorie.id] }, { include_blank: "Aucune" }, label: MotifCategory.model_name.human, hint: MotifCategory.human_attribute_name("category_hint")


### PR DESCRIPTION
# Contexte

Dans l'onglet « Options avancées » du formulaire de motif, il n'était plus possible de retirer la catégorie via l'option vide du select.

Le bug a été introduit lors de la création du partial `_advanced_options.html.slim` (PR #6433), qui a repris le code de `_resa_en_ligne.html.slim` dans son ancienne version — avant la correction apportée lors de la mise à jour de la gem `dsfr-form_builder` de `0.0.7` à `0.0.14` (PR #6356).

# Solution

La gem `dsfr-form_builder` distingue strictement le 3e argument positionnel (`input_options`, transmis au `select` Rails) des kwargs (`html_options`, utilisés pour les attributs HTML). `include_blank` doit donc être passé avec des accolades explicites pour atterrir dans `input_options` :

```ruby
# Avant (bugué)
f.dsfr_select :motif_category_id, choices, label: ..., hint: ..., include_blank: "Aucune"

# Après (correct)
f.dsfr_select :motif_category_id, choices, { include_blank: "Aucune" }, label: ..., hint: ...
```

