### PR TITLE
Afficher la gaufre uniquement sur rdv.numerique

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -345,4 +345,8 @@ class Agent < ApplicationRecord
 
     Organisation.joins(:agents).where(agents: { proconnect_siret: proconnect_siret }).distinct
   end
+
+  def lagaufre_access?
+    email.include?(".gouv.fr")
+  end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -345,5 +345,4 @@ class Agent < ApplicationRecord
 
     Organisation.joins(:agents).where(agents: { proconnect_siret: proconnect_siret }).distinct
   end
-
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -346,7 +346,4 @@ class Agent < ApplicationRecord
     Organisation.joins(:agents).where(agents: { proconnect_siret: proconnect_siret }).distinct
   end
 
-  def lagaufre_access?
-    email.include?(".gouv.fr")
-  end
 end

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -39,7 +39,7 @@ header.header.bg-white
             li = link_to destroy_agent_session_path, method: :delete, class: "dropdown-item-dsfr dropdown-item" do
               span.fr-icon--sm.fr-mr-2v.fr-icon-logout-box-r-line[aria-hidden="true"]
               | Se déconnecter
-        - if current_domain.rdv_service_public? && current_agent.lagaufre_access?
+        - if current_domain == Domain::RDV_SERVICE_PUBLIC_ETAT
           li.list-inline-item.fr-mr-6v.fr-mt-n1v
             = render "layouts/lagaufre_button"
 

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -39,7 +39,7 @@ header.header.bg-white
             li = link_to destroy_agent_session_path, method: :delete, class: "dropdown-item-dsfr dropdown-item" do
               span.fr-icon--sm.fr-mr-2v.fr-icon-logout-box-r-line[aria-hidden="true"]
               | Se déconnecter
-        - if current_domain == Domain::RDV_SERVICE_PUBLIC_ETAT
+        - if (current_domain.rdv_service_public? && current_agent.lagaufre_access?) || current_domain == Domain::RDV_SERVICE_PUBLIC_ETAT
           li.list-inline-item.fr-mr-6v.fr-mt-n1v
             = render "layouts/lagaufre_button"
 


### PR DESCRIPTION
# Contexte

Pour le moment, nous affichions uniquement la gaufre état. Pour ce faire, on se basait sur l’adresse email des agents.
Compte tenu de l’arrivée de rdv.numerique.gouv.fr, je pense que nous pouvons simplifier cette condition et l’afficher pour tous les agents qui sont sur le nouveau domaine.


