### PR TITLE
Correctif pour les créations de comptes sur le nouveau nom de domaine

### DIFF
--- a/app/controllers/concerns/domain_redirection_after_login.rb
+++ b/app/controllers/concerns/domain_redirection_after_login.rb
@@ -1,6 +1,4 @@
 module DomainRedirectionAfterLogin
-  protected
-
   def should_redirect_to_domain_etat?(current_domain, agent)
     organisations = agent.organisations
     current_domain == Domain::RDV_SERVICE_PUBLIC &&
@@ -15,6 +13,8 @@ module DomainRedirectionAfterLogin
       organisations.all?(&:rdv_mairie?) &&
       agent.territories_through_organisations.all?(&:operator_id)
   end
+
+  protected
 
   def redirect_target_url_in_domain(domain)
     stored_path = stored_location_for(:agent)

--- a/app/controllers/concerns/domain_redirection_after_login.rb
+++ b/app/controllers/concerns/domain_redirection_after_login.rb
@@ -10,6 +10,7 @@ module DomainRedirectionAfterLogin
   def should_redirect_to_domain_anct?(current_domain, agent)
     organisations = agent.organisations
     current_domain == Domain::RDV_SERVICE_PUBLIC_ETAT &&
+      organisations.exists? &&
       organisations.all?(&:rdv_mairie?) &&
       agent.territories_through_organisations.all?(&:operator_id)
   end

--- a/spec/controllers/concerns/domain_redirection_after_login_spec.rb
+++ b/spec/controllers/concerns/domain_redirection_after_login_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe DomainRedirectionAfterLogin do
+  subject(:controller) do
+    Object.new.extend(described_class)
+  end
+
+  context "quand l'agent n'a pas encore d'organisation" do
+    let(:agent) { create(:agent) }
+
+    context "et qu'il se connecte sur le domaine de l'état" do
+      let(:domain) { Domain::RDV_SERVICE_PUBLIC_ETAT }
+
+      it "n'est pas redirigé" do
+        expect(controller.should_redirect_to_domain_etat?(domain, agent)).to be_falsey # rubocop:disable RSpec/PredicateMatcher
+        expect(controller.should_redirect_to_domain_anct?(domain, agent)).to be_falsey # rubocop:disable RSpec/PredicateMatcher
+      end
+    end
+
+    context "et qu'il se connecte sur le domaine des collectivités" do
+      let(:domain) { Domain::RDV_SERVICE_PUBLIC }
+
+      it "n'est pas redirigé" do
+        expect(controller.should_redirect_to_domain_etat?(domain, agent)).to be_falsey # rubocop:disable RSpec/PredicateMatcher
+        expect(controller.should_redirect_to_domain_anct?(domain, agent)).to be_falsey # rubocop:disable RSpec/PredicateMatcher
+      end
+    end
+  end
+end


### PR DESCRIPTION
J'avais oublié d'ajouter la bonne condition pour faire qu'on ne soit pas redirigé vers rdv.anct si on n'a pas encore d'organisation.

Ça cause donc un léger bug : pour un agent qui se proconnecte pour la première fois sur rdv.numerique et qui n'a pas encore d'organisation, on le redirigeait vers le domaine rdv.anct.

Cette Pr ajoute donc le correctif.

J'ajoute des specs unitaires qui vont servir de base pour la PR à venir qui va permettre de faire les bonnes redirections pour les premières connexions dans les différents cas.