### PR TITLE
Ne pas appeler l’API de l’ANCT sur numerique.gouv.fr

### DIFF
--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -24,7 +24,7 @@ class Agents::PagesController < AgentAuthController
       if current_agent.possible_duplicate_organisations.empty?
         redirect_to new_agents_territory_path
       end
-    else
+    elsif current_domain != Domain::RDV_SERVICE_PUBLIC_ETAT
       redirect_via_anct_router
     end
   end

--- a/app/controllers/agents/territory_creation_requests_controller.rb
+++ b/app/controllers/agents/territory_creation_requests_controller.rb
@@ -22,6 +22,7 @@ class Agents::TerritoryCreationRequestsController < AgentAuthController
   private
 
   def redirect_if_opsn_restricted
+    return if current_domain == Domain::RDV_SERVICE_PUBLIC_ETAT
     return unless current_domain.allow_self_onboarding
     return unless current_agent.agent_territorial_access_rights.none?
 


### PR DESCRIPTION
# Contexte

Avec l’arrivée du nouveau domaine numerique.gouv.fr, il n’est pas nécessaire de faire l’appel API à l’API de l’ANCT dans le processus d’ouverture de compte.
Je propose donc de rajouter les gardes nécessaires. À terme, on pourra certainement refacto pour gérer ça différemment.

