### PR TITLE
Correction de l’import d’événement CalDAV sans DTEND

### DIFF
--- a/app/jobs/caldav/import_absences_from_caldav_job.rb
+++ b/app/jobs/caldav/import_absences_from_caldav_job.rb
@@ -69,6 +69,8 @@ module Caldav
       updated_events = updated_events.reject { _1.url.in?(urls_of_rdvs) }
 
       updated_events = updated_events.select { consider_busy?(_1) }
+      # Les événements sans DTEND (anniversaires, rappels...) ne sont pas bloquants et sont ignorés
+      updated_events = updated_events.select { _1.dtend.present? }
 
       ExternalCalendarEvent.transaction do
         hashes_to_upsert = updated_events.map do |event|
@@ -77,7 +79,7 @@ module Caldav
             agent_id: agent.id,
             url: event.url,
             starts_at: event.dtstart,
-            ends_at: event.dtend || event.dtstart,
+            ends_at: event.dtend,
             raw_ical:,
           }
         end

--- a/app/jobs/caldav/import_absences_from_caldav_job.rb
+++ b/app/jobs/caldav/import_absences_from_caldav_job.rb
@@ -77,7 +77,7 @@ module Caldav
             agent_id: agent.id,
             url: event.url,
             starts_at: event.dtstart,
-            ends_at: event.dtend,
+            ends_at: event.dtend || event.dtstart,
             raw_ical:,
           }
         end

--- a/app/services/ical/rrule_expander.rb
+++ b/app/services/ical/rrule_expander.rb
@@ -38,8 +38,9 @@ class Ical::RruleExpander
           start_time = exception_ical_event.dtstart.to_time
           next if exception_ical_event.transp == "TRANSPARENT"
           next unless start_time >= time_range.min && start_time < time_range.max
+          next if exception_ical_event.dtend.nil?
 
-          all_occurrences << Recurrence::Occurrence.new(starts_at: exception_ical_event.dtstart.in_time_zone, ends_at: (exception_ical_event.dtend || exception_ical_event.dtstart).in_time_zone)
+          all_occurrences << Recurrence::Occurrence.new(starts_at: exception_ical_event.dtstart.in_time_zone, ends_at: exception_ical_event.dtend.in_time_zone)
         end
       end
     end

--- a/app/services/ical/rrule_expander.rb
+++ b/app/services/ical/rrule_expander.rb
@@ -39,7 +39,7 @@ class Ical::RruleExpander
           next if exception_ical_event.transp == "TRANSPARENT"
           next unless start_time >= time_range.min && start_time < time_range.max
 
-          all_occurrences << Recurrence::Occurrence.new(starts_at: exception_ical_event.dtstart.in_time_zone, ends_at: exception_ical_event.dtend.in_time_zone)
+          all_occurrences << Recurrence::Occurrence.new(starts_at: exception_ical_event.dtstart.in_time_zone, ends_at: (exception_ical_event.dtend || exception_ical_event.dtstart).in_time_zone)
         end
       end
     end

--- a/spec/fixtures/vcr_cassettes/caldav/event_without_dtend.yml
+++ b/spec/fixtures/vcr_cassettes/caldav/event_without_dtend.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: report
+    uri: https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <caldav:calendar-query xmlns:dav="DAV:" xmlns:caldav="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:apple="http://apple.com/ns/ical/">
+          <dav:prop>
+            <dav:getetag/>
+            <caldav:calendar-data/>
+          </dav:prop>
+          <caldav:filter>
+            <caldav:comp-filter name="VCALENDAR">
+              <caldav:comp-filter name="VEVENT"/>
+            </caldav:comp-filter>
+          </caldav:filter>
+        </caldav:calendar-query>
+    headers:
+      Authorization: "[Filtered in vcr.rb -> before_record]"
+      Depth:
+      - '1'
+      Content-Type:
+      - application/xml; charset=utf-8
+      Connection:
+      - close
+      Host:
+      - ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 207
+      message: Multi-Status
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 26 Jan 2026 09:22:56 GMT
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie: "[Filtered in vcr.rb -> before_record]"
+      X-Robots-Tag:
+      - none
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <D:multistatus xmlns:D="DAV:" xmlns:APPLE="http://apple.com/ns/ical/" xmlns:CAL="urn:ietf:params:xml:ns:caldav" xmlns:CS="http://calendarserver.org/ns/">
+          <D:response>
+            <D:href>/dav/caldav/1234_calendar_id/a1b2c3d4-e5f6-7890-abcd-ef1234567890.ics</D:href>
+            <D:propstat>
+              <D:prop>
+                <D:getetag>1-123456-1769419251000</D:getetag>
+                <calendar-data xmlns="urn:ietf:params:xml:ns:caldav">BEGIN:VCALENDAR
+        VERSION:2.0
+        PRODID:-//Some Calendar//EN
+        BEGIN:VEVENT
+        DTSTAMP:20260126T092051Z
+        CLASS:PUBLIC
+        CREATED:20260126T092051Z
+        DTSTART;TZID=Europe/Paris:20260128T140000
+        LAST-MODIFIED:20260126T092051Z
+        SEQUENCE:0
+        SUMMARY:Réunion sans DTEND
+        TRANSP:OPAQUE
+        UID:a1b2c3d4-e5f6-7890-abcd-ef1234567890
+        END:VEVENT
+        END:VCALENDAR</calendar-data>
+              </D:prop>
+              <D:status>HTTP/1.1 200 OK</D:status>
+            </D:propstat>
+          </D:response>
+        </D:multistatus>
+  recorded_at: Mon, 26 Jan 2026 09:22:56 GMT
+recorded_with: VCR 6.4.0

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
       end
     end
 
+    it "stocke starts_at comme ends_at quand l'événement n'a pas de DTEND" do
+      VCR.use_cassette("caldav/event_without_dtend") do
+        expect { described_class.new.perform(agent.id) }.to change(ExternalCalendarEvent, :count).by(1)
+      end
+
+      event = ExternalCalendarEvent.sole
+      expect(event.starts_at).to eq(Time.zone.parse("2026-01-28 14:00"))
+      expect(event.ends_at).to eq(event.starts_at)
+    end
+
     it "ne crée pas d'événements si l'URL externe correspond à un Rdv local" do
       url_of_local_event = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/fa75d9fe-2063-465e-a323-dd8ae7589746.ics"
       url_of_legit_event = "https://ox8-oidc.ox8-oidc.osprod.dimail1.numerique.gouv.fr/dav/caldav/1234_calendar_id/6a54e0b7-93cf-43e4-a854-afd8e3d3f2c4.ics"

--- a/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
+++ b/spec/jobs/caldav/import_absences_from_caldav_job_spec.rb
@@ -55,14 +55,10 @@ RSpec.describe Caldav::ImportAbsencesFromCaldavJob do
       end
     end
 
-    it "stocke starts_at comme ends_at quand l'événement n'a pas de DTEND" do
+    it "ignore les événements sans DTEND (anniversaires, rappels...)" do
       VCR.use_cassette("caldav/event_without_dtend") do
-        expect { described_class.new.perform(agent.id) }.to change(ExternalCalendarEvent, :count).by(1)
+        expect { described_class.new.perform(agent.id) }.not_to change(ExternalCalendarEvent, :count)
       end
-
-      event = ExternalCalendarEvent.sole
-      expect(event.starts_at).to eq(Time.zone.parse("2026-01-28 14:00"))
-      expect(event.ends_at).to eq(event.starts_at)
     end
 
     it "ne crée pas d'événements si l'URL externe correspond à un Rdv local" do

--- a/spec/services/ical/rrule_expander_spec.rb
+++ b/spec/services/ical/rrule_expander_spec.rb
@@ -260,7 +260,8 @@ RSpec.describe Ical::RruleExpander do
 
   describe "recurring event with an exception that has no DTEND" do
     # Événement récurrent hebdomadaire dont une exception ne possède pas de DTEND.
-    # Selon la RFC 5545, la durée est de 0 seconde : ends_at == starts_at.
+    # L'exception sans DTEND est ignorée. Comme elle est dans exception_dates,
+    # l'occurrence du parent pour ce jour est aussi supprimée.
     let(:weekly_with_exception_without_dtend) do
       <<~ICALENDAR
         BEGIN:VCALENDAR
@@ -294,13 +295,14 @@ RSpec.describe Ical::RruleExpander do
       ICALENDAR
     end
 
-    it "ne plante pas et utilise dtstart comme ends_at pour l'exception sans DTEND" do
+    it "ignore l'exception sans DTEND et supprime aussi l'occurrence parente pour ce jour" do
       from = Time.zone.parse("2026-01-13 00:00")
       to = Time.zone.parse("2026-01-27 23:59")
       actual_recurrences = described_class.new(weekly_with_exception_without_dtend).compute_occurrences_within(from..to)
-      exception_occurrence = actual_recurrences.find { |o| o.starts_at == Time.zone.parse("2026-01-20 16:00") }
-      expect(exception_occurrence).not_to be_nil
-      expect(exception_occurrence.ends_at).to eq(Time.zone.parse("2026-01-20 16:00"))
+      expect(actual_recurrences.map { |o| o.starts_at.to_date }).to contain_exactly(
+        Date.parse("2026-01-13"),
+        Date.parse("2026-01-27")
+      )
     end
   end
 

--- a/spec/services/ical/rrule_expander_spec.rb
+++ b/spec/services/ical/rrule_expander_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Ical::RruleExpander do
     end
 
     it "return the only occurrence" do
-      from =  Time.zone.parse("2025-12-18 00:00")
-      to =    Time.zone.parse("2025-12-28 23:59")
+      from = Time.zone.parse("2025-12-18 00:00")
+      to = Time.zone.parse("2025-12-28 23:59")
       expected_recurrence = [
         Time.zone.parse("2025-12-18 14:00"),
         Time.zone.parse("2025-12-18 15:00"),
@@ -255,6 +255,52 @@ RSpec.describe Ical::RruleExpander do
       ]
       actual_recurrences = described_class.new(every_day_with_exceptions).compute_occurrences_within(from..to)
       expect(actual_recurrences.sole.to_a).to match(expected_recurrence)
+    end
+  end
+
+  describe "recurring event with an exception that has no DTEND" do
+    # Événement récurrent hebdomadaire dont une exception ne possède pas de DTEND.
+    # Selon la RFC 5545, la durée est de 0 seconde : ends_at == starts_at.
+    let(:weekly_with_exception_without_dtend) do
+      <<~ICALENDAR
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        BEGIN:VEVENT
+        DTSTAMP:20260113T143923Z
+        CLASS:PUBLIC
+        CREATED:20260113T132954Z
+        DTEND;TZID=Europe/Paris:20260113T120000
+        DTSTART;TZID=Europe/Paris:20260113T110000
+        LAST-MODIFIED:20260113T143923Z
+        RRULE:FREQ=WEEKLY;BYDAY=TU
+        SEQUENCE:0
+        SUMMARY:Weekly
+        TRANSP:OPAQUE
+        UID:bb3e11cb-fb43-4e42-b4ed-954ea11ea3fe
+        END:VEVENT
+        BEGIN:VEVENT
+        DTSTAMP:20260113T142328Z
+        CLASS:PUBLIC
+        CREATED:20260113T142328Z
+        DTSTART;TZID=Europe/Paris:20260120T160000
+        LAST-MODIFIED:20260113T142328Z
+        RECURRENCE-ID;TZID=Europe/Paris:20260120T110000
+        SEQUENCE:1
+        SUMMARY:Weekly
+        TRANSP:OPAQUE
+        UID:bb3e11cb-fb43-4e42-b4ed-954ea11ea3fe
+        END:VEVENT
+        END:VCALENDAR
+      ICALENDAR
+    end
+
+    it "ne plante pas et utilise dtstart comme ends_at pour l'exception sans DTEND" do
+      from = Time.zone.parse("2026-01-13 00:00")
+      to = Time.zone.parse("2026-01-27 23:59")
+      actual_recurrences = described_class.new(weekly_with_exception_without_dtend).compute_occurrences_within(from..to)
+      exception_occurrence = actual_recurrences.find { |o| o.starts_at == Time.zone.parse("2026-01-20 16:00") }
+      expect(exception_occurrence).not_to be_nil
+      expect(exception_occurrence.ends_at).to eq(Time.zone.parse("2026-01-20 16:00"))
     end
   end
 


### PR DESCRIPTION
# Contexte

Suite à un retour d’un agent, je me suis rendu compte que la synchro cassait pour certains agents parce qu’ils avaient dans leur agenda des événements sans DTEND, ce qui est parfaitement conforme avec la norme mais que nous ignorions jusque là.
Lors de la synchro CalDAV, certains événements non récurrents (ou exceptions de récurrences) ne contiennent pas de propriété `DTEND`. Selon la RFC 5545 (voir [ici](https://datatracker.ietf.org/doc/html/rfc5545#section-3.6.1)), un `VEVENT` avec un `DTSTART` de type DATE-TIME et sans `DTEND` ni `DURATION` a une durée de zéro secondes. Sans gestion de ce cas, on se retrouvait avec :

- un `ends_at: nil` qu’on ne pouvait pas insérer en base du fait de la contrainte de non nullité
- un `NoMethodError` dans `Ical::RruleExpander` lors de l'appel à `dtend.in_time_zone` sur une exception récurrente sans `DTEND`.

# Solution

Deux corrections ciblées :

- Dans `Caldav::ImportAbsencesFromCaldavJob` : utiliser `event.dtend || event.dtstart` pour garantir un `ends_at` non-nil en base (durée nulle = commence et finit à la même heure, conforme RFC 5545).
- Dans `Ical::RruleExpander` : même protection sur `exception_ical_event.dtend` pour éviter le crash.

Un test unitaire est ajouté pour chaque cas.

