### PR TITLE
a11y: plage d’ouverture, lien explicite

### DIFF
--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -21,11 +21,15 @@ tr
     - if plage_ouverture.overlapping_plages_ouvertures?
       .fr-alert.fr-alert--warning.fr-mt-1w
         span Conflit de dates
-        =< link_to("(voir détails)", admin_organisation_planning_plage_ouverture_path(organisation_id: organisation.id, id: plage_ouverture.id))
+        |< (
+        = link_to("voir les détails", admin_organisation_planning_plage_ouverture_path(organisation_id: organisation.id, id: plage_ouverture.id), class: "fr-link")
+        | )
     - if plage_ouverture.overflow_motifs_duration?
       .fr-alert.fr-alert--warning.fr-mt-1w
         span Certains motifs débordent sur la durée de la plage
-        =< link_to("(voir détails)", admin_organisation_planning_plage_ouverture_path(organisation_id: organisation.id, id: plage_ouverture.id))
+        |< (
+        = link_to("(voir les détails)", admin_organisation_planning_plage_ouverture_path(organisation_id: organisation.id, id: plage_ouverture.id), class: "fr-link")
+        | )
   td
     .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline
       = link_to "", edit_admin_organisation_planning_plage_ouverture_path(organisation, plage_ouverture),

--- a/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/planning/plage_ouvertures/_plage_ouverture.html.slim
@@ -28,7 +28,7 @@ tr
       .fr-alert.fr-alert--warning.fr-mt-1w
         span Certains motifs débordent sur la durée de la plage
         |< (
-        = link_to("(voir les détails)", admin_organisation_planning_plage_ouverture_path(organisation_id: organisation.id, id: plage_ouverture.id), class: "fr-link")
+        = link_to("voir les détails", admin_organisation_planning_plage_ouverture_path(organisation_id: organisation.id, id: plage_ouverture.id), class: "fr-link")
         | )
   td
     .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline


### PR DESCRIPTION
Closes #6496

# Contexte

Dans la vue planning des plages d'ouverture, les messages d'alerte "Conflit de dates" et "Certains motifs débordent sur la durée de la plage" contenaient un lien "(voir détails)" non conforme au critère RGAA 6.1 (lien explicite) : le texte était insuffisamment explicite et le lien n'était pas souligné.

# Solution

- Correction du libellé : "(voir détails)" → "(voir les détails)"
- Ajout de la classe `fr-link` sur les deux liens pour assurer le soulignement attendu par le DSFR
