### PR TITLE
a11y: correction du focus sur les éléments de navigation de l’agenda

### DIFF
--- a/app/javascript/stylesheets/components/_calendar.scss
+++ b/app/javascript/stylesheets/components/_calendar.scss
@@ -33,6 +33,15 @@ $rdvs-fc-header-bg-color: $gray-200;
       background-color: rgb(246, 246, 246);
     }
 
+    &:focus {
+      box-shadow: rgb(221, 221, 221) 0 0 0 1px inset;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $focus-dsfr;
+      outline-offset: 2px;
+    }
+
     // prend le dessus sur une règle très spécifique dans FullCalendar
     // .fc .fc-button-primary:not(:disabled).fc-button-active
     &.fc-button-active.fc-button-primary:not(:disabled),


### PR DESCRIPTION
Closes #6495

# Contexte

Les boutons de navigation de la vue agenda (« Aujourd'hui », flèches de navigation, boutons de vue mois/semaine/journée/planning, préférences d'affichage) ne montraient pas d'indicateur de focus visible lors de la navigation au clavier, en violation du critère RGAA 10.7.

FullCalendar applique ses propres styles sur `:focus` (via `box-shadow`) qui masquaient le contour natif du navigateur sans en proposer un alternatif conforme.

# Solution

Dans `_calendar.scss`, sur les `.fc-button` :

- Suppression du `box-shadow` de FullCalendar au `:focus` pour éviter l'indicateur parasite
- Ajout d'un contour `:focus-visible` de 2 px avec la couleur DSFR (`$focus-dsfr`), cohérent avec les autres éléments interactifs du projet
