### PR TITLE
Correctif de la verticale sur le nouveau nom de domaine

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -87,7 +87,7 @@ class Domain
       online_reservation_with_public_link: true,
       sms_sender_name: "RDV S.P.",
       support_email: "support@rdv-service-public.fr",
-      verticale: :rdv_mairie,
+      verticale: :rdv_etat,
       allow_self_onboarding: true,
       secretariat_email: "secretariat-auto@rdv-service-public.fr"
     ),

--- a/spec/features/autodoc/ouverture_espace/en_autonomie_spec.rb
+++ b/spec/features/autodoc/ouverture_espace/en_autonomie_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
 
     expect(Organisation.last).to have_attributes(
       name: "CCAS de Montreuil",
-      verticale: :rdv_etat
+      verticale: "rdv_etat"
     )
 
     open_email(agent.email)

--- a/spec/features/autodoc/ouverture_espace/en_autonomie_spec.rb
+++ b/spec/features/autodoc/ouverture_espace/en_autonomie_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     doc.start_section("Côté agent")
     doc.add_text("Contexte: Je suis un agent qui n'a jamais utilisé RDV Service Public")
 
-    visit "http://www.rdv-service-public-test.localhost/"
+    visit root_url(host: Domain::RDV_SERVICE_PUBLIC_ETAT.host_name)
     doc.add_screenshot(page,
                        text: "Je clique sur 'Ouvrir mon espace'",
                        wait_for: "Ouvrir mon espace")
@@ -22,7 +22,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
                        wait_for: "Pour ouvrir votre espace, commencez par vous identifier avec ProConnect.")
 
     # ProConnect ne marche pas en tests, donc on triche en faisant un login par email et mot de passe
-    visit new_agent_session_url(host:  "http://www.rdv-service-public-test.localhost")
+    visit new_agent_session_url(host:  Domain::RDV_SERVICE_PUBLIC_ETAT.host_name)
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"
@@ -38,6 +38,11 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
                        text: "J'arrive dans mon espace RDV Service Public",
                        wait_for: "Pour commencer, vous pouvez créer votre premier motif de rendez-vous.")
 
+    expect(Organisation.last).to have_attributes(
+      name: "CCAS de Montreuil",
+      verticale: :rdv_etat
+    )
+
     open_email(agent.email)
     expect(current_email.subject).to eq "Votre espace RDV Service Public est ouvert 🚀"
 
@@ -47,7 +52,7 @@ RSpec.describe "Ouverture d'un espace", ignore_js_errors: true, js: true do
     super_admin = create :super_admin
     login_as(super_admin, scope: :super_admin)
 
-    visit super_admins_accounts_for_crm_index_url(host: "http://www.rdv-service-public-test.localhost")
+    visit super_admins_accounts_for_crm_index_url(host: Domain::RDV_SERVICE_PUBLIC_ETAT.host_name)
 
     doc.add_screenshot(page,
                        text: "Le nouvel espace apparait dans la liste des comptes à ajouter au CRM.",


### PR DESCRIPTION
# Contexte

Un oubli qui a fait que https://github.com/betagouv/rdv-service-public/pull/6491 n'a pas eu d'effet : la verticale sur `Domain::RDV_SERVICE_PUBLIC_ETAT` n'était pas la bonne. 🤦 Je crois que j'ai besoin de vacances.

# Solution

Je renforce une spec existante au passage.
