### PR TITLE
WIP - filtrer les services

### DIFF
--- a/app/controllers/admin/territories/services_controller.rb
+++ b/app/controllers/admin/territories/services_controller.rb
@@ -20,11 +20,14 @@ class Admin::Territories::ServicesController < Admin::Territories::BaseControlle
 
   def edit
     authorize(current_territory, :manage_services?, policy_class: Agent::TerritoryPolicy)
+    @filter = params[:filter].presence
+    activated_service_ids = current_territory.services.ids.to_set
+    displayed_services = @filter ? Service.filter_by_name(@filter) : Service.all
 
-    activated_services = format_for_checkboxes(current_territory.services.reject(&:secretariat?))
-    other_services = format_for_checkboxes(Service.where.not(id: current_territory.service_ids).reject(&:secretariat?))
+    # Display activated services first
+    displayed_services = displayed_services.sort_by { |service| [service.id.in?(activated_service_ids) ? -1 : 1, service.name] }
 
-    @services = activated_services + other_services
+    @displayed_services = displayed_services.reject(&:secretariat?)
   end
 
   def update
@@ -45,6 +48,7 @@ class Admin::Territories::ServicesController < Admin::Territories::BaseControlle
     params.require(:territory).permit(service_ids: [])
   end
 
+  helper_method :format_for_checkboxes
   def format_for_checkboxes(services)
     services.map do |service|
       label = service.name

--- a/app/controllers/admin/territories/services_controller.rb
+++ b/app/controllers/admin/territories/services_controller.rb
@@ -1,7 +1,8 @@
 class Admin::Territories::ServicesController < Admin::Territories::BaseController
   def new
     authorize(current_territory, :manage_services?, policy_class: Agent::TerritoryPolicy)
-    @service = Service.new
+    permitted_params = params.permit(:name, :short_name)
+    @service = Service.new(permitted_params)
   end
 
   def create

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -26,6 +26,8 @@ class Service < ApplicationRecord
   # Scopes
   default_scope { order(Arel.sql("unaccent(LOWER(services.name))")) }
 
+  scope :filter_by_name, ->(filter) { where(%[unaccent("#{table_name}"."name") ILIKE ?], "%#{filter}%").or(where(%[unaccent("#{table_name}"."short_name") ILIKE ?], "%#{filter}%")) }
+
   ## -
 
   def secretariat?

--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -90,6 +90,18 @@
               h2.fr-tile__title
                 = link_to("Migration vers RDV Service Public", admin_organisation_instance_exports_path(current_organisation))
 
+    - if current_agent.territorial_admin_in?(current_territory)
+      .fr-col-12.fr-col-md-4.fr-mb-2w
+        .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
+          .fr-tile__body
+            .fr-tile__content
+              h2.fr-tile__title
+                = link_to(edit_admin_territory_services_path(current_territory)) do
+                  = settings_icon(class: "fr-mr-1w")
+                  | Services
+              p.fr-tile__desc
+                = current_territory.services.pluck(:name).join(", ").truncate(80)
+
   / Un bricolage pour éviter que le footer déborde sur les tuiles
   br.fr-my-2w
   br.fr-my-2w

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -12,10 +12,15 @@
         p Vous pouvez activer ou désactiver les services auxquels vos agents peuvent être affectés.
 
         = form_with(method: :get) do |f|
+
+          datalist#service_names
+            - Service.pluck(:name).each do |name|
+              option = name
+
           .fr-input-group.mt-4.mb-2
             label.fr-label[for="filter"] Trouvez un service par nom
             .fr-input-wrap.fr-input-wrap--addon
-              input#filter.fr-input[name="filter" value=@filter type="text" aria-describedby="filter-messages"]
+              input#filter.fr-input[name="filter" value=@filter type="text" aria-describedby="filter-messages" list="service_names" autocomplete="off"]
               button.fr-btn.fr-btn--secondary.fr-btn--icon-left.fr-icon-seo-line[type="submit"] Filtrer
             #filter-messages.fr-messages-group[aria-live="polite"]
 
@@ -35,7 +40,8 @@
               = link_to "Créer un nouveau service", new_form_link
             - else
               |> Aucun résultat pour “#{@filter}” ?
-              = link_to "Créer ce service", new_form_link, class: "fr-btn fr-btn--tertiary"
+              div
+                = link_to "Créer ce service", new_form_link, class: "fr-btn fr-btn--primary"
 
           - if @displayed_services.any?
             .d-flex.rdv-flex-direction-row-md.flex-row-aligned

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -21,7 +21,7 @@
             label.fr-label[for="filter"] Trouvez un service par nom
             .fr-input-wrap.fr-input-wrap--addon
               input#filter.fr-input[name="filter" value=@filter type="text" aria-describedby="filter-messages" list="service_names" autocomplete="off"]
-              button.fr-btn.fr-btn--secondary.fr-btn--icon-left.fr-icon-seo-line[type="submit"] Filtrer
+              button.fr-btn.fr-btn--secondary.fr-btn--icon-left.fr-icon-filter-fill[type="submit"] Filtrer
             #filter-messages.fr-messages-group[aria-live="polite"]
 
         = simple_form_for current_territory, url: admin_territory_services_path(current_territory, redirect_to_organisation_id: params[:redirect_to_organisation_id]) do |f|

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -29,9 +29,13 @@
           = f.association :services, collection: format_for_checkboxes(@displayed_services), label: "", as: :check_boxes, label_method: :first, value_method: :second
 
           p.mt-2
-            |> Vous ne trouvez pas votre service dans la liste ?
-            = link_to "Créer un nouveau service", new_admin_territory_services_path(territory_id: current_territory.id)
-            | .
+            - new_form_link = new_admin_territory_services_path(territory_id: current_territory.id, name: @filter)
+            - if @displayed_services.any?
+              |> Vous ne trouvez pas votre service dans la liste ?
+              = link_to "Créer un nouveau service", new_form_link
+            - else
+              |> Aucun résultat pour “#{@filter}” ?
+              = link_to "Créer ce service", new_form_link
 
           .d-flex.rdv-flex-direction-row-md.flex-row-aligned
             - if params[:redirect_to_organisation_id]

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -16,7 +16,7 @@
             label.fr-label[for="filter"] Trouvez un service par nom
             .fr-input-wrap.fr-input-wrap--addon
               input#filter.fr-input[name="filter" value=@filter type="text" aria-describedby="filter-messages"]
-              button.fr-btn.fr-btn--icon-left.fr-icon-seo-line[type="submit"] Filtrer
+              button.fr-btn.fr-btn--secondary.fr-btn--icon-left.fr-icon-seo-line[type="submit"] Filtrer
             #filter-messages.fr-messages-group[aria-live="polite"]
 
         = simple_form_for current_territory, url: admin_territory_services_path(current_territory, redirect_to_organisation_id: params[:redirect_to_organisation_id]) do |f|
@@ -35,10 +35,11 @@
               = link_to "Créer un nouveau service", new_form_link
             - else
               |> Aucun résultat pour “#{@filter}” ?
-              = link_to "Créer ce service", new_form_link
+              = link_to "Créer ce service", new_form_link, class: "fr-btn fr-btn--tertiary"
 
-          .d-flex.rdv-flex-direction-row-md.flex-row-aligned
-            - if params[:redirect_to_organisation_id]
-              .mr-2
-                = link_to("Annuler", new_admin_organisation_agent_path(params[:redirect_to_organisation_id]), class: "fr-btn fr-btn--tertiary")
-            = f.submit "Valider la sélection", class: "fr-btn"
+          - if @displayed_services.any?
+            .d-flex.rdv-flex-direction-row-md.flex-row-aligned
+              - if params[:redirect_to_organisation_id]
+                .mr-2
+                  = link_to("Annuler", new_admin_organisation_agent_path(params[:redirect_to_organisation_id]), class: "fr-btn fr-btn--tertiary")
+              = f.submit "Valider la sélection", class: "fr-btn"

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -11,22 +11,30 @@
 
         p Vous pouvez activer ou désactiver les services auxquels vos agents peuvent être affectés.
 
+        = form_with(method: :get) do |f|
+          .fr-input-group.mt-4.mb-2
+            label.fr-label[for="filter"] Trouvez un service par nom
+            .fr-input-wrap.fr-input-wrap--addon
+              input#filter.fr-input[name="filter" value=@filter type="text" aria-describedby="filter-messages"]
+              button.fr-btn.fr-btn--icon-left.fr-icon-seo-line[type="submit"] Filtrer
+            #filter-messages.fr-messages-group[aria-live="polite"]
+
         = simple_form_for current_territory, url: admin_territory_services_path(current_territory, redirect_to_organisation_id: params[:redirect_to_organisation_id]) do |f|
           = render "model_errors", model: current_territory
 
-          = f.association :services, collection: @services, label: "", as: :check_boxes, label_method: :first, value_method: :second
+          / On ajoute les services déjà activés en hidden fields afin qu'ils soient ré-envoyés au serveur à la validation
+          - (current_territory.services - @displayed_services).each do |not_displayed_but_activated|
+            input[type="hidden" name="territory[service_ids][]" value=not_displayed_but_activated.id]
 
-          p
+          = f.association :services, collection: format_for_checkboxes(@displayed_services), label: "", as: :check_boxes, label_method: :first, value_method: :second
+
+          p.mt-2
             |> Vous ne trouvez pas votre service dans la liste ?
             = link_to "Créer un nouveau service", new_admin_territory_services_path(territory_id: current_territory.id)
             | .
 
-          = dsfr_callout do
-            .fr-text--sm Le service secrétariat a été remplacé par une nouvelle permission « Agent d’accueil » que vous pouvez activer pour chaque agent dans les paramètres de l’organisation.
-
-          .row.align-items-center.mt-3
+          .d-flex.rdv-flex-direction-row-md.flex-row-aligned
             - if params[:redirect_to_organisation_id]
-              .col.text-left
-                = link_to("Annuler", new_admin_organisation_agent_path(params[:redirect_to_organisation_id]))
-            .col.text-right
-              = f.submit class: "fr-btn"
+              .mr-2
+                = link_to("Annuler", new_admin_organisation_agent_path(params[:redirect_to_organisation_id]), class: "fr-btn fr-btn--tertiary")
+            = f.submit "Valider la sélection", class: "fr-btn"

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
       click_link("activer des services supplémentaires")
 
       check("CSS")
-      click_button("Enregistrer")
+      click_button("Valider la sélection")
       expect(page).to have_content("Liste des services disponibles mise à jour")
 
       fill_in "Email", with: "jean@paul.com"

--- a/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
@@ -6,43 +6,38 @@ RSpec.describe "territory admin can manage services", type: :feature do
     login_as(agent, scope: :agent)
   end
 
-  describe "Listing services" do
-    let!(:service_a) { create(:service) }
-    let!(:service_b) { create(:service) }
-    let!(:service_c) { create(:service) }
-
-    it "works" do
-      visit edit_admin_territory_services_path(territory)
-
-      expect(page).to have_content("Vous pouvez activer ou désactiver les services auxquels vos agents peuvent être affectés.")
-      expect(page).to have_content(service_a.name)
-      expect(page).to have_content(service_b.name)
-      expect(page).to have_content(service_c.name)
-    end
-  end
-
   describe "Activating/Deactivating services" do
-    let!(:service_a) { create(:service) }
-    let!(:service_b) { create(:service) }
-    let!(:service_c) { create(:service) }
-
     it "works" do
+      pmi = create(:service, :pmi)
+      social = create(:service, :social)
       visit edit_admin_territory_services_path(territory)
-      check service_a.name
-      check service_b.name
+      expect(territory.reload.services).to be_empty
 
-      expect { click_on "Enregistrer" }.to change {
-        territory.reload.services.ids
-      }.from([]).to([service_a.id, service_b.id])
-      expect(page).to have_content("Liste des services disponibles mise à jour")
+      # Lier un service existant
+      check pmi.name
+      click_on "Valider la sélection"
+      expect(territory.reload.services).to eq([pmi])
 
-      uncheck service_b.name
-      check service_c.name
+      # Dé-lier un service
+      uncheck pmi.name
+      click_on "Valider la sélection"
+      expect(territory.reload.services).to eq([])
 
-      expect { click_on "Enregistrer" }.to change {
-        territory.reload.services.ids
-      }.from([service_a.id, service_b.id]).to([service_a.id, service_c.id])
-      expect(page).to have_content("Liste des services disponibles mise à jour")
+      # Filtrage puis ajout
+      fill_in "Trouvez un service par nom", with: "social"
+      click_on "Filtrer"
+      expect(page).to have_content(social.name)
+      expect(page).not_to have_content(pmi.name)
+      check social.name
+      click_on "Valider la sélection"
+      expect(territory.reload.services).to eq([social])
+      fill_in "Trouvez un service par nom", with: "pmi"
+      click_on "Filtrer"
+      expect(page).to have_content(pmi.name)
+      expect(page).not_to have_content(social.name)
+      check pmi.name
+      click_on "Valider la sélection"
+      expect(territory.reload.services).to contain_exactly(social, pmi)
     end
   end
 


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6501.osc-secnum-fr1.scalingo.io/)

# Contexte

On souhaite permettre de filtrer la liste des services qu'on peut lier à son espace, car cette liste est interminable.

Maquettes ici : 
https://www.figma.com/design/qKzmEmKOb11pRjnzJthXQV/Interface-Agent?node-id=1607-5137&p=f&t=ikJnyAc8WsM2VZ9w-0

# Solution

WIP

## Captures d'écran


<img width="1389" height="1016" alt="image" src="https://github.com/user-attachments/assets/bb085b04-0c0f-4e77-8e63-009ad9c753ac" />

<img width="1384" height="748" alt="image" src="https://github.com/user-attachments/assets/b68eaf74-2c08-48ba-8782-1e5f515c4e60" />

