### PR TITLE
Correctif pour les appointments ANTS ajoutés avec le mauvais nom de domaine

### DIFF
--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -35,7 +35,10 @@ module Ants
       # on n’utilise pas de regex ci-dessous pour éviter un faux-positif de Brakeman
       protocol = Rails.env.production? ? "https" : "http"
       @ants_appointments = ants_status["appointments"].select do |appointment|
-        appointment["management_url"].start_with?("#{protocol}://#{Domain::RDV_SERVICE_PUBLIC.host_name}")
+        # On a mis par erreur des rendez-vous avec le nom de domaine de l'état.
+        # Pour permettre de les supprimer lors de l'annulation du rendez-vous, on regarde les deux noms de domaines
+        appointment["management_url"].start_with?("#{protocol}://#{Domain::RDV_SERVICE_PUBLIC.host_name}") ||
+          appointment["management_url"].start_with?("#{protocol}://#{Domain::RDV_SERVICE_PUBLIC_ETAT.host_name}")
       end
 
       return true unless needs_synchronization?

--- a/scripts/move_etat_organisations_to_new_domain.rb
+++ b/scripts/move_etat_organisations_to_new_domain.rb
@@ -14,7 +14,8 @@ Territory.limit(ARGV[0].presence.to_i).find_each do |territory|
     agent.pro_connect_idp_id.in?(ProconnectIdentityProviders::ETAT) || (etat_email && !france_service_email && !anct)
   end
 
-  if all_admins_from_etat
+  # On vérifie qu'il y a au moins un admin de territoire
+  if admins.present? && all_admins_from_etat
     territory.organisations.each do |organisation|
       organisation.update!(verticale: :rdv_etat)
     end

--- a/spec/jobs/ants/sync_appointment_job_spec.rb
+++ b/spec/jobs/ants/sync_appointment_job_spec.rb
@@ -54,6 +54,39 @@ RSpec.describe Ants::SyncAppointmentJob do
       expect(AntsApi).not_to receive(:create)
       described_class.perform_now(ants_pre_demande_number: "A123456789")
     end
+
+    context "quand on a mis par erreur dans la base ANTS un rendez-vous avec le mauvais nom de domaine" do
+      before do
+        allow(AntsApi).to receive(:status)
+          .with(hash_including(ants_pre_demande_number: "A123456789", meeting_point_id: lieu.id.to_s))
+          .and_return(
+            {
+              "status" => "validated",
+              "appointments" => [
+                {
+                  "management_url" => "http://#{Domain::RDV_SERVICE_PUBLIC_ETAT.host_name}/users/rdvs/#{rdv.id}",
+                  "meeting_point" => "Mairie de Saumur",
+                  "appointment_date" => "2020-04-20 08:00:00",
+                },
+              ],
+            }
+          )
+      end
+
+      it "détecte quand même que c'est le bon rendez-vous à supprimer" do
+        expect(AntsApi).to receive(:delete)
+          .with(
+            {
+              ants_pre_demande_number: "A123456789",
+              meeting_point: "Mairie de Saumur",
+              meeting_point_id: lieu.id.to_s,
+              appointment_date: "2020-04-20 08:00:00",
+            }
+          )
+        expect(AntsApi).not_to receive(:create)
+        described_class.perform_now(ants_pre_demande_number: "A123456789")
+      end
+    end
   end
 
   context "Synchro pour un ants_pre_demande_number correspondant à un usager ayant un RDV mais qui n’est pas un RDV ANTS" do


### PR DESCRIPTION
# Contexte

Le territoire 1 avec toutes les mairies a été déplacé dans la verticale de l'état par erreur. Cela a causé des appointments ANCT avec le mauvais nom de domaine.
Vu qu'on filtre ensuite ces appointments avec le nom de domaine rdv.anct, on risque de bloquer des usagers qui veulent annuler leur rendez-vous dans une mairie pour le faire ailleurs.

voir https://sentry.incubateur.net/organizations/betagouv/issues/291954

# Solution

On élargi donc la condition pour agir sur tous les rendez-vous dont le nom de domaine nous concerne.


