### PR TITLE
Correction de la modification d'email usager 

### DIFF
--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -121,24 +121,29 @@ class Users::RdvWizardStepsController < UserAuthController
     result
   end
 
+  def user_params_permitted_keys
+    keys = [
+      :first_name,
+      :last_name,
+      :birth_name,
+      :phone_number,
+      :birth_date,
+      :address,
+      :caisse_affiliation,
+      :affiliation_number,
+      :family_situation,
+      :number_of_children,
+      :notify_by_email,
+      :notify_by_sms,
+      :ants_pre_demande_number,
+      :ignore_benign_errors,
+      { user_profiles_attributes: %i[logement id organisation_id] },
+    ]
+    keys << :email if current_user.email_editable?
+    keys
+  end
+
   def user_params
-    params.permit(user: [
-                    :first_name,
-                    :last_name,
-                    :birth_name,
-                    :phone_number,
-                    :birth_date,
-                    :email,
-                    :address,
-                    :caisse_affiliation,
-                    :affiliation_number,
-                    :family_situation,
-                    :number_of_children,
-                    :notify_by_email,
-                    :notify_by_sms,
-                    :ants_pre_demande_number,
-                    :ignore_benign_errors,
-                    { user_profiles_attributes: %i[logement id organisation_id] },
-                  ])
+    params.permit(user: user_params_permitted_keys)
   end
 end

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -21,25 +21,30 @@ class Users::UsersController < UserAuthController
 
   private
 
+  def user_params_permitted_keys
+    keys = %i[
+      first_name
+      last_name
+      birth_name
+      phone_number
+      birth_date
+      address
+      city_name
+      post_code
+      city_code
+      caisse_affiliation
+      affiliation_number
+      family_situation
+      number_of_children
+      notify_by_email
+      notify_by_sms
+      address_details
+    ]
+    keys << :email if @user.email_editable?
+    keys
+  end
+
   def user_params
-    params.require(:user).permit(
-      :email,
-      :first_name,
-      :last_name,
-      :birth_name,
-      :phone_number,
-      :birth_date,
-      :address,
-      :city_name,
-      :post_code,
-      :city_code,
-      :caisse_affiliation,
-      :affiliation_number,
-      :family_situation,
-      :number_of_children,
-      :notify_by_email,
-      :notify_by_sms,
-      :address_details
-    )
+    params.require(:user).permit(*user_params_permitted_keys)
   end
 end

--- a/app/form_models/concerns/users/user_form_concern.rb
+++ b/app/form_models/concerns/users/user_form_concern.rb
@@ -15,7 +15,7 @@ module Users::UserFormConcern
              :connected_with_sso?, :pro_connect_openid_sub,
              :logged_once_with_franceconnect?, :signed_in_with_invitation_token?,
              :errors, :errors_are_all_benign?, :benign_errors,
-             :ants_pre_demande_number, :already_logged_in?,
+             :ants_pre_demande_number, :already_logged_in?, :email_editable?,
              to: :user
 
     def self.human_attribute_name(...) = User.human_attribute_name(...)
@@ -35,13 +35,7 @@ module Users::UserFormConcern
 
   def show_franceconnect_frozen_fields_warning? = logged_once_with_franceconnect?
 
-  # Champ email du parcours de RDV :
-  # - Usager invité via token → affiché, modifiable sauf si il s'est déjà connecté
-  # - SSO (FC/ProConnect) → affiché, modifiable
-  # - Usager connecté via code → pas affiché (A voir plus tard https://github.com/betagouv/rdv-service-public/pull/6259#discussion_r2959304082)
-  def show_email_field? = signed_in_with_invitation_token? || connected_with_sso?
-
-  def email_disabled? = signed_in_with_invitation_token? && email.present? && already_logged_in?
+  def show_email_field? = true
 
   def show_landline_phone_number_warning? = phone_number.present? && !phone_number_mobile?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -276,6 +276,12 @@ class User < ApplicationRecord
     latest_login_at?
   end
 
+  # Seul un usager invité via token, qui n'a pas encore d'email confirmé par une précédente connexion,
+  # peut modifier son email. Dans tous les autres cas (SSO, usager déjà connecté, usager connecté via code…) il est figé.
+  def email_editable?
+    signed_in_with_invitation_token? && !(email.present? && already_logged_in?)
+  end
+
   protected
 
   def generate_rdv_invitation_token

--- a/app/views/users/users/_form_fields.html.slim
+++ b/app/views/users/users/_form_fields.html.slim
@@ -21,7 +21,7 @@
     = I18n.t("users.franceconnect_frozen_fields")
 
 - if f.object.show_email_field?
-  = f.dsfr_email_field :email, disabled: f.object.email_disabled?, required: false, autocomplete: "email"
+  = f.dsfr_email_field :email, disabled: !f.object.email_editable?, required: false, autocomplete: "email"
 
 = f.dsfr_phone_field :phone_number, as: :tel, required: f.object.phone_required?, autocomplete: "tel"
 - if f.object.show_landline_phone_number_warning?

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -73,4 +73,39 @@ RSpec.describe Users::RdvWizardStepsController, type: :controller do
       end
     end
   end
+
+  describe "#create quand l'usager tente de modifier son email en bypassant le disabled HTML" do
+    let!(:user) { create(:user, email: "original@exemple.fr") }
+    let!(:organisation) { create(:organisation) }
+    let!(:motif) { create(:motif, :at_public_office, organisation:, default_duration_in_min: 30) }
+
+    before { sign_in user }
+
+    it "ignore le paramètre email" do
+      post :create, params: {
+        rdv: { starts_at: 1.month.from_now, motif_id: motif.id, user_ids: [user.id] },
+        user: { first_name: "Léa", last_name: "Boubakar", phone_number: nil, email: "hacked@exemple.fr" },
+      }
+      expect(response).to have_http_status(:redirect) # pas d'erreur
+      expect(user.reload).to have_attributes(email: "original@exemple.fr", first_name: "Léa", last_name: "Boubakar")
+    end
+  end
+
+  describe "#create quand l'usager invité pour la premiere fois via RDVI tente de modifier son email" do
+    let!(:user) { create(:user, email: "original@exemple.fr", latest_login_at: nil) }
+    let!(:organisation) { create(:organisation) }
+    let!(:motif) { create(:motif, :at_public_office, organisation:, default_duration_in_min: 30) }
+    let!(:invitation_token) { user.set_rdv_invitation_token! }
+
+    before { request.session[:invitation] = { invitation_token:, expires_at: 1.hour.from_now } }
+
+    it "autorise la modification de l'email" do
+      post :create, params: {
+        rdv: { starts_at: 1.month.from_now, motif_id: motif.id, user_ids: [user.id] },
+        user: { first_name: "Léa", last_name: "Boubakar", phone_number: nil, email: "nouvel@email.fr" },
+      }
+      expect(response).to have_http_status(:redirect) # pas d'erreur
+      expect(user.reload.email).to eq("nouvel@email.fr")
+    end
+  end
 end

--- a/spec/controllers/users/users_controller_spec.rb
+++ b/spec/controllers/users/users_controller_spec.rb
@@ -1,9 +1,6 @@
 RSpec.describe Users::UsersController, type: :controller do
   render_views
 
-  let(:user) { create(:user) }
-  let!(:relative) { create(:user, first_name: "Katia", last_name: "Garcia", birth_date: Date.parse("12/10/1990"), responsible_id: user.id) }
-
   before do
     travel_to(Time.zone.local(2019, 7, 20))
     sign_in user
@@ -12,10 +9,23 @@ RSpec.describe Users::UsersController, type: :controller do
   describe "GET #edit" do
     subject { get :edit }
 
+    let(:user) { create(:user) }
+    let!(:relative) { create(:user, first_name: "Katia", last_name: "Garcia", birth_date: Date.parse("12/10/1990"), responsible_id: user.id) }
+
     it "lists relatives" do
       subject
       expect(response.body).to include("Mes proches")
       expect(response.body).to include("Katia GARCIA (28 ans)")
+    end
+  end
+
+  describe "PATCH #update qui force l'envoi d'un email en contournant le disabled HTML" do
+    let(:user) { create(:user, email: "test@blah.fr") }
+
+    it do
+      patch :update, params: { user: { email: "hacked@exemple.fr" } }
+
+      expect(user.reload.email).to eq("test@blah.fr")
     end
   end
 end

--- a/spec/features/users/account/user_can_update_their_information_spec.rb
+++ b/spec/features/users/account/user_can_update_their_information_spec.rb
@@ -161,12 +161,9 @@ RSpec.describe "User can update their information" do
     context "when the user is connected with FranceConnect" do
       let(:user) { create(:user, :using_france_connect, organisations: [organisation]) }
 
-      it "allows changing the email" do
+      it "does not allow changing the email" do
         visit users_informations_path
-        fill_in("Email", with: "nouvelle.adresse@exemple.fr")
-        click_on("Enregistrer")
-        expect(page).to have_content "Vos informations ont été mises à jour."
-        expect(user.reload.email).to eq "nouvelle.adresse@exemple.fr"
+        expect(page).to have_field("Email", with: user.email, disabled: true)
       end
     end
   end

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "User can search for rdvs" do
         # FranceConnect ne gèle pas le nom de famille (seul ProConnect le fait)
         expect(page).to have_field("Nom", disabled: false)
         expect(page).to have_content("Les champs d'état civil ne peuvent plus être modifiés suite à la connexion certifiée par FranceConnect")
-        expect(page).to have_field("Email", with: user.email)
+        expect(page).to have_field("Email", with: user.email, disabled: true)
       end
     end
 

--- a/spec/features/users/online_booking/with_invitation_spec.rb
+++ b/spec/features/users/online_booking/with_invitation_spec.rb
@@ -169,6 +169,33 @@ RSpec.describe "User can be invited" do
     end
   end
 
+  describe "quand l'usager invité a un email mais ne s'est jamais connecté" do
+    let!(:user) do
+      create(
+        :user,
+        first_name: "john", last_name: "doe", email: "jesuis@unemail.fr", latest_login_at: nil,
+        phone_number: "0682605955", address: "26 avenue de la resistance, Paris, 75016",
+        birth_date: Date.new(1988, 12, 20), organisations: [organisation]
+      )
+    end
+
+    before { travel_to(now) }
+
+    it "affiche le champ Email modifiable et le prend en compte" do
+      # Une visite sur prendre_rdv_path est nécessaire pour valider le token d'invitation et
+      # stocker la session, avant de pouvoir accéder directement à l'étape "Vos informations"
+      visit prendre_rdv_path(departement: departement_number, invitation_token: invitation_token)
+      visit new_users_rdv_wizard_step_path(
+        step: 1, motif_id: motif.id, lieu_id: lieu.id, departement: departement_number, starts_at: (now + 1.month).change(hour: 11, min: 0)
+      )
+      expect(page).to have_content("Vos informations")
+      expect(page).to have_field("Email", with: "jesuis@unemail.fr", disabled: false)
+      fill_in("Email", with: "nouvel@email.fr")
+      click_button("Continuer")
+      expect(user.reload.email).to eq("nouvel@email.fr")
+    end
+  end
+
   describe "in motifs selection page" do
     let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
     let!(:motif2) do


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6507.osc-secnum-fr1.scalingo.io/)


# Contexte

Depuis l'introduction du code à 6 chiffres pour la connexion usager, on ne permet plus aux usagers de modifier leur email. C'est une regression par rapport à avant et on va rétablir ça bientôt dans une PR successive cf https://github.com/betagouv/rdv-service-public/issues/6058

Cependant, actuellement : 
1. un usager FranceConnecté peut modifier son email depuis la page Mes informations. 
2. un usager invité depuis RDVI peut modifier son email dans le parcours de prise de RDV Usager. 

Le 1 : est un bug probablement introduit suite a la suppression de notification_email. L'usager pouvait en effet modifier cet email, mais il ne devrait pas pouvoir modifier son vrai email.

Le 2 est un comportement souhaité mais non couvert par les tests

# Solution

Je propose ici : 
- de rajouter des specs pour les différents cas
- de rajouter des specs pour verifier le comportement coté backend aussi, pas uniquement que le champ soit visible ou disabled
- de déplacer la méthode `email_editable?` du user form concern vers le modèle `User` pour simplifier.
- de TOUJOURS afficher le champ email dans le parcours de prise de RDV usagers
- de par défaut l'afficher disabled et de l'activer dans le seul cas de RDVI 

Review : 

à lire [avec l'option whitespaces cachés](https://github.com/betagouv/rdv-service-public/pull/6507/changes?w=1)

## Captures d’écran

|Avant|après|
|-|-|
<img width="786" height="2574" alt="image" src="https://github.com/user-attachments/assets/b4b7f84f-1e5c-4c18-9fd8-f363de482334" />|<img width="786" height="2574" alt="image" src="https://github.com/user-attachments/assets/28e75d07-838a-44c7-bdb2-4064d795d678" />
<img width="786" height="2334" alt="image" src="https://github.com/user-attachments/assets/5dfe471e-8221-4656-8c6e-c1ea8af9ad3e" />|<img width="786" height="2334" alt="image" src="https://github.com/user-attachments/assets/76c9aa4a-7285-41c0-8b3f-aa603feb2b85" />
<img width="786" height="2118" alt="image" src="https://github.com/user-attachments/assets/a4bad026-346f-471b-80c7-f024538ce14a" />|<img width="786" height="2310" alt="image" src="https://github.com/user-attachments/assets/45571423-1f12-4023-9ac1-d49e85fb35b0" />
