### PR TITLE
a11y: ajout du ul/li liste motif nouveau RDV Collectif

### DIFF
--- a/app/views/admin/rdvs_collectifs/motifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/motifs/index.html.slim
@@ -17,17 +17,16 @@
           - else
             div Il n'existe aucun motif de RDV collectif et vous ne pouvez pas en créer un. Demandez à un administrateur ou une administratrice.
         - else
-          ul.list-unstyled
+          ul.fr-raw-list
             - @motifs.each do |motif|
-              li.card.fr-enlarge-link
-                .card-body
-                    .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
-                      h3.fr-h5 = link_to motif.name, new_admin_organisation_rdvs_collectif_path(current_organisation, { motif_id: motif.id })
-                    .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
-                      p.fr-mb-0
+              li.fr-card.fr-enlarge-link.fr-enlarge-link.fr-mb-2w
+                .fr-card__body
+                  .fr-card__content
+                    .fr-card__title
+                      = link_to motif.name, new_admin_organisation_rdvs_collectif_path(current_organisation, { motif_id: motif.id })
+                    .fr-card__end
+                      .fr-card__detail
                         = location_type_icon(motif.location_type, class: "fr-mr-1w")
                         = motif.human_attribute_value(:location_type)
                         = " · "
                         = "#{motif.default_duration_in_min} mn"
-
-                      = icon("fr-icon-arrow-right-line", class: "rdv-color-text-action-high-blue-france")

--- a/app/views/admin/rdvs_collectifs/motifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/motifs/index.html.slim
@@ -17,16 +17,17 @@
           - else
             div Il n'existe aucun motif de RDV collectif et vous ne pouvez pas en créer un. Demandez à un administrateur ou une administratrice.
         - else
-          - @motifs.each do |motif|
-            .card.fr-enlarge-link.fr-card--shadow
-              .card-body
-                .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
-                  h3.fr-h5 = link_to motif.name, new_admin_organisation_rdvs_collectif_path(current_organisation, { motif_id: motif.id })
-                .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
-                  p.fr-mb-0
-                    = location_type_icon(motif.location_type, class: "fr-mr-1w")
-                    = motif.human_attribute_value(:location_type)
-                    = " · "
-                    = "#{motif.default_duration_in_min} mn"
+          ul.list-unstyled
+            - @motifs.each do |motif|
+              li.card.fr-enlarge-link
+                .card-body
+                    .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
+                      h3.fr-h5 = link_to motif.name, new_admin_organisation_rdvs_collectif_path(current_organisation, { motif_id: motif.id })
+                    .d-flex.rdv-justify-content-space-between.rdv-align-items-baseline
+                      p.fr-mb-0
+                        = location_type_icon(motif.location_type, class: "fr-mr-1w")
+                        = motif.human_attribute_value(:location_type)
+                        = " · "
+                        = "#{motif.default_duration_in_min} mn"
 
-                  = icon("fr-icon-arrow-right-line", class: "rdv-color-text-action-high-blue-france")
+                      = icon("fr-icon-arrow-right-line", class: "rdv-color-text-action-high-blue-france")


### PR DESCRIPTION
# Contexte

Pour des questions d’accessibilités, je mets un ul > li sur la liste de sélection de motif pour la création de RDV collectif.

Suite à un retour de Téo, j’en profite également pour retirer le shadow.

