### PR TITLE
Script pour extraire toutes les organisations du territoire historique des mairies

### DIFF
--- a/scripts/extract_mairie_from_territory.rb
+++ b/scripts/extract_mairie_from_territory.rb
@@ -1,4 +1,6 @@
 # Ce script permet de sortir une mairie du territory historique des mairies, pour lui donner son propre territoire.
+#
+# Exemple pour toutes les mairies : ExtractMairieFromTerritory.extract_all!
 
 # exemple pour une mairie a juste une organisation dans le territoire existant:
 # ExtractMairieFromTerritory.run(110, 155)
@@ -13,14 +15,24 @@ class MotifCategoriesTerritory < ApplicationRecord
 end
 
 class ExtractMairieFromTerritory
-  # organisation_id : l'id de l'organisation d'origine de la mairie
-  def self.run(organisation_id, admin_agent_id, new_territory_id: nil)
-    new(organisation_id, admin_agent_id, new_territory_id:).run
+  def self.extract_all!
+    territory = Territory.where(name: Territory::MAIRIES_NAME).find(1)
+
+    territory.organisations.each do |organisation|
+      admin_agent_ids = AgentRole.where(organisation_id: organisation.id, access_level: :admin).pluck(:agent_id)
+
+      run(organisation.id, admin_agent_ids)
+    end
   end
 
-  def initialize(organisation_id, admin_agent_id, new_territory_id:)
+  # organisation_id : l'id de l'organisation d'origine de la mairie
+  def self.run(organisation_id, admin_agent_ids, new_territory_id: nil)
+    new(organisation_id, admin_agent_ids, new_territory_id:).run
+  end
+
+  def initialize(organisation_id, admin_agent_ids, new_territory_id:)
     @organisation_id = organisation_id
-    @admin_agent_id = admin_agent_id
+    @admin_agent_ids = admin_agent_ids
     @new_territory = Territory.find_by(id: new_territory_id)
   end
 
@@ -28,7 +40,11 @@ class ExtractMairieFromTerritory
     ActiveRecord::Base.logger = Logger.new($stdout)
 
     ActiveRecord::Base.transaction do
-      @new_territory ||= Territory.create!(
+      @new_territory ||= Territory.new(
+        mairies_territory.attributes.except("id", "created_at", "updated_at")
+      )
+
+      @new_territory.update!(
         name: organisation.name,
         departement_number: departement_number
       )
@@ -55,10 +71,12 @@ class ExtractMairieFromTerritory
           service: service
         )
       end
-      AgentTerritorialRole.find_or_initialize_by(
-        territory: @new_territory,
-        agent_id: @admin_agent_id
-      ).save!
+      @admin_agent_ids.each do |admin_agent_id|
+        AgentTerritorialRole.find_or_initialize_by(
+          territory: @new_territory,
+          agent_id: admin_agent_id
+        ).save!
+      end
     end
   end
 

--- a/scripts/extract_mairie_from_territory.rb
+++ b/scripts/extract_mairie_from_territory.rb
@@ -83,6 +83,8 @@ class ExtractMairieFromTerritory
   private
 
   def departement_number
+    return "MA" if organisation.lieux.empty?
+
     zipcode_regex = /\d{5}/
     zipcode = organisation.lieux.first.address[zipcode_regex]
 


### PR DESCRIPTION
# Contexte

J'ai à nouveau basculé les organisations du territoires Mairies sur la verticale `:rdv_etat` par erreur, parce que les admins ont des comptes avec des adresse `beta.gouv.fr`.

Pour rappel, le territoire Mairies est le territoire avec l'id numéro 1, sur lequel on avait mis toutes les mairies qui faisaient des rendez-vous pour les passeports et les cartes d'identité à l'été 2023, quand on était ouvert uniquement pour ce cas d'usage.
Depuis il est obsolète (on a ajouté le flag ants_connectable sur les orgas), mais on n'avait pas encore sorti toutes les orgas de ce territoires

J'avais déjà fait cette erreur la semaine dernière, et on a déjà un script qui permet de sortir à la main des orgas de ce territoires

# Solution

On étend le script pour gérer toutes les organisations. J'ai testé sur un dump de la prod et ça marche sans soucis.

