### PR TITLE
Allow env disabling of refresh sensitive account CRON job

### DIFF
--- a/app/jobs/cron_job/refresh_agents_sensitive_account_job.rb
+++ b/app/jobs/cron_job/refresh_agents_sensitive_account_job.rb
@@ -2,6 +2,8 @@ class CronJob::RefreshAgentsSensitiveAccountJob < CronJob
   SENSITIVE_TERRITORY_RDV_THRESHOLD = 5_000
 
   def perform
+    return if disabled?
+
     sensitive_ids = (sensitive_territory_admin_ids + rdv_insertion_admin_agent_ids).uniq
 
     # rubocop:disable Rails/SkipsModelValidations
@@ -11,6 +13,10 @@ class CronJob::RefreshAgentsSensitiveAccountJob < CronJob
   end
 
   private
+
+  def disabled?
+    ENV["DISABLE_REFRESH_AGENTS_SENSITIVE_ACCOUNT_JOB"] == "true"
+  end
 
   def territory_admin_ids
     AgentTerritorialRole.distinct.pluck(:agent_id)


### PR DESCRIPTION
# Contexte

Sur notre environnement de staging (app scalingo `rdv-solidarites-staging`), on a des comptes agents qui sont partagés et qui ont des adresses email fictives. C'est le cas notamment pour le compte que se partagent les hunters du bug bounty.
Du coup si ces comptes sont taggés comme étant sensibles, il n'y a aucun moyen de se connecter puisqu'on aura pas accès à la boite mail en question.
Je propose donc de pouvoir désactiver le CRON sur cet environnement.

# Solution

Je fais en sorte de pouvoir skipper l'exécution du CRON en settant une variable d'environnement `DISABLE_REFRESH_AGENTS_SENSITIVE_ACCOUNT_JOB` dans l'environnement en question. 
Je n'ai pas trouvé de mécanismes dans l'appli autre que les guard clause au sein du job pour skipper l'exécution d'un CRON sur un environnement donné. Je suis donc parti là-dessus.

