### PR TITLE
Utilise la recherche usager full-text dans le super admin

### DIFF
--- a/app/controllers/super_admins/users_controller.rb
+++ b/app/controllers/super_admins/users_controller.rb
@@ -1,4 +1,10 @@
 module SuperAdmins
   class UsersController < SuperAdmins::ApplicationController
+    private
+
+    # Utilise notre index plutôt que la méthode de recherche inefficiente de Administrate
+    def filter_resources(resources, search_term:)
+      search_term.present? ? resources.search_by_text(search_term) : resources
+    end
   end
 end

--- a/spec/features/super_admin/can_search_user_spec.rb
+++ b/spec/features/super_admin/can_search_user_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Un super admin peut chercher un utilisateur", js: true do
   let(:super_admin) { create(:super_admin) }
-  let!(:user) { create(:user, first_name: "Katia", last_name: "Garcia") }
+  let!(:user) { create(:user, first_name: "Katia", last_name: "Garcia", phone_number: "0611223344") }
   let!(:another_user) { create(:user, first_name: "Tanguy", last_name: "Laverdure") } # On crée un autre utilisateur pour s’assurer que la recherche fonctionne correctement
 
   it "par email" do
@@ -24,7 +24,7 @@ RSpec.describe "Un super admin peut chercher un utilisateur", js: true do
     visit super_admins_users_path
 
     field = find_field("search")
-    field.set(user.phone_number)
+    field.set("061122")
     page.execute_script <<-JS
       var form = document.querySelector('form');
       form.requestSubmit();


### PR DESCRIPTION
La recherche d'usager côté superadmin est lente et coûteuse car elle doit parcourir toute la table des usagers (1,5 million de lignes) pour trouver ceux qui correspondent à la recherche : 

https://github.com/thoughtbot/administrate/blob/acc0e6c7265f7bd9ccf344368f918cd3084b9f12/lib/administrate/search.rb#L99

Cela génère la requête suivante : 

```sql
SELECT *
FROM 
  "users" 
WHERE 
  "users"."deleted_at" IS NULL 
  AND (
    LOWER(
      CAST(
        "users"."first_name" AS CHAR(256)
      )
    ) LIKE $1 
    OR LOWER(
      CAST(
        "users"."last_name" AS CHAR(256)
      )
    ) LIKE $2 
    OR LOWER(
      CAST(
        "users"."birth_name" AS CHAR(256)
      )
    ) LIKE $3 
    OR LOWER(
      CAST(
        "users"."email" AS CHAR(256)
      )
    ) LIKE $4 
    OR LOWER(
      CAST(
        "users"."address" AS CHAR(256)
      )
    ) LIKE $5 
    OR LOWER(
      CAST(
        "users"."phone_number" AS CHAR(256)
      )
    ) LIKE $6 
    OR LOWER(
      CAST(
        "users"."affiliation_number" AS CHAR(256)
      )
    ) LIKE $7
  ) 
LIMIT 
  $8 OFFSET $9
```

Or, nous avons déjà un index pour la recherche usager, donc autant l'utiliser.

Avantage au passage : on utilise le même moteur de recherche que les agents et donc on peut manger notre propre bouffe pour chien et se rendre compte de ses limitations.

Risque : on couvre moins de colonne mais je pense que ça répondra quand-même au besoin des super admins.