### PR TITLE
Ne spécifier l'attribut CalDAV "METHOD" que dans un contexte e-mail

### DIFF
--- a/app/mailers/concerns/ics_multipart_attached.rb
+++ b/app/mailers/concerns/ics_multipart_attached.rb
@@ -10,6 +10,14 @@ module IcsMultipartAttached
 
     cal = IcalFormatters::Ics.from_payload(ics_payload)
 
+    cal.ip_method = if ics_payload[:action] == :destroy
+                      "CANCEL"
+                    elsif ics_payload[:attendees].present?
+                      "REQUEST" # REQUEST is only allowed if ATTENDEEs are present.
+                    else
+                      "PUBLISH"
+                    end
+
     # Specs
     # iCalendar: https://datatracker.ietf.org/doc/html/rfc5545#section-3.6.1
     #   * See section 3.6.1 for VEVENT

--- a/app/services/ical_formatters/ics.rb
+++ b/app/services/ical_formatters/ics.rb
@@ -26,13 +26,7 @@ module IcalFormatters
       cal.add_timezone(tz.ical_timezone(payload[:starts_at]))
       cal.prodid = ICS_UID_SUFFIX
       cal.event { |event| populate_event(event, payload, tzid) }
-      cal.ip_method = if payload[:action] == :destroy
-                        "CANCEL"
-                      elsif payload[:attendees].present?
-                        "REQUEST" # REQUEST is only allowed if ATTENDEEs are present.
-                      else
-                        "PUBLISH"
-                      end
+
       cal
     end
 

--- a/spec/services/ical_formatters/ics_spec.rb
+++ b/spec/services/ical_formatters/ics_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe IcalFormatters::Ics do
       end
     end
 
+    describe "METHOD property" do
+      it "is absent (CalDAV resources must not include METHOD per RFC 4791 §4.1)" do
+        expect(subject).not_to include("METHOD")
+      end
+    end
+
     describe "status" do
       let(:payload) { { starts_at: Time.zone.parse("20190704 15h00"), action: action, domain: Domain::RDV_SOLIDARITES } }
 


### PR DESCRIPTION
Erreur Sentry : 
https://sentry.incubateur.net/organizations/betagouv/issues/256719/events/fbcb0f6fc6ab419e9bba1cbe41d7acb7

```
<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>Sabre\DAV\Exception\UnsupportedMediaType</s:exception>
  <s:message>Validation error in iCalendar: A calendar object on a CalDAV server MUST NOT have a METHOD property.</s:message>
</d:error>
```

## Contexte

Le serveur CalDAV de cet agent utilise [sabre/dav](https://sabre.io/) qui est très strict sur la spec CalDAV, et la spec.

Or, la propriété `METHOD` est définie par le protocole iTIP (RFC 5546) pour les échanges de calendrier par **email** (pièces jointes `.ics`). Elle indique l'intention de l'expéditeur (`REQUEST`, `CANCEL`, `PUBLISH`, etc.) aux clients mail comme Outlook ou Apple Mail.

CalDAV (RFC 4791) utilise les méthodes HTTP (`PUT`, `DELETE`) pour exprimer l'intention — `METHOD` est donc redondant dans ce contexte, et la **RFC 4791 §4.1 interdit explicitement** sa présence dans les ressources CalDAV.

## Changements

- Suppression de `cal.ip_method` dans `IcalFormatters::Ics.from_payload`, qui était systématiquement inclus dans tous les calendriers générés.
- Déplacement de la logique `METHOD` dans `IcsMultipartAttached`, le seul endroit où elle est légitime (envoi par email).
- Ajout d'un test dans `ics_spec.rb` qui vérifie l'absence de `METHOD` dans les payloads CalDAV, conformément à la RFC.
