### PR TITLE
Ajout d'une api de gestion des webhooks pour visioplainte

### DIFF
--- a/app/controllers/api/visioplainte/webhook_endpoints_controller.rb
+++ b/app/controllers/api/visioplainte/webhook_endpoints_controller.rb
@@ -16,7 +16,7 @@ class Api::Visioplainte::WebhookEndpointsController < Api::Visioplainte::BaseCon
   def update
     @webhook_endpoint = authorized_webhook_endpoint_scope.find(params[:id])
     @webhook_endpoint.update!(permitted_params)
-    render_record @webhook_endpoint
+    render json: WebhookEndpointBlueprint.render(@webhook_endpoint), status: :ok
   end
 
   def destroy

--- a/app/controllers/api/visioplainte/webhook_endpoints_controller.rb
+++ b/app/controllers/api/visioplainte/webhook_endpoints_controller.rb
@@ -1,0 +1,37 @@
+# cf docs/interconnexions/visioplainte.md
+
+class Api::Visioplainte::WebhookEndpointsController < Api::Visioplainte::BaseController
+  def index
+    render_collection(authorized_webhook_endpoint_scope.order(:id))
+  end
+
+  def create
+    @webhook_endpoint = WebhookEndpoint.new(permitted_params)
+    authorize(@webhook_endpoint, policy_class: Agent::WebhookEndpointPolicy)
+    @webhook_endpoint.save!
+    render_record @webhook_endpoint
+  end
+
+  def update
+    @webhook_endpoint = authorized_webhook_endpoint_scope.find(params[:id])
+    @webhook_endpoint.update!(permitted_params)
+    render_record @webhook_endpoint
+  end
+
+  def delete; end
+
+  private
+
+  def set_webhook_endpoint
+    @webhook_endpoint = policy_scope(WebhookEndpoint, policy_scope_class: Agent::WebhookEndpointPolicy::Scope).find(params[:id])
+    authorize(@webhook_endpoint, policy_class: Agent::WebhookEndpointPolicy)
+  end
+
+  def authorized_webhook_endpoint_scope
+    WebhookEndpoint.joins(organisation: :territory).merge(Territory.visioplainte)
+  end
+
+  def permitted_params
+    params.permit(:target_url, :secret, subscriptions: [])
+  end
+end

--- a/app/controllers/api/visioplainte/webhook_endpoints_controller.rb
+++ b/app/controllers/api/visioplainte/webhook_endpoints_controller.rb
@@ -8,9 +8,9 @@ class Api::Visioplainte::WebhookEndpointsController < Api::Visioplainte::BaseCon
 
   def create
     @webhook_endpoint = WebhookEndpoint.new(permitted_params)
-    authorize(@webhook_endpoint, policy_class: Agent::WebhookEndpointPolicy)
+    @webhook_endpoint.organisation_id = Territory.visioplainte.first.organisations.sole.id
     @webhook_endpoint.save!
-    render_record @webhook_endpoint
+    render json: WebhookEndpointBlueprint.render(@webhook_endpoint), status: :created
   end
 
   def update

--- a/app/controllers/api/visioplainte/webhook_endpoints_controller.rb
+++ b/app/controllers/api/visioplainte/webhook_endpoints_controller.rb
@@ -21,7 +21,7 @@ class Api::Visioplainte::WebhookEndpointsController < Api::Visioplainte::BaseCon
 
   def destroy
     @webhook_endpoint = authorized_webhook_endpoint_scope.find(params[:id])
-    @webhook_endpoint.delete!
+    @webhook_endpoint.destroy!
 
     head :no_content
   end

--- a/app/controllers/api/visioplainte/webhook_endpoints_controller.rb
+++ b/app/controllers/api/visioplainte/webhook_endpoints_controller.rb
@@ -2,7 +2,8 @@
 
 class Api::Visioplainte::WebhookEndpointsController < Api::Visioplainte::BaseController
   def index
-    render_collection(authorized_webhook_endpoint_scope.order(:id))
+    webhook_endpoints = authorized_webhook_endpoint_scope.order(:id)
+    render json: WebhookEndpointBlueprint.render(webhook_endpoints, root: :webhook_endpoints)
   end
 
   def create
@@ -18,14 +19,14 @@ class Api::Visioplainte::WebhookEndpointsController < Api::Visioplainte::BaseCon
     render_record @webhook_endpoint
   end
 
-  def delete; end
+  def destroy
+    @webhook_endpoint = authorized_webhook_endpoint_scope.find(params[:id])
+    @webhook_endpoint.delete!
+
+    head :no_content
+  end
 
   private
-
-  def set_webhook_endpoint
-    @webhook_endpoint = policy_scope(WebhookEndpoint, policy_scope_class: Agent::WebhookEndpointPolicy::Scope).find(params[:id])
-    authorize(@webhook_endpoint, policy_class: Agent::WebhookEndpointPolicy)
-  end
 
   def authorized_webhook_endpoint_scope
     WebhookEndpoint.joins(organisation: :territory).merge(Territory.visioplainte)

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -75,7 +75,7 @@ namespace :api do
         put :cancel
       end
     end
-    resources :webhooks, only: %i[index create show update delete] do
+    resources :webhook_endpoints, only: %i[index create show update destroy]
 
     # Une route pour réinitialiser les données en staging
     if ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "STAGING"

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -75,6 +75,7 @@ namespace :api do
         put :cancel
       end
     end
+    resources :webhooks, only: %i[index create show update delete] do
 
     # Une route pour réinitialiser les données en staging
     if ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "STAGING"

--- a/docs/interconnexions/visioplainte.md
+++ b/docs/interconnexions/visioplainte.md
@@ -24,10 +24,14 @@ En date d’octobre 2024, nous avons fini de développer la première version de
 Nous sommes en train de mettre en place l’environnement de staging.
 Les équipes de SensioLabs nous indiquent travailler sur l’intégration de leur côté.
 
+L'application VisioPlainte a été mise en production en février 2026.
+
 ## Fonctionnement de l’API
 
 L’API est implémenté par des contrôleurs tous regroupés dans `app/controllers/api/visioplainte`.
 Les appels à notre API sont authentifiées via un header `X-VISIOPLAINTE-API-KEY`.
+
+Des webhooks sont configurés par API pour notifier l'application Visioplainte si un rendez-vous est annulé depuis l'interface de RDV Service Public.
 
 ## Intégration avec MaSécurité
 

--- a/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
@@ -11,6 +11,20 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
     Organisation.find_by(name: "Plateforme Visioplainte Gendarmerie") # créée dans les seeds
   end
 
+  def self.document_schema
+    schema({
+      type: :object,
+      properties: {
+        id: { type: :integer },
+        target_url: { type: :string },
+        organisation_id: { type: :integer },
+        subscriptions: { type: :array },
+      },
+      required: WebhookEndpointBlueprint.reflections[:default].fields.keys,
+    })
+  end
+
+
   path "/api/visioplainte/webhook_endpoints" do
     get "Lister les endpoints de webhooks" do
       with_visioplainte_authentication
@@ -49,21 +63,11 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
       parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour"
       parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels"
       parameter name: "subscriptions[]", in: :query, type: :array,
-                description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}"
+        description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
 
       response 201, "Crée l'endpoint de webhook" do
         run_test!
-        schema({
-                 type: :object,
-                 properties: {
-                   id: { type: :integer },
-                   target_url: { type: :string },
-                   organisation_id: { type: :integer },
-                   subscriptions: { type: :array },
-                 },
-                 required: WebhookEndpointBlueprint.reflections[:default].fields.keys,
-               })
-
+        document_schema
         let(:target_url) { "https://exemple.fr/webhook_rdv_service_public" }
         let(:"subscriptions[]") { ["rdv"] } # rubocop:disable Rspec/VariableName
         let(:secret) { "fake_test_secret_123" }
@@ -79,4 +83,40 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
       end
     end
   end
+
+  path "/api/visioplainte/webhook_endpoints/{id}" do
+    patch "Modifier un endpoint de webhook" do
+      with_visioplainte_authentication
+
+      description "Crée un endpoint de webhook dans l'espace Visioplainte"
+      parameter name: "id", in: :path, type: :integer, description: "L'id de l'endpoint de webhook à modifier"
+      parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour", required: false
+      parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels", required: false
+      parameter name: "subscriptions[]", in: :query, type: :array, required: false,
+        description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
+
+      response 200, "Modifie un endpoint de webhook" do
+        run_test!
+        document_schema
+        let(:secret) { "new_fake_test_secret_456"}
+        let(:id) { webhook_endpoint.id }
+        let!(:webhook_endpoint) do
+          create(:webhook_endpoint, organisation: orga_gendarmerie, target_url: "https://exemple.fr/webhook_rdv_service_public", subscriptions: [:rdv])
+        end
+
+
+        specify do
+          expect(webhook_endpoint.reload.secret).to eq "new_fake_test_secret_456"
+        end
+      end
+    end
+
+    delete "Supprimer un endpoint de webhook" do
+
+      with_visioplainte_authentication
+    end
+
+
 end
+end
+

--- a/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
@@ -61,8 +61,10 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
       description "Crée un endpoint de webhook dans l'espace Visioplainte"
       parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour"
       parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels"
-      parameter name: "subscriptions[]", in: :query, type: :array,
-                description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
+      parameter name: "subscriptions[]", in: :query, type: :array, description: <<~DOC
+        Le type de mises à jours pour lesquelles les notifications seront envoyées.
+        Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
+      DOC
 
       response 201, "Crée l'endpoint de webhook" do
         run_test!
@@ -92,7 +94,8 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
       parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour", required: false
       parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels", required: false
       parameter name: "subscriptions[]", in: :query, type: :array, required: false,
-                description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
+                description: "Le type de mises à jours pour lesquelles les notifications seront envoyées.\
+                Les valeurs possibles à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
 
       response 200, "Modifie un endpoint de webhook" do
         run_test!

--- a/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
@@ -40,5 +40,43 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
         end
       end
     end
+
+    post "Créer un endpoint de webhook" do
+      with_visioplainte_authentication
+
+      tags "WebhookEndpoint"
+      description "Crée un endpoint de webhook dans l'espace Visioplainte"
+      parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour"
+      parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels"
+      parameter name: "subscriptions[]", in: :query, type: :array,
+                description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}"
+
+      response 201, "Crée l'endpoint de webhook" do
+        run_test!
+        schema({
+                 type: :object,
+                 properties: {
+                   id: { type: :integer },
+                   target_url: { type: :string },
+                   organisation_id: { type: :integer },
+                   subscriptions: { type: :array },
+                 },
+                 required: WebhookEndpointBlueprint.reflections[:default].fields.keys,
+               })
+
+        let(:target_url) { "https://exemple.fr/webhook_rdv_service_public" }
+        let(:"subscriptions[]") { ["rdv"] } # rubocop:disable Rspec/VariableName
+        let(:secret) { "fake_test_secret_123" }
+
+        specify do
+          expect(WebhookEndpoint.last).to have_attributes(
+            organisation: orga_gendarmerie,
+            target_url: "https://exemple.fr/webhook_rdv_service_public",
+            secret: "fake_test_secret_123",
+            subscriptions: ["rdv"]
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
@@ -1,0 +1,44 @@
+require "swagger_helper"
+
+RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
+  stub_env_with(DB_SEEDS_USERS_AND_AGENTS_PASSWORD: "Rdvservicepublictest1!")
+
+  before do
+    load Rails.root.join("db/seeds/visioplainte.rb")
+  end
+
+  let(:orga_gendarmerie) do
+    Organisation.find_by(name: "Plateforme Visioplainte Gendarmerie") # créée dans les seeds
+  end
+
+  path "/api/visioplainte/webhook_endpoints" do
+    get "Lister les endpoints de webhooks" do
+      with_visioplainte_authentication
+
+      tags "WebhookEndpoint"
+      description "Liste tous les endpoints de webhooks de l'espace Visioplainte"
+
+      let!(:webhook_endpoint) do
+        create(:webhook_endpoint, organisation: orga_gendarmerie, target_url: "https://exemple.fr/webhook_rdv_service_public", subscriptions: [:rdv])
+      end
+
+      response 200, "Renvoie la liste" do
+        run_test!
+
+        specify do
+          expect(parsed_response_body).to eq(
+            {
+              "webhook_endpoints" =>
+                        [{
+                          "id" => webhook_endpoint.id,
+                          "organisation_id" => orga_gendarmerie.id,
+                          "subscriptions" => ["rdv"],
+                          "target_url" => "https://exemple.fr/webhook_rdv_service_public",
+                        }],
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
     patch "Modifier un endpoint de webhook" do
       with_visioplainte_authentication
 
-      description "Crée un endpoint de webhook dans l'espace Visioplainte"
+      description "Crée un endpoint de webhook dans l'espace Visioplainte, typiquement pour faire une rotation de secret"
       parameter name: "id", in: :path, type: :integer, description: "L'id de l'endpoint de webhook à modifier"
       parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour", required: false
       parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels", required: false
@@ -112,11 +112,22 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
     end
 
     delete "Supprimer un endpoint de webhook" do
-
       with_visioplainte_authentication
+      description "Supprime un endpoint de webhook dans l'espace Visioplainte"
+      parameter name: "id", in: :path, type: :integer, description: "L'id de l'endpoint de webhook à supprimer"
+
+      response 204, "Supprime un endpoint de webhook" do
+        run_test!
+        let(:id) { webhook_endpoint.id }
+        let!(:webhook_endpoint) do
+          create(:webhook_endpoint, organisation: orga_gendarmerie, target_url: "https://exemple.fr/webhook_rdv_service_public", subscriptions: [:rdv])
+        end
+
+        specify do
+          expect(WebhookEndpoint.find_by(id: webhook_endpoint.id)).to be_blank
+        end
+      end
     end
-
-
-end
+  end
 end
 

--- a/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/webhook_endpoints_spec.rb
@@ -13,17 +13,16 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
 
   def self.document_schema
     schema({
-      type: :object,
-      properties: {
-        id: { type: :integer },
-        target_url: { type: :string },
-        organisation_id: { type: :integer },
-        subscriptions: { type: :array },
-      },
-      required: WebhookEndpointBlueprint.reflections[:default].fields.keys,
-    })
+             type: :object,
+             properties: {
+               id: { type: :integer },
+               target_url: { type: :string },
+               organisation_id: { type: :integer },
+               subscriptions: { type: :array },
+             },
+             required: WebhookEndpointBlueprint.reflections[:default].fields.keys,
+           })
   end
-
 
   path "/api/visioplainte/webhook_endpoints" do
     get "Lister les endpoints de webhooks" do
@@ -63,13 +62,13 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
       parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour"
       parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels"
       parameter name: "subscriptions[]", in: :query, type: :array,
-        description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
+                description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
 
       response 201, "Crée l'endpoint de webhook" do
         run_test!
         document_schema
         let(:target_url) { "https://exemple.fr/webhook_rdv_service_public" }
-        let(:"subscriptions[]") { ["rdv"] } # rubocop:disable Rspec/VariableName
+        let(:"subscriptions[]") { ["rdv"] } # rubocop:disable RSpec/VariableName
         let(:secret) { "fake_test_secret_123" }
 
         specify do
@@ -93,17 +92,16 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
       parameter name: "target_url", in: :query, type: :string, description: "L'url à appeler pour notifier d'une mise à jour", required: false
       parameter name: "secret", in: :query, type: :string, description: "Le secret qui servira à signer les appels", required: false
       parameter name: "subscriptions[]", in: :query, type: :array, required: false,
-        description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
+                description: "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont #{WebhookEndpoint::ALL_SUBSCRIPTIONS}. Typiquement c'est la valeur rdv qui sera la plus utile."
 
       response 200, "Modifie un endpoint de webhook" do
         run_test!
         document_schema
-        let(:secret) { "new_fake_test_secret_456"}
+        let(:secret) { "new_fake_test_secret_456" }
         let(:id) { webhook_endpoint.id }
         let!(:webhook_endpoint) do
           create(:webhook_endpoint, organisation: orga_gendarmerie, target_url: "https://exemple.fr/webhook_rdv_service_public", subscriptions: [:rdv])
         end
-
 
         specify do
           expect(webhook_endpoint.reload.secret).to eq "new_fake_test_secret_456"
@@ -130,4 +128,3 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
     end
   end
 end
-

--- a/spec/requests/api/visioplainte/webhook_endpoints_spec.rb
+++ b/spec/requests/api/visioplainte/webhook_endpoints_spec.rb
@@ -1,0 +1,63 @@
+# Cette spec vérifie les aspects de sécurité liés à ces endpoints d'api. Le comportement de l'api est documenté par des specs swagger.
+RSpec.describe "Visioplainte Webhook Endpoints" do
+  stub_env_with(DB_SEEDS_USERS_AND_AGENTS_PASSWORD: "Rdvservicepublictest1!")
+  before { load Rails.root.join("db/seeds/visioplainte.rb") }
+
+  include_context "Visioplainte Auth"
+
+  let(:orga_gendarmerie) do
+    Organisation.find_by(name: "Plateforme Visioplainte Gendarmerie") # créée dans les seeds
+  end
+
+  describe "#index" do
+    let!(:visioplainte_webhook_endpoint) { create(:webhook_endpoint, organisation: orga_gendarmerie) }
+    let!(:other_webhook_endpoint) { create(:webhook_endpoint) }
+
+    it "doesn't include webhook endpoints of organisations from other territories" do
+      get "/api/visioplainte/webhook_endpoints", headers: auth_header
+
+      response_endpoints = response.parsed_body["webhook_endpoints"]
+
+      expect(response_endpoints.count).to eq 1
+      expect(response_endpoints.first["id"]).to eq visioplainte_webhook_endpoint.id
+    end
+  end
+
+  describe "#create" do
+    let!(:organisation) { create(:organisation) }
+
+    it "doesn't allow injection an organisation_id param to create the endpoint for another organisation" do
+      post "/api/visioplainte/webhook_endpoints", headers: auth_header, params: {
+        organisation_id: organisation.id,
+        target_url: "https://exemple.fr/webhook_rdv_service_public", subscriptions: [:rdv], secret: "fake_test_secret_123",
+      }
+
+      expect(orga_gendarmerie.webhook_endpoints.first.target_url).to eq "https://exemple.fr/webhook_rdv_service_public"
+      expect(organisation.reload.webhook_endpoints).to be_blank
+    end
+  end
+
+  describe "#update" do
+    let!(:webhook_endpoint_from_other_organisation) { create(:webhook_endpoint, target_url: "https://exemple.fr") }
+
+    it "doesn't allow using the id of an unrelated organisation's webhook endpoint" do
+      expect do
+        patch "/api/visioplainte/webhook_endpoints/#{webhook_endpoint_from_other_organisation.id}", headers: auth_header, params: { target_url: "https://new-url.fr" }
+      end.to raise_error(ActiveRecord::RecordNotFound)
+
+      expect(webhook_endpoint_from_other_organisation.reload.target_url).to eq "https://exemple.fr"
+    end
+  end
+
+  describe "#delete" do
+    let!(:webhook_endpoint_from_other_organisation) { create(:webhook_endpoint) }
+
+    it "doesn't allow using the id of an unrelated organisation's webhook endpoint" do
+      expect do
+        delete "/api/visioplainte/webhook_endpoints/#{webhook_endpoint_from_other_organisation.id}", headers: auth_header
+      end.to raise_error(ActiveRecord::RecordNotFound)
+
+      expect(webhook_endpoint_from_other_organisation.reload).to be_present
+    end
+  end
+end

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -602,123 +602,123 @@
                     "value": {
                       "guichets": [
                         {
-                          "id": 312,
+                          "id": 4559,
                           "name": "GUICHET 0"
                         },
                         {
-                          "id": 313,
+                          "id": 4560,
                           "name": "GUICHET 1"
                         },
                         {
-                          "id": 314,
+                          "id": 4561,
                           "name": "GUICHET 2"
                         },
                         {
-                          "id": 315,
+                          "id": 4562,
                           "name": "GUICHET 3"
                         },
                         {
-                          "id": 316,
+                          "id": 4563,
                           "name": "GUICHET 4"
                         },
                         {
-                          "id": 317,
+                          "id": 4564,
                           "name": "GUICHET 5"
                         },
                         {
-                          "id": 318,
+                          "id": 4565,
                           "name": "GUICHET 6"
                         },
                         {
-                          "id": 319,
+                          "id": 4566,
                           "name": "GUICHET 7"
                         },
                         {
-                          "id": 320,
+                          "id": 4567,
                           "name": "GUICHET 8"
                         },
                         {
-                          "id": 321,
+                          "id": 4568,
                           "name": "GUICHET 9"
                         },
                         {
-                          "id": 322,
+                          "id": 4569,
                           "name": "GUICHET 10"
                         },
                         {
-                          "id": 323,
+                          "id": 4570,
                           "name": "GUICHET 11"
                         },
                         {
-                          "id": 324,
+                          "id": 4571,
                           "name": "GUICHET 12"
                         },
                         {
-                          "id": 325,
+                          "id": 4572,
                           "name": "GUICHET 13"
                         },
                         {
-                          "id": 326,
+                          "id": 4573,
                           "name": "GUICHET 14"
                         },
                         {
-                          "id": 327,
+                          "id": 4574,
                           "name": "GUICHET 15"
                         },
                         {
-                          "id": 328,
+                          "id": 4575,
                           "name": "GUICHET 16"
                         },
                         {
-                          "id": 329,
+                          "id": 4576,
                           "name": "GUICHET 17"
                         },
                         {
-                          "id": 330,
+                          "id": 4577,
                           "name": "GUICHET 18"
                         },
                         {
-                          "id": 331,
+                          "id": 4578,
                           "name": "GUICHET 19"
                         },
                         {
-                          "id": 332,
+                          "id": 4579,
                           "name": "GUICHET 20"
                         },
                         {
-                          "id": 333,
+                          "id": 4580,
                           "name": "GUICHET 21"
                         },
                         {
-                          "id": 334,
+                          "id": 4581,
                           "name": "GUICHET 22"
                         },
                         {
-                          "id": 335,
+                          "id": 4582,
                           "name": "GUICHET 23"
                         },
                         {
-                          "id": 336,
+                          "id": 4583,
                           "name": "GUICHET 24"
                         },
                         {
-                          "id": 337,
+                          "id": 4584,
                           "name": "GUICHET 25"
                         },
                         {
-                          "id": 338,
+                          "id": 4585,
                           "name": "GUICHET 26"
                         },
                         {
-                          "id": 339,
+                          "id": 4586,
                           "name": "GUICHET 27"
                         },
                         {
-                          "id": 340,
+                          "id": 4587,
                           "name": "GUICHET 28"
                         },
                         {
-                          "id": 341,
+                          "id": 4588,
                           "name": "GUICHET 29"
                         }
                       ]
@@ -796,31 +796,31 @@
                           "id": 11,
                           "starts_at": "2024-08-19T09:00:00+02:00",
                           "ends_at": "2024-08-19T12:00:00+02:00",
-                          "guichet_id": 372
+                          "guichet_id": 4619
                         },
                         {
                           "id": 11,
                           "starts_at": "2024-08-20T09:00:00+02:00",
                           "ends_at": "2024-08-20T12:00:00+02:00",
-                          "guichet_id": 372
+                          "guichet_id": 4619
                         },
                         {
                           "id": 11,
                           "starts_at": "2024-08-21T09:00:00+02:00",
                           "ends_at": "2024-08-21T12:00:00+02:00",
-                          "guichet_id": 372
+                          "guichet_id": 4619
                         },
                         {
                           "id": 11,
                           "starts_at": "2024-08-22T09:00:00+02:00",
                           "ends_at": "2024-08-22T12:00:00+02:00",
-                          "guichet_id": 372
+                          "guichet_id": 4619
                         },
                         {
                           "id": 11,
                           "starts_at": "2024-08-23T09:00:00+02:00",
                           "ends_at": "2024-08-23T12:00:00+02:00",
-                          "guichet_id": 372
+                          "guichet_id": 4619
                         }
                       ]
                     }
@@ -973,7 +973,7 @@
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 466,
+                        "id": 4713,
                         "name": "Superviseur FICTIF"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
@@ -1155,7 +1155,7 @@
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 559,
+                        "id": 4806,
                         "name": "Superviseur FICTIF"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
@@ -1207,6 +1207,296 @@
                     "status",
                     "user_id"
                   ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/visioplainte/webhook_endpoints": {
+      "get": {
+        "summary": "Lister les endpoints de webhooks",
+        "security": [
+          {
+            "X-VISIOPLAINTE-API-KEY": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-VISIOPLAINTE-API-KEY",
+            "in": "header",
+            "description": "Clé d'API",
+            "example": "visioplainte-api-test-key-123456",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "WebhookEndpoint"
+        ],
+        "description": "Liste tous les endpoints de webhooks de l'espace Visioplainte",
+        "responses": {
+          "200": {
+            "description": "Renvoie la liste",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": {
+                      "webhook_endpoints": [
+                        {
+                          "id": 124,
+                          "organisation_id": 161,
+                          "subscriptions": [
+                            "rdv"
+                          ],
+                          "target_url": "https://exemple.fr/webhook_rdv_service_public"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Créer un endpoint de webhook",
+        "security": [
+          {
+            "X-VISIOPLAINTE-API-KEY": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-VISIOPLAINTE-API-KEY",
+            "in": "header",
+            "description": "Clé d'API",
+            "example": "visioplainte-api-test-key-123456",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "target_url",
+            "in": "query",
+            "description": "L'url à appeler pour notifier d'une mise à jour",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "query",
+            "description": "Le secret qui servira à signer les appels",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subscriptions[]",
+            "in": "query",
+            "description": "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont [\"rdv\", \"absence\", \"plage_ouverture\", \"user\", \"user_profile\", \"organisation\", \"motif\", \"lieu\", \"agent\", \"agent_role\", \"referent_assignation\"]. Typiquement c'est la valeur rdv qui sera la plus utile.",
+            "schema": {
+              "type": "array"
+            }
+          }
+        ],
+        "tags": [
+          "WebhookEndpoint"
+        ],
+        "description": "Crée un endpoint de webhook dans l'espace Visioplainte",
+        "responses": {
+          "201": {
+            "description": "Crée l'endpoint de webhook",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": {
+                      "id": 126,
+                      "organisation_id": 163,
+                      "subscriptions": [
+                        "rdv"
+                      ],
+                      "target_url": "https://exemple.fr/webhook_rdv_service_public"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "target_url": {
+                      "type": "string"
+                    },
+                    "organisation_id": {
+                      "type": "integer"
+                    },
+                    "subscriptions": {
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "organisation_id",
+                    "subscriptions",
+                    "target_url"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/visioplainte/webhook_endpoints/{id}": {
+      "patch": {
+        "summary": "Modifier un endpoint de webhook",
+        "security": [
+          {
+            "X-VISIOPLAINTE-API-KEY": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-VISIOPLAINTE-API-KEY",
+            "in": "header",
+            "description": "Clé d'API",
+            "example": "visioplainte-api-test-key-123456",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "L'id de l'endpoint de webhook à modifier",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "target_url",
+            "in": "query",
+            "description": "L'url à appeler pour notifier d'une mise à jour",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "query",
+            "description": "Le secret qui servira à signer les appels",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subscriptions[]",
+            "in": "query",
+            "required": false,
+            "description": "Le type de mises à jours pour lesquelles les notifications seront envoyées. Les valeurs possibles  à envoyer dans le tableau sont [\"rdv\", \"absence\", \"plage_ouverture\", \"user\", \"user_profile\", \"organisation\", \"motif\", \"lieu\", \"agent\", \"agent_role\", \"referent_assignation\"]. Typiquement c'est la valeur rdv qui sera la plus utile.",
+            "schema": {
+              "type": "array"
+            }
+          }
+        ],
+        "description": "Crée un endpoint de webhook dans l'espace Visioplainte, typiquement pour faire une rotation de secret",
+        "responses": {
+          "200": {
+            "description": "Modifie un endpoint de webhook",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": {
+                      "id": 128,
+                      "organisation_id": 165,
+                      "subscriptions": [
+                        "rdv"
+                      ],
+                      "target_url": "https://exemple.fr/webhook_rdv_service_public"
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "target_url": {
+                      "type": "string"
+                    },
+                    "organisation_id": {
+                      "type": "integer"
+                    },
+                    "subscriptions": {
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "organisation_id",
+                    "subscriptions",
+                    "target_url"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Supprimer un endpoint de webhook",
+        "security": [
+          {
+            "X-VISIOPLAINTE-API-KEY": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-VISIOPLAINTE-API-KEY",
+            "in": "header",
+            "description": "Clé d'API",
+            "example": "visioplainte-api-test-key-123456",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "L'id de l'endpoint de webhook à supprimer",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "description": "Supprime un endpoint de webhook dans l'espace Visioplainte",
+        "responses": {
+          "204": {
+            "description": "Supprime un endpoint de webhook",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": ""
+                  }
                 }
               }
             }


### PR DESCRIPTION
# Contexte

L'application Visioplainte a besoin d'être notifiée si un rendez-vous est annulé depuis l'interface web de RDV Service Public.
Notre système de webhooks est la solution la plus naturelle pour ce problème.

Afin de pouvoir gérer les webhooks de manière répétable et automatisée, on ouvre donc une api pour permettre à visioplainte de manipuler les webhooks.
Cela servira notamment à faire de la rotation de secrets des webhooks.

# Solution

On fait une api la plus simple possible. On ne demande pas d'envoyer un ID d'orga, vu que normalement il n'y en a qu'une pour visioplainte, donc inutile de compliquer l'api plus que ça.
Pour le moment je ne mets pas de gestion d'erreurs, mais ça serait peut-être sympa à ajouter dans une pr suivante si j'ai le temps.
