### PR TITLE
Correction de la synchronisation Outlook avec les fuseaux horaires

### DIFF
--- a/app/models/concerns/outlook/event_serializer_and_listener.rb
+++ b/app/models/concerns/outlook/event_serializer_and_listener.rb
@@ -69,11 +69,11 @@ module Outlook
           content: event_description,
         },
         start: {
-          dateTime: rdv.starts_at.iso8601,
+          dateTime: rdv.starts_at.strftime("%Y-%m-%dT%H:%M:%S"),
           timeZone: rdv.organisation.time_zone,
         },
         end: {
-          dateTime: rdv.ends_at.iso8601,
+          dateTime: rdv.ends_at.strftime("%Y-%m-%dT%H:%M:%S"),
           timeZone: rdv.organisation.time_zone,
         },
         location: {

--- a/app/models/concerns/outlook/event_serializer_and_listener.rb
+++ b/app/models/concerns/outlook/event_serializer_and_listener.rb
@@ -70,11 +70,11 @@ module Outlook
         },
         start: {
           dateTime: rdv.starts_at.iso8601,
-          timeZone: Time.zone_default.tzinfo.identifier,
+          timeZone: rdv.organisation.time_zone,
         },
         end: {
           dateTime: rdv.ends_at.iso8601,
-          timeZone: Time.zone_default.tzinfo.identifier,
+          timeZone: rdv.organisation.time_zone,
         },
         location: {
           displayName: rdv.address_without_personal_information,

--- a/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
+++ b/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
@@ -260,6 +260,25 @@ RSpec.describe Outlook::EventSerializerAndListener do
     end
   end
 
+  describe "timezone handling" do
+    it "uses the organisation's timezone, not the server default" do
+      organisation_guadeloupe = create(:organisation, time_zone: "America/Guadeloupe")
+      motif_guadeloupe = create(:motif, organisation: organisation_guadeloupe)
+      agent_guadeloupe = create(:agent, microsoft_graph_token: "token", organisations: [organisation_guadeloupe])
+
+      create_request_stub = stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events")
+        .to_return(status: 200, body: { id: "event_id" }.to_json, headers: {})
+
+      create(:rdv, agents: [agent_guadeloupe], motif: motif_guadeloupe, organisation: organisation_guadeloupe,
+                   starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30)
+
+      expect(create_request_stub.with(body: hash_including(
+        "start" => hash_including("timeZone" => "America/Guadeloupe"),
+        "end" => hash_including("timeZone" => "America/Guadeloupe")
+      ))).to have_been_requested.once
+    end
+  end
+
   context "when the rdv has a link in a partner application" do
     let(:rdv_plan) do
       create(:rdv_plan, dossier_url: "http://demarches-simplifies.test/exemple", oauth_application: oauth_application)

--- a/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
+++ b/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe Outlook::EventSerializerAndListener do
   end
 
   describe "timezone handling" do
-    it "uses the organisation's timezone, not the server default" do
+    it "sends datetime without UTC offset so Outlook respects the timeZone field" do
       organisation_guadeloupe = create(:organisation, time_zone: "America/Guadeloupe")
       motif_guadeloupe = create(:motif, organisation: organisation_guadeloupe)
       agent_guadeloupe = create(:agent, microsoft_graph_token: "token", organisations: [organisation_guadeloupe])
@@ -273,8 +273,8 @@ RSpec.describe Outlook::EventSerializerAndListener do
                    starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30)
 
       expect(create_request_stub.with(body: hash_including(
-        "start" => hash_including("timeZone" => "America/Guadeloupe"),
-        "end" => hash_including("timeZone" => "America/Guadeloupe")
+        "start" => { "dateTime" => "2023-01-01T11:00:00", "timeZone" => "America/Guadeloupe" },
+        "end" => { "dateTime" => "2023-01-01T11:30:00", "timeZone" => "America/Guadeloupe" }
       ))).to have_been_requested.once
     end
   end

--- a/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
+++ b/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe Outlook::EventSerializerAndListener do
           content: expected_description,
         },
         start: {
-          dateTime: "2023-01-01T11:00:00+01:00",
+          dateTime: "2023-01-01T11:00:00",
           timeZone: "Europe/Paris",
         },
         end: {
-          dateTime: "2023-01-01T11:30:00+01:00",
+          dateTime: "2023-01-01T11:30:00",
           timeZone: "Europe/Paris",
         },
         location: {
@@ -80,11 +80,11 @@ RSpec.describe Outlook::EventSerializerAndListener do
             content: expected_description,
           },
           start: {
-            dateTime: "2023-01-01T11:00:00+01:00",
+            dateTime: "2023-01-01T11:00:00",
             timeZone: "Europe/Paris",
           },
           end: {
-            dateTime: "2023-01-01T11:40:00+01:00",
+            dateTime: "2023-01-01T11:40:00",
             timeZone: "Europe/Paris",
           },
           location: {
@@ -138,11 +138,11 @@ RSpec.describe Outlook::EventSerializerAndListener do
             content: expected_description,
           },
           start: {
-            dateTime: "2023-01-01T11:00:00+01:00",
+            dateTime: "2023-01-01T11:00:00",
             timeZone: "Europe/Paris",
           },
           end: {
-            dateTime: "2023-01-01T11:40:00+01:00",
+            dateTime: "2023-01-01T11:40:00",
             timeZone: "Europe/Paris",
           },
           location: {


### PR DESCRIPTION
Closes #6523

# Contexte

Des agents en poste à l'étranger ou dans les DROM-COM signalaient que les rendez-vous synchronisés dans Outlook apparaissaient avec un décalage horaire. Le fuseau horaire envoyé à l'API Microsoft Graph était systématiquement celui du serveur (`Europe/Paris`), quelle que soit la timezone de l'organisation du rendez-vous.

# Solution

Dans `serialize_for_outlook_api`, le champ `timeZone` des dates de début et de fin utilise désormais `rdv.organisation.time_zone` au lieu de `Time.zone_default.tzinfo.identifier`. C'est le même correctif que celui appliqué pour la synchro CalDAV dans la PR #5719.

Un test d'intégration est ajouté pour couvrir le cas d'une organisation en `America/Guadeloupe` et vérifier que ce fuseau est bien transmis à Outlook.


Testé avec un vrai compte Outlook