### PR TITLE
Ajout du menu latéral dans les liens d’évitements

### DIFF
--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -22,7 +22,7 @@ aside.left-side-menu-wrapper
         active_item = @current_menu_item || active_menu_item
         selected_agent = @agent || @contextual_agents&.first
         query_params = selected_agent ? { agent_id: selected_agent } : {}
-      = render(DsfrComponent::SideMenuComponent.new(title: "Menu")) do |menu|
+      = render(DsfrComponent::SideMenuComponent.new(title: "Menu", html_attributes: {id: "menu"} )) do |menu|
         ruby:
           menu.with_item(title: safe_join([icon("fr-icon-calendar-event-line", class: "fr-icon--sm fr-mr-1w"), "Planning"]), path: admin_organisation_planning_agenda_path(current_organisation, **query_params), current_page: active_item == :menu_planning)
           menu.with_item(title: safe_join([icon("fr-icon-group-line", class: "fr-icon--sm fr-mr-1w"), "Usagers"]), path: admin_organisation_users_path(current_organisation), current_page: active_item == :menu_users)

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -4,7 +4,7 @@ html lang="fr"
     = yield :html_head_prepend
     = render "common/head_agent"
   body
-    - links = [dsfr_link_to("Contenu", "#main"), link_to("Pied de page", "#footer")]
+    - links = [dsfr_link_to("Contenu", "#main"), dsfr_link_to("Menu", "#menu"), dsfr_link_to("Pied de page", "#footer")]
     = dsfr_skiplink label: "Accès rapide", links: links
 
     = render "layouts/agent_header"


### PR DESCRIPTION
# Contexte

Nous avons pas mal d’éléments avant le menu latéral. 
Je propose donc de simplifier la navigation au clavier en permettant d’aller directement au menu latéral pour les agents.

