### PR TITLE
Correction de la saisie d’une durée négative RDV Wizard agent

### DIFF
--- a/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
+++ b/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
@@ -35,6 +35,8 @@ module Admin::RdvWizardFormConcern
   end
 
   def minutes_after_rdv_from_plage_ouvertures
+    return 0 if @rdv.ends_at.nil? || @rdv.starts_at >= @rdv.ends_at
+
     PlageOuverture
       .joins(:motifs)
       .where(motifs: @rdv.motif)

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -68,7 +68,7 @@ class Rdv < ApplicationRecord
   validates :starts_at, :ends_at, :agents, :status, presence: true
   validate :lieu_is_not_disabled_if_needed
   validates :starts_at, realistic_date: true
-  validate :duration_is_plausible
+  validates :duration_in_min, numericality: { greater_than: 0, allow_nil: true }
   validates :max_participants_count, numericality: { greater_than: 0, allow_nil: true }
 
   validates :participations, presence: true, unless: :collectif?
@@ -405,12 +405,6 @@ class Rdv < ApplicationRecord
     else
       unknown!
     end
-  end
-
-  def duration_is_plausible
-    return if starts_at.nil? || ends_at.nil?
-
-    errors.add(:duration_in_min, :must_be_positive) if starts_at >= ends_at
   end
 
   def lieu_is_not_disabled_if_needed

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -9,7 +9,7 @@ ruby:
       .fr-grid-row.fr-grid-row--gutters.fr-mb-4v
         .fr-col-md-6 data={ "controller": "past-date-alert" }
           = dsfr_datetime_input(f, :starts_at, label: Rdv.human_attribute_name(:starts_at), data: { "past-date-alert-target": "date-input" })
-        .fr-col-md-6= f.dsfr_number_field :duration_in_min, label: Rdv.human_attribute_name(:duration_in_min)
+        .fr-col-md-6= f.dsfr_number_field :duration_in_min, label: Rdv.human_attribute_name(:duration_in_min), min: 1
       - if @rdv.public_office?
         - new_lieu_record = @rdv.lieu&.new_record?
         - controller_data = { "controller": "rdv-lieu",

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -26,7 +26,7 @@
             .fr-grid-row.fr-grid-row--gutters.fr-mb-4v
               .fr-col-md-6 data={ "controller": "past-date-alert" }
                 = dsfr_datetime_input(f, :starts_at, label: Rdv.human_attribute_name(:starts_at), data: { "past-date-alert-target": "date-input" })
-              .fr-col-md-6= f.dsfr_number_field :duration_in_min, label: Rdv.human_attribute_name(:duration_in_min)
+              .fr-col-md-6= f.dsfr_number_field :duration_in_min, label: Rdv.human_attribute_name(:duration_in_min), min: 1
             - if @rdv_form.motif.public_office?
 
               - controller_data = { "controller": "rdv-lieu",


### PR DESCRIPTION
Fixes LAPINS-789

# Contexte

Saisir une durée négative dans le wizard de création de RDV (côté agent) provoquait une erreur 500. Le problème venait de `minutes_after_rdv_from_plage_ouvertures`, appelé dans le constructeur du wizard : quand `duration_in_min` était négatif, `set_ends_at` calculait un `ends_at` antérieur à `starts_at`, ce qui produisait une plage inversée (`starts_at..ends_at`) transmise à une requête PostgreSQL `tsrange`, laquelle rejette les bornes inversées.

# Solution

Trois niveaux de correction :

**Modèle (`Rdv`)**
- La validation custom `duration_is_plausible` est remplacée par un `validates :duration_in_min, numericality: { greater_than: 0, allow_nil: true }` standard, plus explicite. Le getter `duration_in_min` calculant la durée à partir des timestamps quand les deux sont présents, cette validation couvre aussi le cas où `ends_at` est assigné directement (ex. `CreateRdvInNewInstance`).

**Concern (`Admin::RdvWizardFormConcern`)**
- `minutes_after_rdv_from_plage_ouvertures` reçoit un garde-fou sur `ends_at` nil ou invalide, pour éviter tout crash résiduel si le constructeur est appelé avec des données incohérentes.

**Vues**
- Ajout de `min: 1` sur les champs de durée du wizard (étape 3) et du formulaire d'édition de RDV, pour bloquer la saisie côté navigateur avant même la soumission.
