### PR TITLE
Fixer l'ordre des agents dans les vues multi agents

### DIFF
--- a/app/controllers/concerns/admin/planning/planning_concern.rb
+++ b/app/controllers/concerns/admin/planning/planning_concern.rb
@@ -9,8 +9,9 @@ module Admin::Planning::PlanningConcern
   private
 
   def set_agents
+    agent_ids = Array(params[:agent_id]).compact_blank
     agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
-      .where(id: Array(params[:agent_id]).compact_blank)
+      .in_order_of(:id, agent_ids) # equivalent to WHERE IN + ORDER BY respecting array values
       .load
 
     case agents.size


### PR DESCRIPTION
# Contexte

Issu de [l'exploration pour réduire la flakiness des specs](https://github.com/botadrien/rdv-service-public/pull/2)

Actuellement l'ordre des agents dans les vues multi agents (par ex la vue calendrier des RDV) n'est pas garanti. En effet, `set_agents` appelle `Agent.where(id: agent_ids).load` sans `ORDER BY`.

C'est un léger et rare bug d'UX pour les utilisateurs, l'ordre des agents peut changer d'une requête à l’autre. 

# Solution

On utilise plutôt `in_order_of` pour trier de façon déterministe selon l'ordre du paramètre `agent_id[]` qui reflète l'ordre des options du select multi-agent. [cf doc rails de in_order_of](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-in_order_of)