### PR TITLE
Specs: remplacer les sleep par des expect pour limiter la flakiness

### DIFF
--- a/spec/features/agents/rdvs/cancel_rdv_spec.rb
+++ b/spec/features/agents/rdvs/cancel_rdv_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Agent can cancel a RDV", js: true do
     accept_alert do
       find("span", text: "Annulé à l’initiative du service").click
     end
-    sleep 1 # Pour attendre que la requête ajax se finisse
+    expect(page).to have_css("#rdv-status-#{rdv.id} .rdv-status-revoked")
     expect(rdv.reload.status).to eq("revoked")
 
     perform_enqueued_jobs

--- a/spec/features/agents/rdvs/rdv_details_spec.rb
+++ b/spec/features/agents/rdvs/rdv_details_spec.rb
@@ -107,10 +107,9 @@ RSpec.describe "Agent can see RDV details correctly" do
       it "allows editing the RDV status", js: true do
         visit admin_organisation_rdv_path(organisation, rdv)
         find(".btn", text: "À renseigner").click
-        expect do
-          find("span", text: "Rendez-vous honoré").click
-          sleep 1
-        end.to change { rdv.reload.status }.to("seen")
+        find("span", text: "Rendez-vous honoré").click
+        expect(page).to have_content("Rendez-vous mis à jour")
+        expect(rdv.reload.status).to eq("seen")
       end
     end
   end

--- a/spec/features/agents/rdvs/renseigner_rdv_spec.rb
+++ b/spec/features/agents/rdvs/renseigner_rdv_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe "Les agents peuvent renseigner le statut des rendez-vous pour nou
     visit root_path
     click_link "1 RDV à renseigner"
     find(".fr-btn", text: "Rendez-vous honoré").click
-    sleep 1 # Pour attendre que la requête ajax se finisse
+    expect(page).to have_css("#rdv-status-#{rdv.id} .rdv-status-seen")
     expect(page).to have_content("Rendez-vous mis à jour")
     expect(rdv.reload.status).to eq("seen")
 
     # Et on peut faire un reset
     find(".btn", text: "Rendez-vous honoré").click
     find("span", text: "Réinitialiser").click
-    sleep 1 # Pour attendre que la requête ajax se finisse
+    expect(page).to have_css(".fr-btn", text: "Rendez-vous honoré")
     expect(page).to have_content("Rendez-vous mis à jour")
     expect(rdv.reload.status).to eq("unknown")
   end
@@ -30,7 +30,7 @@ RSpec.describe "Les agents peuvent renseigner le statut des rendez-vous pour nou
       find(".fr-btn", text: "Autre").click
       find("span", text: "Annulé à l’initiative du service").click
 
-      sleep 1 # Pour attendre que la requête ajax se finisse
+      expect(page).to have_css("#rdv-status-#{rdv.id} .rdv-status-revoked")
       expect(page).to have_content("Rendez-vous mis à jour")
       expect(rdv.reload.status).to eq("revoked")
     end
@@ -40,14 +40,14 @@ RSpec.describe "Les agents peuvent renseigner le statut des rendez-vous pour nou
     visit admin_organisation_rdv_path(rdv.organisation, rdv)
     find(".btn", text: "À renseigner").click
     find("span", text: "Rendez-vous honoré").click
-    sleep 1 # Pour attendre que la requête ajax se finisse
+    expect(page).to have_css("#rdv-status-#{rdv.id} .rdv-status-seen")
     expect(page).to have_content("Rendez-vous mis à jour")
     expect(rdv.reload.status).to eq("seen")
 
     # Et on peut faire un reset
     find(".btn", text: "Rendez-vous honoré").click
     find("span", text: "Réinitialiser").click
-    sleep 1 # Pour attendre que la requête ajax se finisse
+    expect(page).to have_css("#rdv-status-#{rdv.id} .rdv-status-unknown_past")
     expect(page).to have_content("Rendez-vous mis à jour")
     expect(rdv.reload.status).to eq("unknown")
   end

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Agent can create a Rdv collectif from the agenda" do
     expect(page).to have_selector(".list-group-item", text: /Agent, horaires & lieu/)
 
     click_button("Confirmer le RDV")
-    sleep 1
+    expect(page).to have_content("Le rendez-vous a été créé.")
     perform_enqueued_jobs
     open_email("alain@tiptop.fr")
     expect(current_email.subject).to match(/Nouveau RDV ajouté pour .+ sur votre agenda RDV Service Public/)

--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -127,14 +127,14 @@ RSpec.describe "Agent can organize a rdv collectif", js: true do
 
       # on vérifie qu'un clic sur "Annuler" dans la boite de confirmation annuler bien l'action
       all("td .dropdown-toggle").first.click
-      dismiss_confirm do
-        expect { all("a.dropdown-item").first.click and sleep 0.5 }.not_to change { rdv_collectif.participations.sole.reload.status }
-      end
+      dismiss_confirm { all("a.dropdown-item").first.click }
+      expect(page).to have_css("td .dropdown-toggle.rdv-status-unknown_future")
+      expect(rdv_collectif.participations.sole.reload.status).to eq("unknown")
 
       all("td .dropdown-toggle").first.click
-      accept_confirm do
-        expect { all("a.dropdown-item").first.click and sleep 0.5 }.to change { rdv_collectif.participations.sole.reload.status }
-      end
+      accept_confirm { all("a.dropdown-item").first.click }
+      expect(page).to have_css("td .dropdown-toggle.rdv-status-excused")
+      expect(rdv_collectif.participations.sole.reload.status).to eq("excused")
     end
   end
 end


### PR DESCRIPTION
# Contexte

Issu de [l'exploration pour réduire la flakiness des specs](https://github.com/botadrien/rdv-service-public/pull/2)

# Solution

On remplace plusieurs `sleep` des expect du code par des `expect` qui attendent la fin des requêtes asynchrones automatiquement si nécessaire.