### PR TITLE
Limiter la flakiness du test de recherche textuelle d'usagers

### DIFF
--- a/spec/models/concerns/text_search_spec.rb
+++ b/spec/models/concerns/text_search_spec.rb
@@ -11,19 +11,19 @@ RSpec.describe TextSearch, type: :concern do
 
   describe(User) do
     it "returns users that match with first name" do
-      create(:user, first_name: "jean")
-      patricia = create(:user, first_name: "patricia")
+      create(:user, first_name: "jean", last_name: "valjean")
+      patricia = create(:user, first_name: "patricia", last_name: "duroy")
       expect(described_class.search_by_text("patricia")).to eq([patricia])
     end
 
     it "returns users that match with partial email" do
-      create(:user, email: "jean@moustache.fr")
-      patricia = create(:user, email: "patoche@duroy.fr")
+      create(:user, email: "jean@moustache.fr", first_name: "Jean", last_name: "Bernard")
+      patricia = create(:user, email: "patoche@duroy.fr", first_name: "Patricia", last_name: "Girard")
       expect(described_class.search_by_text("patoche@dur")).to eq([patricia])
       expect(described_class.search_by_text("patoche@")).to eq([patricia])
       expect(described_class.search_by_text("pato")).to eq([patricia])
 
-      francis = create(:user, email: "francis_du_74@msn.com")
+      francis = create(:user, email: "francis_du_74@msn.com", first_name: "Francis", last_name: "Lemoine")
       expect(described_class.search_by_text("francis")).to eq([francis])
       expect(described_class.search_by_text("francis_")).to eq([francis])
       # Ces deux recherches ne fonctionnent pas actuellement, à voir plus tard
@@ -65,9 +65,9 @@ RSpec.describe TextSearch, type: :concern do
     end
 
     it "ignores accents" do
-      francois = create(:user, first_name: "François")
-      emilie = create(:user, first_name: "Émilie")
-      dede = create(:user, first_name: "Dédé")
+      francois = create(:user, first_name: "François", last_name: "Girard")
+      emilie = create(:user, first_name: "Émilie", last_name: "Robert")
+      dede = create(:user, first_name: "Dédé", last_name: "Lefevre")
       expect(described_class.search_by_text("franco")).to eq([francois])
       expect(described_class.search_by_text("franço")).to eq([francois])
       expect(described_class.search_by_text("emi")).to eq([emilie])


### PR DESCRIPTION
# Contexte

PR extraite de [l'exploration pour limiter la flakiness des specs](https://github.com/botadrien/rdv-service-public/pull/2)

Le test `ignores accents` échouait par intermittence car les `last_name` générés aléatoirement par `Faker` pour les users du test pouvaient, par coïncidence, matcher un des termes de recherche testés. 

Exemple observé en CI ([run upstream](https://github.com/betagouv/rdv-service-public/actions/runs/29728051611/job/88307053682)) : le `last_name` tiré aléatoirement pour "Émilie" était "FRANCOIS", ce qui matchait la recherche `franco` attendue uniquement pour l'utilisateur "François" - et avec un score supérieur, car `last_name` a un poids de recherche plus élevé que `first_name` dans le `tsvector`. 

c'est similaire à ce qui se passait dans #5155

# Solution

On fixe explicitement les `first_name` et `last_name` pour tous les users impliqués dans une recherche de cette spec.