### PR TITLE
Correction des liens pour reprendre RDV après annulation (email et SMS)

### DIFF
--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -10,4 +10,27 @@ class RedirectController < ApplicationController
     redirect_to users_rdv_path(params[:id], invitation_token: params[:tkn])
   end
   # >> REMOVE AFTER 01/01/2027
+
+  def reprendre_rdv_from_participation_invitation_token
+    participation = Participation.find_by(restricted_auth_token: params[:tkn])
+
+    if participation
+      redirect_to prendre_rdv_path_for(participation.rdv, params[:tkn])
+    else
+      redirect_to root_path, flash: { error: t("devise.invitations.invitation_token_invalid") }
+    end
+  end
+
+  private
+
+  def prendre_rdv_path_for(rdv, token)
+    prendre_rdv_path(
+      departement: rdv.organisation.departement_number,
+      motif_name_with_location_type: rdv.motif.name_with_location_type,
+      public_link_organisation_id: rdv.organisation_id,
+      lieu_id: rdv.lieu_id,
+      address: rdv.address,
+      invitation_token: token
+    )
+  end
 end

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -47,11 +47,15 @@ class Users::RdvSms < Users::BaseSms
   end
 
   def cancellation_footer(rdv, token)
-    url = prendre_rdv_short_url(host: domain_host, tkn: token)
-    if rdv.phone_number.present?
-      "Appelez le #{rdv.phone_number} ou allez sur #{url} pour reprendre RDV."
-    else
-      "Allez sur #{url} pour reprendre RDV."
+    if rdv.motif.bookable_by_everyone?
+      url = reprendre_rdv_from_participation_invitation_token_short_url(host: domain_host, tkn: token)
+      if rdv.phone_number.present?
+        "Appelez le #{rdv.phone_number} ou allez sur #{url} pour reprendre RDV."
+      else
+        "Allez sur #{url} pour reprendre RDV."
+      end
+    elsif rdv.phone_number.present?
+      "Appelez le #{rdv.phone_number} pour reprendre RDV."
     end
   end
 

--- a/app/views/mailers/users/rdv_mailer/participation_cancelled.html.slim
+++ b/app/views/mailers/users/rdv_mailer/participation_cancelled.html.slim
@@ -16,14 +16,7 @@ div
     p
       | Vous pouvez reprendre un rendez-vous en cliquant sur le lien ci-dessous :
     .btn-wrapper
-      / Il y a peut-être un bug ici : il manquerait le lieu_id, qui fait partie des choix de l'usager
-      = link_to "Reprendre RDV", prendre_rdv_url(\
-        departement: @rdv.organisation.departement_number,
-        motif_name_with_location_type: @rdv.motif.name_with_location_type,
-        organisation_ids: [@rdv.organisation_id],
-        address: @rdv.address,
-        invitation_token: @token \
-      ), class: "btn btn-primary"
+      = link_to "Reprendre RDV", reprendre_rdv_from_participation_invitation_token_short_url(tkn: @token), class: "btn btn-primary"
 
   br
   = t("mailers.common.farewell_html", domain_name: domain.name)

--- a/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
@@ -16,14 +16,7 @@ div
     p
       | Vous pouvez reprendre un rendez-vous en cliquant sur le lien ci-dessous :
     .btn-wrapper
-      / Il y a peut-être un bug ici : il manquerait le lieu_id, qui fait partie des choix de l'usager
-      = link_to "Reprendre RDV", prendre_rdv_url(\
-        departement: @rdv.organisation.departement_number,
-        motif_name_with_location_type: @rdv.motif.name_with_location_type,
-        organisation_ids: [@rdv.organisation_id],
-        address: @rdv.address,
-        invitation_token: @token \
-      ), class: "btn btn-primary"
+      = link_to "Reprendre RDV", reprendre_rdv_from_participation_invitation_token_short_url(tkn: @token), class: "btn btn-primary"
 
   br
   = t("mailers.common.farewell_html", domain_name: domain.name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -435,10 +435,7 @@ Rails.application.routes.draw do
   get "r/:id/:tkn" => "redirect#rdv_short", as: "rdv_short"
   # >> REMOVE AFTER 01/01/2027
 
-  get "prdv", to: (redirect do |_path_params, req|
-    query_params = format_redirect_params(req.params)
-    "prendre_rdv#{query_params}"
-  end), as: "prendre_rdv_short"
+  get "prdv", to: "redirect#reprendre_rdv_from_participation_invitation_token", as: "reprendre_rdv_from_participation_invitation_token_short"
 
   def format_redirect_params(params)
     # we rename the short parameter tkn

--- a/spec/features/users/online_booking/reprendre_rdv_apres_annulation_spec.rb
+++ b/spec/features/users/online_booking/reprendre_rdv_apres_annulation_spec.rb
@@ -1,0 +1,83 @@
+REPRENDRE_RDV_URL_REGEX = %r{https?://\S+/prdv\?tkn=[A-Z0-9]+}
+
+RSpec.describe "Liens reprendre RDV après annulation (email et SMS)" do
+  context "RDV individuel avec une seule participation, notifier RdvCancelled" do
+    let(:territory) { create(:territory) }
+    let(:organisation) { create(:organisation, territory:) }
+    let(:autre_organisation) { create(:organisation, territory:) }
+    let(:motif) { create(:motif, name: "Accompagnement", organisation:, bookable_by: :everyone) }
+    let(:autre_motif) { create(:motif, name: "Accompagnement", organisation: autre_organisation, bookable_by: :everyone) }
+    let(:lieu) { create(:lieu, name: "MDS Issy", organisation:) }
+    let(:autre_lieu) { create(:lieu, name: "MDS Là bas", organisation: autre_organisation) }
+    let(:user) { create(:user) }
+    let(:agent) { create(:agent) }
+    let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu:, organisation:) }
+    let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [autre_motif], lieu: autre_lieu, organisation: autre_organisation) }
+    let(:rdv) { create(:rdv, :excused, organisation:, motif:, lieu:, users: [user]) }
+
+    it "amène à la recherche scopée pour l’organisation du RDV annulé, via le lien de l’email ou du SMS" do
+      stub_netsize_ok
+      Notifiers::RdvCancelled.perform_with(rdv, agent)
+      perform_enqueued_jobs
+      mail_body = first_email_sent_to(user.email).html_part.body.to_s
+      mail_link_url = Nokogiri::HTML(mail_body).to_s.match(REPRENDRE_RDV_URL_REGEX)&.to_s
+      sms_link_url = Receipt.last.content.match(REPRENDRE_RDV_URL_REGEX)&.to_s
+      expect(mail_link_url).to eq sms_link_url
+      visit mail_link_url
+      expect(page).to have_content("MDS Issy")
+      expect(page).not_to have_content("MDS Là bas")
+    end
+  end
+
+  context "RDV avec plusieurs participations, notifier ParticipationCancelled" do
+    let(:territory) { create(:territory) }
+    let(:organisation) { create(:organisation, territory:) }
+    let(:autre_organisation) { create(:organisation, territory:) }
+    let(:motif) { create(:motif, name: "Accompagnement", organisation:, bookable_by: :everyone) }
+    let(:autre_motif) { create(:motif, name: "Accompagnement", organisation: autre_organisation, bookable_by: :everyone) }
+    let(:lieu) { create(:lieu, name: "MDS Issy", organisation:) }
+    let(:autre_lieu) { create(:lieu, name: "MDS Là bas", organisation: autre_organisation) }
+    let(:user) { create(:user) }
+    let(:agent) { create(:agent) }
+    let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu:, organisation:) }
+    let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [autre_motif], lieu: autre_lieu, organisation: autre_organisation) }
+    let(:autre_user) { create(:user) }
+    let(:rdv) { create(:rdv, organisation:, motif:, lieu:, users: [user, autre_user]) }
+    let(:participation) { rdv.participations.find_by(user:) }
+
+    it "amène à la recherche scopée pour l’organisation du RDV annulé, via le lien de l’email ou du SMS" do
+      stub_netsize_ok
+      Notifiers::ParticipationCancelled.perform_with(participation:, author: agent)
+      perform_enqueued_jobs
+      mail_body = first_email_sent_to(user.email).body.to_s
+      mail_link_url = Nokogiri::HTML(mail_body).to_s.match(REPRENDRE_RDV_URL_REGEX)&.to_s
+      sms_link_url = Receipt.last.content.match(REPRENDRE_RDV_URL_REGEX)&.to_s
+      expect(mail_link_url).to eq sms_link_url
+      visit mail_link_url
+      expect(page).to have_content("MDS Issy")
+      expect(page).not_to have_content("MDS Là bas")
+    end
+  end
+
+  context "RDV non réservable publiquement par les usagers" do
+    let(:territory) { create(:territory) }
+    let(:organisation) { create(:organisation, territory:) }
+    let(:motif) { create(:motif, name: "Accompagnement", organisation:, bookable_by: "agents") }
+    let(:lieu) { create(:lieu, name: "MDS Issy", organisation:) }
+    let(:user) { create(:user) }
+    let(:agent) { create(:agent, organisations: [organisation]) }
+    let(:rdv) { create(:rdv, organisation:, motif:, lieu:, users: [user], agents: [agent]) }
+    let(:participation) { rdv.participations.find_by(user:) }
+
+    it "n'affiche pas de lien pour reprendre RDV ni dans le mail ni dans le SMS" do
+      stub_netsize_ok
+      Notifiers::ParticipationCancelled.perform_with(participation:, author: agent)
+      perform_enqueued_jobs
+      mail_body = first_email_sent_to(user.email).body.to_s
+      mail_link_url = Nokogiri::HTML(mail_body).to_s.match(REPRENDRE_RDV_URL_REGEX)&.to_s
+      sms_link_url = Receipt.last.content.match(REPRENDRE_RDV_URL_REGEX)&.to_s
+      expect(mail_link_url).to be_blank
+      expect(sms_link_url).to be_blank
+    end
+  end
+end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -188,14 +188,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
-      expected_url = prendre_rdv_url(
-        departement: rdv.organisation.departement_number,
-        motif_name_with_location_type: rdv.motif.name_with_location_type,
-        organisation_ids: [rdv.organisation_id],
-        address: rdv.address,
-        invitation_token: token,
-        host: Domain::RDV_SOLIDARITES.host_name
-      )
+      expected_url = reprendre_rdv_from_participation_invitation_token_short_url(tkn: token, host: Domain::RDV_SOLIDARITES.host_name)
 
       expect(mail.html_part.body).to have_link("Reprendre RDV", href: expected_url)
     end
@@ -242,14 +235,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       let(:motif) { create(:motif, :collectif, organisation:, bookable_by: :everyone) }
 
       it "le corps contient un lien pour reprendre RDV" do
-        expected_url = prendre_rdv_url(
-          departement: rdv.organisation.departement_number,
-          motif_name_with_location_type: rdv.motif.name_with_location_type,
-          organisation_ids: [rdv.organisation_id],
-          address: rdv.address,
-          invitation_token: token,
-          host: Domain::RDV_SOLIDARITES.host_name
-        )
+        expected_url = reprendre_rdv_from_participation_invitation_token_short_url(tkn: token, host: Domain::RDV_SOLIDARITES.host_name)
 
         expect(mail.body).to have_link("Reprendre RDV", href: expected_url)
       end

--- a/spec/requests/redirect_controller_spec.rb
+++ b/spec/requests/redirect_controller_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe "RedirectController#reprendre_rdv_from_participation_invitation_token", type: :request do
+  describe "GET /prdv" do
+    context "avec un token de participation valide" do
+      let(:organisation) { create(:organisation) }
+      let(:motif) { create(:motif, organisation:) }
+      let(:lieu) { create(:lieu, organisation:) }
+      let(:rdv) { create(:rdv, organisation:, motif:, lieu:) }
+      let(:token) { rdv.participations.first.restricted_auth_token }
+
+      it "redirige vers la recherche scopée à l'organisation, au lieu et au motif du RDV" do
+        get "/prdv", params: { tkn: token }
+
+        expect(response).to redirect_to(
+          prendre_rdv_path(
+            departement: organisation.departement_number,
+            motif_name_with_location_type: motif.name_with_location_type,
+            public_link_organisation_id: organisation.id,
+            lieu_id: lieu.id,
+            address: rdv.address,
+            invitation_token: token
+          )
+        )
+      end
+    end
+
+    context "avec un token inconnu" do
+      it "redirige vers l'accueil avec un message d'erreur" do
+        get "/prdv", params: { tkn: "token-inconnu" }
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to eq(I18n.t("devise.invitations.invitation_token_invalid"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Contexte

Découverte lors des correctifs sur #6456

Plusieurs bugs existent actuellement sur les liens « Reprendre RDV » envoyés lors de l'annulation d'un RDV (ou d'une participation) : 

1. ceux dans les mails d'annulation perdent silencieusement le scoping à l'organisation
2. ceux dans les SMS ne passent aucun param de recherche (!). ils ne font que logger l'usager et le renvoyer a la home
3. dans les SMS on affiche le lien même si le motif n'est pas réservable par les usagers

## Causes & Détails

Cause de 1 :

  - Ces mails utilisent toujours un `restricted_auth_token` de `Participation` comme `invitation_token` (cf. [`Notifiers::RdvBase#generate_invitation_tokens`](https://github.com/betagouv/rdv-service-public/blob/production/app/services/notifiers/rdv_base.rb#L51)) et jamais un `rdv_invitation_token` d'`User.`
  - `Invitation#to_take_rdv?` valait donc toujours false
  - `SearchController#search_rdv` construit dans ce cas un `WebSearchContext` (et non un `WebInvitationSearchContext`).
  - Or `WebSearchContext` ne lit jamais le paramètre `organisation_ids` (celui-ci n'est utilisé que par InvitationSearchContext, pour le flux  « invitation à prendre un nouveau RDV »). Il lit en revanche `public_link_organisation_id`.
  - Les vues des mails envoyaient `organisation_ids: [@rdv.organisation_id]` → paramètre silencieusement ignoré, recherche non scopée.

Causes de 2 : 

je ne sais pas si ça a un jour fonctionné. sur RDVS c'est à peu près utilisable depuis la home mais sur RDVSP c'est vraiment contre-productif

# Solution

- Remplacement de `organisation_ids: [@rdv.organisation_id]` par `public_link_organisation_id: @rdv.organisation_id`
- Au passage je rajoute le lieu_id manquant signalé par un commentaire

# Review app

https://rdv-service-public-review-app-pr6535.osc-secnum-fr1.scalingo.io/

⚠️ mails activés sur cette Review app

1. prendre RDV en tant qu'usager depuis https://rdv-service-public-review-app-pr6535.osc-secnum-fr1.scalingo.io/prendre_rdv?autofocus=first&date=2026-07-28&departement=75&lieu_id=6&motif_id=9&public_link_organisation_id=4 AVEC UN VRAI EMAIL à vous
2. se deconnecter en tant qu'usagr
3. se connecter en tant que martine agent
4. annuler le RDV qui vient d'être pris
5. se déconnecter en tant qu'agent
6. cliquer dans le lien reçu par mai

=> vous devriez pouvoir reprendre RDV sans vous logger, bien filtré sur l'orga