### PR TITLE
Corrige le message d'erreur trompeur pour les usagers FranceConnect/ProConnect

### DIFF
--- a/app/form_models/users/login_code_request_form.rb
+++ b/app/form_models/users/login_code_request_form.rb
@@ -25,7 +25,9 @@ module Users
       return true if User.loginable_by_code_for_email(email).any?
 
       error =
-        if Agent.exists?(email:)
+        if User.fiches_for_email(email).with_sso.any?
+          "Ce compte usager se connecte avec FranceConnect ou ProConnect. Merci d’utiliser ce moyen de connexion."
+        elsif Agent.exists?(email:)
           <<~ERROR
             Aucun compte usager n’existe pour cet email.
             Si vous souhaitez vous connecter en tant qu’agent, veuillez vous rendre sur la page de connexion agent.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,6 +101,7 @@ class User < ApplicationRecord
   scope :relative, -> { where.not(responsible_id: nil) }
   scope :fiches_for_email, ->(email) { where(email:) }
   scope :without_sso, -> { where(franceconnect_openid_sub: nil, pro_connect_openid_sub: nil) }
+  scope :with_sso, -> { where.not(franceconnect_openid_sub: nil).or(where.not(pro_connect_openid_sub: nil)) }
   scope :loginable_by_code_for_email, ->(email) { fiches_for_email(email).without_sso }
   scope :loginable_by_code_for_email_in_territory_or_without_territory, lambda { |email, territory_id:|
     loginable_by_code_for_email(email)

--- a/spec/form_models/users/login_code_request_form_spec.rb
+++ b/spec/form_models/users/login_code_request_form_spec.rb
@@ -17,6 +17,36 @@ RSpec.describe Users::LoginCodeRequestForm, type: :form_model do
     end
   end
 
+  context "l’usager existe mais s’est créé via FranceConnect" do
+    let!(:user) { create(:user, :using_france_connect, email: "us@ger.fr") }
+
+    it "le form est invalide et suggère d’utiliser FranceConnect" do
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", first_name: "Jean", last_name: "Dupont", domain_id: "RDV_SERVICE_PUBLIC"))
+      expect(form).to be_invalid
+      expect(form.errors[:base]).to include("Ce compte usager se connecte avec FranceConnect ou ProConnect. Merci d’utiliser ce moyen de connexion.")
+    end
+  end
+
+  context "l’usager existe mais s’est créé via ProConnect" do
+    let!(:user) { create(:user, :using_pro_connect, email: "us@ger.fr") }
+
+    it "le form est invalide et suggère d’utiliser ProConnect" do
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", first_name: "Jean", last_name: "Dupont", domain_id: "RDV_SERVICE_PUBLIC"))
+      expect(form).to be_invalid
+      expect(form.errors[:base]).to include("Ce compte usager se connecte avec FranceConnect ou ProConnect. Merci d’utiliser ce moyen de connexion.")
+    end
+  end
+
+  context "l'usager n'existe pas mais un agent existe avec cet email" do
+    let!(:agent) { create(:agent, email: "us@ger.fr") }
+
+    it "le form est invalide et suggère la page de connexion agent" do
+      form = described_class.new(LoginCode.new(email: "us@ger.fr", first_name: "Jean", last_name: "Dupont", domain_id: "RDV_SERVICE_PUBLIC"))
+      expect(form).to be_invalid
+      expect(form.errors[:base].join).to include("page de connexion agent")
+    end
+  end
+
   context "l'usager n'existe pas, avec behaviour :upsert_user" do
     it "le form est valide et la sauvegarde créé le login_code" do
       form = described_class.new(LoginCode.new(email: "new@user.fr", first_name: "Nina", last_name: "Personne", domain_id: "RDV_SERVICE_PUBLIC"), behaviour: "upsert_user")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe ".with_sso" do
+    let!(:user_normal)          { create(:user, email: "test@example.fr") }
+    let!(:user_france_connect)  { create(:user, email: "test@example.fr", franceconnect_openid_sub: "abc123") }
+    let!(:user_pro_connect)     { create(:user, email: "test@example.fr", pro_connect_openid_sub: "def456") }
+
+    it "ne retourne que les fiches connectées via SSO (FranceConnect ou ProConnect)" do
+      expect(described_class.with_sso).to contain_exactly(user_france_connect, user_pro_connect)
+    end
+
+    it "exclut les fiches non connectées via SSO" do
+      expect(described_class.with_sso).not_to include(user_normal)
+    end
+  end
+
   describe ".loginable_by_code_for_email_in_territory_or_without_territory" do
     let!(:territory_1)    { create(:territory) }
     let!(:territory_2)    { create(:territory) }


### PR DESCRIPTION
Fixes #6320

## Contexte

Quand un⋅e usager⋅e a créé son compte via FranceConnect ou ProConnect, puis tente ensuite de se connecter via le login par code à 6 chiffres (email), `User.loginable_by_code_for_email` exclut correctement son compte de la recherche (`.without_sso`, pour ne pas envoyer de code à un compte qui n'en utilise pas). Mais le message d'erreur affiché est alors le même que si aucun compte n'existait du tout pour cet email :

> Aucun compte usager n'existe pour cet email

alors qu'un compte existe bel et bien — l'usager⋅e est juste redirigé⋅e vers la mauvaise méthode de connexion, sans indication de la bonne.

## Changements

- Ajoute un scope `User.with_sso` (symétrique à `User.without_sso`, déjà existant) dans `app/models/user.rb`.
- Dans `Users::LoginCodeRequestForm#validate_user_exists_or_suggest_agent`, vérifie ce cas en priorité et affiche un message explicite invitant à utiliser FranceConnect ou ProConnect, avant de retomber sur les cas existants (agent avec le même email, ou vraiment aucun compte).
- Ajoute des tests pour les deux nouveaux cas (FranceConnect, ProConnect) dans `login_code_request_form_spec.rb`, ainsi qu'un test direct pour le nouveau scope dans `user_spec.rb`. En profite pour ajouter un test manquant sur le cas "agent existe avec cet email" (branche existante, non testée jusqu'ici).

## Test manuel

- Créer un compte usager via FranceConnect (`franceconnect_openid_sub` renseigné).
- Sur la page de connexion, tenter le login par code avec le même email.
- Avant : "Aucun compte usager n'existe pour cet email". Après : "Ce compte usager se connecte avec FranceConnect ou ProConnect. Merci d'utiliser ce moyen de connexion."

---

🤖 PR proposée par Claude Code, à partir de l'issue #6320.
