### PR TITLE
correction de l'info d'usager insupprimable

### DIFF
--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -40,10 +40,10 @@ ruby:
             - if @user.can_be_soft_deleted_from_organisation?(current_organisation)
               = link_to "Supprimer", admin_organisation_user_path(current_organisation, @user), method: :delete, class: "fr-btn fr-btn--tertiary fr-mb-0 fr-icon-delete-fill", data: { confirm: user_soft_delete_confirm_message(@user)}
             - else
-              button.fr-btn--tooltip.fr-btn.fr-m-0.fr-p-0 aria-describedby="tooltip-cannot-delete" type="button"
+              button.fr-btn--tooltip.fr-btn.fr-hidden-md.fr-m-0.fr-p-0 aria-describedby="tooltip-cannot-delete" type="button"
               span.fr-tooltip.fr-placement#tooltip-cannot-delete role="tooltip"
                 = I18n.t("users.can_not_delete_because_has_future_rdvs")
-              = button_to "Supprimer", "#", class: "fr-btn fr-btn--tertiary fr-mb-0 fr-icon-delete-fill", disabled: true
+              = button_to "Supprimer", "#", class: "fr-btn fr-btn--tertiary fr-mb-0 fr-icon-delete-fill", disabled: true, aria: { describedby: "tooltip-cannot-delete" }
           li
             = link_to "Modifier", edit_admin_organisation_user_path(current_organisation, @user), class: "fr-btn fr-btn--secondary fr-mb-0 fr-icon-edit-fill"
 

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -40,7 +40,11 @@ ruby:
             - if @user.can_be_soft_deleted_from_organisation?(current_organisation)
               = link_to "Supprimer", admin_organisation_user_path(current_organisation, @user), method: :delete, class: "fr-btn fr-btn--tertiary fr-mb-0 fr-icon-delete-fill", data: { confirm: user_soft_delete_confirm_message(@user)}
             - else
-              = link_to "Supprimer", "#", class: "fr-btn fr-btn--tertiary fr-mb-0 fr-icon-delete-fill", onclick: "alert(this.dataset.message)", data: { message: I18n.t("users.can_not_delete_because_has_future_rdvs") }
+              button aria-describedby="tooltip-cannot-delete" type="button" class="fr-btn--tooltip fr-btn fr-m-0 fr-p-0"
+                infobulle
+              span.fr-tooltip.fr-placement#tooltip-cannot-delete role="tooltip"
+                = I18n.t("users.can_not_delete_because_has_future_rdvs")
+              = button_to "Supprimer", "#", class: "fr-btn fr-btn--tertiary fr-mb-0 fr-icon-delete-fill", disabled: true
           li
             = link_to "Modifier", edit_admin_organisation_user_path(current_organisation, @user), class: "fr-btn fr-btn--secondary fr-mb-0 fr-icon-edit-fill"
 

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -41,7 +41,7 @@ ruby:
               = link_to "Supprimer", admin_organisation_user_path(current_organisation, @user), method: :delete, class: "fr-btn fr-btn--tertiary fr-mb-0 fr-icon-delete-fill", data: { confirm: user_soft_delete_confirm_message(@user)}
             - else
               button aria-describedby="tooltip-cannot-delete" type="button" class="fr-btn--tooltip fr-btn fr-m-0 fr-p-0"
-                infobulle
+                | infobulle
               span.fr-tooltip.fr-placement#tooltip-cannot-delete role="tooltip"
                 = I18n.t("users.can_not_delete_because_has_future_rdvs")
               = button_to "Supprimer", "#", class: "fr-btn fr-btn--tertiary fr-mb-0 fr-icon-delete-fill", disabled: true

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -40,8 +40,7 @@ ruby:
             - if @user.can_be_soft_deleted_from_organisation?(current_organisation)
               = link_to "Supprimer", admin_organisation_user_path(current_organisation, @user), method: :delete, class: "fr-btn fr-btn--tertiary fr-mb-0 fr-icon-delete-fill", data: { confirm: user_soft_delete_confirm_message(@user)}
             - else
-              button aria-describedby="tooltip-cannot-delete" type="button" class="fr-btn--tooltip fr-btn fr-m-0 fr-p-0"
-                | infobulle
+              button.fr-btn--tooltip.fr-btn.fr-m-0.fr-p-0 aria-describedby="tooltip-cannot-delete" type="button"
               span.fr-tooltip.fr-placement#tooltip-cannot-delete role="tooltip"
                 = I18n.t("users.can_not_delete_because_has_future_rdvs")
               = button_to "Supprimer", "#", class: "fr-btn fr-btn--tertiary fr-mb-0 fr-icon-delete-fill", disabled: true


### PR DESCRIPTION
# Contexte

Une agent nous demande comment supprimer un usager ça m'a surpris https://zammad10.ethibox.fr/#ticket/zoom/43991

Je me suis rendu compte d'un bug pour un usager qui a des RDV a venir (ou un de ses proches) : 
- le bouton supprimer apparait cliquable
- on n'affiche pas la raison de l'impossibilité de supprimer à cause d'une CSP (c'est un vieux onclick)

# Solution

J'ai essayé de mettre le texte visible tout le temps au dessus ou au dessous du bloc de boutons mais ça faisait bizarre

J’ai essayé de mettre le tooltip au survol du bouton disabled mais ça ne marche pas sur mobile.

J’ai essayé de mettre le bouton du tooltip à droite du bouton supprimer mais ça fait bizarre aussi. 

J’ai essayé de mettre "infobulle" comme contenu du tag `button.fr-btn--tooltip` comme dans [l'exemple de la doc](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/infobulle/demonstration-de-l-infobulle) mais il apparaissait tout le temps 🤷 j'imagine que c'est pour l'accessibilité pour les lecteurs d'écran


## Captures d'écran

Avant : 

<img width="1017" height="689" alt="image" src="https://github.com/user-attachments/assets/adccbf74-d696-4bca-a854-5d56763bc99e" />


Après :
|desktop|mobile|
|-|-|
<img width="1004" height="491" alt="image" src="https://github.com/user-attachments/assets/19583790-f580-4e3e-a5a6-7c036ee7edb6" />|<img width="444" height="908" alt="image" src="https://github.com/user-attachments/assets/6c4ba025-07db-4535-bad7-21dc64e3640e" />
