### PR TITLE
Revert "Débloquer l'e-mail sur Brevo avant d'envoyer le mail de réinitialisation du mot de passe"

### DIFF
--- a/app/controllers/agents/passwords_controller.rb
+++ b/app/controllers/agents/passwords_controller.rb
@@ -7,8 +7,6 @@ class Agents::PasswordsController < Devise::PasswordsController
 
     agent = Agent.find_by(email: email)
     if agent
-      UnblockBrevoTransactionalContact.new(email).call
-
       if agent.complete? && agent.pro_connect_openid_sub.blank? # Les agents qui sont ProConnectés ne peuvent plus se connecter par mot de passe
         agent.send_reset_password_instructions
       elsif agent.invitation_sent_at

--- a/app/services/unblock_brevo_transactional_contact.rb
+++ b/app/services/unblock_brevo_transactional_contact.rb
@@ -10,24 +10,15 @@ class UnblockBrevoTransactionalContact
       return
     end
 
-    response = connection.delete("https://api.brevo.com/v3/smtp/blockedContacts/#{CGI.escape(@email)}")
+    response = Faraday.delete("https://api.brevo.com/v3/smtp/blockedContacts/#{CGI.escape(@email)}") do |req|
+      req.headers["accept"] = "application/json"
+      req.headers["api-key"] = ENV["BREVO_API_KEY"]
+    end
 
     # On reçoit une 204 si le contact a été débloqué avec succès et une 404 si le contact n’était pas bloqué
     # Dans les deux cas, on considère que l’opération est un succès. Dans les autres cas, on logue l’erreur dans Sentry.
     unless response.status.in?([204, 404])
       Sentry.capture_message("Failed to unblock Brevo transactional contact", level: :error, extra: { email: @email, status: response.status, body: response.body })
-    end
-  end
-
-  private
-
-  def connection
-    Faraday.new do |builder|
-      builder.response :raise_error
-      builder.use :sentry_breadcrumbs
-
-      builder.headers["accept"] = "application/json"
-      builder.headers["api-key"] = ENV["BREVO_API_KEY"]
     end
   end
 end

--- a/spec/services/unblock_brevo_transactional_contact_spec.rb
+++ b/spec/services/unblock_brevo_transactional_contact_spec.rb
@@ -26,19 +26,13 @@ RSpec.describe UnblockBrevoTransactionalContact, type: :service do
     stub_env_with(BREVO_API_KEY: "fake-key")
 
     it "fait l'appel Faraday" do
-      stub_request(:delete, "https://api.brevo.com/v3/smtp/blockedContacts/test%40example.com")
+      stub = instance_double(Faraday::Response, status: 204)
+      faraday_double = instance_double(Faraday::Connection, headers: {})
+      allow(faraday_double).to receive(:headers=)
+      expect(Faraday).to receive(:delete).with("https://api.brevo.com/v3/smtp/blockedContacts/#{CGI.escape(email)}")
+        .and_yield(faraday_double)
+        .and_return(stub)
       subject.call
-      expect(WebMock).to have_requested(:delete, "https://api.brevo.com/v3/smtp/blockedContacts/test%40example.com").with(headers: { "Api-Key" => "fake-key", "Accept" => "application/json" })
-    end
-
-    it "loggue l'appel à Sentry en cas d'échec" do
-      stub_request(:delete, "https://api.brevo.com/v3/smtp/blockedContacts/#{CGI.escape(email)}").and_return({ status: 500, body: { error: "something happened and i'm sorry" }.to_json })
-      expect { subject.call }.to raise_error(Faraday::ServerError)
-
-      Sentry.capture_message("woops")
-      request_breadcrumb, response_breadcrumb = sentry_events.last.breadcrumbs.compact
-      expect(request_breadcrumb.data[:url].to_s).to eq("https://api.brevo.com/v3/smtp/blockedContacts/test%40example.com")
-      expect(response_breadcrumb.data[:body]).to eq({ error: "something happened and i'm sorry" }.to_json)
     end
   end
 end


### PR DESCRIPTION
Reverts betagouv/rdv-service-public#6522

https://sentry.incubateur.net/organizations/betagouv/issues/298516/events/?project=74&referrer=webhooks_plugin