### PR TITLE
Débloquer l'e-mail sur Brevo avant d'envoyer le mail de réinitialisation du mot de passe - 2ème tentative

### DIFF
--- a/app/controllers/agents/passwords_controller.rb
+++ b/app/controllers/agents/passwords_controller.rb
@@ -7,6 +7,8 @@ class Agents::PasswordsController < Devise::PasswordsController
 
     agent = Agent.find_by(email: email)
     if agent
+      UnblockBrevoTransactionalContact.new(email).call
+
       if agent.complete? && agent.pro_connect_openid_sub.blank? # Les agents qui sont ProConnectés ne peuvent plus se connecter par mot de passe
         agent.send_reset_password_instructions
       elsif agent.invitation_sent_at


### PR DESCRIPTION
# Contexte

Dans la PR précédente (#6522 que nous avons revert), nous avions ajouté un raise_error, sur les appels à l’API Brevo.
Cela a généré un problème. L’API Brevo renvoie une 404 lorsque l’email n’est pas bloqué (ce qui est le cas dans la majorité des cas). On remet donc en place le déblocage sans le raise, car on ne veut pas bloquer le flux de reset password à cause d’une erreur de l’API Brevo.
Nous avons déjà dans le service d’unlock le nécessaire pour envoyer un message Sentry pour nous informer d’un potentiel problème (hors 404).

