### PR TITLE
Revert "Ajout des scopes Visio à la connexion ProConnect"

### DIFF
--- a/app/services/pro_connect_open_id_client/auth.rb
+++ b/app/services/pro_connect_open_id_client/auth.rb
@@ -1,7 +1,7 @@
 # voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique
 module ProConnectOpenIdClient
   class Auth
-    SCOPES = "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create".freeze
+    SCOPES = "openid email given_name usual_name siret idp_id".freeze
     ACR_FOR_2FA = %w[eidas0-mfa eidas1-mfa eidas2 eidas3].freeze
 
     def initialize(client_id:, client_secret:, login_hint: nil, prompt: nil)

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProConnectController do
         client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
         redirect_uri: "http://test.host/agent_connect/callback",
         response_type: "code",
-        scope: "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create",
+        scope: "openid email given_name usual_name siret idp_id",
         state: be_a(String),
         nonce: be_a(String),
         claims: {
@@ -42,7 +42,7 @@ RSpec.describe ProConnectController do
           client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
           redirect_uri: "http://test.host/agent_connect/callback",
           response_type: "code",
-          scope: "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create",
+          scope: "openid email given_name usual_name siret idp_id",
           state: be_a(String),
           nonce: be_a(String),
           claims: {
@@ -71,7 +71,7 @@ RSpec.describe ProConnectController do
         client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
         redirect_uri: "http://test.host/agent_connect/callback",
         response_type: "code",
-        scope: "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create",
+        scope: "openid email given_name usual_name siret idp_id",
         state: be_a(String),
         nonce: be_a(String),
         claims: {

--- a/spec/features/agents/account/proconnect_silent_login_spec.rb
+++ b/spec/features/agents/account/proconnect_silent_login_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Agent is automatically logged in with pro connect" do
         redirect_uri: "#{Capybara.app_host}/agent_connect/callback",
         response_type: "code",
         prompt: "none",
-        scope: "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create",
+        scope: "openid email given_name usual_name siret idp_id",
         state: be_a(String),
         nonce: be_a(String),
         claims: {
@@ -150,7 +150,7 @@ RSpec.describe "Agent is automatically logged in with pro connect" do
         redirect_uri: "#{Capybara.app_host}/agent_connect/callback",
         response_type: "code",
         prompt: "none",
-        scope: "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create",
+        scope: "openid email given_name usual_name siret idp_id",
         state: be_a(String),
         nonce: be_a(String),
         claims: {


### PR DESCRIPTION
Reverts betagouv/rdv-service-public#6543

Il semble qu’il y ait eu un problème de communication avec l’équipe de PC car nous n’arrivons plus à nous authentifier
Les scopes n’ont pas dû être activés

EDIT : il y a effectivement eu un quiproco, seuls les scopes en sandbox avaient été activés