### PR TITLE
Changement de l’emplacement du lien « Donnez votre avis »

### DIFF
--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -33,8 +33,8 @@ ruby:
     .fr-card__img
       = dsfr_svg "artwork/pictograms/leisure/community", class: "fr-responsive-img"
 
-.fr-grid-row.fr-grid-row--gutters.fr-mt-4w
-  .fr-col.fr-col-12.fr-col-md-4
+.fr-grid-row.fr-grid-row--gutters.fr-mt-4w.fr-mb-4w
+  .fr-col.fr-col-12.fr-col-md-6.fr-col-lg-3
     .fr-card.fr-enlarge-link.fr-card--sm
       .fr-card__body
         .fr-card__content
@@ -43,7 +43,7 @@ ruby:
           p.fr-card__desc
             | Explorez les fonctionnalités de l'outil à travers la documentation, et trouvez les informations dont vous avez besoin.
 
-  .fr-col.fr-col-12.fr-col-md-4
+  .fr-col.fr-col-12.fr-col-md-6.fr-col-lg-3
     .fr-card.fr-enlarge-link.fr-card--sm
       .fr-card__body
         .fr-card__content
@@ -51,7 +51,7 @@ ruby:
             = link_to "Feuille de route", "https://projets.numerique.gouv.fr/boards/1790017229354436112", target: "_blank"
           p.fr-card__desc
             | Découvrez les nouvelles fonctionnalités et améliorations principales sur lesquelles nous sommes en train de travailler.
-  .fr-col.fr-col-12.fr-col-md-4
+  .fr-col.fr-col-12.fr-col-md-6.fr-col-lg-3
     .fr-card.fr-enlarge-link.fr-card--sm
       .fr-card__body
         .fr-card__content
@@ -59,3 +59,16 @@ ruby:
             = link_to "État du service", "https://rdv-service-public.instatus.com", target: "_blank"
           .fr-card__desc
             | Suivez en temps réel l'état du service et abonnez-vous pour recevoir une notification en cas de panne.
+  .fr-col.fr-col-12.fr-col-md-6.fr-col-lg-3
+    .fr-card.fr-enlarge-link.fr-card--sm
+      .fr-card__body
+        .fr-card__content
+          h3.fr-card__title
+            - if current_domain.rdv_service_public?
+              = link_to "Donnez votre avis", "https://tally.so/r/obBope", target: "_blank"
+            - elsif current_domain == Domain::RDV_SOLIDARITES
+              = link_to "Donnez votre avis", "https://tally.so/r/5BkP56", target: "_blank"
+            - else
+              = link_to "Donnez votre avis", "https://tally.so/r/0QMR5N", target: "_blank"
+          p.fr-card__desc
+            | Aidez nous a améliorer le produit en nous partageant vos remarques et suggestions.

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -9,14 +9,6 @@ header.header.bg-white
       i.fr-icon-menu-fill.rdv-color-active-blue
     #navbarSupportedContent.collapse.navbar-collapse
       ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
-        li.list-inline-item
-          - if current_domain.rdv_service_public?
-            = link_to "Donnez votre avis", "https://tally.so/r/obBope", class: "btn rdv-color-active-blue link-dsfr", target: "_blank"
-          - elsif current_domain == Domain::RDV_SOLIDARITES
-            = link_to "Donnez votre avis", "https://tally.so/r/5BkP56", class: "btn rdv-color-active-blue link-dsfr", target: "_blank"
-          - else
-            = link_to "Donnez votre avis", "https://tally.so/r/0QMR5N", class: "btn rdv-color-active-blue link-dsfr", target: "_blank"
-
         = render "layouts/rdv_a_renseigner", organisation: defined?(current_organisation) && current_organisation
         li.list-inline-item
           = link_to agents_blog_posts_path, class: "btn rdv-color-active-blue link-dsfr d-flex justify-content-center", data: { modal: true } do


### PR DESCRIPTION
# Contexte

Dans le cadre du trio de navigation, on souhaite épurer le menu du haut. On propose donc de retirer le bouton « Donnez mon avis » et de le mettre dans le centre d’aide.

## Captures d'écran

Avant | Après
:- | -:
<img width="687" height="168" alt="image" src="https://github.com/user-attachments/assets/bb958ed9-7aec-431c-86be-66c056c82377" /> | <img width="762" height="111" alt="image" src="https://github.com/user-attachments/assets/291f9c37-1bc7-4a6a-989b-83504675f08b" />
<img width="1269" height="588" alt="image" src="https://github.com/user-attachments/assets/5e2eb471-28b5-4e71-b3cc-33f9bbc42ca3" /> | <img width="1295" height="730" alt="image" src="https://github.com/user-attachments/assets/4eed1879-4419-4960-a90d-a89138cbf87d" />
