### PR TITLE
Étoffer le dropdown agent avec les différents paramètres de son compte

### DIFF
--- a/app/views/agents/_preferences_menu.html.slim
+++ b/app/views/agents/_preferences_menu.html.slim
@@ -1,6 +1,6 @@
 ruby:
    menu_items = [
-      [:compte, "Votre compte", edit_agent_registration_path],
+      [:compte, "Vos informations", edit_agent_registration_path],
       [:notifications, t("agents.preferences.show.title"), agents_preferences_path],
       [:synchronisation, "Synchronisation d'agenda", agents_calendar_sync_path],
       [:organisations, "Vos organisations", admin_organisations_path],

--- a/app/views/agents/registrations/edit.html.slim
+++ b/app/views/agents/registrations/edit.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "Votre compte"
+- content_for :title, "Vos informations"
 
 - if resource.pro_connect_openid_sub
   = render "infos", resource: resource, resource_name: resource_name, devise_mapping: devise_mapping

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -22,7 +22,20 @@ header.header.bg-white
           ul.dropdown-menu.dropdown-menu-right
             li = link_to edit_agent_registration_path, class: "dropdown-item-dsfr dropdown-item" do
               span.fr-icon--sm.fr-mr-2v.fr-icon-account-line[aria-hidden="true"]
-              = "Mon compte"
+              = "Vos informations"
+            li = link_to agents_preferences_path, class: "dropdown-item-dsfr dropdown-item" do
+              span.fr-icon--sm.fr-mr-2v.fr-icon-notification-3-line[aria-hidden="true"]
+              = "Préférences de notifications"
+            li = link_to agents_calendar_sync_path, class: "dropdown-item-dsfr dropdown-item" do
+              span.fr-icon--sm.fr-mr-2v.fr-icon-links-line[aria-hidden="true"]
+              = "Synchronisation d’agenda"
+            li = link_to admin_organisations_path, class: "dropdown-item-dsfr dropdown-item" do
+              span.fr-icon--sm.fr-mr-2v.fr-icon-building-line[aria-hidden="true"]
+              = "Vos organisations"
+            li = link_to agents_exports_path, class: "dropdown-item-dsfr dropdown-item" do
+              span.fr-icon--sm.fr-mr-2v.fr-icon-booklet-line[aria-hidden="true"]
+              = "Vos exports"
+            li.dropdown-divider.my-1[aria-hidden="true"]
             - Agent::TerritoryPolicy::Scope.new(current_agent, Territory.all).resolve.distinct.order(:name).each do |territory|
               li = link_to admin_territory_path(territory), class: "dropdown-item-dsfr dropdown-item" do
                 span.fr-icon--sm.fr-mr-2v.fr-icon-settings-5-line[aria-hidden="true"]

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -33,7 +33,7 @@ header.header.bg-white
               span.fr-icon--sm.fr-mr-2v.fr-icon-building-line[aria-hidden="true"]
               = "Vos organisations"
             li = link_to agents_exports_path, class: "dropdown-item-dsfr dropdown-item" do
-              span.fr-icon--sm.fr-mr-2v.fr-icon-booklet-line[aria-hidden="true"]
+              span.fr-icon--sm.fr-mr-2v.fr-icon-file-download-line[aria-hidden="true"]
               = "Vos exports"
             li.dropdown-divider.my-1[aria-hidden="true"]
             - Agent::TerritoryPolicy::Scope.new(current_agent, Territory.all).resolve.distinct.order(:name).each do |territory|


### PR DESCRIPTION
[Review app](https://rdv-service-public-review-app-pr6549.osc-secnum-fr1.scalingo.io/)

# Contexte

Dans le cadre du trio navigation, on souhaite rendre plus explicite et plus accessible les éléments de configuration du compte agent.

# Solution

On propose donc de rapatrier tous les éléments du menu « Configuration agent » dans le dropdown en haut à droite.
La seule limite que nous voyons, c'est dans le cas d’agents qui seraient administrateurs de nombreux espaces.
Après export des données de RDV-S et RDV-SP ça concerne moins de 10 agents, et c’est déjà un problème pour eux d’avoir pleins de « Paramètres de ESPACE » dans ce dropdown. 
On traitera donc ce problème dans une autre PR.

## Captures d'écran

Avant | Après
:- | -:
<img width="272" height="266" alt="image" src="https://github.com/user-attachments/assets/a729c234-9657-480a-b3fc-2e225a217443" /> | <img width="331" height="406" alt="image" src="https://github.com/user-attachments/assets/d11937c9-706c-43ae-9b49-958d58150570" />

