### PR TITLE
Ajout des scopes Visio à la connexion ProConnect (2ème tentative)

### DIFF
--- a/app/services/pro_connect_open_id_client/auth.rb
+++ b/app/services/pro_connect_open_id_client/auth.rb
@@ -1,7 +1,7 @@
 # voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique
 module ProConnectOpenIdClient
   class Auth
-    SCOPES = "openid email given_name usual_name siret idp_id".freeze
+    SCOPES = "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create".freeze
     ACR_FOR_2FA = %w[eidas0-mfa eidas1-mfa eidas2 eidas3].freeze
 
     def initialize(client_id:, client_secret:, login_hint: nil, prompt: nil)

--- a/spec/controllers/pro_connect_controller_spec.rb
+++ b/spec/controllers/pro_connect_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProConnectController do
         client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
         redirect_uri: "http://test.host/agent_connect/callback",
         response_type: "code",
-        scope: "openid email given_name usual_name siret idp_id",
+        scope: "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create",
         state: be_a(String),
         nonce: be_a(String),
         claims: {
@@ -42,7 +42,7 @@ RSpec.describe ProConnectController do
           client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
           redirect_uri: "http://test.host/agent_connect/callback",
           response_type: "code",
-          scope: "openid email given_name usual_name siret idp_id",
+          scope: "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create",
           state: be_a(String),
           nonce: be_a(String),
           claims: {
@@ -71,7 +71,7 @@ RSpec.describe ProConnectController do
         client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
         redirect_uri: "http://test.host/agent_connect/callback",
         response_type: "code",
-        scope: "openid email given_name usual_name siret idp_id",
+        scope: "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create",
         state: be_a(String),
         nonce: be_a(String),
         claims: {

--- a/spec/features/agents/account/proconnect_silent_login_spec.rb
+++ b/spec/features/agents/account/proconnect_silent_login_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Agent is automatically logged in with pro connect" do
         redirect_uri: "#{Capybara.app_host}/agent_connect/callback",
         response_type: "code",
         prompt: "none",
-        scope: "openid email given_name usual_name siret idp_id",
+        scope: "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create",
         state: be_a(String),
         nonce: be_a(String),
         claims: {
@@ -150,7 +150,7 @@ RSpec.describe "Agent is automatically logged in with pro connect" do
         redirect_uri: "#{Capybara.app_host}/agent_connect/callback",
         response_type: "code",
         prompt: "none",
-        scope: "openid email given_name usual_name siret idp_id",
+        scope: "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create",
         state: be_a(String),
         nonce: be_a(String),
         claims: {


### PR DESCRIPTION
Lié à #6087

# Contexte

Cette PR est préliminaire à l'intégration de visio.numerique.gouv.fr comme alternative à Webconf pour les RDV en visio.

L'API de visio.numerique.gouv.fr est protégée par OAuth 2.0 via ProConnect, avec des scopes dédiés (`lasuite_visio` et `lasuite_visio:rooms:create`). Pour pouvoir créer des salles de visio au nom des agents, il faut que ces scopes soient demandés lors de la connexion ProConnect — et donc que tous les agents se soient reconnectés avec ces scopes avant que la fonctionnalité soit activée.

Cette PR est déployée en premier, de façon à laisser le temps aux sessions d'expirer et aux agents de se reconnecter avec les bons scopes. La PR d'intégration de l'API pourra ensuite être déployée sans risque que des agents aient un token sans les scopes visio.

**⚠️ Cette PR ne doit être mergée qu'une fois les scopes activés côté ProConnect.**

# Solution

Ajout des scopes `lasuite_visio` et `lasuite_visio:rooms:create` à la constante `SCOPES` de `ProConnectOpenIdClient::Auth`. Ces scopes seront demandés à ProConnect lors de chaque connexion agent, et inclus dans l'access token retourné.
