### PR TITLE
Mise à jour de latest_login_at lors de l’utilisation de FC

### DIFF
--- a/app/services/upsert_user_for_franceconnect_service.rb
+++ b/app/services/upsert_user_for_franceconnect_service.rb
@@ -33,7 +33,6 @@ class UpsertUserForFranceconnectService < BaseService
         created_through: "franceconnect_sign_up"
       )
     )
-    @user.latest_login_at = Time.zone.now
     @user.save!(context: :france_connect_login)
     @user
   end
@@ -46,6 +45,7 @@ class UpsertUserForFranceconnectService < BaseService
       franceconnect_openid_sub: omniauth_info.sub,
       last_name: omniauth_info.preferred_username.presence || omniauth_info.family_name, # nom d'usage (optionnel),
       logged_once_with_franceconnect: true,
+      latest_login_at: Time.zone.now,
     }.compact # do not fill with missing values
   end
 end

--- a/spec/services/upsert_user_for_franceconnect_service_spec.rb
+++ b/spec/services/upsert_user_for_franceconnect_service_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe UpsertUserForFranceconnectService, type: :service do
 
       expect_france_connect_fields_to_be_up_to_date(service.user.reload)
     end
+
+    it "sets latest_login_at" do
+      freeze_time do
+        service = described_class.new(omniauth_info)
+        service.perform
+        expect(service.user.reload.latest_login_at).to eq(Time.zone.now)
+      end
+    end
   end
 
   context "pre-existing user with same franceconnect sub but different infos" do
@@ -48,6 +56,14 @@ RSpec.describe UpsertUserForFranceconnectService, type: :service do
         expect(service.new_user?).to be(false)
 
         expect_france_connect_fields_to_be_up_to_date(service.user.reload)
+      end
+
+      it "updates latest_login_at" do
+        freeze_time do
+          service = described_class.new(omniauth_info)
+          service.perform
+          expect(service.user.reload.latest_login_at).to eq(Time.zone.now)
+        end
       end
 
       context "when the france connect email has capital letters" do


### PR DESCRIPTION
# Contexte

Lors d'une connexion via FranceConnect, le champ `latest_login_at` n'était pas mis à jour pour les usagers existants. Le champ n'était renseigné que lors de la création d'un nouveau compte (dans `create_new_user`), mais pas lors de la reconnexion d'un usager déjà enregistré (dans `update_existing_user`).

# Solution

Le champ `latest_login_at: Time.zone.now` a été déplacé dans `user_attribute_values_from_fc`, le hash commun utilisé par les deux chemins (création et mise à jour). Cela garantit que la date de dernière connexion est toujours mise à jour à chaque connexion FranceConnect, quelle que soit la situation de l'usager.

Deux specs ont été ajoutées pour couvrir explicitement les deux cas :
- création d'un nouvel usager via FranceConnect
- connexion d'un usager existant via FranceConnect
