### PR TITLE
Ajoute le referer dans le message de contact support depuis la page 404

### DIFF
--- a/app/views/errors/not_found.html.slim
+++ b/app/views/errors/not_found.html.slim
@@ -14,7 +14,7 @@
       |> Vous pouvez retourner sur la page d’accueil, ou nous contacter pour que l’on puisse vous rediriger vers la bonne page.
 
     .fr-btns-group.fr-btns-group--inline
-      = link_to "Contactez-nous", new_aide_demande_support_path(sujet: "Erreur 404", message: "\n\n--- votre message au-dessus ---\n\nErreur rencontrée sur la page : #{request.original_url}"), class: "fr-btn"
+      = link_to "Contactez-nous", new_aide_demande_support_path(sujet: "Erreur 404", message: "\n\n--- votre message au-dessus ---\n\nErreur rencontrée sur la page : #{request.original_url}\nPage précédente (referer) : #{request.referer || 'inconnue'}"), class: "fr-btn"
       = link_to("Retour à l'accueil", root_path, class: "fr-btn fr-btn--secondary")
 
   .fr-col-0.fr-col-md-4


### PR DESCRIPTION
## Contexte

Des usagers arrivent parfois sur des 404 via des liens externes mal formés (ex: un site de mairie qui pointe vers une mauvaise URL du type `rdv.anct.gouv.fr/www.seiches.fr`). La page 404 propose un bouton "Contactez-nous" qui pré-remplit une demande de support (ticket Zammad) avec l'URL de la page en erreur, mais pas avec la page d'origine.

## Changement

Ajoute `request.referer` au message pré-rempli du formulaire de contact sur la page 404 (`app/views/errors/not_found.html.slim`), pour permettre d'identifier la source du lien cassé et la faire corriger en amont.

## Test plan

- [ ] Vérifier en local que le lien "Contactez-nous" sur une page 404 pré-remplit bien le message avec l'URL de la page ET le referer (arriver sur une 404 depuis un lien externe/interne et vérifier le contenu du champ message)