### PR TITLE
Correctif pour les redirections lors de recherches usagers pour de motifs sans service

### DIFF
--- a/app/services/users/rdv_builder.rb
+++ b/app/services/users/rdv_builder.rb
@@ -68,8 +68,8 @@ class Users::RdvBuilder
 
   def to_query_for_search_redirection
     q = @attributes.slice(:address, :city_code, :street_ban_id, :departement, :organisation_ids, :ants_pre_demandes_count).merge(
-      service: motif.service_id,
-      motif_name_with_location_type: motif.name_with_location_type
+      service: motif&.service_id,
+      motif_name_with_location_type: motif&.name_with_location_type
     )
     q[:address] ||= @attributes[:where]
     q

--- a/spec/form_models/users/rdv_builder_spec.rb
+++ b/spec/form_models/users/rdv_builder_spec.rb
@@ -75,6 +75,11 @@ RSpec.describe Users::RdvBuilder do
       expect(rdv_builder.rdv.duration_in_min).to be_nil
       expect(rdv_builder.creneau).to be_nil
     end
+
+    it "to_query_for_search_redirection ne lève pas d'erreurs" do
+      rdv_builder = described_class.new(user, attributes)
+      expect(rdv_builder.to_query_for_search_redirection).to include(service: nil, motif_name_with_location_type: nil)
+    end
   end
 
   context "le lieu_id ne correspond à aucun lieu existant" do


### PR DESCRIPTION
`RdvBuilder#to_query_for_search_redirection` introduit dans #6421 échoue si motif est nil, or il est maintenant possible d'avoir des motifs sans service. 