### PR TITLE
Logger les params des recherches de RDV usagers

### DIFF
--- a/app/controllers/concerns/search/log_params_concern.rb
+++ b/app/controllers/concerns/search/log_params_concern.rb
@@ -4,8 +4,8 @@ module Search::LogParamsConcern
   # on recopie ici et on commente explicitement les params à ne pas logger
   LOGGABLE_SEARCH_PARAMS = [
     # -- from WebSearchContext::ADDRESS_SELECTION_PARAMS
-    "latitude",
-    "longitude",
+    # "latitude",
+    # "longitude",
     # "address",
     "city_code",
     # "street_ban_id",

--- a/app/controllers/concerns/search/log_params_concern.rb
+++ b/app/controllers/concerns/search/log_params_concern.rb
@@ -1,16 +1,32 @@
 module Search::LogParamsConcern
   extend ActiveSupport::Concern
 
-  # on recopie ici plutôt que de référencer les constantes pour éviter que
-  # des futurs ajouts potentiellement sensibles soient automatiquement loggés
-  LOGGABLE_SEARCH_PARAMS = (
-    # from WebSearchContext::ADDRESS_SELECTION_PARAMS
-    %i[latitude longitude address city_code street_ban_id departement] +
-    # from WebSearchContext::USER_CHOICE_PARAMS
-    %i[service_id motif_name_with_location_type lieu_id user_selected_organisation_id motif_id ants_pre_demandes_count] +
-    # from SearchController#search_params
-    %i[motif_category_short_name date public_link_organisation_id prescripteur organisation_ids external_organisation_ids]
-  ).freeze
+  # on recopie ici et on commente explicitement les params à ne pas logger
+  LOGGABLE_SEARCH_PARAMS = [
+    # -- from WebSearchContext::ADDRESS_SELECTION_PARAMS
+    "latitude",
+    "longitude",
+    # "address",
+    "city_code",
+    # "street_ban_id",
+    "departement",
+    # -- from WebSearchContext::USER_CHOICE_PARAMS
+    "service_id",
+    "motif_name_with_location_type",
+    "lieu_id",
+    "user_selected_organisation_id",
+    "motif_id",
+    "ants_pre_demandes_count",
+    # -- from SearchController#search_params
+    "motif_category_short_name",
+    "date",
+    "public_link_organisation_id",
+    "prescripteur",
+    # "autofocus",
+    "organisation_ids",
+    # "referent_ids",
+    "external_organisation_ids",
+  ].freeze
 
   # méthode automatiquement appelée par lograge cf https://github.com/roidrage/lograge/#installation
   def append_info_to_payload(payload)

--- a/app/controllers/concerns/search/log_params_concern.rb
+++ b/app/controllers/concerns/search/log_params_concern.rb
@@ -1,0 +1,23 @@
+module Search::LogParamsConcern
+  extend ActiveSupport::Concern
+
+  # on recopie ici plutôt que de référencer les constantes pour éviter que
+  # des futurs ajouts potentiellement sensibles soient automatiquement loggés
+  LOGGABLE_SEARCH_PARAMS = (
+    # from WebSearchContext::ADDRESS_SELECTION_PARAMS
+    %i[latitude longitude address city_code street_ban_id departement] +
+    # from WebSearchContext::USER_CHOICE_PARAMS
+    %i[service_id motif_name_with_location_type lieu_id user_selected_organisation_id motif_id ants_pre_demandes_count] +
+    # from SearchController#search_params
+    %i[motif_category_short_name date public_link_organisation_id prescripteur organisation_ids external_organisation_ids]
+  ).freeze
+
+  # méthode automatiquement appelée par lograge cf https://github.com/roidrage/lograge/#installation
+  def append_info_to_payload(payload)
+    super
+    return unless action_name == "search_rdv" # uniquement pour la recherche GET
+
+    payload[:search_params] = params.slice(*LOGGABLE_SEARCH_PARAMS).to_unsafe_h.compact_blank
+    payload[:user_agent] = request.user_agent
+  end
+end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,6 +2,7 @@ class SearchController < ApplicationController
   layout "application_base"
 
   include TokenInvitable
+  include Search::LogParamsConcern
   prepend_before_action :store_invitation_in_session_and_redirect, only: %i[search_rdv]
 
   def home
@@ -103,21 +104,6 @@ class SearchController < ApplicationController
 
   def prescripteur
     redirect_to prendre_rdv_path(request.query_parameters.merge(prescripteur: 1))
-  end
-
-  # Permet d'identifier dans les logs (via lograge) quelle organisation/motif est ciblé par une
-  # recherche sur /prendre_rdv, pour repérer un éventuel scraping massif d'une organisation donnée.
-  LOGGABLE_SEARCH_PARAMS = %i[
-    public_link_organisation_id external_organisation_ids user_selected_organisation_id organisation_ids
-    referent_ids service_id motif_id motif_name_with_location_type motif_category_short_name departement prescripteur
-  ].freeze
-
-  def append_info_to_payload(payload)
-    super
-    return unless action_name == "search_rdv"
-
-    payload[:search_params] = params.slice(*LOGGABLE_SEARCH_PARAMS).to_unsafe_h.compact_blank
-    payload[:user_agent] = request.user_agent
   end
 
   private

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -105,6 +105,21 @@ class SearchController < ApplicationController
     redirect_to prendre_rdv_path(request.query_parameters.merge(prescripteur: 1))
   end
 
+  # Permet d'identifier dans les logs (via lograge) quelle organisation/motif est ciblé par une
+  # recherche sur /prendre_rdv, pour repérer un éventuel scraping massif d'une organisation donnée.
+  LOGGABLE_SEARCH_PARAMS = %i[
+    public_link_organisation_id external_organisation_ids user_selected_organisation_id organisation_ids
+    referent_ids service_id motif_id motif_name_with_location_type motif_category_short_name departement prescripteur
+  ].freeze
+
+  def append_info_to_payload(payload)
+    super
+    return unless action_name == "search_rdv"
+
+    payload[:search_params] = params.slice(*LOGGABLE_SEARCH_PARAMS).to_unsafe_h.compact_blank
+    payload[:user_agent] = request.user_agent
+  end
+
   private
 
   def search_on_migrated_organisation

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,3 +1,8 @@
 Rails.application.configure do
   config.lograge.enabled = true
+
+  # Ajout des infos poussées via `append_info_to_payload` (ex. SearchController) dans la ligne de log.
+  config.lograge.custom_options = lambda do |event|
+    event.payload.slice(:search_params, :user_agent)
+  end
 end


### PR DESCRIPTION
# Contexte

On soupçonne un scraping important sur RDVSP. J’aimerais comprendre s'il est concentré sur une organisation en particulier avant de décider quoi faire. Actuellement rien ne permet de le vérifier.

Lograge est activé mais sans `custom_options` : aucun param n'est loggué (cf. commit `28db875b5`, PR #3374, qui avait volontairement désactivé le logging large des params HTTP à cause de PII).

# Solution

Je propose de rajouter un logging ciblé et whitelisté, uniquement sur `SearchController#search_rdv`.

Ça ne réintroduit pas le logging large de params retiré en 2023 : c'est une whitelist explicite, limitée à une seule action, sans aucun des champs PII déjà identifiés dans `filter_parameter_logging.rb` (adresse, email, téléphone, etc.).

Avantages : ça nous permettrait de reconstruire des stats de recherches à l’avenir si besoin, par exemple pouvoir dire telle orga génère tel nombre de recherches pour tant de RDV par mois.

# Review App

[Review app](https://rdv-service-public-review-app-pr6564.osc-secnum-fr1.scalingo.io/)

`scalingo logs  --app  rdv-service-public-review-app-pr6564 -F web --follow`
