### PR TITLE
Permettre de désactiver Visio sur une instance

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -122,3 +122,6 @@ DISPLAY_LOGIN_CODES=true
 
 # API Visio LaSuite pour les rendez-vous en visio
 VISIO_NUMERIQUE_API_URL=https://visio-sandbox.beta.numerique.gouv.fr/external-api/v1.0
+# Désactive la fonctionnalité Visio (scopes ProConnect non demandés, création de salon non tentée),
+# utile sur les instances où le client ID ProConnect n'a pas les scopes lasuite_visio
+# VISIO_NUMERIQUE_DISABLED=true

--- a/app/controllers/admin/rdv_wizard_steps_controller.rb
+++ b/app/controllers/admin/rdv_wizard_steps_controller.rb
@@ -80,6 +80,7 @@ class Admin::RdvWizardStepsController < AgentAuthController
   def assign_visio_numerique_room_if_applicable
     return unless current_step == "step4"
     return unless @rdv.motif&.visio?
+    return if ENV["VISIO_NUMERIQUE_DISABLED"]
     return if session[:pro_connect_access_token].blank?
 
     result = VisioNumerique::CreateRoom.new(access_token: session[:pro_connect_access_token]).call

--- a/app/services/pro_connect_open_id_client/auth.rb
+++ b/app/services/pro_connect_open_id_client/auth.rb
@@ -1,7 +1,8 @@
 # voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique
 module ProConnectOpenIdClient
   class Auth
-    SCOPES = "openid email given_name usual_name siret idp_id lasuite_visio lasuite_visio:rooms:create".freeze
+    BASE_SCOPES = "openid email given_name usual_name siret idp_id".freeze
+    VISIO_SCOPES = "lasuite_visio lasuite_visio:rooms:create".freeze
     ACR_FOR_2FA = %w[eidas0-mfa eidas1-mfa eidas2 eidas3].freeze
 
     def initialize(client_id:, client_secret:, login_hint: nil, prompt: nil)
@@ -20,7 +21,7 @@ module ProConnectOpenIdClient
         response_type: "code",
         client_id: @client_id,
         redirect_uri: callback_url,
-        scope: SCOPES,
+        scope: scopes,
         state: state,
         nonce: nonce,
         login_hint: @login_hint,
@@ -32,6 +33,12 @@ module ProConnectOpenIdClient
     end
 
     private
+
+    def scopes
+      return BASE_SCOPES if ENV["VISIO_NUMERIQUE_DISABLED"]
+
+      "#{BASE_SCOPES} #{VISIO_SCOPES}"
+    end
 
     def claims(force_2fa:)
       {

--- a/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
@@ -100,6 +100,33 @@ RSpec.describe Admin::RdvWizardStepsController, type: :controller do
         expect(response.body).to include("Ce rendez-vous a une date située dans le passé")
       end
     end
+
+    context "with a visio motif and a ProConnect access_token in session" do
+      let(:motif) { create(:motif, location_type: :visio) }
+
+      before { session[:pro_connect_access_token] = "un-token" }
+
+      it "creates a Visio Numérique room and assigns its url" do
+        stub_request(:post, "#{VisioNumerique::CreateRoom::DEFAULT_API_URL}/rooms/")
+          .to_return(status: 200, body: { url: "https://visio.numerique.gouv.fr/room-xyz" }.to_json, headers: { "Content-Type" => "application/json" })
+
+        create_request
+
+        expect(Rdv.last.visio_url_custom).to eq("https://visio.numerique.gouv.fr/room-xyz")
+      end
+
+      context "when VISIO_NUMERIQUE_DISABLED is set" do
+        stub_env_with(VISIO_NUMERIQUE_DISABLED: "true")
+
+        it "doesn't try to create a Visio Numérique room" do
+          expect(VisioNumerique::CreateRoom).not_to receive(:new)
+
+          create_request
+
+          expect(Rdv.last.visio_url_custom).to be_nil
+        end
+      end
+    end
   end
 
   context "POST step2 avec motif téléphonique et l’usager a un numéro de téléphone" do

--- a/spec/services/pro_connect_open_id_client/auth_spec.rb
+++ b/spec/services/pro_connect_open_id_client/auth_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe ProConnectOpenIdClient::Auth do
+  stub_env_for_proconnect
+
+  subject(:auth) { described_class.new(client_id: "client_id", client_secret: "client_secret") }
+
+  describe "#redirect_url" do
+    subject(:scope_param) do
+      url = auth.redirect_url("https://example.org/callback")
+      Rack::Utils.parse_query(URI.parse(url).query)["scope"]
+    end
+
+    it "requests the Visio scopes" do
+      expect(scope_param).to include("lasuite_visio")
+      expect(scope_param).to include("lasuite_visio:rooms:create")
+    end
+
+    context "when VISIO_NUMERIQUE_DISABLED is set" do
+      stub_env_with(VISIO_NUMERIQUE_DISABLED: "true")
+
+      it "doesn't request the Visio scopes" do
+        expect(scope_param).not_to include("lasuite_visio")
+      end
+
+      it "still requests the other scopes" do
+        expect(scope_param).to include("openid")
+        expect(scope_param).to include("siret")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Contexte

Sur certaines instances, le client ID ProConnect ne dispose pas des scopes nécessaires à Visio (`lasuite_visio` / `lasuite_visio:rooms:create`). Sans ces scopes, la demande de connexion ProConnect échoue.

# Solution

Ajout d'une variable d'environnement `VISIO_NUMERIQUE_DISABLED` permettant de désactiver entièrement la fonctionnalité Visio sur une instance :

- `ProConnectOpenIdClient::Auth` ne demande plus les scopes `lasuite_visio` et `lasuite_visio:rooms:create` lors de la redirection vers ProConnect quand la variable est activée.
- `Admin::RdvWizardStepsController#assign_visio_numerique_room_if_applicable` n'essaie plus de créer de salon Visio dans ce cas.
- Documentation de la variable dans `.env.sample`, à côté de `VISIO_NUMERIQUE_API_URL`.
- Ajout de tests couvrant les deux comportements (scopes ProConnect et garde à la création de salon).
