### PR TITLE
Fix LAPINS-7A3

### DIFF
--- a/app/lib/geo_coding.rb
+++ b/app/lib/geo_coding.rb
@@ -1,6 +1,6 @@
 class GeoCoding
   def find_geo_coordinates(address)
-    address_api_response(address).dig("features", 0, "geometry", "coordinates")
+    address_api_response(address)&.dig("features", 0, "geometry", "coordinates")
   end
 
   def get_geolocation_results(address, departement_number)
@@ -29,10 +29,12 @@ class GeoCoding
   end
 
   def address_api_response(address)
-    address_api_response = Rails.cache.fetch("api-adresse:#{address}") do
-      Faraday.get("https://data.geopf.fr/geocodage/search/", q: address)
+    Rails.cache.fetch("api-adresse:#{address}", skip_nil: true) do
+      response = Faraday.get("https://data.geopf.fr/geocodage/search/", q: address)
+      JSON.parse(response.body) if response.success?
     end
-
-    JSON.parse(address_api_response.body)
+  rescue JSON::ParserError => e
+    Sentry.capture_exception(e)
+    nil
   end
 end

--- a/spec/lib/geo_coding_spec.rb
+++ b/spec/lib/geo_coding_spec.rb
@@ -108,5 +108,26 @@ RSpec.describe GeoCoding do
         expect(result).to be_nil
       end
     end
+
+    context "quand l'API renvoie une erreur (ex: page HTML de maintenance)" do
+      before do
+        stub_request(
+          :get,
+          "https://data.geopf.fr/geocodage/search/?q=20%20avenue%20de%20S%C3%A9gur,%20Paris,%2075007"
+        ).to_return(status: 503, body: "<html><body>Service indisponible</body></html>", headers: {})
+      end
+
+      it "retourne nil sans lever d'exception" do
+        result = geo_coding.get_geolocation_results(address, departement_number)
+
+        expect(result).to be_nil
+      end
+
+      it "ne met pas la réponse en échec en cache" do
+        geo_coding.get_geolocation_results(address, departement_number)
+
+        expect(Rails.cache.read("api-adresse:#{address}")).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Corrige le Sentry LAPINS-7A3

# Contexte

Sur la route `/admin/organisations/:id/prescription/search_creneau`, une erreur `ActionView::Template::Error` remontait de façon persistante : `unexpected character: '<html>' at line 1 column 1`.

L'origine est un géocodage d'adresse usager via l'API `data.geopf.fr` (`GeoCoding#address_api_response`) : lors d'une panne transitoire de cette API (réponse 503 sous forme de page HTML), la réponse était tout de même mise en cache via `Rails.cache.fetch`, quel que soit son statut HTTP. Résultat : une fois la panne survenue pour l'adresse d'un usager donné, chaque nouvelle recherche de créneau pour cet usager continuait à lire cette réponse cassée depuis le cache et à planter au `JSON.parse`, même après le retour à la normale de l'API externe.

# Solution

- `GeoCoding#address_api_response` ne met désormais en cache la réponse que si l'appel a réussi (`response.success?`), avec `skip_nil: true` pour ne jamais stocker un résultat vide ou en échec.
- Le `JSON.parse` est protégé par un `rescue JSON::ParserError` qui logue l'exception dans Sentry et retourne `nil` au lieu de faire planter la vue, à l'image de ce qui existe déjà dans `GeoApiGouv`.
- `find_geo_coordinates` est sécurisé avec `&.` pour gérer proprement le cas où l'API ne répond pas.
- Ajout de tests couvrant le cas d'une réponse en erreur (503 / HTML) : pas d'exception levée, et pas de mise en cache de la réponse en échec.