### PR TITLE
Correction de l’affichage du séparateur dans le menu agent

### DIFF
--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -35,7 +35,7 @@ header.header.bg-white
             li = link_to agents_exports_path, class: "dropdown-item-dsfr dropdown-item" do
               span.fr-icon--sm.fr-mr-2v.fr-icon-file-download-line[aria-hidden="true"]
               = "Vos exports"
-            - territories = Agent::TerritoryPolicy::Scope.new(current_agent, Territory.all).resolve.distinct.order(:name)
+            - territories = Agent::TerritoryPolicy::Scope.new(current_agent, Territory.all).resolve.distinct.order(:name).load
             - if territories.any?
               li.dropdown-divider.my-1[aria-hidden="true"]
               - territories.each do |territory|

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -35,11 +35,13 @@ header.header.bg-white
             li = link_to agents_exports_path, class: "dropdown-item-dsfr dropdown-item" do
               span.fr-icon--sm.fr-mr-2v.fr-icon-file-download-line[aria-hidden="true"]
               = "Vos exports"
-            li.dropdown-divider.my-1[aria-hidden="true"]
-            - Agent::TerritoryPolicy::Scope.new(current_agent, Territory.all).resolve.distinct.order(:name).each do |territory|
-              li = link_to admin_territory_path(territory), class: "dropdown-item-dsfr dropdown-item" do
-                span.fr-icon--sm.fr-mr-2v.fr-icon-settings-5-line[aria-hidden="true"]
-                | Paramètres de #{territory.name_for_agent}
+            - territories = Agent::TerritoryPolicy::Scope.new(current_agent, Territory.all).resolve.distinct.order(:name)
+            - if territories.any?
+              li.dropdown-divider.my-1[aria-hidden="true"]
+              - territories.each do |territory|
+                li = link_to admin_territory_path(territory), class: "dropdown-item-dsfr dropdown-item" do
+                  span.fr-icon--sm.fr-mr-2v.fr-icon-settings-5-line[aria-hidden="true"]
+                  | Paramètres de #{territory.name_for_agent}
             li.dropdown-divider.my-1[aria-hidden="true"]
             li = link_to destroy_agent_session_path, method: :delete, class: "dropdown-item-dsfr dropdown-item" do
               span.fr-icon--sm.fr-mr-2v.fr-icon-logout-box-r-line[aria-hidden="true"]


### PR DESCRIPTION
Suite à #6549 

J’ai ajouté un séparateur entre les options de l’agent et les paramètres de l’espace dans le menu. 
Néanmoins, lorsque l’agent n’est administrateur d’aucune organisation, ce séparateur s’affichait quand même.

<img width="314" height="159" alt="image" src="https://github.com/user-attachments/assets/6588433b-f426-4872-8c95-065ee8891ac7" />

On corrige donc avec cette PR