### PR TITLE
Permettre de tester les webhooks en local pour l'équipe visioplainte

### DIFF
--- a/app/controllers/api/visioplainte/base_controller.rb
+++ b/app/controllers/api/visioplainte/base_controller.rb
@@ -16,6 +16,8 @@ class Api::Visioplainte::BaseController < ActionController::Base # rubocop:disab
 
     territory = Territory.visioplainte.first
 
+    territory.roles.delete_all
+
     territory.organisations.find_each do |organisation|
       organisation.plage_ouvertures.delete_all
       organisation.rdvs.destroy_all

--- a/db/seeds/visioplainte.rb
+++ b/db/seeds/visioplainte.rb
@@ -37,6 +37,7 @@ superviseur_gendarmerie = Agent.new(
 superviseur_gendarmerie.skip_confirmation!
 superviseur_gendarmerie.save!
 AgentTerritorialAccessRight.create(agent: superviseur_gendarmerie, territory: territory)
+AgentTerritorialRole.create(agent: superviseur_gendarmerie, territory: territory)
 
 30.times do |i|
   Agent.create!(


### PR DESCRIPTION
Une toute petite PR pour permettre à l'équipe de développement de Visioplainte d'accéder à l'espace admin en local, pour qu'ils puissent tester plus facilement les webhooks qu'ils commencent à utiliser.

Fix https://zammad10.ethibox.fr/#ticket/zoom/44472