### PR TITLE
Correctif pour le lien de réservation à l'échelle de l'espace pour le CDAD21

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -142,7 +142,16 @@ class SearchController < ApplicationController
 
   def search_allowed?
     current_domain.provides_address_selection? || # toujours autorisé sur RDVS
-      (@current_step != :address_selection && params[:public_link_organisation_id].present?) # toujours scopé sur RDVSP
+      (@current_step != :address_selection && params[:public_link_organisation_id].present?) || # toujours scopé sur RDVSP
+      exception_for_cdad_21?
+  end
+
+  def exception_for_cdad_21?
+    # dans le le CDAD de la Côte d'Or,  les agents ont distribué un lien de prise de rendez-vous à
+    # l'échelle de leur espace. Pour éviter de casser ce lien, et en attendant d'avoir une solution plus pérenne,
+    # on autorise l'utilisation du paramètre departement dans ce cas.
+    # Leur nom de département étant C21, il n'y a pas de risque de permettre de scraper d'autres territoires.
+    params[:departement] == "C21"
   end
 
   def search_params

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -132,4 +132,13 @@ RSpec.describe "Search", type: :request do
       end
     end
   end
+
+  # dans le le CDAD de la Côte d'Or,  les agents ont distribué un lien de prise de rendez-vous à
+  # l'échelle de leur espace. Pour éviter de casser ce lien, et en attendant d'avoir une solution plus pérenne,
+  # on autorise l'utilisation du paramètre departement dans ce cas.
+  # Leur nom de département étant C21, il n'y a pas de risque de permettre de scraper d'autres territoires.
+  it "marche pour le lien du CDAD de la Côte d'Or" do
+    get prendre_rdv_url(host: "www.rdv-service-public-test.localhost", departement: "C21")
+    expect(response).to be_successful
+  end
 end


### PR DESCRIPTION

Ticket zammad : https://zammad10.ethibox.fr/#ticket/zoom/44688
Discussion mattermost : https://mattermost.incubateur.net/betagouv/pl/a9ks6a75upntpp65877m38bnyy

C'est un fix temporaire pour éviter de bloquer la prise de rendez-vous dans ce département (cassée parce qu'ils faisaient un détournement d'une feature disparue depuis https://github.com/betagouv/rdv-service-public/pull/6456.

Comme le propose Adrien sur la discussion mattermost, ça serait bien qu'on ai des liens pour les espaces (territoires) similaires à ceux pour les organisations (avec un id non énumérable), mais pour le moment la prio c'est de débloquer ce cdad.

