### PR TITLE
Pré-remplir les couleurs de motifs avec les couleurs d'illustration du DSFR

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -74,6 +74,7 @@ class Motif < ApplicationRecord
   # Hooks
 
   after_initialize { self.public_link_id ||= SecureRandom.base58(8) }
+  after_initialize { self.color ||= random_color }
 
   # Scopes
   scope :active, lambda { |active = true|
@@ -321,5 +322,12 @@ class Motif < ApplicationRecord
 
       errors.add(:base, :duplicate_detected, message: error_message)
     end
+  end
+
+  def random_color
+    # Liste des couleurs d'illustration du DSFR (thème clair)
+    ["#B7A73F", "#68A532", "#00A95F", "#009081", "#009099", "#465F9D", "#417DC4", "#A558A0",
+     "#E18B76", "#CE614A", "#C8AA39", "#C3992A", "#E4794A", "#D1B781", "#C08C65", "#BD987A",
+     "#AEA397",].sample
   end
 end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -74,7 +74,12 @@ class Motif < ApplicationRecord
   # Hooks
 
   after_initialize { self.public_link_id ||= SecureRandom.base58(8) }
-  after_initialize { self.color ||= random_color }
+  DSFR_ILLUSTRATION_COLORS = [
+    "#B7A73F", "#68A532", "#00A95F", "#009081", "#009099", "#465F9D", "#417DC4", "#A558A0",
+    "#E18B76", "#CE614A", "#C8AA39", "#C3992A", "#E4794A", "#D1B781", "#C08C65", "#BD987A",
+    "#AEA397",
+  ].freeze
+  after_initialize { self.color ||= DSFR_ILLUSTRATION_COLORS.sample }
 
   # Scopes
   scope :active, lambda { |active = true|
@@ -322,12 +327,5 @@ class Motif < ApplicationRecord
 
       errors.add(:base, :duplicate_detected, message: error_message)
     end
-  end
-
-  def random_color
-    # Liste des couleurs d'illustration du DSFR (thème clair)
-    ["#B7A73F", "#68A532", "#00A95F", "#009081", "#009099", "#465F9D", "#417DC4", "#A558A0",
-     "#E18B76", "#CE614A", "#C8AA39", "#C3992A", "#E4794A", "#D1B781", "#C08C65", "#BD987A",
-     "#AEA397",].sample
   end
 end

--- a/app/services/motif_templates/france_service.rb
+++ b/app/services/motif_templates/france_service.rb
@@ -24,7 +24,7 @@ module MotifTemplates
 
         motif_attrs = template_attrs
           .slice(:name, :location_type, :default_duration_in_min, :restriction_for_rdv, :instruction_for_rdv)
-          .merge(service:, color: "#99CC99")
+          .merge(service:)
 
         Motif.new(motif_attrs)
       end

--- a/app/services/motif_templates/france_service.rb
+++ b/app/services/motif_templates/france_service.rb
@@ -24,7 +24,7 @@ module MotifTemplates
 
         motif_attrs = template_attrs
           .slice(:name, :location_type, :default_duration_in_min, :restriction_for_rdv, :instruction_for_rdv)
-          .merge(service:)
+          .merge(service:, color: "#99CC99")
 
         Motif.new(motif_attrs)
       end

--- a/db/seeds/cdad.rb
+++ b/db/seeds/cdad.rb
@@ -27,7 +27,6 @@ territory_gironde.services << service_cdad
 # Motifs
 motif1_cdad1 = Motif.create!(
   name: "RDV Avocat",
-  color: "#00ffff",
   default_duration_in_min: 60,
   organisation: org_cdad1,
   bookable_by: "agents",

--- a/db/seeds/cnfs.rb
+++ b/db/seeds/cnfs.rb
@@ -22,7 +22,6 @@ if ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "RDV_SOLIDARITES_DEV"
 
   motif_accompagnement_individuel = Motif.create!(
     name: "Accompagnement individuel",
-    color: "#99CC99",
     default_duration_in_min: 60,
     location_type: :public_office,
     bookable_by: :everyone,
@@ -32,7 +31,6 @@ if ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "RDV_SOLIDARITES_DEV"
 
   motif_atelier_collectif = Motif.create!(
     name: "Atelier collectif",
-    color: "#4A86E8",
     default_duration_in_min: 120,
     location_type: :public_office,
     collectif: true,

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -195,7 +195,7 @@ motifs_attributes = 1000.times.map do |i|
     created_at: now,
     updated_at: now,
     name: "motif_#{i}",
-    color: Motif.new.send(:random_color),
+    color: Motif::DSFR_ILLUSTRATION_COLORS.sample,
     organisation_id: org_arques.id,
     service_id: service_pmi.id,
     bookable_by: :everyone,

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -84,7 +84,6 @@ territory75.services << [service_pmi, service_social, service_secretariat]
 
 motif_org_paris_nord_pmi_rappel = Motif.create!(
   name: "Être rappelé par la PMI",
-  color: "#FF7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   bookable_by: :everyone,
@@ -92,7 +91,6 @@ motif_org_paris_nord_pmi_rappel = Motif.create!(
 )
 motif_org_paris_nord_pmi_gyneco = Motif.create!(
   name: "Consultation gynécologie / contraception",
-  color: "#FF7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   bookable_by: :agents,
@@ -100,7 +98,6 @@ motif_org_paris_nord_pmi_gyneco = Motif.create!(
 )
 motif_org_paris_nord_pmi_prenatale = Motif.create!(
   name: "Consultation prénatale",
-  color: "#CC7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   bookable_by: :everyone,
@@ -108,7 +105,6 @@ motif_org_paris_nord_pmi_prenatale = Motif.create!(
 )
 motif_org_paris_nord_pmi_prenatale_phone = Motif.create!(
   name: "Consultation prénatale",
-  color: "#CC7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   bookable_by: :everyone,
@@ -116,7 +112,6 @@ motif_org_paris_nord_pmi_prenatale_phone = Motif.create!(
 )
 motif_org_paris_nord_pmi_suivi = Motif.create!(
   name: "Suivi après naissance",
-  color: "#00FC60",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   bookable_by: :everyone,
@@ -125,7 +120,6 @@ motif_org_paris_nord_pmi_suivi = Motif.create!(
 )
 motif_org_paris_nord_pmi_securite = Motif.create!(
   name: "Sécurité du domicile",
-  color: "#1010FF",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   bookable_by: :everyone,
@@ -133,7 +127,6 @@ motif_org_paris_nord_pmi_securite = Motif.create!(
 )
 motif_org_paris_nord_pmi_collectif = Motif.create!(
   name: "Atelier Collectif",
-  color: "#1049F3",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   collectif: true,
@@ -143,7 +136,6 @@ motif_org_paris_nord_pmi_collectif = Motif.create!(
 )
 motif_org_paris_nord_social_rappel = Motif.create!(
   name: "Être rappelé par la MDS",
-  color: "#FF7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_social.id,
   bookable_by: :everyone,
@@ -151,7 +143,6 @@ motif_org_paris_nord_social_rappel = Motif.create!(
 )
 motif_org_paris_nord_social_suivi = Motif.create!(
   name: "Suivi RSA",
-  color: "#CC7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_social.id,
   bookable_by: :everyone,
@@ -160,7 +151,6 @@ motif_org_paris_nord_social_suivi = Motif.create!(
 )
 _motif_org_paris_nord_social_droits = Motif.create!(
   name: "Droits sociaux",
-  color: "#00FC60",
   organisation_id: org_paris_nord.id,
   service_id: service_social.id,
   bookable_by: :everyone,
@@ -168,7 +158,6 @@ _motif_org_paris_nord_social_droits = Motif.create!(
 )
 _motif_org_paris_nord_social_collectif = Motif.create!(
   name: "Forum",
-  color: "#113C65",
   organisation_id: org_paris_nord.id,
   service_id: service_social.id,
   collectif: true,
@@ -184,7 +173,6 @@ Organisation.where(territory: territory62).each do |org|
   motifs[org] ||= {}
   motifs[org][:pmi_rappel] = Motif.create!(
     name: "Être rappelé par la PMI",
-    color: "#10FF10",
     organisation_id: org.id,
     service_id: service_pmi.id,
     bookable_by: :everyone,
@@ -193,7 +181,6 @@ Organisation.where(territory: territory62).each do |org|
   )
   motifs[org][:pmi_prenatale] = Motif.create!(
     name: "Consultation prénatale",
-    color: "#FF1010",
     organisation_id: org.id,
     service_id: service_pmi.id,
     bookable_by: :everyone,
@@ -208,7 +195,7 @@ motifs_attributes = 1000.times.map do |i|
     created_at: now,
     updated_at: now,
     name: "motif_#{i}",
-    color: "#000000",
+    color: Motif.new.send(:random_color),
     organisation_id: org_arques.id,
     service_id: service_pmi.id,
     bookable_by: :everyone,

--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -60,7 +60,6 @@ territory_yonne.services << service_rsa
 # MOTIFS Drome
 motif1_drome1 = Motif.create!(
   name: "RSA - Orientation : rdv sur site",
-  color: "#00ffff",
   default_duration_in_min: 60,
   organisation: org_drome1,
   bookable_by: :agents_and_prescripteurs_and_invited_users,
@@ -76,7 +75,6 @@ motif1_drome1 = Motif.create!(
 )
 motif2_drome1 = Motif.create!(
   name: "RSA accompagnement",
-  color: "#000000",
   default_duration_in_min: 30,
   organisation: org_drome1,
   bookable_by: :agents_and_prescripteurs_and_invited_users,
@@ -87,7 +85,6 @@ motif2_drome1 = Motif.create!(
 )
 motif_drome2 = Motif.create!(
   name: "RSA - Orientation : rdv sur site",
-  color: "#00ffff",
   default_duration_in_min: 60,
   organisation: org_drome2,
   bookable_by: :agents_and_prescripteurs_and_invited_users,
@@ -99,7 +96,6 @@ motif_drome2 = Motif.create!(
 )
 motif_convoc_drome1 = Motif.create!(
   name: "Convocation RSA - Orientation : rdv sur site",
-  color: "#00ffff",
   default_duration_in_min: 60,
   organisation: org_drome1,
   bookable_by: :agents,
@@ -113,7 +109,6 @@ motif_convoc_drome1 = Motif.create!(
 # MOTIFS Yonne
 motif_yonne_physique = Motif.create!(
   name: "RSA - Codiagnostic d'orientation",
-  color: "#000000",
   default_duration_in_min: 30,
   organisation: org_yonne,
   service: service_rsa,
@@ -122,7 +117,6 @@ motif_yonne_physique = Motif.create!(
 )
 motif_yonne_telephone = Motif.create!(
   name: "RSA - Orientation : rdv téléphonique",
-  color: "#000000",
   default_duration_in_min: 30,
   organisation: org_yonne,
   service: service_rsa,

--- a/db/seeds/visioplainte.rb
+++ b/db/seeds/visioplainte.rb
@@ -15,7 +15,6 @@ Motif.create!(
   name: "Dépôt de plainte par visioconférence (Visioplainte)",
   default_duration_in_min: 30,
   min_public_booking_delay: 2 * 60 * 60,
-  color: "#FF7C00",
   location_type: :visio,
   service: service_gendarmerie,
   visibility_type: Motif::VISIBLE_AND_NOT_NOTIFIED,

--- a/spec/controllers/admin/motifs_controller_spec.rb
+++ b/spec/controllers/admin/motifs_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
     context "with invalid params" do
       let(:invalid_attributes) do
         {
-          name: "test motif",
+          name: motif.name, # On a une condition d'unicité sur les intitulés de motifs
         }
       end
 


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="730" height="310" alt="Screenshot 2026-08-04 at 12 14 19" src="https://github.com/user-attachments/assets/6b40e1c7-78c6-4bc5-aa25-807876f265d9" />|<img width="725" height="310" alt="Screenshot 2026-08-04 at 12 14 09" src="https://github.com/user-attachments/assets/2d1a34cb-d335-41e8-a3d3-8e6ce043edc9" />

Le DSFR fourni des couleurs d'illustration. On peut s'en servir de couleurs par défaut quand on crée des motifs (mais quand même laisser l'agent choisir n'importe quelle couleur).

Ça sera aussi utile pour le formulaire de motif intégré à la prise de rendez-vous par intégration. Pour le simplifier, on ne demandera pas de choisir une couleur, donc c'est pratique d'avoir des valeurs par défaut.

