### PR TITLE
Indiquer à l’admin d’orga qu’il essaye d’inviter un agent déjà invité

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -41,6 +41,7 @@ class Admin::AgentsController < AgentAuthController
       flash[:alert] = create_agent.warning_message
       redirect_to admin_organisation_agents_path(current_organisation)
     else
+      @pending_invitation_conflict_organisation = create_agent.pending_invitation_conflict_organisation
       render_new
     end
   end

--- a/app/services/admin_creates_agent.rb
+++ b/app/services/admin_creates_agent.rb
@@ -40,6 +40,11 @@ class AdminCreatesAgent
 
   attr_reader :warning_message
 
+  # @return [Organisation, nil] l'organisation pour laquelle l'agent a déjà une invitation en attente, si c'est la raison de l'échec
+  def pending_invitation_conflict_organisation
+    @agent&.roles&.find { |role| !role.persisted? && role.errors.of_kind?(:agent, :taken_invited) }&.organisation
+  end
+
   def confirmation_message
     return nil unless @agent.valid?
 

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -8,7 +8,16 @@
     .card
       .card-body.js_agent_role_form
         = form_for [:admin, @agent], url: admin_organisation_agents_path(current_organisation), html: { method: :post }, builder: Dsfr::FormBuilder do |f|
-          = render "devise/shared/error_messages", resource: @agent
+          - if @pending_invitation_conflict_organisation
+            = dsfr_alert type: :error, title: "Invitation déjà en cours", html_attributes: { class: "fr-mb-2w" } do
+              | Une invitation a déjà été envoyée à #{@agent.email} pour rejoindre #{@pending_invitation_conflict_organisation.name} et n’a pas encore été acceptée.
+              br
+              = link_to "Renvoyer l’invitation",
+                      reinvite_admin_organisation_invitation_path(current_organisation, @agent),
+                      method: :post,
+                      class: "fr-btn fr-btn--sm fr-mt-2v"
+          - else
+            = render "devise/shared/error_messages", resource: @agent
           = f.fields_for @agent_role do |ff|
             ruby:
               role_choices = @roles.map do |role|

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -66,6 +66,29 @@ RSpec.describe "Agents can be managed by organisation admins" do
       end
     end
 
+    describe "when the agent already has a pending invitation for this organisation" do
+      let!(:invited_agent) do
+        create(:agent, :not_confirmed, email: "jean@paul.com", service: pmi, basic_role_in_organisations: [organisation1], invitation_accepted_at: nil)
+      end
+
+      before do
+        allow(UnblockBrevoTransactionalContact).to receive(:new).and_return(instance_double(UnblockBrevoTransactionalContact, call: true))
+      end
+
+      it "proposes to resend the invitation instead of a generic error" do
+        click_link "Ajouter un agent", match: :first
+        fill_in "Email", with: "jean@paul.com"
+        click_button "Enregistrer"
+
+        expect(page).to have_content("Une invitation a déjà été envoyée à jean@paul.com")
+        expect(Agent.count).to eq(2)
+
+        click_link "Renvoyer l’invitation"
+
+        expect(page).to have_content("Une nouvelle invitation a été envoyée à l'agent jean@paul.com")
+      end
+    end
+
     stub_env_for_proconnect
     specify "CRUD on agents" do
       create(:agent, first_name: "Tony", last_name: "Patrick", email: "tony@patrick.fr", service: pmi, basic_role_in_organisations: [organisation1], invitation_accepted_at: nil)

--- a/spec/services/admin_creates_agent_spec.rb
+++ b/spec/services/admin_creates_agent_spec.rb
@@ -24,4 +24,28 @@ RSpec.describe AdminCreatesAgent do
       expect(agent.organisations).to eq [organisation]
     end
   end
+
+  context "when the agent already has a pending invitation for this organisation" do
+    subject(:service) do
+      described_class.new(
+        agent_params: { email: existing_agent.email, service_ids: [] },
+        current_agent: admin,
+        organisations: [organisation],
+        access_level: :basic
+      )
+    end
+
+    let(:organisation) { create(:organisation) }
+    let(:admin) { create(:agent, admin_role_in_organisations: [organisation]) }
+    let!(:existing_agent) do
+      create(:agent, :not_confirmed, basic_role_in_organisations: [organisation], invitation_accepted_at: nil)
+    end
+
+    it "does not add a new role and exposes the conflicting organisation" do
+      agent = service.call
+
+      expect(agent).to be_invalid
+      expect(service.pending_invitation_conflict_organisation).to eq(organisation)
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

On a souvent au support des agents qui : 

- Invite un autre agent
- L’autre agent laisse passer le délai de 48h pour accepter l’invitation donc elle devient invalide
- L’agent qui est à l’origine de l’invitation essayer de réinviter l’agent via le formulaire d’ajout plutôt que de cliquer sur « Réinviter l’agent »

Il se prend alors une erreur et nous écrit au support.

# Solution

Je propose donc qu’on affiche un message plus clair, qui permet de réinviter directement l’agent.
En solution complémentaire, on pourrait remonter le bouton pour voir la vue des agents en attente.

## Captures d'écran

<img width="814" height="545" alt="image" src="https://github.com/user-attachments/assets/ef7c16dd-c336-4f99-982e-782bde448460" />
